### PR TITLE
feat(mobile): wire Sentry crash/error reporting into the Android app

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -73,8 +73,10 @@ android {
             // the published debug `dev-latest` APK ships with an empty DSN even though it is
             // downloadable. A DSN baked into any distributed client APK is extractable; keeping it
             // opt-in and local-only is the guarantee. See SentryInitializer.
-            val sentryDsn = (System.getenv("SENTRY_DSN")
-                ?: (project.findProperty("sentryDsn") as? String).orEmpty()).trim()
+            // A blank env var is treated as absent (so an exported-but-empty SENTRY_DSN= still
+            // falls back to the -PsentryDsn property rather than forcing it empty).
+            val sentryDsn = (System.getenv("SENTRY_DSN")?.takeIf { it.isNotBlank() }
+                ?: (project.findProperty("sentryDsn") as? String)).orEmpty().trim()
             // Hard guard: never let a DSN ride along in a CI-produced (publishable) artifact.
             if (sentryDsn.isNotEmpty() && System.getenv("CI") == "true") {
                 throw GradleException(
@@ -82,13 +84,14 @@ android {
                         "downloadable artifact and the DSN would be extractable from it.",
                 )
             }
-            val sentryEnv = (System.getenv("SENTRY_ENVIRONMENT")
-                ?: (project.findProperty("sentryEnvironment") as? String).orEmpty())
-                .trim().ifEmpty { "development" }
+            val sentryEnv = (System.getenv("SENTRY_ENVIRONMENT")?.takeIf { it.isNotBlank() }
+                ?: (project.findProperty("sentryEnvironment") as? String))
+                .orEmpty().trim().ifEmpty { "development" }
             // Escape backslash/quote so an unusual value can't break the generated Java literal.
-            val sentryDsnLiteral = "\"" + sentryDsn.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
-            buildConfigField("String", "SENTRY_DSN", sentryDsnLiteral)
-            buildConfigField("String", "SENTRY_ENVIRONMENT", "\"$sentryEnv\"")
+            fun toJavaStringLiteral(value: String) =
+                "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+            buildConfigField("String", "SENTRY_DSN", toJavaStringLiteral(sentryDsn))
+            buildConfigField("String", "SENTRY_ENVIRONMENT", toJavaStringLiteral(sentryEnv))
         }
         release {
             isMinifyEnabled = true

--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -66,6 +66,29 @@ android {
             buildConfigField("String", "UPDATE_CHANNEL", "\"dev\"")
             val devBuildNumber = (project.findProperty("devBuildNumber") as? String)?.toIntOrNull() ?: 0
             buildConfigField("int", "DEV_BUILD_NUMBER", devBuildNumber.toString())
+
+            // Sentry DSN is compiled in ONLY when a developer explicitly provides it at build time
+            // (env SENTRY_DSN or -PsentryDsn), e.g. `op run -- ./gradlew assembleDebug` for local
+            // testing. It is empty otherwise -> Sentry stays disabled. CI does NOT provide it, so
+            // the published debug `dev-latest` APK ships with an empty DSN even though it is
+            // downloadable. A DSN baked into any distributed client APK is extractable; keeping it
+            // opt-in and local-only is the guarantee. See SentryInitializer.
+            val sentryDsn = (System.getenv("SENTRY_DSN")
+                ?: (project.findProperty("sentryDsn") as? String).orEmpty()).trim()
+            // Hard guard: never let a DSN ride along in a CI-produced (publishable) artifact.
+            if (sentryDsn.isNotEmpty() && System.getenv("CI") == "true") {
+                throw GradleException(
+                    "SENTRY_DSN must not be set for CI builds: the debug APK is published as a " +
+                        "downloadable artifact and the DSN would be extractable from it.",
+                )
+            }
+            val sentryEnv = (System.getenv("SENTRY_ENVIRONMENT")
+                ?: (project.findProperty("sentryEnvironment") as? String).orEmpty())
+                .trim().ifEmpty { "development" }
+            // Escape backslash/quote so an unusual value can't break the generated Java literal.
+            val sentryDsnLiteral = "\"" + sentryDsn.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+            buildConfigField("String", "SENTRY_DSN", sentryDsnLiteral)
+            buildConfigField("String", "SENTRY_ENVIRONMENT", "\"$sentryEnv\"")
         }
         release {
             isMinifyEnabled = true
@@ -82,6 +105,10 @@ android {
             }
             buildConfigField("String", "UPDATE_CHANNEL", "\"stable\"")
             buildConfigField("int", "DEV_BUILD_NUMBER", "0")
+
+            // Never embed a Sentry DSN in a distributed/downloadable APK (it is client-extractable).
+            buildConfigField("String", "SENTRY_DSN", "\"\"")
+            buildConfigField("String", "SENTRY_ENVIRONMENT", "\"production\"")
         }
     }
 
@@ -183,6 +210,11 @@ dependencies {
 
     // Logging
     implementation(libs.timber)
+
+    // Crash/error reporting. The DSN is injected only into debug builds (see buildTypes); it is
+    // never embedded in a distributed/release APK, where it would be client-extractable.
+    implementation(libs.sentry.android)
+    implementation(libs.sentry.android.timber)
 
     // Wearable Data Layer (phone-to-watch sync)
     implementation(libs.play.services.wearable)

--- a/apps/mobile/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/app/src/main/AndroidManifest.xml
@@ -56,6 +56,12 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="35">
 
+        <!-- Sentry: disable ContentProvider auto-init; we initialize manually in
+             SentryInitializer so the DSN, scrubbing, and privacy options are applied in one place. -->
+        <meta-data
+            android:name="io.sentry.auto-init"
+            android:value="false" />
+
         <!-- Intentional: MAIN/LAUNCHER activity must be exported (required since API 31).
              Safe because: no incoming intent data/extras are processed, auth is enforced
              in GlycemicGptNavHost before any sensitive data is shown.

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
@@ -9,6 +9,7 @@ import androidx.work.WorkManager
 import com.glycemicgpt.mobile.data.auth.AuthManager
 import com.glycemicgpt.mobile.data.local.PumpCredentialStore
 import com.glycemicgpt.mobile.logging.ReleaseTree
+import com.glycemicgpt.mobile.logging.SentryInitializer
 import com.glycemicgpt.mobile.plugin.PluginRegistry
 import com.glycemicgpt.mobile.service.DataRetentionWorker
 import com.glycemicgpt.mobile.service.PumpConnectionService
@@ -44,6 +45,9 @@ class GlycemicGptApp : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        // Initialize crash/error reporting first so failures during the rest of startup are
+        // captured. No-op when no DSN is compiled in (release builds, or debug without one).
+        SentryInitializer.init(this)
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         } else {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
@@ -45,14 +45,16 @@ class GlycemicGptApp : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-        // Initialize crash/error reporting first so failures during the rest of startup are
-        // captured. No-op when no DSN is compiled in (release builds, or debug without one).
-        SentryInitializer.init(this)
+        // Plant Timber first so SentryInitializer's own diagnostics (including an init-failure
+        // log) are not silently dropped, then bring Sentry up before the rest of startup so those
+        // failures are captured. Sentry is a no-op when no DSN is compiled in (release builds, or
+        // debug without one).
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         } else {
             Timber.plant(ReleaseTree())
         }
+        SentryInitializer.init(this)
         scheduleDataRetention()
 
         // Initialize the plugin system (discovers and creates all registered plugins)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/logging/SentryInitializer.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/logging/SentryInitializer.kt
@@ -1,0 +1,141 @@
+package com.glycemicgpt.mobile.logging
+
+import android.content.Context
+import com.glycemicgpt.mobile.BuildConfig
+import io.sentry.SentryLevel
+import io.sentry.SentryOptions
+import io.sentry.android.core.SentryAndroid
+import io.sentry.android.timber.SentryTimberIntegration
+import io.sentry.protocol.User
+import timber.log.Timber
+
+/**
+ * Initializes Sentry crash/error reporting.
+ *
+ * Posture (mirrors the backend, locked down for a medical app): error events only, no performance
+ * traces, no profiling, no session/release-health telemetry, no Session Replay, no screenshots /
+ * view hierarchy, no user-interaction tracking, and `isSendDefaultPii = false`. The DSN is compiled
+ * in **only when a developer explicitly provides it at build time** ([BuildConfig.SENTRY_DSN]); it
+ * is empty otherwise (release builds, and the CI-published debug `dev-latest` APK), so distributed
+ * artifacts never report. When the DSN is blank this is a no-op -- "Sentry disabled".
+ *
+ * Defense in depth against PHI/PII leaving the device:
+ * - [SentryOptions.setBeforeBreadcrumb] drops high-risk auto-instrumentation breadcrumbs (HTTP,
+ *   navigation, UI, network) wholesale, since their `data` maps are unbounded.
+ * - [SentryOptions.setBeforeSend] runs every surviving string field (message + params, exception
+ *   values, breadcrumb message + `data`, tag values) through [ReleaseTree.scrubSensitiveData]
+ *   (glucose / token / email redaction), drops `request`, nulls `serverName`, and pins a
+ *   non-routable placeholder IP so Sentry cannot geo-locate the real connection IP (a null user was
+ *   empirically insufficient -- the server still inferred city-level geo from the ingest IP).
+ * - The Timber integration only forwards WARN+ to limit how much raw log text reaches Sentry ahead
+ *   of the scrub. Note the Sentry Timber tree sees the *raw* message (not the [ReleaseTree]-scrubbed
+ *   one), so `beforeSend` is the real safety net.
+ *
+ * The project should also have "Prevent Storing of IP Addresses" enabled in Sentry settings as the
+ * canonical server-side guarantee; the SDK-side controls here do not depend on it but reinforce it.
+ */
+object SentryInitializer {
+
+    /**
+     * Non-routable placeholder so Sentry cannot geo-locate the user's real connection IP. A null
+     * user was empirically insufficient (the server inferred city-level geo from the ingest IP);
+     * an explicit unroutable address suppresses it.
+     */
+    private const val PLACEHOLDER_IP = "0.0.0.0"
+
+    /** Auto-instrumentation breadcrumb categories that routinely carry URLs, params, or routes. */
+    private val DROPPED_BREADCRUMB_PREFIXES =
+        listOf("http", "navigation", "ui.", "network", "device.event")
+
+    fun init(context: Context) {
+        val dsn = BuildConfig.SENTRY_DSN
+        if (dsn.isBlank()) {
+            Timber.i("Sentry disabled (no DSN for this build)")
+            return
+        }
+
+        // Monitoring must never crash the app it monitors.
+        try {
+            SentryAndroid.init(context) { options ->
+                options.dsn = dsn
+                options.environment = BuildConfig.SENTRY_ENVIRONMENT
+                options.release = "${BuildConfig.APPLICATION_ID}@${BuildConfig.VERSION_NAME}"
+
+                // ---- Telemetry off: error events only. ----
+                options.isSendDefaultPii = false
+                options.isAttachScreenshot = false
+                options.isAttachViewHierarchy = false
+                options.isEnableUserInteractionTracing = false
+                options.isEnableUserInteractionBreadcrumbs = false
+                options.isEnableAutoSessionTracking = false
+                options.tracesSampleRate = 0.0
+                options.profilesSampleRate = 0.0
+                // Session Replay is structurally absent (sentry-android-replay is not a dependency).
+                // Sentry structured logging is off by default and intentionally not enabled here.
+
+                // Forward Timber WARN+ as events; nothing below WARN becomes a breadcrumb.
+                options.addIntegration(
+                    SentryTimberIntegration(SentryLevel.ERROR, SentryLevel.WARNING),
+                )
+
+                // Drop high-risk auto-instrumentation breadcrumbs before they are attached; scrub
+                // whatever survives.
+                options.beforeBreadcrumb =
+                    SentryOptions.BeforeBreadcrumbCallback { crumb, _ ->
+                        val category = crumb.category.orEmpty()
+                        if (DROPPED_BREADCRUMB_PREFIXES.any { category.startsWith(it) }) {
+                            null
+                        } else {
+                            crumb.message = scrub(crumb.message)
+                            scrubData(crumb.data)
+                            crumb
+                        }
+                    }
+
+                // Final scrub on every outgoing event.
+                options.beforeSend =
+                    SentryOptions.BeforeSendCallback { event, _ ->
+                        event.user = User().apply { ipAddress = PLACEHOLDER_IP }
+                        event.serverName = null
+                        event.request = null
+                        // Strip coarse-location signals from the device context (the SDK collects
+                        // these by default); model / OS / memory stay for debugging.
+                        event.contexts.device?.apply {
+                            timezone = null
+                            locale = null
+                        }
+                        event.message?.let { msg ->
+                            msg.formatted = scrub(msg.formatted)
+                            msg.message = scrub(msg.message)
+                            msg.params = msg.params?.map { scrub(it).orEmpty() }
+                        }
+                        event.exceptions?.forEach { it.value = scrub(it.value) }
+                        event.breadcrumbs?.forEach { crumb ->
+                            crumb.message = scrub(crumb.message)
+                            scrubData(crumb.data)
+                        }
+                        event.tags?.keys?.toList()?.forEach { key ->
+                            event.tags?.get(key)?.let { event.setTag(key, scrub(it).orEmpty()) }
+                        }
+                        event
+                    }
+            }
+            Timber.i("Sentry initialized (environment=%s)", BuildConfig.SENTRY_ENVIRONMENT)
+        } catch (t: Throwable) {
+            Timber.e(t, "Sentry initialization failed; continuing without crash reporting")
+        }
+    }
+
+    private fun scrub(value: String?): String? = value?.let(ReleaseTree::scrubSensitiveData)
+
+    /** Redact string values in a breadcrumb `data` map in place (keys iterated over a snapshot). */
+    private fun scrubData(data: MutableMap<String, Any>?) {
+        if (data.isNullOrEmpty()) return
+        for (key in data.keys.toList()) {
+            val value = data[key]
+            if (value is String) {
+                data[key] = ReleaseTree.scrubSensitiveData(value)
+            }
+        }
+    }
+}

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ okhttp = "4.12.0"
 retrofit = "2.12.0"
 moshi = "1.15.1"
 timber = "5.0.1"
+sentry = "8.43.0"
 security-crypto = "1.1.0"
 work = "2.11.1"
 junit = "4.13.2"
@@ -90,6 +91,8 @@ work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref
 
 # Logging
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
+sentry-android = { group = "io.sentry", name = "sentry-android", version.ref = "sentry" }
+sentry-android-timber = { group = "io.sentry", name = "sentry-android-timber", version.ref = "sentry" }
 
 # Coroutines
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary

Wires the **Sentry Android SDK** into the mobile app so runtime crashes/errors can be caught before they reach users — the `glycemicgpt-mobile` Sentry project existed but nothing reported to it. Initialized manually in a new `SentryInitializer` with a locked-down, medical-grade privacy posture mirroring the backend.

This was **verified end-to-end on the emulator** against `glycemicgpt-mobile` (events ingest correctly; validation issues resolved). Wiring it up also surfaced and fixed a real privacy gap — see below.

## DSN handling (never shipped in a distributed build)

- The DSN is compiled in **only when a developer explicitly provides it** at build time (`SENTRY_DSN` env or `-PsentryDsn`), e.g. `op run --env-file=.env.sentry.mobile.local -- ./gradlew assembleDebug`. It is empty otherwise.
- The `release` build hardcodes an empty DSN, and a **build-time guard fails any CI build that carries a DSN** — so neither the release APK nor the CI-published downloadable `dev-latest` debug APK can embed an extractable DSN.
- With no DSN, Sentry is a no-op ("disabled"), so ordinary local iteration is unaffected.

## Privacy posture (this is a medical app)

- **Telemetry off:** error events only — no performance traces, profiling, session/release-health, Session Replay (artifact not even a dependency), screenshots, view hierarchy, or user-interaction tracking; `isSendDefaultPii = false`.
- **No PII/PHI leaves the device:** `beforeBreadcrumb` drops HTTP/navigation/UI/network breadcrumbs wholesale; `beforeSend` redacts message + params, exception values, breadcrumb message + `data`, and tag values via the existing `ReleaseTree.scrubSensitiveData` (glucose/token/email), drops `request`, nulls `serverName`, strips device `timezone`/`locale`, and pins a placeholder IP so no user geo is stored.
- Manual init (the auto-init ContentProvider is disabled in the manifest) guarantees these options always apply; init is wrapped so a Sentry failure can never crash the app.

### Privacy gap found & fixed during verification
The first validation event showed `user.geo: US, Westerly` — Sentry inferring **city-level location from the ingest IP** despite `isSendDefaultPii=false`. Pinning a placeholder IP in `beforeSend` (plus stripping device timezone/locale) removed all location data from subsequent events, confirmed against Sentry.

## Verification

- Built + ran the debug APK on the Android emulator with a DSN injected; confirmed events land in `glycemicgpt-mobile` and that no user/geo/location or PII is present (checked via the Sentry MCP). Synthetic validation issues resolved.
- `./gradlew testDebugUnitTest lintDebug` → BUILD SUCCESSFUL on the final (no-DSN) build.
- Adversarial + senior-engineer code-quality + security reviews run; findings addressed (init guard, comprehensive scrubbing, breadcrumb gating, telemetry opt-outs, DSN escaping + CI guard).

## Follow-ups (need you / separate)

- Create a **`Sentry DSN - Mobile`** item in the 1Password `develop` vault (password field) so the `op run` path works for everyone — I lack write access to that vault. The DSN is the standard `glycemicgpt-mobile` project DSN.
- Enable **"Prevent Storing of IP Addresses"** on the `glycemicgpt-mobile` Sentry project as the canonical server-side guarantee (the SDK-side controls here already suppress it, but this is belt-and-suspenders).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in error reporting in debug builds with manual initialization; release builds ship with reporting disabled.
  * Improved startup logging order to ensure consistent log capture.

* **Chores**
  * Added runtime safeguards and extensive automatic redaction to strip sensitive data from any error reports.
  * Build-time checks prevent accidental embedding of reporting credentials in CI/published artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->