### PR TITLE
fix(integrations): refresh Glooko card status after a failed sync/import

### DIFF
--- a/apps/web/src/components/integrations/glooko-sync-card.tsx
+++ b/apps/web/src/components/integrations/glooko-sync-card.tsx
@@ -170,7 +170,19 @@ export function GlookoSyncCard({ isOffline }: { isOffline: boolean }) {
         /* keep the successful sync result */
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Sync failed");
+      // A failed sync may have flipped the connection to disconnected; refresh so
+      // the card reflects it instead of showing a stale "Connected" banner. When
+      // it did disconnect, the reconnect prompt already explains it -- skip the
+      // redundant error banner; otherwise surface the failure.
+      try {
+        const s = await getGlookoStatus();
+        applyStatus(s);
+        if (s.status !== "disconnected") {
+          setError(e instanceof Error ? e.message : "Sync failed");
+        }
+      } catch {
+        setError(e instanceof Error ? e.message : "Sync failed");
+      }
     } finally {
       setIsSyncing(false);
     }
@@ -188,7 +200,17 @@ export function GlookoSyncCard({ isOffline }: { isOffline: boolean }) {
         /* keep the successful import result */
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Import failed");
+      // Same as syncNow: refresh so a disconnect is reflected; when disconnected
+      // the reconnect prompt covers it, so skip the redundant error banner.
+      try {
+        const s = await getGlookoStatus();
+        applyStatus(s);
+        if (s.status !== "disconnected") {
+          setError(e instanceof Error ? e.message : "Import failed");
+        }
+      } catch {
+        setError(e instanceof Error ? e.message : "Import failed");
+      }
     } finally {
       setIsImporting(false);
     }


### PR DESCRIPTION
## Summary

Fixes a contradictory state in the Omnipod / Glooko card: after a manual **Sync** or **Import** failed with an auth error (e.g. the user changed their Glooko password), the card showed a stale green **"Connected"** banner *next to* a red **"Your Glooko login is no longer valid. Please reconnect."** error.

## Cause

The backend flips the connection to `disconnected` when a sync's live login fails, but the card's failure handler only set the error — it never refreshed the status, so the UI kept rendering the previous `connected` state. (The success path already refreshes status, in a nested `try` so a refresh failure can't mask a successful sync.)

## Fix

Mirror the success-path refresh on the failure path of `syncNow` / `importHistory`:
- Refresh status after a failure, so a disconnect is reflected and the card flips to the reconnect prompt instead of a stale "Connected" banner.
- When the row did disconnect, the reconnect prompt already explains it, so the now-redundant bottom error banner is suppressed; transient (non-disconnect) failures still surface the error.

## Testing

Reproduced the original contradiction with a connected connection whose live login fails, then verified the card flips cleanly to a single reconnect prompt (no stale "Connected", no duplicate message). Web lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Glooko sync and import: the app now refreshes connection status before showing an error to avoid redundant failure messages when the operation caused a disconnect. If the status refresh fails, the original error is shown. Users will see the reconnect prompt instead of duplicate error banners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->