### PR TITLE
feat(medtronic): peripheral-mode BLE connection manager with SAKE session and reconnect

### DIFF
--- a/plugins/shipped/medtronic/src/main/AndroidManifest.xml
+++ b/plugins/shipped/medtronic/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!--
+      The Medtronic 700-series driver is a BLE *peripheral* (the pump is the central and connects
+      to us), so it needs BLUETOOTH_ADVERTISE in addition to the BLUETOOTH_CONNECT the host app
+      already declares. Merged into the app manifest; the host app requests it at runtime.
+    -->
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE"
+        tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+</manifest>

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicPeripheral.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicPeripheral.kt
@@ -1,0 +1,446 @@
+/*
+ * Android BluetoothLeAdvertiser + BluetoothGattServer implementation of [MedtronicPeripheral].
+ *
+ * GlycemicGPT code (GPL-3.0). Structurally modelled on OpenMinimed's JavaPumpConnector
+ * BlePeripheralDevice (GPL-3.0, used with permission): advertise as a "Mobile …" device, stand up a
+ * read-only GATT server (SAKE + Device Information), and forward GATT-server events to a
+ * [PeripheralListener]. All UUIDs and the advertising contract come from B1's [MedtronicProtocol].
+ *
+ * This is thin Android glue with no unit-test surface (the Android BLE stack is not mockable in
+ * local unit tests); it is exercised over-the-air against a real pump in 48.A2 / Milestone F. The
+ * testable connection logic lives in [MedtronicBleConnectionManager] / [SakeHandshakeDriver].
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.BluetoothStatusCodes
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.content.Context
+import android.os.Build
+import android.os.ParcelUuid
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.protocol.PduFramer
+import timber.log.Timber
+import java.util.ArrayDeque
+
+/**
+ * Real-device [MedtronicPeripheral]. Construct with the application [Context]; permissions
+ * (`BLUETOOTH_ADVERTISE` / `BLUETOOTH_CONNECT` on API 31+, `ACCESS_FINE_LOCATION` below) are
+ * declared in the module manifest and granted by the host app before use.
+ */
+@SuppressLint("MissingPermission")
+class AndroidMedtronicPeripheral(context: Context) : MedtronicPeripheral {
+
+    private val appContext = context.applicationContext
+    private val bluetoothManager: BluetoothManager? =
+        appContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+    private val adapter get() = bluetoothManager?.adapter
+
+    private var advertiser: BluetoothLeAdvertiser? = null
+    private var advertiseCallback: AdvertiseCallback? = null
+
+    // Written when the server is opened (caller/worker thread) and read from sendSakeNotification on
+    // the worker thread + the GATT-server callbacks on the binder thread, so they need a memory
+    // barrier for the cross-thread reads.
+    @Volatile
+    private var gattServer: BluetoothGattServer? = null
+
+    @Volatile
+    private var sakeCharacteristic: BluetoothGattCharacteristic? = null
+
+    @Volatile
+    private var listener: PeripheralListener? = null
+
+    @Volatile
+    private var peer: BluetoothDevice? = null
+
+    @Volatile
+    private var currentMode: AdvertisingMode = AdvertisingMode.FIRST_PAIR
+
+    @Volatile
+    private var currentName: String = MedtronicBleConnectionManager.DEFAULT_LOCAL_NAME
+
+    // Advertising parameters held until the GATT services finish registering (see start()). Set on
+    // the worker thread and consumed from onServiceAdded on the binder thread.
+    @Volatile
+    private var pendingAdvertise: Pair<AdvertisingMode, String>? = null
+
+    // Services are added one at a time: addService -> onServiceAdded -> addNextService (the Android
+    // GATT server only accepts a new service once the previous add has completed).
+    private val pendingServices = ArrayDeque<BluetoothGattService>()
+
+    override fun isSupported(): Boolean {
+        val ad = adapter ?: return false
+        return ad.isEnabled && ad.isMultipleAdvertisementSupported && ad.bluetoothLeAdvertiser != null
+    }
+
+    override fun start(mode: AdvertisingMode, localName: String, listener: PeripheralListener) {
+        this.listener = listener
+        currentMode = mode
+        currentName = localName
+        if (gattServer == null) {
+            // Defer advertising until the SAKE + Device Info services are registered (service adds are
+            // async via onServiceAdded): otherwise a fast pump could connect and discover an empty
+            // GATT table before the services land.
+            pendingAdvertise = mode to localName
+            openGattServer()
+        } else {
+            startAdvertising(mode, localName)
+        }
+    }
+
+    override fun advertise(mode: AdvertisingMode, localName: String) {
+        currentMode = mode
+        currentName = localName
+        stopAdvertising()
+        startAdvertising(mode, localName)
+    }
+
+    override fun stopAdvertising() {
+        val ad = advertiser ?: return
+        val cb = advertiseCallback ?: return
+        try {
+            ad.stopAdvertising(cb)
+        } catch (e: SecurityException) {
+            Timber.w(e, "stopAdvertising failed")
+        } finally {
+            advertiseCallback = null
+        }
+    }
+
+    override fun sendSakeNotification(payload: ByteArray): Boolean {
+        val server = gattServer
+        val characteristic = sakeCharacteristic
+        val target = peer
+        if (server == null || characteristic == null || target == null) {
+            Timber.w("Cannot notify SAKE: server/characteristic/peer not ready")
+            return false
+        }
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                server.notifyCharacteristicChanged(target, characteristic, false, payload) ==
+                    BluetoothStatusCodes.SUCCESS
+            } else {
+                @Suppress("DEPRECATION")
+                characteristic.value = payload
+                @Suppress("DEPRECATION")
+                server.notifyCharacteristicChanged(target, characteristic, false)
+            }
+        } catch (e: SecurityException) {
+            Timber.w(e, "SAKE notification failed")
+            false
+        }
+    }
+
+    override fun removeBond(address: String): Boolean {
+        val device = adapter?.getRemoteDevice(address) ?: return false
+        if (device.bondState != BluetoothDevice.BOND_BONDED) return false
+        return try {
+            // BluetoothDevice.removeBond() is a hidden API; reflection is the standard workaround.
+            val method = device.javaClass.getMethod("removeBond")
+            (method.invoke(device) as? Boolean) ?: false
+        } catch (e: Exception) {
+            // Do not log the MAC at WARN -- WARN+ is Sentry-eligible and the address is a device id.
+            Timber.w(e, "removeBond failed")
+            false
+        }
+    }
+
+    override fun stop() {
+        stopAdvertising()
+        peer = null
+        sakeCharacteristic = null
+        pendingAdvertise = null
+        pendingServices.clear()
+        gattServer?.let {
+            try {
+                it.close()
+            } catch (e: SecurityException) {
+                Timber.w(e, "closing GATT server failed")
+            }
+        }
+        gattServer = null
+    }
+
+    // -- Advertising --------------------------------------------------------
+
+    private fun startAdvertising(mode: AdvertisingMode, localName: String) {
+        val ad = adapter?.bluetoothLeAdvertiser
+        if (ad == null) {
+            Timber.e("BluetoothLeAdvertiser unavailable")
+            listener?.onAdvertiseFailed(ADVERTISER_UNAVAILABLE)
+            return
+        }
+        advertiser = ad
+
+        // Reconnect uses a low-latency (short) interval because the paired pump scans infrequently
+        // and misses long intervals (Sec. 7); first pairing uses the balanced interval.
+        val advertiseMode = when (mode) {
+            AdvertisingMode.RECONNECT -> AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY
+            AdvertisingMode.FIRST_PAIR -> AdvertiseSettings.ADVERTISE_MODE_BALANCED
+        }
+        val settings = AdvertiseSettings.Builder()
+            .setAdvertiseMode(advertiseMode)
+            .setConnectable(true)
+            .setTimeout(0) // advertise until explicitly stopped
+            .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_MEDIUM)
+            .build()
+
+        // The "Mobile …" name is carried in the manufacturer data (company 0x01F9), mirroring the
+        // proven JavaPumpConnector advertisement; the GAP device name is intentionally excluded to
+        // keep the 31-byte advertisement within budget. Pump-side name matching is confirmed live in
+        // 48.A2 (Sec. 3).
+        val serviceUuid = ParcelUuid(MedtronicProtocol.sigUuid(mode.serviceUuid16))
+        val data = AdvertiseData.Builder()
+            .addManufacturerData(MedtronicProtocol.COMPANY_ID, MedtronicProtocol.manufacturerData(localName))
+            .addServiceUuid(serviceUuid)
+            .setIncludeDeviceName(false)
+            .setIncludeTxPowerLevel(true)
+            .build()
+
+        val callback = object : AdvertiseCallback() {
+            override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
+                Timber.d("Advertising started: %s", settingsInEffect)
+                listener?.onAdvertiseStarted(mode)
+            }
+
+            override fun onStartFailure(errorCode: Int) {
+                Timber.e("Advertising failed: errorCode=%d", errorCode)
+                listener?.onAdvertiseFailed(errorCode)
+            }
+        }
+        advertiseCallback = callback
+        try {
+            ad.startAdvertising(settings, data, callback)
+        } catch (e: SecurityException) {
+            Timber.e(e, "startAdvertising failed")
+            advertiseCallback = null
+            listener?.onAdvertiseFailed(ADVERTISER_UNAVAILABLE)
+        }
+    }
+
+    // -- GATT server --------------------------------------------------------
+
+    private fun openGattServer() {
+        val manager = bluetoothManager ?: run {
+            Timber.e("BluetoothManager unavailable; cannot open GATT server")
+            failPendingAdvertise()
+            return
+        }
+        try {
+            val server = manager.openGattServer(appContext, gattServerCallback) ?: run {
+                Timber.e("openGattServer returned null")
+                failPendingAdvertise()
+                return
+            }
+            gattServer = server
+            pendingServices.clear()
+            pendingServices.add(createDeviceInfoService())
+            pendingServices.add(createSakeService())
+            addNextService()
+        } catch (e: SecurityException) {
+            // Missing BLUETOOTH_CONNECT: surface it instead of leaving the manager hung in CONNECTING.
+            Timber.e(e, "Failed to open GATT server")
+            failPendingAdvertise()
+        }
+    }
+
+    private fun failPendingAdvertise() {
+        pendingAdvertise = null
+        listener?.onAdvertiseFailed(GATT_SERVER_UNAVAILABLE)
+    }
+
+    private fun addNextService() {
+        val server = gattServer ?: return
+        val next = pendingServices.poll()
+        if (next == null) {
+            // All services registered -- now it is safe to advertise (see start()).
+            pendingAdvertise?.let { (mode, name) ->
+                pendingAdvertise = null
+                startAdvertising(mode, name)
+            }
+            return
+        }
+        try {
+            server.addService(next)
+        } catch (e: SecurityException) {
+            Timber.e(e, "addService failed for %s", next.uuid)
+            failPendingAdvertise()
+        }
+    }
+
+    private fun createSakeService(): BluetoothGattService {
+        val service = BluetoothGattService(
+            MedtronicProtocol.SAKE_SERVICE_FIRST_PAIR_UUID,
+            BluetoothGattService.SERVICE_TYPE_PRIMARY,
+        )
+        // SAKE characteristic: NOTIFY (phone -> pump) + WRITE (pump -> phone). Read-only data path;
+        // no control/calibration characteristic is ever exposed. TODO(48.A2): confirm the pump
+        // accepts MedtronicProtocol.SAKE_CHARACTERISTIC_UUID (JavaPumpConnector used a vendor-base
+        // variant of the same 16-bit code) against real hardware.
+        val sake = BluetoothGattCharacteristic(
+            MedtronicProtocol.SAKE_CHARACTERISTIC_UUID,
+            BluetoothGattCharacteristic.PROPERTY_NOTIFY or BluetoothGattCharacteristic.PROPERTY_WRITE,
+            BluetoothGattCharacteristic.PERMISSION_WRITE,
+        )
+        sake.addDescriptor(
+            BluetoothGattDescriptor(
+                MedtronicProtocol.CCCD_UUID,
+                BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE,
+            ),
+        )
+        service.addCharacteristic(sake)
+        sakeCharacteristic = sake
+        return service
+    }
+
+    private fun createDeviceInfoService(): BluetoothGattService {
+        val service = BluetoothGattService(
+            MedtronicProtocol.DEVICE_INFO_SERVICE_UUID,
+            BluetoothGattService.SERVICE_TYPE_PRIMARY,
+        )
+        fun readChar(uuid: java.util.UUID, value: ByteArray): BluetoothGattCharacteristic =
+            BluetoothGattCharacteristic(
+                uuid,
+                BluetoothGattCharacteristic.PROPERTY_READ,
+                BluetoothGattCharacteristic.PERMISSION_READ,
+            ).apply { @Suppress("DEPRECATION") setValue(value) }
+
+        // Placeholder DIS values: the read-only handshake authenticates at the app layer (SAKE), not
+        // off these fields. JavaPumpConnector spoofs a realistic app-version string; TODO(48.A2):
+        // confirm a real pump does not validate any DIS field before falling back to these.
+        val ascii = Charsets.US_ASCII
+        service.addCharacteristic(readChar(MedtronicProtocol.MANUFACTURER_NAME_UUID, "GlycemicGPT".toByteArray(ascii)))
+        service.addCharacteristic(readChar(MedtronicProtocol.MODEL_NUMBER_UUID, "Mobile".toByteArray(ascii)))
+        service.addCharacteristic(readChar(MedtronicProtocol.SERIAL_NUMBER_UUID, currentName.toByteArray(ascii)))
+        service.addCharacteristic(readChar(MedtronicProtocol.FIRMWARE_REVISION_UUID, "0".toByteArray(ascii)))
+        service.addCharacteristic(readChar(MedtronicProtocol.SOFTWARE_REVISION_UUID, "0".toByteArray(ascii)))
+        service.addCharacteristic(readChar(MedtronicProtocol.SYSTEM_ID_UUID, ByteArray(8)))
+        service.addCharacteristic(readChar(MedtronicProtocol.PNP_ID_UUID, ByteArray(7)))
+        return service
+    }
+
+    private val gattServerCallback = object : BluetoothGattServerCallback() {
+        override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
+            when (newState) {
+                BluetoothProfile.STATE_CONNECTED -> {
+                    peer = device
+                    listener?.onPumpConnected(device.address)
+                }
+                BluetoothProfile.STATE_DISCONNECTED -> {
+                    peer = null
+                    listener?.onPumpDisconnected(status)
+                }
+            }
+        }
+
+        override fun onServiceAdded(status: Int, service: BluetoothGattService) {
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                addNextService()
+            } else {
+                // Without this the manager would hang in CONNECTING -- service registration is the one
+                // BLE step with no timeout in this layer.
+                Timber.e("Failed to add service %s (status=%d)", service.uuid, status)
+                failPendingAdvertise()
+            }
+        }
+
+        override fun onCharacteristicReadRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            offset: Int,
+            characteristic: BluetoothGattCharacteristic,
+        ) {
+            @Suppress("DEPRECATION")
+            val stored = characteristic.value ?: ByteArray(0)
+            if (offset > stored.size) {
+                sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, ByteArray(0))
+                return
+            }
+            val value = stored.copyOfRange(offset, stored.size)
+            sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
+        }
+
+        override fun onCharacteristicWriteRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            characteristic: BluetoothGattCharacteristic,
+            preparedWrite: Boolean,
+            responseNeeded: Boolean,
+            offset: Int,
+            value: ByteArray,
+        ) {
+            if (characteristic.uuid == MedtronicProtocol.SAKE_CHARACTERISTIC_UUID) {
+                listener?.onSakeWrite(value)
+            }
+            if (responseNeeded) {
+                sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
+            }
+        }
+
+        override fun onDescriptorWriteRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            descriptor: BluetoothGattDescriptor,
+            preparedWrite: Boolean,
+            responseNeeded: Boolean,
+            offset: Int,
+            value: ByteArray,
+        ) {
+            val isSakeCccd = descriptor.uuid == MedtronicProtocol.CCCD_UUID &&
+                descriptor.characteristic?.uuid == MedtronicProtocol.SAKE_CHARACTERISTIC_UUID
+            if (isSakeCccd && value.size >= 2) {
+                when {
+                    (value[0].toInt() and 0x01) != 0 -> {
+                        Timber.d("Pump subscribed to SAKE notifications")
+                        listener?.onSakeSubscribed()
+                    }
+                    value[0].toInt() == 0 && value[1].toInt() == 0 -> {
+                        Timber.d("Pump unsubscribed from SAKE notifications")
+                        listener?.onSakeUnsubscribed()
+                    }
+                    else -> Timber.d("Unexpected SAKE CCCD value %02x%02x; ignoring", value[1], value[0])
+                }
+            }
+            @Suppress("DEPRECATION")
+            descriptor.value = value
+            if (responseNeeded) {
+                sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
+            }
+        }
+
+        override fun onMtuChanged(device: BluetoothDevice, mtu: Int) {
+            // We never request a larger MTU and keep every PDU <= 20 bytes regardless of what the
+            // central negotiates (Sec. 6). This is observational only.
+            Timber.d("Central negotiated MTU=%d (ignored; PDUs stay <= %d bytes)", mtu, PduFramer.MAX_PDU_SIZE)
+        }
+    }
+
+    private fun sendResponse(device: BluetoothDevice, requestId: Int, status: Int, offset: Int, value: ByteArray) {
+        try {
+            gattServer?.sendResponse(device, requestId, status, offset, value)
+        } catch (e: SecurityException) {
+            Timber.w(e, "sendResponse failed")
+        }
+    }
+
+    private companion object {
+        /** Synthetic AdvertiseCallback error code for "no advertiser available" (not a platform code). */
+        const val ADVERTISER_UNAVAILABLE = -1
+
+        /** Synthetic error code for "GATT server could not be opened" (e.g. missing permission). */
+        const val GATT_SERVER_UNAVAILABLE = -2
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicPeripheral.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicPeripheral.kt
@@ -33,7 +33,7 @@ import android.os.ParcelUuid
 import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
 import com.glycemicgpt.mobile.ble.protocol.PduFramer
 import timber.log.Timber
-import java.util.ArrayDeque
+import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
  * Real-device [MedtronicPeripheral]. Construct with the application [Context]; permissions
@@ -78,8 +78,10 @@ class AndroidMedtronicPeripheral(context: Context) : MedtronicPeripheral {
     private var pendingAdvertise: Pair<AdvertisingMode, String>? = null
 
     // Services are added one at a time: addService -> onServiceAdded -> addNextService (the Android
-    // GATT server only accepts a new service once the previous add has completed).
-    private val pendingServices = ArrayDeque<BluetoothGattService>()
+    // GATT server only accepts a new service once the previous add has completed). The queue is
+    // populated on the worker thread but drained from onServiceAdded on the binder thread, so it must
+    // be thread-safe.
+    private val pendingServices = ConcurrentLinkedQueue<BluetoothGattService>()
 
     override fun isSupported(): Boolean {
         val ad = adapter ?: return false

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
@@ -283,7 +283,8 @@ class MedtronicBleConnectionManager(
     }
 
     private fun onCentralConnected(address: String) {
-        Timber.i("Pump connected: %s", address)
+        // Debug level only: the MAC is a device identifier and WARN+/INFO can be Sentry-eligible.
+        Timber.d("Pump connected: %s", address)
         pairingWaitJob?.cancel()
         pairingWaitJob = null
         _fault.value = null

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
@@ -1,0 +1,439 @@
+/*
+ * Phone-as-peripheral BLE connection manager for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). This is the inverted-topology connection core that has no Tandem
+ * equivalent to clone: the phone advertises as a "Mobile …" peripheral and the pump connects to it
+ * as the central (medtronic-ble-reverse-engineering.md Sec. 3). It owns the connection lifecycle,
+ * drives the SAKE handshake (Sec. 4) to a live encrypted session, and auto-reconnects to an
+ * already-paired pump. The Android BLE plumbing it sits on top of is modelled on OpenMinimed's
+ * JavaPumpConnector (GPL-3.0, used with permission).
+ *
+ * Scope (Milestone B2): connection + authentication + reconnect only. The data readers (CGM/IOB/
+ * history) and the MedtronicDevicePlugin / Hilt registration that consume this manager land in
+ * Milestone C. Over-the-air validation against a real pump rides with 48.A2 / Milestone F -- nothing
+ * here is claimed live-verified.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import android.content.Context
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.DiscoveredDevice
+import com.glycemicgpt.mobile.domain.pump.PumpCredentialProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
+import org.openminimed.sake.Constants
+import org.openminimed.sake.KeyDatabase
+import timber.log.Timber
+
+/**
+ * A connection fault surfaced alongside [MedtronicBleConnectionManager.connectionState] to explain
+ * *why* a connection is not progressing -- in particular the single-peer condition (the pump only
+ * talks to one phone at a time, so it must be removed from the official app first; Sec. 7).
+ */
+enum class MedtronicConnectionFault {
+    /** This device cannot advertise as a BLE peripheral, so it can never pair (Sec. 3). */
+    PERIPHERAL_UNSUPPORTED,
+
+    /** The BLE advertiser rejected the advertisement (e.g. too many advertisers active). */
+    ADVERTISE_FAILED,
+
+    /** The pump connected but the SAKE handshake did not complete within the timeout. */
+    HANDSHAKE_TIMEOUT,
+
+    /** The SAKE handshake ran but authentication failed (CMAC/permit verification). */
+    AUTH_FAILED,
+
+    /**
+     * First-pair advertising has been running with no pump connecting -- the pump is likely still
+     * bound to another phone (e.g. the official Medtronic app) and must be removed from it first.
+     * Working assumption from desk research; exact live behavior is confirmed in 48.A2 (Sec. 7).
+     */
+    BOUND_ELSEWHERE_SUSPECTED,
+}
+
+/**
+ * Selects the advertising mode for a connection attempt. Already-paired pumps reconnect via the
+ * `0xFE81` service ([AdvertisingMode.RECONNECT]); everything else is a first pairing via `0xFE82`.
+ * Pure logic, separated out so the reconnect-service selection (AC5) is directly unit-testable.
+ */
+internal fun advertisingModeFor(paired: Boolean, forceFirstPair: Boolean): AdvertisingMode =
+    if (paired && !forceFirstPair) AdvertisingMode.RECONNECT else AdvertisingMode.FIRST_PAIR
+
+/**
+ * Manages the phone-as-peripheral BLE connection to a Medtronic 700-series pump.
+ *
+ * Responsibilities:
+ *  - Advertise as a "Mobile …" peripheral + stand up the read-only GATT server (delegated to
+ *    [MedtronicPeripheral]).
+ *  - Drive the SAKE handshake on a worker thread (delegated to [SakeHandshakeDriver]).
+ *  - Expose the connection lifecycle as [connectionState] and the reason for a stall as [fault].
+ *  - Auto-reconnect to an already-paired pump and persist pairing via [PumpCredentialProvider].
+ *
+ * Inject the collaborators for tests (the BLE layer is mocked); on-device, use the [Context]
+ * secondary constructor which wires the real Android peripheral + a HandlerThread worker.
+ */
+class MedtronicBleConnectionManager(
+    private val peripheral: MedtronicPeripheral,
+    private val credentialStore: PumpCredentialProvider,
+    private val worker: SerialWorker,
+    private val scope: CoroutineScope,
+    private val keyDatabase: KeyDatabase = Constants.KEYDB_PUMP_EXTRACTED,
+    private val localName: String = DEFAULT_LOCAL_NAME,
+    private val handshakeTimeoutMs: Long = DEFAULT_HANDSHAKE_TIMEOUT_MS,
+    private val pairingWaitMs: Long = DEFAULT_PAIRING_WAIT_MS,
+) {
+
+    /** On-device constructor: real Android peripheral + dedicated SAKE worker thread. */
+    constructor(context: Context, credentialStore: PumpCredentialProvider) : this(
+        peripheral = AndroidMedtronicPeripheral(context),
+        credentialStore = credentialStore,
+        worker = HandlerThreadSerialWorker(SAKE_WORKER_THREAD_NAME),
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    )
+
+    private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+
+    /** Observable BLE/auth connection lifecycle. */
+    val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+    private val _fault = MutableStateFlow<MedtronicConnectionFault?>(null)
+
+    /** The reason the connection is not progressing, or `null` when there is nothing to report. */
+    val fault: StateFlow<MedtronicConnectionFault?> = _fault.asStateFlow()
+
+    /** The live SAKE session after a successful handshake -- the read layer (Milestone C) decrypts with it. */
+    @Volatile
+    var sakeSession: MedtronicSakeSession? = null
+        private set
+
+    @Volatile
+    private var autoReconnect = false
+
+    @Volatile
+    private var connectedAddress: String? = null
+
+    @Volatile
+    private var onDiscovered: ((DiscoveredDevice) -> Unit)? = null
+
+    // All connection-lifecycle state below is confined to the SerialWorker thread: every public
+    // entry point and every BLE callback hops onto [worker] before touching it, so the check-then-set
+    // transitions run on a single thread with no locking (the same discipline SakeHandshakeDriver
+    // uses). The fields stay @Volatile so the read layer / UI can still observe the latest value.
+    @Volatile
+    private var authTimeoutJob: Job? = null
+
+    @Volatile
+    private var pairingWaitJob: Job? = null
+
+    private val handshakeListener = object : SakeHandshakeDriver.HandshakeListener {
+        // Invoked on the worker thread already (the driver runs on [worker]).
+        override fun onAuthenticated(session: MedtronicSakeSession) = onHandshakeComplete(session)
+        override fun onAuthFailed(cause: Throwable?) = onHandshakeFailed(cause)
+    }
+
+    private val driver = SakeHandshakeDriver(
+        worker = worker,
+        sessionFactory = { MedtronicSakeSession(keyDatabase) },
+        notifySink = peripheral::sendSakeNotification,
+        listener = handshakeListener,
+    )
+
+    // BLE callbacks arrive on the binder thread; hop onto the worker so all lifecycle mutation is
+    // serialized with the handshake. onSakeUnsubscribed/onSakeWrite already post via the driver.
+    private val peripheralListener = object : PeripheralListener {
+        override fun onAdvertiseStarted(mode: AdvertisingMode) = worker.post { onAdvertising(mode) }
+        override fun onAdvertiseFailed(errorCode: Int) = worker.post { onAdvertisingFailed(errorCode) }
+        override fun onPumpConnected(address: String) = worker.post { onCentralConnected(address) }
+        override fun onSakeSubscribed() = worker.post { startAuthentication() }
+        override fun onSakeUnsubscribed() = driver.onUnsubscribed()
+        override fun onSakeWrite(value: ByteArray) = driver.onPumpWrite(value)
+        override fun onPumpDisconnected(status: Int) = worker.post { onCentralDisconnected(status) }
+    }
+
+    // -- Public lifecycle ---------------------------------------------------
+
+    /**
+     * Begin a connection: advertise + stand up the GATT server and wait for the pump to connect and
+     * complete SAKE. Picks [AdvertisingMode.RECONNECT] for an already-paired pump unless
+     * [forceFirstPair] is set (e.g. the user is re-pairing). No-op if the device cannot advertise as
+     * a peripheral.
+     */
+    fun startSession(forceFirstPair: Boolean = false) = worker.post {
+        if (!ensureSupported()) return@post
+        val mode = advertisingModeFor(credentialStore.isPaired(), forceFirstPair)
+        autoReconnect = true
+        beginAdvertising(mode, ConnectionState.CONNECTING)
+    }
+
+    /** Auto-reconnect to a previously paired pump. No-op if no pump is paired. */
+    fun reconnectIfPaired() = worker.post {
+        if (!credentialStore.isPaired()) {
+            Timber.d("reconnectIfPaired: no paired pump")
+            return@post
+        }
+        if (!ensureSupported()) return@post
+        autoReconnect = true
+        beginAdvertising(AdvertisingMode.RECONNECT, ConnectionState.CONNECTING)
+    }
+
+    /** Stop advertising + reconnect and drop the session, but keep the pairing. Safe to call when idle. */
+    fun disconnect() = worker.post {
+        autoReconnect = false
+        teardown(ConnectionState.DISCONNECTED, fault = null)
+    }
+
+    /** Clear the pairing, remove the BLE bond, and disconnect. */
+    fun unpair() = worker.post {
+        val address = credentialStore.getPairedAddress() ?: connectedAddress
+        autoReconnect = false
+        teardown(ConnectionState.DISCONNECTED, fault = null)
+        credentialStore.clearPairing()
+        val bondRemoved = if (address != null) peripheral.removeBond(address) else false
+        Timber.d("Medtronic pump unpaired; credentials cleared, bondRemoved=%b", bondRemoved)
+    }
+
+    /**
+     * Discovery in the inverted topology. There is **no active central scan** here -- the pump is
+     * the central and *it* finds *us*, so discovery is advertise-and-wait: this starts first-pair
+     * advertising and emits a [DiscoveredDevice] when a pump connects to the GATT server. Cancelling
+     * collection stops advertising if no pump has connected yet. The connection that a discovered
+     * pump initiates then proceeds straight into the SAKE handshake (the central cannot be made to
+     * "connect later" the way an active scan implies). C wires this into `DevicePlugin.scan()`.
+     */
+    fun scan(): Flow<DiscoveredDevice> = callbackFlow {
+        if (!peripheral.isSupported()) {
+            Timber.e("BLE peripheral advertising not supported; cannot scan")
+            worker.post { _fault.value = MedtronicConnectionFault.PERIPHERAL_UNSUPPORTED }
+            close()
+            return@callbackFlow
+        }
+        onDiscovered = { trySend(it) }
+        worker.post {
+            autoReconnect = false
+            beginAdvertising(AdvertisingMode.FIRST_PAIR, ConnectionState.SCANNING)
+        }
+        awaitClose {
+            onDiscovered = null
+            worker.post {
+                // Only tear down if discovery was cancelled before a pump actually connected; once a
+                // pump is connecting/authenticating the session owns the lifecycle, not the scan.
+                if (_connectionState.value == ConnectionState.SCANNING) {
+                    teardown(ConnectionState.DISCONNECTED, fault = null)
+                }
+            }
+        }
+    }
+
+    /** Release the worker thread and cancel the scope. The manager is unusable afterwards. */
+    fun close() {
+        // Tear down synchronously on the caller thread: the worker is about to stop, so a posted
+        // teardown could be dropped before it runs.
+        autoReconnect = false
+        cancelTimers()
+        resetSessionState()
+        peripheral.stop()
+        _fault.value = null
+        _connectionState.value = ConnectionState.DISCONNECTED
+        worker.stop()
+        scope.cancel()
+    }
+
+    // -- Advertising / peripheral callbacks ---------------------------------
+
+    private fun beginAdvertising(mode: AdvertisingMode, state: ConnectionState) {
+        cancelTimers()
+        resetSessionState()
+        _fault.value = null
+        _connectionState.value = state
+        Timber.d("Advertising as '%s' in %s mode", localName, mode)
+        peripheral.start(mode, localName, peripheralListener)
+    }
+
+    /** Drop the live session, the remembered peer, and arm a fresh handshake. */
+    private fun resetSessionState() {
+        sakeSession = null
+        connectedAddress = null
+        driver.reset()
+    }
+
+    private fun onAdvertising(mode: AdvertisingMode) {
+        Timber.d("Advertising started (%s)", mode)
+        // First-pair single-peer detection (Sec. 7): if no pump connects in the window, the pump is
+        // probably still bound to another phone. Reconnect mode waits indefinitely because the pump
+        // scans infrequently. TODO(48.A2): tune/confirm this window against a real pump.
+        if (mode == AdvertisingMode.FIRST_PAIR) armPairingWaitTimer()
+    }
+
+    private fun onAdvertisingFailed(errorCode: Int) {
+        Timber.e("Advertising failed (errorCode=%d)", errorCode)
+        autoReconnect = false
+        teardown(ConnectionState.DISCONNECTED, fault = MedtronicConnectionFault.ADVERTISE_FAILED)
+    }
+
+    private fun onCentralConnected(address: String) {
+        Timber.i("Pump connected: %s", address)
+        pairingWaitJob?.cancel()
+        pairingWaitJob = null
+        _fault.value = null
+        connectedAddress = address
+        // Single-peer: stop advertising so no second central can connect mid-handshake (Sec. 7).
+        peripheral.stopAdvertising()
+        // A pump connecting from any advertising state (first pair, scan, or reconnect) is "connected,
+        // pre-auth"; AUTHENTICATING/CONNECTED are reached via onSakeSubscribed/handshake completion.
+        when (_connectionState.value) {
+            ConnectionState.SCANNING,
+            ConnectionState.CONNECTING,
+            ConnectionState.RECONNECTING -> _connectionState.value = ConnectionState.CONNECTING
+            else -> Unit
+        }
+        onDiscovered?.invoke(
+            DiscoveredDevice(
+                name = localName,
+                address = address,
+                pluginId = PLUGIN_ID,
+            ),
+        )
+    }
+
+    private fun startAuthentication() {
+        Timber.d("Pump subscribed to SAKE; starting handshake")
+        _connectionState.value = ConnectionState.AUTHENTICATING
+        armAuthTimeout()
+        driver.onSubscribed()
+    }
+
+    private fun onCentralDisconnected(status: Int) {
+        Timber.w("Pump disconnected (status=%d)", status)
+        cancelTimers()
+        resetSessionState()
+
+        // A terminal auth failure latches AUTH_FAILED; the inevitable disconnect must not reset it
+        // or kick off a reconnect loop against a pump that just rejected us.
+        if (_connectionState.value == ConnectionState.AUTH_FAILED) {
+            peripheral.stopAdvertising()
+            return
+        }
+
+        if (autoReconnect && credentialStore.isPaired()) {
+            _connectionState.value = ConnectionState.RECONNECTING
+            Timber.d("Re-advertising for reconnect (%s)", AdvertisingMode.RECONNECT)
+            peripheral.advertise(AdvertisingMode.RECONNECT, localName)
+        } else {
+            teardown(ConnectionState.DISCONNECTED, fault = null)
+        }
+    }
+
+    // -- Handshake callbacks (worker thread) --------------------------------
+
+    private fun onHandshakeComplete(session: MedtronicSakeSession) {
+        authTimeoutJob?.cancel()
+        authTimeoutJob = null
+        sakeSession = session
+        _fault.value = null
+        // Persist the pairing. SAKE has no pairing code (authentication is the static-key handshake
+        // plus the OS BLE bond), so the credential "code" slot records the advertised identity.
+        connectedAddress?.let { credentialStore.savePairing(it, localName) }
+        _connectionState.value = ConnectionState.CONNECTED
+        Timber.i("Pump authenticated; session ready")
+    }
+
+    private fun onHandshakeFailed(cause: Throwable?) {
+        authTimeoutJob?.cancel()
+        authTimeoutJob = null
+        sakeSession = null
+        autoReconnect = false
+        // Stop attracting the pump; the user must re-pair. Matches the handshake-timeout path. The
+        // GATT server stays open (the pump will drop the link; onCentralDisconnected keeps AUTH_FAILED).
+        peripheral.stopAdvertising()
+        _fault.value = MedtronicConnectionFault.AUTH_FAILED
+        _connectionState.value = ConnectionState.AUTH_FAILED
+        Timber.e(cause, "SAKE authentication failed")
+    }
+
+    // -- Timers -------------------------------------------------------------
+
+    private fun armAuthTimeout() {
+        authTimeoutJob?.cancel()
+        // The delay runs on [scope]; the check-then-set hops back onto the worker so it is serialized
+        // with onHandshakeComplete -- the guard then can't flip an already-CONNECTED session.
+        authTimeoutJob = scope.launch {
+            delay(handshakeTimeoutMs)
+            worker.post {
+                if (_connectionState.value == ConnectionState.AUTHENTICATING) {
+                    Timber.e("SAKE handshake timed out after %d ms", handshakeTimeoutMs)
+                    _fault.value = MedtronicConnectionFault.HANDSHAKE_TIMEOUT
+                    _connectionState.value = ConnectionState.AUTH_FAILED
+                    autoReconnect = false
+                    peripheral.stopAdvertising()
+                }
+            }
+        }
+    }
+
+    private fun armPairingWaitTimer() {
+        pairingWaitJob?.cancel()
+        pairingWaitJob = scope.launch {
+            delay(pairingWaitMs)
+            worker.post {
+                val state = _connectionState.value
+                if (state == ConnectionState.CONNECTING || state == ConnectionState.SCANNING) {
+                    Timber.w("No pump connected after %d ms; pump may be bound to another phone", pairingWaitMs)
+                    _fault.value = MedtronicConnectionFault.BOUND_ELSEWHERE_SUSPECTED
+                }
+            }
+        }
+    }
+
+    private fun cancelTimers() {
+        authTimeoutJob?.cancel()
+        authTimeoutJob = null
+        pairingWaitJob?.cancel()
+        pairingWaitJob = null
+    }
+
+    // -- Helpers ------------------------------------------------------------
+
+    private fun ensureSupported(): Boolean {
+        if (peripheral.isSupported()) return true
+        Timber.e("BLE peripheral advertising not supported on this device")
+        _fault.value = MedtronicConnectionFault.PERIPHERAL_UNSUPPORTED
+        _connectionState.value = ConnectionState.DISCONNECTED
+        return false
+    }
+
+    private fun teardown(state: ConnectionState, fault: MedtronicConnectionFault?) {
+        cancelTimers()
+        resetSessionState()
+        peripheral.stop()
+        _fault.value = fault
+        _connectionState.value = state
+    }
+
+    companion object {
+        /** Default advertised local name. Must match `Mobile .{0,7}`. TODO(48.A2/D): per-install identity. */
+        const val DEFAULT_LOCAL_NAME = "Mobile 000001"
+
+        /** Plugin id stamped on discovered devices. The MedtronicDevicePlugin (Milestone C) owns the canonical id. */
+        const val PLUGIN_ID = "medtronic"
+
+        private const val SAKE_WORKER_THREAD_NAME = "medtronic-sake"
+
+        /** SAKE has six round trips of 20-byte frames; 30s is generous even on a slow BLE link. */
+        private const val DEFAULT_HANDSHAKE_TIMEOUT_MS = 30_000L
+
+        /** First-pair window before suspecting the pump is bound to another phone (Sec. 7). */
+        private const val DEFAULT_PAIRING_WAIT_MS = 60_000L
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicPeripheral.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicPeripheral.kt
@@ -1,0 +1,99 @@
+/*
+ * Peripheral-mode BLE transport seam for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * The phone is the BLE peripheral and the pump is the central (the inverted topology vs Tandem --
+ * see medtronic-ble-reverse-engineering.md Sec. 3), so there is no Tandem GATT-client equivalent to
+ * reuse. This interface abstracts the Android BluetoothLeAdvertiser + BluetoothGattServer plumbing
+ * (implemented by AndroidMedtronicPeripheral, modelled on OpenMinimed's JavaPumpConnector
+ * BlePeripheralDevice, GPL-3.0, used with permission) so the connection lifecycle in
+ * MedtronicBleConnectionManager can be driven and unit-tested without the Android BLE stack.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+
+/**
+ * Which SAKE service the phone advertises, selecting the 16-bit service-class UUID the pump scans
+ * for (medtronic-ble-reverse-engineering.md Sec. 3):
+ *
+ *  - [FIRST_PAIR] advertises `0xFE82` for an initial pairing.
+ *  - [RECONNECT] advertises `0xFE81` (the reconnect bit-flip) for an already-paired pump, at a
+ *    shorter advertising interval because the pump scans infrequently to save battery (Sec. 7).
+ *
+ * The interval choice is the implementation's concern; this enum only fixes the advertised service.
+ */
+enum class AdvertisingMode(val serviceUuid16: Int) {
+    FIRST_PAIR(MedtronicProtocol.SAKE_SERVICE_FIRST_PAIR_16),
+    RECONNECT(MedtronicProtocol.SAKE_SERVICE_RECONNECT_16),
+}
+
+/**
+ * Events the [MedtronicPeripheral] surfaces from the Android GATT-server / advertiser callbacks.
+ *
+ * Implementations deliver these from the binder thread; the listener must not block (the
+ * connection manager hands SAKE work straight to a worker thread).
+ */
+interface PeripheralListener {
+    /** Advertising started successfully in [mode]. */
+    fun onAdvertiseStarted(mode: AdvertisingMode)
+
+    /** Advertising could not start (e.g. peripheral mode unsupported, too many advertisers). */
+    fun onAdvertiseFailed(errorCode: Int)
+
+    /** A central (the pump) opened a connection to the GATT server. */
+    fun onPumpConnected(address: String)
+
+    /** The pump enabled notifications on the SAKE characteristic -- the cue to emit the wake-up. */
+    fun onSakeSubscribed()
+
+    /** The pump disabled notifications on the SAKE characteristic (a mid-handshake resubscribe aborts). */
+    fun onSakeUnsubscribed()
+
+    /** The pump wrote [value] to the SAKE characteristic (a handshake or session frame). */
+    fun onSakeWrite(value: ByteArray)
+
+    /** The central disconnected; [status] is the GATT status code from the stack. */
+    fun onPumpDisconnected(status: Int)
+}
+
+/**
+ * Phone-as-peripheral BLE transport: advertise as a "Mobile …" device and stand up the read-only
+ * GATT server (SAKE + Device Information) the 700-series pump connects to.
+ *
+ * The GATT server is opened once via [start] and persists across advertising changes; [advertise]
+ * switches the advertised service/interval (e.g. first-pair -> reconnect) without tearing it down.
+ * All methods are no-ops when the underlying adapter is unavailable.
+ */
+interface MedtronicPeripheral {
+    /**
+     * Whether this device can advertise as a BLE peripheral at all. Emulators and some chipsets
+     * cannot (medtronic-ble-reverse-engineering.md Sec. 3); the device support matrix is filled in
+     * live in 48.A2.
+     */
+    fun isSupported(): Boolean
+
+    /**
+     * Open the GATT server and begin advertising in [mode] under [localName] (which must match
+     * `Mobile .{0,7}`), routing subsequent events to [listener]. Safe to call again to re-advertise.
+     */
+    fun start(mode: AdvertisingMode, localName: String, listener: PeripheralListener)
+
+    /** Switch the advertised service/interval (e.g. [AdvertisingMode.RECONNECT]) without closing the GATT server. */
+    fun advertise(mode: AdvertisingMode, localName: String)
+
+    /** Stop BLE advertising while keeping the GATT server open. */
+    fun stopAdvertising()
+
+    /**
+     * Notify the connected pump on the SAKE characteristic. Returns `false` if there is no
+     * subscribed peer or the stack rejects the notification. The payload must already be a single
+     * <= 20-byte PDU (the manager fragments before calling this).
+     */
+    fun sendSakeNotification(payload: ByteArray): Boolean
+
+    /** Best-effort removal of the OS-level BLE bond for [address] (used by unpair). */
+    fun removeBond(address: String): Boolean
+
+    /** Stop advertising and close the GATT server, releasing all BLE resources. */
+    fun stop()
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/SakeHandshakeDriver.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/SakeHandshakeDriver.kt
@@ -1,0 +1,123 @@
+/*
+ * Drives the SAKE handshake from GATT-server events for the Medtronic 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The handshake wire choreography -- wake-up on subscribe, then advance
+ * one stage per pump write -- mirrors OpenMinimed's JavaPumpConnector SakeHandler (GPL-3.0, used with
+ * permission); the cryptographic state machine itself lives in the vendored JavaSake behind
+ * MedtronicSakeSession (B1). See medtronic-ble-reverse-engineering.md Sec. 4.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import com.glycemicgpt.mobile.ble.protocol.PduFramer
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import timber.log.Timber
+
+/**
+ * Translates SAKE-characteristic GATT events into [MedtronicSakeSession] steps, serialized onto a
+ * [SerialWorker] so the binder thread that delivers BLE callbacks is never blocked by crypto work.
+ *
+ * Wire order (Sec. 4):
+ *  1. [onSubscribed] -- the pump enabled notifications: emit the 20-byte wake-up notification.
+ *  2. [onPumpWrite] -- for each write the pump sends, advance the handshake and notify the response;
+ *     a `null` response means the handshake completed and the session cipher is ready.
+ *
+ * A resubscribe before completion is treated as an abort and restarts the handshake with a fresh
+ * session (matching JavaPumpConnector). All callbacks ([HandshakeListener], [notifySink]) are
+ * invoked on the worker thread.
+ */
+class SakeHandshakeDriver(
+    private val worker: SerialWorker,
+    private val sessionFactory: () -> MedtronicSakeSession,
+    private val notifySink: (ByteArray) -> Boolean,
+    private val listener: HandshakeListener,
+) {
+
+    /** Outcome callbacks from the handshake. Invoked on the [SerialWorker] thread. */
+    interface HandshakeListener {
+        /** The six-stage handshake completed; [session] holds the live cipher for the read layer. */
+        fun onAuthenticated(session: MedtronicSakeSession)
+
+        /** Authentication failed (CMAC/permit verification or an unexpected error). */
+        fun onAuthFailed(cause: Throwable?)
+    }
+
+    // All mutable state is confined to the worker thread; only [post] touches it.
+    private var session: MedtronicSakeSession = sessionFactory()
+    private var pumpSubscribed = false
+    private var complete = false
+    private var failed = false
+
+    /** Discard the current handshake and arm a fresh session for the next connection. */
+    fun reset() = worker.post {
+        session = sessionFactory()
+        pumpSubscribed = false
+        complete = false
+        failed = false
+    }
+
+    /**
+     * The pump disabled SAKE notifications. Clearing the subscribed flag lets a later [onSubscribed]
+     * restart an unfinished handshake from a fresh wake-up (the pump resubscribes when it retries).
+     */
+    fun onUnsubscribed() = worker.post {
+        pumpSubscribed = false
+    }
+
+    /**
+     * The pump subscribed to SAKE notifications: emit the wake-up frame. If the pump resubscribes
+     * mid-handshake the session is rebuilt so the new wake-up starts cleanly.
+     */
+    fun onSubscribed() = worker.post {
+        if (pumpSubscribed) return@post
+        if (!complete && session.stage != 0) {
+            Timber.w("Pump resubscribed mid-handshake; restarting SAKE state")
+            session = sessionFactory()
+        }
+        pumpSubscribed = true
+        Timber.d("Pump subscribed to SAKE; sending wake-up")
+        notify(session.newWakeUpFrame())
+    }
+
+    /**
+     * Advance the handshake with a 20-byte write from the pump. Writes after completion are session
+     * traffic for the read layer (Milestone C) and are ignored here.
+     */
+    fun onPumpWrite(value: ByteArray) {
+        val copy = value.copyOf()
+        worker.post {
+            if (complete || failed) {
+                Timber.d("Ignoring SAKE write after handshake terminated (len=%d)", copy.size)
+                return@post
+            }
+            try {
+                val response = session.onPumpWrite(copy)
+                if (response != null) {
+                    notify(response)
+                } else {
+                    complete = true
+                    Timber.i("SAKE handshake complete")
+                    listener.onAuthenticated(session)
+                }
+            } catch (e: Exception) {
+                // Latch the failure so further writes on the now-corrupted session do not re-throw and
+                // fire onAuthFailed repeatedly; reset() re-arms a fresh session.
+                failed = true
+                Timber.e(e, "SAKE handshake failed")
+                listener.onAuthFailed(e)
+            }
+        }
+    }
+
+    /**
+     * Emit [payload] to the pump, fragmented to <= 20-byte PDUs via the B1 framer so no oversized
+     * PDU is ever sent (medtronic-ble-reverse-engineering.md Sec. 6). SAKE frames are exactly 20
+     * bytes, so this is a single PDU in practice; the framer is the single MTU choke point.
+     */
+    private fun notify(payload: ByteArray) {
+        for (pdu in PduFramer.fragment(payload)) {
+            if (!notifySink(pdu)) {
+                Timber.w("SAKE notification not delivered (len=%d)", pdu.size)
+            }
+        }
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/SerialWorker.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/SerialWorker.kt
@@ -1,0 +1,50 @@
+/*
+ * Single-threaded work serialization for the Medtronic peripheral driver.
+ *
+ * The SAKE handshake and session crypto must never run on the binder thread that delivers BLE
+ * GATT-server callbacks (blocking it stalls the whole Bluetooth stack). OpenMinimed's JavaPumpConnector
+ * SakeHandler (GPL-3.0, used with permission) serializes that work onto a dedicated HandlerThread;
+ * this interface is the same idea behind a seam so the handshake driver is unit-testable with an
+ * inline worker instead of a real Android looper. See medtronic-ble-reverse-engineering.md Sec. 11.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import android.os.Handler
+import android.os.HandlerThread
+
+/**
+ * Posts tasks to a single background thread, preserving submission order. Implementations guarantee
+ * tasks never run concurrently, so the [com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession] (which
+ * is documented as not thread-safe) can be driven without additional locking.
+ */
+interface SerialWorker {
+    /** Enqueue [task] to run on the worker thread. */
+    fun post(task: () -> Unit)
+
+    /** Stop the worker and drop any queued tasks. After this, [post] is a no-op. */
+    fun stop()
+}
+
+/**
+ * [SerialWorker] backed by an Android [HandlerThread] -- the production worker that keeps SAKE work
+ * off the binder thread, mirroring JavaPumpConnector's SakeHandler. The thread is started eagerly
+ * and reused across pump connect/disconnect cycles.
+ */
+class HandlerThreadSerialWorker(threadName: String) : SerialWorker {
+    private val thread = HandlerThread(threadName).apply { start() }
+    private val handler = Handler(thread.looper)
+
+    @Volatile
+    private var stopped = false
+
+    override fun post(task: () -> Unit) {
+        if (stopped) return
+        handler.post(task)
+    }
+
+    override fun stop() {
+        stopped = true
+        handler.removeCallbacksAndMessages(null)
+        thread.quitSafely()
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/ConnectionTestSupport.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/ConnectionTestSupport.kt
@@ -1,0 +1,87 @@
+/*
+ * Shared test doubles and SAKE vectors for the peripheral connection-manager unit tests.
+ *
+ * The SAKE key databases here are the same shared, published-upstream OpenMinimed protocol
+ * constants used by the B1 MedtronicSakeSessionTest -- firmware-extracted pump keys and a synthetic
+ * matched key-DB pair, not session secrets and not unique per device. See
+ * medtronic-ble-reverse-engineering.md Sec. 12.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import com.glycemicgpt.mobile.domain.pump.PumpCredentialProvider
+import org.openminimed.sake.KeyDatabase
+
+/** [SerialWorker] that runs posted tasks inline, so handshake steps complete synchronously in tests. */
+class DirectSerialWorker : SerialWorker {
+    var stopped = false
+        private set
+
+    override fun post(task: () -> Unit) {
+        if (!stopped) task()
+    }
+
+    override fun stop() {
+        stopped = true
+    }
+}
+
+/** In-memory [PumpCredentialProvider]; only the pairing slots matter for the connection manager. */
+class FakeCredentialStore : PumpCredentialProvider {
+    private var address: String? = null
+    private var code: String? = null
+    var savePairingCount = 0
+        private set
+    var clearPairingCount = 0
+        private set
+
+    override fun getPairedAddress(): String? = address
+    override fun getPairingCode(): String? = code
+    override fun isPaired(): Boolean = address != null
+
+    override fun savePairing(address: String, pairingCode: String) {
+        this.address = address
+        this.code = pairingCode
+        savePairingCount++
+    }
+
+    override fun clearPairing() {
+        address = null
+        code = null
+        clearPairingCount++
+    }
+
+    // SAKE does not use JPAKE; these are unused here.
+    override fun saveJpakeCredentials(derivedSecretHex: String, serverNonceHex: String) = Unit
+    override fun getJpakeDerivedSecret(): String? = null
+    override fun getJpakeServerNonce(): String? = null
+    override fun clearJpakeCredentials() = Unit
+}
+
+internal object SakeVectors {
+    /** Insulin-pump key database recovered from real 780G firmware (OpenMinimed, public). */
+    const val PUMP_KEYDB_HEX =
+        "f75995e70401011bc1bf7cbf36fa1e2367d795ff09211903da6afbe986b650f1" +
+            "4179c0e6852e0ce393781078ffc6f51919e2eaefbde69b8eca21e41ab59b881a" +
+            "0bea0286ea91dc7582a86a714e1737f558f0d66dc1895c"
+
+    /** Server-side (MOBILE_APPLICATION) half of the matched synthetic two-sided test pair. */
+    const val CUSTOM_SERVER_KEYDB_HEX =
+        "b079cdc504010144455249564154494f4e5f5f5f4b4559484e4453484b455f41" +
+            "5554485f4b455950484f4e455f5045524d49545f454e4350484f4e455f5045" +
+            "524d49545f4d4143ad14ad2780437db892d5650567d491b9"
+
+    /** Client-side (INSULIN_PUMP) half of the matched synthetic two-sided test pair. */
+    const val CUSTOM_CLIENT_KEYDB_HEX =
+        "db8c1f2801010444455249564154494f4e5f5f5f4b4559484e4453484b455f41" +
+            "5554485f4b455950554d505f5045524d49545f454e435250554d505f504552" +
+            "4d49545f434d4143f2f8dbbb51563d4fa98fdaff0042a432"
+
+    fun pumpKeyDb(): KeyDatabase = KeyDatabase.fromBytes(hex(PUMP_KEYDB_HEX))
+    fun customServerKeyDb(): KeyDatabase = KeyDatabase.fromBytes(hex(CUSTOM_SERVER_KEYDB_HEX))
+    fun customClientKeyDb(): KeyDatabase = KeyDatabase.fromBytes(hex(CUSTOM_CLIENT_KEYDB_HEX))
+
+    fun hex(s: String): ByteArray {
+        require(s.length % 2 == 0) { "Hex string has odd length" }
+        return ByteArray(s.length / 2) { i -> s.substring(2 * i, 2 * i + 2).toInt(16).toByte() }
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManagerTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManagerTest.kt
@@ -1,0 +1,291 @@
+/*
+ * State-machine, reconnect, MTU-discipline and discovery tests for MedtronicBleConnectionManager.
+ *
+ * The Android BLE layer is mocked (mockk MedtronicPeripheral); the SAKE worker runs inline
+ * (DirectSerialWorker) so a full handshake completes synchronously, and the pump is simulated with
+ * SakeClient + the matched synthetic key-DB pair. No real pump and no Android BLE stack are
+ * involved -- over-the-air validation is deferred to 48.A2 / Milestone F.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import com.glycemicgpt.mobile.ble.protocol.PduFramer
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.DiscoveredDevice
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.openminimed.sake.DeviceType
+import org.openminimed.sake.SakeClient
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MedtronicBleConnectionManagerTest {
+
+    private val notifications = mutableListOf<ByteArray>()
+    private val credentialStore = FakeCredentialStore()
+    private val peripheral = mockk<MedtronicPeripheral>(relaxUnitFun = true)
+    private val listenerSlot = slot<PeripheralListener>()
+
+    private val testScope = TestScope(StandardTestDispatcher())
+
+    init {
+        every { peripheral.isSupported() } returns true
+        every { peripheral.start(any(), any(), capture(listenerSlot)) } returns Unit
+        every { peripheral.sendSakeNotification(any()) } answers { notifications.add(firstArg()); true }
+        every { peripheral.removeBond(any()) } returns true
+    }
+
+    private val listener: PeripheralListener get() = listenerSlot.captured
+
+    private fun newManager(
+        scope: CoroutineScope = testScope,
+        handshakeTimeoutMs: Long = 30_000L,
+        pairingWaitMs: Long = 60_000L,
+    ) = MedtronicBleConnectionManager(
+        peripheral = peripheral,
+        credentialStore = credentialStore,
+        worker = DirectSerialWorker(),
+        scope = scope,
+        keyDatabase = SakeVectors.customServerKeyDb(),
+        handshakeTimeoutMs = handshakeTimeoutMs,
+        pairingWaitMs = pairingWaitMs,
+    )
+
+    /** Drive a full SAKE handshake through the captured listener, leaving the manager CONNECTED. */
+    private fun completeHandshake(address: String = PUMP_ADDRESS) {
+        listener.onPumpConnected(address)
+        listener.onSakeSubscribed()
+        val pump = SakeClient(SakeVectors.customClientKeyDb(), DeviceType.INSULIN_PUMP)
+        listener.onSakeWrite(ByteArray(SAKE_FRAME_SIZE)) // pump wake-up write -> msg0
+        listener.onSakeWrite(pump.handshake(notifications.last()))
+        listener.onSakeWrite(pump.handshake(notifications.last()))
+        listener.onSakeWrite(pump.handshake(notifications.last()))
+    }
+
+    @Test
+    fun `initial state is disconnected with no fault`() {
+        val manager = newManager()
+        assertEquals(ConnectionState.DISCONNECTED, manager.connectionState.value)
+        assertNull(manager.fault.value)
+        assertNull(manager.sakeSession)
+    }
+
+    @Test
+    fun `startSession unpaired advertises first-pair and enters connecting`() {
+        val manager = newManager()
+        manager.startSession()
+        assertEquals(ConnectionState.CONNECTING, manager.connectionState.value)
+        verify { peripheral.start(AdvertisingMode.FIRST_PAIR, any(), any()) }
+    }
+
+    @Test
+    fun `startSession paired advertises reconnect`() {
+        credentialStore.savePairing(PUMP_ADDRESS, "Mobile 000001")
+        val manager = newManager()
+        manager.startSession()
+        verify { peripheral.start(AdvertisingMode.RECONNECT, any(), any()) }
+    }
+
+    @Test
+    fun `pump connect stops advertising and clears fault`() {
+        val manager = newManager()
+        manager.startSession()
+        listener.onPumpConnected(PUMP_ADDRESS)
+        verify { peripheral.stopAdvertising() }
+        assertEquals(ConnectionState.CONNECTING, manager.connectionState.value)
+        assertNull(manager.fault.value)
+    }
+
+    @Test
+    fun `sake subscribe transitions to authenticating`() {
+        val manager = newManager()
+        manager.startSession()
+        listener.onPumpConnected(PUMP_ADDRESS)
+        listener.onSakeSubscribed()
+        assertEquals(ConnectionState.AUTHENTICATING, manager.connectionState.value)
+    }
+
+    @Test
+    fun `successful handshake connects holds session and persists pairing`() {
+        val manager = newManager()
+        manager.startSession()
+        completeHandshake()
+
+        assertEquals(ConnectionState.CONNECTED, manager.connectionState.value)
+        assertNull(manager.fault.value)
+        assertTrue(manager.sakeSession?.isComplete == true)
+        assertEquals(1, credentialStore.savePairingCount)
+        assertEquals(PUMP_ADDRESS, credentialStore.getPairedAddress())
+    }
+
+    @Test
+    fun `no notification emitted during a session exceeds the PDU cap`() {
+        val manager = newManager()
+        manager.startSession()
+        completeHandshake()
+        assertTrue(notifications.isNotEmpty())
+        notifications.forEach { assertTrue("PDU ${it.size}B too large", it.size <= PduFramer.MAX_PDU_SIZE) }
+    }
+
+    @Test
+    fun `disconnect after connect re-advertises in reconnect mode`() {
+        val manager = newManager()
+        manager.startSession()
+        completeHandshake()
+
+        listener.onPumpDisconnected(GATT_TERMINATE_PEER_USER)
+
+        assertEquals(ConnectionState.RECONNECTING, manager.connectionState.value)
+        assertNull(manager.sakeSession)
+        verify { peripheral.advertise(AdvertisingMode.RECONNECT, any()) }
+    }
+
+    @Test
+    fun `auth failure latches auth_failed and survives the following disconnect`() {
+        val manager = newManager()
+        manager.startSession()
+        listener.onPumpConnected(PUMP_ADDRESS)
+        listener.onSakeSubscribed()
+        val pump = SakeClient(SakeVectors.customClientKeyDb(), DeviceType.INSULIN_PUMP)
+        listener.onSakeWrite(ByteArray(SAKE_FRAME_SIZE))
+        listener.onSakeWrite(pump.handshake(notifications.last()))
+        listener.onSakeWrite(pump.handshake(notifications.last()))
+        val msg5 = pump.handshake(notifications.last())
+        listener.onSakeWrite(msg5.clone().also { it[0] = (it[0].toInt() xor 0x01).toByte() })
+
+        assertEquals(ConnectionState.AUTH_FAILED, manager.connectionState.value)
+        assertEquals(MedtronicConnectionFault.AUTH_FAILED, manager.fault.value)
+
+        // The pump drops the link after rejecting us; AUTH_FAILED must not be overwritten or retried.
+        listener.onPumpDisconnected(GATT_TERMINATE_PEER_USER)
+        assertEquals(ConnectionState.AUTH_FAILED, manager.connectionState.value)
+        verify(exactly = 0) { peripheral.advertise(any(), any()) }
+    }
+
+    @Test
+    fun `handshake timeout reports auth_failed with timeout fault`() {
+        val manager = newManager(handshakeTimeoutMs = 5_000L)
+        manager.startSession()
+        listener.onPumpConnected(PUMP_ADDRESS)
+        listener.onSakeSubscribed()
+
+        testScope.advanceTimeBy(5_001L)
+        testScope.runCurrent()
+
+        assertEquals(ConnectionState.AUTH_FAILED, manager.connectionState.value)
+        assertEquals(MedtronicConnectionFault.HANDSHAKE_TIMEOUT, manager.fault.value)
+    }
+
+    @Test
+    fun `first-pair single-peer wait surfaces bound-elsewhere fault`() {
+        val manager = newManager(pairingWaitMs = 10_000L)
+        manager.startSession()
+        listener.onAdvertiseStarted(AdvertisingMode.FIRST_PAIR)
+
+        testScope.advanceTimeBy(10_001L)
+        testScope.runCurrent()
+
+        assertEquals(MedtronicConnectionFault.BOUND_ELSEWHERE_SUSPECTED, manager.fault.value)
+        assertEquals(ConnectionState.CONNECTING, manager.connectionState.value)
+    }
+
+    @Test
+    fun `disconnect stops the peripheral and prevents reconnect`() {
+        credentialStore.savePairing(PUMP_ADDRESS, "Mobile 000001")
+        val manager = newManager()
+        manager.startSession()
+
+        manager.disconnect()
+
+        assertEquals(ConnectionState.DISCONNECTED, manager.connectionState.value)
+        verify { peripheral.stop() }
+        // A late disconnect callback must not start a reconnect after the user disconnected.
+        listener.onPumpDisconnected(GATT_TERMINATE_PEER_USER)
+        assertEquals(ConnectionState.DISCONNECTED, manager.connectionState.value)
+        verify(exactly = 0) { peripheral.advertise(any(), any()) }
+    }
+
+    @Test
+    fun `unpair clears credentials and removes the bond`() {
+        credentialStore.savePairing(PUMP_ADDRESS, "Mobile 000001")
+        val manager = newManager()
+
+        manager.unpair()
+
+        assertNull(credentialStore.getPairedAddress())
+        assertEquals(1, credentialStore.clearPairingCount)
+        verify { peripheral.removeBond(PUMP_ADDRESS) }
+    }
+
+    @Test
+    fun `advertise failure reports advertise_failed`() {
+        val manager = newManager()
+        manager.startSession()
+        listener.onAdvertiseFailed(ADVERTISE_ERROR)
+
+        assertEquals(ConnectionState.DISCONNECTED, manager.connectionState.value)
+        assertEquals(MedtronicConnectionFault.ADVERTISE_FAILED, manager.fault.value)
+    }
+
+    @Test
+    fun `unsupported peripheral reports unsupported fault and does not advertise`() {
+        every { peripheral.isSupported() } returns false
+        val manager = newManager()
+        manager.startSession()
+
+        assertEquals(MedtronicConnectionFault.PERIPHERAL_UNSUPPORTED, manager.fault.value)
+        assertEquals(ConnectionState.DISCONNECTED, manager.connectionState.value)
+        verify(exactly = 0) { peripheral.start(any(), any(), any()) }
+    }
+
+    @Test
+    fun `scan advertises and emits the pump that connects`() = runTest {
+        val manager = newManager(scope = TestScope(StandardTestDispatcher(testScheduler)))
+        val received = mutableListOf<DiscoveredDevice>()
+        val job = launch { manager.scan().collect { received.add(it) } }
+        runCurrent()
+
+        assertEquals(ConnectionState.SCANNING, manager.connectionState.value)
+        verify { peripheral.start(AdvertisingMode.FIRST_PAIR, any(), any()) }
+
+        listener.onPumpConnected(PUMP_ADDRESS)
+        runCurrent()
+
+        assertEquals(1, received.size)
+        assertEquals(PUMP_ADDRESS, received[0].address)
+        assertEquals(MedtronicBleConnectionManager.PLUGIN_ID, received[0].pluginId)
+        job.cancel()
+    }
+
+    @Test
+    fun `scan on an unsupported device completes with the unsupported fault`() = runTest {
+        every { peripheral.isSupported() } returns false
+        val manager = newManager(scope = TestScope(StandardTestDispatcher(testScheduler)))
+        val received = mutableListOf<DiscoveredDevice>()
+
+        manager.scan().collect { received.add(it) } // closes immediately
+
+        assertTrue(received.isEmpty())
+        assertEquals(MedtronicConnectionFault.PERIPHERAL_UNSUPPORTED, manager.fault.value)
+        verify(exactly = 0) { peripheral.start(any(), any(), any()) }
+    }
+
+    private companion object {
+        const val PUMP_ADDRESS = "AA:BB:CC:DD:EE:FF"
+        const val SAKE_FRAME_SIZE = 20
+        const val GATT_TERMINATE_PEER_USER = 0x13
+        const val ADVERTISE_ERROR = 3
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/MedtronicConnectionLogicTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/MedtronicConnectionLogicTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Pure-logic tests for the advertising-mode selection and the mode -> SAKE service-UUID mapping.
+ * These pin the reconnect bit-flip contract (0xFE82 first pair / 0xFE81 reconnect) independently of
+ * the Android BLE layer (medtronic-ble-reverse-engineering.md Sec. 3 / Sec. 7).
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MedtronicConnectionLogicTest {
+
+    @Test
+    fun `unpaired connection uses first-pair mode`() {
+        assertEquals(AdvertisingMode.FIRST_PAIR, advertisingModeFor(paired = false, forceFirstPair = false))
+    }
+
+    @Test
+    fun `paired connection uses reconnect mode`() {
+        assertEquals(AdvertisingMode.RECONNECT, advertisingModeFor(paired = true, forceFirstPair = false))
+    }
+
+    @Test
+    fun `forcing first pair overrides an existing pairing`() {
+        assertEquals(AdvertisingMode.FIRST_PAIR, advertisingModeFor(paired = true, forceFirstPair = true))
+    }
+
+    @Test
+    fun `first-pair mode advertises the 0xFE82 SAKE service`() {
+        assertEquals(MedtronicProtocol.SAKE_SERVICE_FIRST_PAIR_16, AdvertisingMode.FIRST_PAIR.serviceUuid16)
+        assertEquals(0xFE82, AdvertisingMode.FIRST_PAIR.serviceUuid16)
+    }
+
+    @Test
+    fun `reconnect mode advertises the 0xFE81 service bit-flip`() {
+        assertEquals(MedtronicProtocol.SAKE_SERVICE_RECONNECT_16, AdvertisingMode.RECONNECT.serviceUuid16)
+        assertEquals(0xFE81, AdvertisingMode.RECONNECT.serviceUuid16)
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/SakeHandshakeDriverTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/SakeHandshakeDriverTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Tests for SakeHandshakeDriver: the worker-thread handshake driving on top of the vendored JavaSake
+ * (proven byte-for-byte by org.openminimed.sake.* and exercised through the wrapper by
+ * MedtronicSakeSessionTest). Here the pump side is simulated with SakeClient + the matched synthetic
+ * key-DB pair, so a full six-stage handshake runs end-to-end without any Android BLE stack.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import com.glycemicgpt.mobile.ble.protocol.PduFramer
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.openminimed.sake.DeviceType
+import org.openminimed.sake.KeyDatabase
+import org.openminimed.sake.MacFailureException
+import org.openminimed.sake.SakeClient
+import org.openminimed.sake.Session
+
+class SakeHandshakeDriverTest {
+
+    private val notifications = mutableListOf<ByteArray>()
+    private val worker = DirectSerialWorker()
+    private var authenticatedSession: MedtronicSakeSession? = null
+    private var failure: Throwable? = null
+    private var authCount = 0
+    private var failCount = 0
+
+    private fun newDriver(keyDb: KeyDatabase) = SakeHandshakeDriver(
+        worker = worker,
+        sessionFactory = { MedtronicSakeSession(keyDb) },
+        notifySink = { notifications.add(it.copyOf()); true },
+        listener = object : SakeHandshakeDriver.HandshakeListener {
+            override fun onAuthenticated(session: MedtronicSakeSession) {
+                authenticatedSession = session
+                authCount++
+            }
+
+            override fun onAuthFailed(cause: Throwable?) {
+                failure = cause
+                failCount++
+            }
+        },
+    )
+
+    private fun newPump() = SakeClient(SakeVectors.customClientKeyDb(), DeviceType.INSULIN_PUMP)
+
+    @Test
+    fun `wake-up notification on subscribe is 20 zero bytes`() {
+        newDriver(SakeVectors.pumpKeyDb()).onSubscribed()
+        assertEquals(1, notifications.size)
+        assertArrayEquals(ByteArray(Session.MESSAGE_SIZE), notifications[0])
+    }
+
+    @Test
+    fun `full handshake drives to completion and holds the session`() {
+        val driver = newDriver(SakeVectors.customServerKeyDb())
+        val pump = newPump()
+
+        driver.onSubscribed()
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE)) // pump's wake-up write -> msg0
+        val msg1 = pump.handshake(notifications.last())
+        driver.onPumpWrite(msg1) // -> msg2
+        val msg3 = pump.handshake(notifications.last())
+        driver.onPumpWrite(msg3) // -> msg4
+        val msg5 = pump.handshake(notifications.last())
+        driver.onPumpWrite(msg5) // -> completes, no further notification
+
+        assertNotNull(authenticatedSession)
+        assertTrue(authenticatedSession!!.isComplete)
+        assertEquals(1, authCount)
+        assertEquals(0, failCount)
+        // Wake-up + msg0 + msg2 + msg4 = 4 notifications; the completing write produces none.
+        assertEquals(4, notifications.size)
+    }
+
+    @Test
+    fun `no notification exceeds the 20-byte PDU cap`() {
+        // B2 only ever emits 20-byte SAKE frames, so this proves the driver never exceeds the cap on
+        // the handshake path (AC4). The driver routes every notification through PduFramer.fragment,
+        // whose fragmentation of larger (Milestone C reader) payloads is covered by PduFramerTest.
+        val driver = newDriver(SakeVectors.customServerKeyDb())
+        val pump = newPump()
+
+        driver.onSubscribed()
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+
+        assertTrue(notifications.isNotEmpty())
+        notifications.forEach { assertTrue("PDU ${it.size}B exceeds cap", it.size <= PduFramer.MAX_PDU_SIZE) }
+    }
+
+    @Test
+    fun `tampered final permit fails authentication`() {
+        val driver = newDriver(SakeVectors.customServerKeyDb())
+        val pump = newPump()
+
+        driver.onSubscribed()
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        val msg5 = pump.handshake(notifications.last())
+        val tampered = msg5.clone().also { it[0] = (it[0].toInt() xor 0x01).toByte() }
+        driver.onPumpWrite(tampered)
+
+        assertNull(authenticatedSession)
+        assertEquals(1, failCount)
+        assertTrue(failure is MacFailureException)
+
+        // Further pump writes on the now-corrupted session must not re-fire onAuthFailed.
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE))
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE))
+        assertEquals(1, failCount)
+    }
+
+    @Test
+    fun `writes after completion are ignored`() {
+        val driver = newDriver(SakeVectors.customServerKeyDb())
+        val pump = newPump()
+
+        driver.onSubscribed()
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        val countAfterComplete = notifications.size
+
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE))
+
+        assertEquals(1, authCount)
+        assertEquals(0, failCount)
+        assertEquals(countAfterComplete, notifications.size)
+    }
+
+    @Test
+    fun `resubscribe after unsubscribe restarts the handshake cleanly`() {
+        val driver = newDriver(SakeVectors.customServerKeyDb())
+
+        // Begin a handshake, then the pump drops its subscription mid-flight.
+        driver.onSubscribed()
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE)) // advances past stage 0
+        driver.onUnsubscribed()
+        notifications.clear()
+
+        // A fresh subscribe re-emits the wake-up and a brand-new handshake completes.
+        driver.onSubscribed()
+        assertArrayEquals(ByteArray(Session.MESSAGE_SIZE), notifications.last())
+        val pump = newPump()
+        driver.onPumpWrite(ByteArray(Session.MESSAGE_SIZE))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+        driver.onPumpWrite(pump.handshake(notifications.last()))
+
+        assertNotNull(authenticatedSession)
+        assertTrue(authenticatedSession!!.isComplete)
+        assertEquals(1, authCount)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the inverted-topology BLE connection core for the Medtronic MiniMed 700-series (680G/770G/780G) read-only driver. Unlike Tandem, the phone is the BLE **peripheral** (advertiser + GATT server) and the pump connects to it as the central, so there is no existing GATT-client to reuse — this is a new connection manager.

This delivers the connection manager as a standalone, injectable class. The data readers (CGM/IOB/history) and the device-plugin + DI registration that consume it land in a later milestone.

## What's included

- **`MedtronicPeripheral` / `PeripheralListener` / `AdvertisingMode`** — the transport seam. `FIRST_PAIR` advertises service `0xFE82`; `RECONNECT` advertises the `0xFE81` bit-flip at a short interval. Decoupling the BLE layer behind this seam makes the connection logic unit-testable without the Android BLE stack.
- **`AndroidMedtronicPeripheral`** — `BluetoothLeAdvertiser` + `BluetoothGattServer` implementation exposing the SAKE characteristic (NOTIFY+WRITE) and a read-only Device Information service. Advertises only after the GATT services finish registering; never calls `requestMtu()`; keeps every PDU ≤ 20 bytes.
- **`SerialWorker` / `HandlerThreadSerialWorker`** — serializes the SAKE handshake and session crypto onto a dedicated worker thread so the binder thread delivering GATT-server callbacks is never blocked.
- **`SakeHandshakeDriver`** — drives the existing `MedtronicSakeSession` through the six handshake stages (wake-up on subscribe, advance per pump write, fragment outbound via `PduFramer`), holds the completed session for the read layer, and latches/fails closed on authentication errors.
- **`MedtronicBleConnectionManager`** — exposes `connectionState: StateFlow<ConnectionState>` plus a `fault` flow, with all lifecycle mutation confined to the worker thread. Enforces a handshake timeout, auto-reconnects to an already-paired pump via `0xFE81`, persists pairing through `PumpCredentialProvider`, and provides `disconnect()` / `unpair()`. `scan()` is advertise-and-wait: in the inverted topology the pump finds us, so it emits a discovered device when a pump connects rather than running an active central scan.
- Module manifest declares `BLUETOOTH_ADVERTISE` for the peripheral role.

## Read-only

The GATT server exposes only the SAKE authentication characteristic and read-only Device Information. No control, bolus, basal, or calibration characteristic is exposed, by design.

## Testing

- `:medtronic-pump-driver` `testDebugUnitTest`, `lintDebug`, `assembleDebug` all green — 111 unit tests, 0 failures.
- The BLE layer is mocked; the pump side is simulated with the SAKE client and a matched test key pair, so a full six-stage handshake runs end-to-end in tests. Coverage includes the state-machine transitions, MTU discipline (no PDU > 20 bytes), reconnect mode/service selection, handshake timeout, single-peer surfacing, and the advertise-and-wait scan.
- Over-the-air validation against a real 700-series pump is pump-gated and is **not** claimed here; it is tracked as follow-up work alongside the live-pump spike. Anything not verified over the air is marked as such in code.

## Notes for the follow-up reader milestone

- The read layer consumes `MedtronicBleConnectionManager.sakeSession` (held after `CONNECTED`) to decrypt pump→phone session traffic.
- A few items are confirmed only against a real pump and carry `TODO` markers: the SAKE characteristic UUID base, a per-install advertised name, the single-peer wait window, and whether the pump validates any Device Information field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Medtronic MiniMed 700-series pairing and BLE connectivity added; phone can act as a BLE peripheral for pump pairing and reconnection.
  * Connection state monitoring, auth/paired error handling, and persistent pairing support.
  * Enforced notification/PDU sizing and bond removal support.

* **Platform**
  * Added required Bluetooth advertise/connect permissions for Android S+.

* **Tests**
  * Comprehensive unit tests for connection manager, handshake driver, and peripheral logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->