### PR TITLE
fix(ci): green develop after Medtronic Connect merge (helper-src context + x/sys CVE)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -156,7 +156,8 @@
         "gradle",
         "gradle-wrapper",
         "docker-compose",
-        "dockerfile"
+        "dockerfile",
+        "gomod"
       ],
       "matchUpdateTypes": ["patch", "minor"],
       "addLabels": ["automerge"]
@@ -243,6 +244,14 @@
       "description": "Group Python dependencies",
       "matchManagers": ["pip_requirements", "pip-compile", "poetry", "pep621"],
       "groupName": "Python dependencies"
+    },
+    // Group Go dependencies -- the Medtronic Connect desktop-helper
+    // (tools/connect-helper) is the project's only Go module. Keep its
+    // updates in one PR so the chromedp/cdproto stack moves together.
+    {
+      "description": "Group Go dependencies",
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies"
     },
     // Group Node.js dependencies
     {

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -107,6 +107,12 @@ jobs:
         with:
           context: ./apps/api
           file: ./apps/api/Dockerfile
+          # The Medtronic Connect Go-helper sources live outside the API build
+          # context (at repo root), so expose them as a named additional build
+          # context. Mirrors docker-compose.yml api.build.additional_contexts;
+          # the Dockerfile's connect-helper-builder stage COPYs --from=helper-src.
+          build-contexts: |
+            helper-src=./tools/connect-helper
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/tools/connect-helper/go.mod
+++ b/tools/connect-helper/go.mod
@@ -13,5 +13,5 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 )

--- a/tools/connect-helper/go.sum
+++ b/tools/connect-helper/go.sum
@@ -17,5 +17,5 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Problem

The **Containers** badge on the README has been red since the Medtronic CareLink Connect autonomous-sync feature landed on `develop`. The `Build API Image` job in `container-build.yml` fails with:

```
helper-src: failed to resolve source metadata for docker.io/library/helper-src:latest:
pull access denied, repository does not exist or may require authorization
```

## Root cause

The API `Dockerfile` gained a `connect-helper-builder` stage that cross-compiles the Go login-helper. Its sources live at repo root (outside the `./apps/api` build context), so they're pulled in via a **named additional build context** called `helper-src`:

```dockerfile
COPY --from=helper-src go.mod go.sum ./
COPY --from=helper-src . .
```

That context was wired into `docker-compose.yml` (`api.build.additional_contexts.helper-src`), so local `docker compose build` and the Docker Integration Test job both work. But `container-build.yml` invokes `docker/build-push-action` directly and never passed the context — so buildx treated `helper-src` as a registry image and failed.

## Fix

Add the `build-contexts` input to the `Build API image` step, mirroring the compose `additional_contexts` entry. One-line plumbing; no Dockerfile or app changes.

## Verification

Reproduced and fixed locally with raw `docker buildx` (exactly how `build-push-action` invokes it from repo root):

- **Without** the flag → reproduces the CI error verbatim.
- **With** `--build-context helper-src=./tools/connect-helper` → all 5 platform binaries cross-compile and the image exports cleanly.

CI on this PR exercises the real path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced container build workflow to include an additional build context for the API image.
  * Updated an internal helper module's dependency to a newer patch release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlycemicGPT/GlycemicGPT/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 3. Renovate — track the new Go module

The helper is the project's first Go module. Renovate's `gomod` manager is on by default (no `enabledManagers` allow-list), so it already discovers `go.mod` — but it had no tier rule, leaving Go the only ecosystem without a deliberate auto-merge policy. Added `gomod` to the Tier B (patch+minor) auto-merge allow-list and a "Go dependencies" group, matching pep621/npm/gradle. Majors stay manual. Validated with `renovate-config-validator`.