### PR TITLE
feat(medtronic): session-read framework + CGM/SG, Device Info, and Battery readers

### DIFF
--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/protocol/MedtronicProtocol.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/protocol/MedtronicProtocol.kt
@@ -114,6 +114,7 @@ object MedtronicProtocol {
     val MODEL_NUMBER_UUID: UUID = sigUuid(0x2A24)
     val SERIAL_NUMBER_UUID: UUID = sigUuid(0x2A25)
     val FIRMWARE_REVISION_UUID: UUID = sigUuid(0x2A26)
+    val HARDWARE_REVISION_UUID: UUID = sigUuid(0x2A27)
     val SOFTWARE_REVISION_UUID: UUID = sigUuid(0x2A28)
     val SYSTEM_ID_UUID: UUID = sigUuid(0x2A23)
     val PNP_ID_UUID: UUID = sigUuid(0x2A50)

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/BatteryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/BatteryReader.kt
@@ -1,0 +1,51 @@
+/*
+ * Battery reader for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The battery-level read and its 0..100 sanity check are ported from
+ * OpenMinimed PythonPumpConnector `device_info.py` (DeviceInfo.read_battery_level / _batt_cb),
+ * GPL-3.0, used with the author's permission. Copyright (C) OpenMinimed contributors: palmarci
+ * (Pal Marci), drfubar, Morten Fyhn Amundsen, Stenium; original medtronic-bt-decrypt PoC by
+ * @planiitis. GlycemicGPT is itself GPL-3.0.
+ *
+ * Battery Service (0x180F) Battery Level (0x2A19) is a standard Bluetooth SIG percentage byte and is
+ * NOT SAKE-encrypted -- a plain GATT read.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import java.time.Instant
+
+/** Reads the pump's battery level into a [BatteryStatus]. */
+class BatteryReader(
+    private val link: MedtronicGattLink,
+    private val now: () -> Instant = Instant::now,
+) {
+
+    /**
+     * Read the Battery Level characteristic (one percentage byte). A value outside the valid
+     * 1..100 range is **rejected** rather than clamped. 0 is rejected as a no/empty reading, matching
+     * upstream `device_info.py` (`0 < batt < 101`): a pump reporting a true 0% over an active link
+     * would already be powered off, so 0x00 is spurious. [BatteryStatus.isCharging] is always
+     * `false`: the 700-series runs on a replaceable battery and exposes no charging state over the
+     * standard Battery Service.
+     */
+    fun read(): BatteryStatus {
+        val raw = link.read(MedtronicProtocol.BATTERY_LEVEL_UUID)
+        if (raw.isEmpty()) {
+            throw MedtronicReadException("Battery Level characteristic is empty")
+        }
+        val percentage = raw[0].toInt() and 0xFF
+        if (percentage !in MIN_PERCENTAGE..MAX_PERCENTAGE) {
+            throw MedtronicReadException(
+                "Battery percentage $percentage outside $MIN_PERCENTAGE..$MAX_PERCENTAGE",
+            )
+        }
+        return BatteryStatus(percentage = percentage, isCharging = false, timestamp = now())
+    }
+
+    private companion object {
+        const val MIN_PERCENTAGE = 1
+        const val MAX_PERCENTAGE = 100
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/CgmFeature.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/CgmFeature.kt
@@ -1,0 +1,67 @@
+/*
+ * CGM Feature characteristic parser for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * Ported to Kotlin from OpenMinimed PythonPumpConnector `cgm_features.py` (CGMFeatures),
+ * https://github.com/OpenMinimed, GPL-3.0, used with the author's permission. Copyright (C)
+ * OpenMinimed contributors: palmarci (Pal Marci), drfubar, Morten Fyhn Amundsen, Stenium; original
+ * medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is itself GPL-3.0, so this is redistributed
+ * under the same license.
+ *
+ * Bluetooth SIG "CGM Feature" characteristic (GSS section 3.42), read from 0x2AA8.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+/**
+ * Decoded CGM Feature characteristic. The single field this driver acts on is [e2eCrcEnabled] (the
+ * E2E_CRC feature bit), which governs whether CGM Measurement records carry a trailing E2E-CRC.
+ *
+ * Reading this flag per pump is the fix for the upstream 780G hard-code: 680G / 770G must not be
+ * assumed to use the CRC (medtronic-ble-reverse-engineering.md Sec. 9).
+ */
+internal data class CgmFeature(
+    val featureBits: Int,
+    val e2eCrcEnabled: Boolean,
+) {
+    companion object {
+        /** E2E_CRC feature bit (1 << 12) in the 24-bit feature field. */
+        private const val E2E_CRC_BIT = 1 shl 12
+
+        /** feature field (3 bytes LE) + type/sample-location (1 byte) + E2E-CRC (2 bytes). */
+        private const val EXPECTED_LENGTH = 6
+        private const val FEATURE_FIELD_SIZE = 3
+
+        /** Sentinel in the CRC field meaning "E2E-safety unsupported" (the chicken-and-egg workaround). */
+        private const val CRC_UNSUPPORTED = 0xFFFF
+
+        /**
+         * Decode the 6-byte CGM Feature value.
+         *
+         * The spec's chicken-and-egg workaround: the flag that says whether E2E-safety is supported
+         * lives inside the otherwise CRC-protected packet, so the CRC field is *always* present and
+         * set to 0xffff when unsupported. We therefore validate the CRC only when the field isn't the
+         * 0xffff sentinel, then take [e2eCrcEnabled] from the feature bit itself.
+         *
+         * (Upstream's `cgm_features.py` compares `data[:-2]` instead of the trailing two bytes to the
+         * 0xffff sentinel, which never matches and so always validates the CRC; we compare the actual
+         * CRC field, per the documented intent.)
+         *
+         * @throws MedtronicReadException on an unexpected length or a CRC mismatch.
+         */
+        fun parse(value: ByteArray): CgmFeature {
+            if (value.size != EXPECTED_LENGTH) {
+                throw MedtronicReadException(
+                    "CGM Feature length ${value.size} != expected $EXPECTED_LENGTH",
+                )
+            }
+            val crcField = MedtronicCodec.readUIntLe(value, EXPECTED_LENGTH - MedtronicCodec.CRC_SIZE, MedtronicCodec.CRC_SIZE)
+            if (crcField != CRC_UNSUPPORTED && !MedtronicCodec.checkE2eCrc(value)) {
+                throw MedtronicReadException("CGM Feature E2E-CRC mismatch")
+            }
+            val featureBits = MedtronicCodec.readUIntLe(value, 0, FEATURE_FIELD_SIZE)
+            return CgmFeature(
+                featureBits = featureBits,
+                e2eCrcEnabled = featureBits and E2E_CRC_BIT != 0,
+            )
+        }
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/CgmMeasurement.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/CgmMeasurement.kt
@@ -1,0 +1,125 @@
+/*
+ * CGM Measurement record parser for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * Ported to Kotlin from OpenMinimed PythonPumpConnector `cgm_measurement.py` (CGMMeasurement),
+ * https://github.com/OpenMinimed, GPL-3.0, used with the author's permission. Copyright (C)
+ * OpenMinimed contributors: palmarci (Pal Marci), drfubar, Morten Fyhn Amundsen, Stenium; original
+ * medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is itself GPL-3.0, so this is redistributed
+ * under the same license.
+ *
+ * Bluetooth SIG "CGM Measurement" record (GSS section 3.43). The pump SAKE-encrypts this record on
+ * the wire; the caller decrypts it (MedtronicSessionReader) before parsing here.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+/**
+ * A decoded CGM Measurement record. Glucose and trend are in **mg/dL** (the 700-series reports
+ * mg/dL); [trendMgDlPerMin] is the rate of change. Optional fields are `null`/absent when their
+ * presence flag is clear, matching the SIG record's flag-driven layout.
+ *
+ * Use [parse] to decode a (already-decrypted) record; it throws [MedtronicReadException] on any
+ * structural inconsistency rather than returning a half-populated object.
+ */
+internal data class CgmMeasurement(
+    val flags: Int,
+    val glucoseMgDl: Double,
+    val timeOffsetMinutes: Int,
+    val status: Int,
+    val trendMgDlPerMin: Double?,
+    val quality: Double?,
+) {
+    companion object {
+        // Flag bits (GSS 3.43), low to high.
+        private const val FLAG_TREND_PRESENT = 0x01
+        private const val FLAG_QUALITY_PRESENT = 0x02
+        private const val FLAG_WARNING_PRESENT = 0x20
+        private const val FLAG_CAL_TEMP_PRESENT = 0x40
+        private const val FLAG_STATUS_PRESENT = 0x80
+
+        // Mandatory prefix: size(1) + flags(1) + glucose SFLOAT(2) + time offset(2).
+        private const val MANDATORY_SIZE = 6
+
+        /**
+         * Decode a decrypted CGM Measurement record. [useCrc] selects the E2E-CRC-protected layout
+         * (the CRC is validated and stripped first); it must come from the CGM Feature's E2E_CRC bit
+         * (see [CgmFeature]), never a per-model assumption.
+         *
+         * @throws MedtronicReadException if the record is too short, the size field disagrees with
+         *     the buffer length, the E2E-CRC fails, or trailing bytes remain after the declared
+         *     optional fields.
+         */
+        fun parse(record: ByteArray, useCrc: Boolean): CgmMeasurement {
+            val minLength = if (useCrc) MANDATORY_SIZE + MedtronicCodec.CRC_SIZE else MANDATORY_SIZE
+            if (record.size < minLength) {
+                throw MedtronicReadException(
+                    "CGM record too short: need >= $minLength bytes, got ${record.size}",
+                )
+            }
+
+            // The size field counts the whole record including the CRC, so validate it before the
+            // CRC is stripped (matches upstream, which compares against the original length).
+            val sizeField = MedtronicCodec.readUIntLe(record, 0, 1)
+            if (sizeField != record.size) {
+                throw MedtronicReadException(
+                    "CGM record length ${record.size} != size field $sizeField",
+                )
+            }
+
+            var end = record.size
+            if (useCrc) {
+                if (!MedtronicCodec.checkE2eCrc(record)) {
+                    throw MedtronicReadException("CGM record E2E-CRC mismatch")
+                }
+                end -= MedtronicCodec.CRC_SIZE
+            }
+
+            val flags = MedtronicCodec.readUIntLe(record, 1, 1)
+            val glucose = MedtronicCodec.decodeMedFloat16(MedtronicCodec.readUIntLe(record, 2, 2))
+            val timeOffset = MedtronicCodec.readUIntLe(record, 4, 2)
+
+            // Walk the optional octets in wire order, bounds-checking each so a flag that promises a
+            // field the buffer doesn't contain is rejected rather than read out of bounds.
+            var offset = MANDATORY_SIZE
+            fun consume(n: Int, field: String): Int {
+                if (offset + n > end) {
+                    throw MedtronicReadException("CGM record missing $field field")
+                }
+                val value = MedtronicCodec.readUIntLe(record, offset, n)
+                offset += n
+                return value
+            }
+
+            var status = 0
+            if (flags and FLAG_STATUS_PRESENT != 0) status = consume(1, "status")
+            if (flags and FLAG_CAL_TEMP_PRESENT != 0) consume(1, "cal/temp")
+            if (flags and FLAG_WARNING_PRESENT != 0) consume(1, "warning")
+            val trend =
+                if (flags and FLAG_TREND_PRESENT != 0) {
+                    MedtronicCodec.decodeMedFloat16(consume(2, "trend"))
+                } else {
+                    null
+                }
+            val quality =
+                if (flags and FLAG_QUALITY_PRESENT != 0) {
+                    MedtronicCodec.decodeMedFloat16(consume(2, "quality"))
+                } else {
+                    null
+                }
+
+            if (offset != end) {
+                throw MedtronicReadException(
+                    "CGM record has ${end - offset} trailing byte(s) after declared fields",
+                )
+            }
+
+            return CgmMeasurement(
+                flags = flags,
+                glucoseMgDl = glucose,
+                timeOffsetMinutes = timeOffset,
+                status = status,
+                trendMgDlPerMin = trend,
+                quality = quality,
+            )
+        }
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/CgmReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/CgmReader.kt
@@ -1,0 +1,118 @@
+/*
+ * SG / CGM reader for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The read flow -- read the CGM Feature for the E2E-CRC flag, then RACP
+ * "report last stored record" to pull the latest measurement -- is ported from OpenMinimed
+ * PythonPumpConnector `sg_reader.py` (SGReader), GPL-3.0, used with the author's permission.
+ * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar, Morten Fyhn Amundsen,
+ * Stenium; original medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is itself GPL-3.0.
+ *
+ * Crucially, the E2E-CRC use is read from the CGM Feature characteristic per pump rather than
+ * hard-coded for 780G as upstream does (medtronic-ble-reverse-engineering.md Sec. 9).
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import java.time.Instant
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Reads the latest sensor glucose as a [CgmReading] (glucose in **mg/dL**, trend arrow, timestamp).
+ *
+ * Every value is gated by [safetyLimits]: an out-of-physiological-range glucose is **rejected**, not
+ * clamped (a wrong SG is more dangerous than a missing one). Over-the-air behavior rides with 48.A2;
+ * nothing here is claimed live-verified.
+ *
+ * @param now clock for stamping the reading. "Report last stored record" returns the most recent
+ *     measurement, so the read time approximates its capture time; per-record absolute timestamps
+ *     via the CGM Session Start Time characteristic are a later (48.C2/D) refinement.
+ */
+class CgmReader(
+    private val link: MedtronicGattLink,
+    session: MedtronicSakeSession,
+    private val safetyLimits: SafetyLimits = SafetyLimits(),
+    private val now: () -> Instant = Instant::now,
+) {
+    private val sessionReader = MedtronicSessionReader(link, session)
+
+    /**
+     * Read the CGM Feature flag, then pull and decode the latest measurement into a [CgmReading].
+     *
+     * The feature flag is static per session; re-reading it on each call is acceptable for this
+     * single-shot read but should be cached once polling is added in Milestone D.
+     */
+    fun readLatest(onResult: (Result<CgmReading>) -> Unit) {
+        val useCrc =
+            try {
+                CgmFeature.parse(link.read(MedtronicProtocol.CGM_FEATURE_UUID)).e2eCrcEnabled
+            } catch (e: MedtronicReadException) {
+                onResult(Result.failure(e))
+                return
+            }
+
+        sessionReader.reportLastRecord(
+            dataChar = MedtronicProtocol.CGM_MEASUREMENT_UUID,
+            controlPoint = MedtronicProtocol.RACP_UUID,
+        ) { result ->
+            onResult(result.mapCatching { record -> toReading(record, useCrc) })
+        }
+    }
+
+    private fun toReading(record: ByteArray, useCrc: Boolean): CgmReading {
+        val measurement = CgmMeasurement.parse(record, useCrc)
+        // TODO(48.C2/F): gate on the sensor-status annunciation (CgmMeasurement.status) so a sensor in
+        // warm-up or error doesn't surface a misleading SG.
+        if (!measurement.glucoseMgDl.isFinite()) {
+            throw MedtronicReadException("SG is a non-finite SFLOAT sentinel (no value)")
+        }
+        val mgDl = measurement.glucoseMgDl.roundToInt()
+        // SafetyLimits is the authoritative reject-not-clamp gate; we check it (and fail with a clear
+        // MedtronicReadException) before constructing CgmReading, whose own init re-asserts 20..500.
+        // Keep this check: removing it would leak CgmReading's IllegalArgumentException to callers.
+        if (mgDl < safetyLimits.minGlucoseMgDl || mgDl > safetyLimits.maxGlucoseMgDl) {
+            throw MedtronicReadException(
+                "SG $mgDl mg/dL outside safe range " +
+                    "${safetyLimits.minGlucoseMgDl}..${safetyLimits.maxGlucoseMgDl}",
+            )
+        }
+        return CgmReading(
+            glucoseMgDl = mgDl,
+            trendArrow = trendArrowFor(measurement.trendMgDlPerMin),
+            timestamp = now(),
+        )
+    }
+
+    companion object {
+        /**
+         * Map the CGM rate of change (mg/dL/min) onto the app-wide 7-state [CgmTrend]. The thresholds
+         * follow the 780G manual (1-2 / 2-3 / >3 mg/dL/min = 1 / 2 / 3 arrows), folding Medtronic's
+         * three-arrow scale onto the Dexcom-style enum: 3 arrows -> DOUBLE, 2 -> SINGLE, 1 -> 45deg.
+         * A measurement without trend information, or a non-finite SFLOAT sentinel, is
+         * [CgmTrend.UNKNOWN].
+         */
+        internal fun trendArrowFor(ratePerMin: Double?): CgmTrend {
+            if (ratePerMin == null || !ratePerMin.isFinite()) return CgmTrend.UNKNOWN
+            val magnitude = abs(ratePerMin)
+            return when {
+                magnitude < 1.0 -> CgmTrend.FLAT
+                ratePerMin > 0 ->
+                    when {
+                        magnitude >= 3.0 -> CgmTrend.DOUBLE_UP
+                        magnitude >= 2.0 -> CgmTrend.SINGLE_UP
+                        else -> CgmTrend.FORTY_FIVE_UP
+                    }
+                else ->
+                    when {
+                        magnitude >= 3.0 -> CgmTrend.DOUBLE_DOWN
+                        magnitude >= 2.0 -> CgmTrend.SINGLE_DOWN
+                        else -> CgmTrend.FORTY_FIVE_DOWN
+                    }
+            }
+        }
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/DeviceInfoReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/DeviceInfoReader.kt
@@ -1,0 +1,57 @@
+/*
+ * Device Information reader for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The characteristic set and the trailing-terminator handling are ported
+ * from OpenMinimed PythonPumpConnector `device_info.py` (DeviceInfo), GPL-3.0, used with the
+ * author's permission. Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
+ * Morten Fyhn Amundsen, Stenium; original medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is
+ * itself GPL-3.0.
+ *
+ * Device Information Service (0x180A) characteristics are standard Bluetooth SIG strings and are NOT
+ * SAKE-encrypted -- plain GATT reads, the simplest proof of the read plumbing.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+
+/**
+ * Identifying hardware/firmware strings from the pump's Device Information Service.
+ *
+ * Medtronic's DIS values are alphanumeric strings (e.g. model "MMT-1880", serial "NG..."), so they
+ * are kept as strings here rather than forced into the Tandem-shaped, `Long`-keyed
+ * [com.glycemicgpt.mobile.domain.model.PumpHardwareInfo]. Adapting this native shape onto the shared
+ * capability surface is a Milestone C3 concern (the capability delegates that wrap these readers).
+ */
+data class MedtronicDeviceInfo(
+    val modelNumber: String,
+    val serialNumber: String,
+    val hardwareRevision: String,
+    val firmwareRevision: String,
+    val softwareRevision: String,
+    val systemId: String,
+)
+
+/** Reads the pump's Device Information Service into a [MedtronicDeviceInfo]. */
+class DeviceInfoReader(private val link: MedtronicGattLink) {
+
+    /**
+     * Read all Device Information characteristics. String fields are UTF-8 with any trailing NUL
+     * terminator trimmed (upstream strips a fixed terminator byte; trimming only NULs avoids
+     * truncating a value that isn't null-terminated). The 8-byte System ID is rendered as hex.
+     */
+    fun read(): MedtronicDeviceInfo =
+        MedtronicDeviceInfo(
+            modelNumber = readString(MedtronicProtocol.MODEL_NUMBER_UUID),
+            serialNumber = readString(MedtronicProtocol.SERIAL_NUMBER_UUID),
+            hardwareRevision = readString(MedtronicProtocol.HARDWARE_REVISION_UUID),
+            firmwareRevision = readString(MedtronicProtocol.FIRMWARE_REVISION_UUID),
+            softwareRevision = readString(MedtronicProtocol.SOFTWARE_REVISION_UUID),
+            systemId = readHex(MedtronicProtocol.SYSTEM_ID_UUID),
+        )
+
+    private fun readString(characteristic: java.util.UUID): String =
+        link.read(characteristic).dropLastWhile { it.toInt() == 0 }.toByteArray().toString(Charsets.UTF_8)
+
+    private fun readHex(characteristic: java.util.UUID): String =
+        link.read(characteristic).joinToString("") { "%02x".format(it) }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicCodec.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicCodec.kt
@@ -21,9 +21,16 @@ package com.glycemicgpt.mobile.ble.read
  */
 internal object MedtronicCodec {
 
-    /** Read [n] bytes of [data] starting at [offset] as a little-endian unsigned integer. */
+    /**
+     * Read [n] bytes of [data] starting at [offset] as a little-endian unsigned integer.
+     *
+     * Bounded to 1..3 bytes: a signed [Int] cannot represent a full unsigned 32-bit value, so a
+     * 4-byte field with the top bit set would read back negative and silently violate the unsigned
+     * contract. The 4-byte (uint32) fields appear only in the history records (48.C2); add a
+     * `Long`-returning reader there rather than widening this one.
+     */
     fun readUIntLe(data: ByteArray, offset: Int, n: Int): Int {
-        require(n in 1..4) { "n must be in 1..4, was $n" }
+        require(n in 1..3) { "n must be in 1..3 (Int cannot hold a full uint32), was $n" }
         require(offset >= 0 && offset + n <= data.size) {
             "range [$offset, ${offset + n}) out of bounds for ${data.size} bytes"
         }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicCodec.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicCodec.kt
@@ -1,0 +1,107 @@
+/*
+ * Low-level value decoding for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * Ported to Kotlin from OpenMinimed PythonPumpConnector (https://github.com/OpenMinimed),
+ * GPL-3.0, used with the author's permission: the IEEE-11073 SFLOAT decode and the little-endian
+ * field consumers from `parse_utils.py` (ParseUtils) and the E2E-CRC / medfloat helpers from
+ * `value_converter.py` (ValueConverter). Copyright (C) OpenMinimed contributors: palmarci
+ * (Pal Marci), drfubar, Morten Fyhn Amundsen, Stenium; original medtronic-bt-decrypt PoC by
+ * @planiitis. GlycemicGPT is itself GPL-3.0, so this is redistributed under the same license.
+ *
+ * See medtronic-ble-reverse-engineering.md Sec. 8-9.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+/**
+ * Pure byte-level decoders shared by the Medtronic CGM / device-info parsers: little-endian
+ * integers, the IEEE-11073 16-bit SFLOAT ("medfloat16") used by the CGM Measurement record, and the
+ * E2E-CRC (CRC-16/CCITT-FALSE) that guards CGM packets.
+ *
+ * Stateless and side-effect free so the parsers stay unit-testable against captured frames.
+ */
+internal object MedtronicCodec {
+
+    /** Read [n] bytes of [data] starting at [offset] as a little-endian unsigned integer. */
+    fun readUIntLe(data: ByteArray, offset: Int, n: Int): Int {
+        require(n in 1..4) { "n must be in 1..4, was $n" }
+        require(offset >= 0 && offset + n <= data.size) {
+            "range [$offset, ${offset + n}) out of bounds for ${data.size} bytes"
+        }
+        var value = 0
+        for (i in 0 until n) {
+            value = value or ((data[offset + i].toInt() and 0xFF) shl (8 * i))
+        }
+        return value
+    }
+
+    /**
+     * Decode a 16-bit IEEE-11073 SFLOAT: a 4-bit signed exponent in the high nibble and a 12-bit
+     * signed mantissa, valued as `mantissa * 10^exponent`. Mirrors `ValueConverter.decode_medfloat16`.
+     * For CGM glucose the exponent is 0, so the value is the integer mantissa in mg/dL; the trend
+     * field uses a small negative exponent (e.g. mantissa 116, exponent -2 -> 1.16 mg/dL/min).
+     *
+     * Computed as `mantissa * 10^exponent` via a precomputed power-of-ten table. Upstream
+     * `value_converter.py` instead parses `float(f"{m}e{e}")` to minimize floating-point drift; the
+     * difference is immaterial here because glucose is rounded to an Int and trend is only
+     * magnitude-bucketed into arrows.
+     *
+     * The reserved IEEE-11073 SFLOAT mantissa codes are returned as non-finite Doubles
+     * (NaN / +-Infinity) rather than decoded as ordinary numbers, so callers reject them instead of
+     * surfacing a "no value" sentinel (e.g. 0x07FF) as a real glucose or trend. Upstream
+     * `value_converter.py` does not special-case these; we do, because the trend field is only
+     * magnitude-bucketed and would otherwise turn a sentinel into a bogus arrow.
+     */
+    fun decodeMedFloat16(raw: Int): Double {
+        when (raw and 0x0FFF) {
+            SFLOAT_NAN, SFLOAT_NRES, SFLOAT_RESERVED -> return Double.NaN
+            SFLOAT_POSITIVE_INFINITY -> return Double.POSITIVE_INFINITY
+            SFLOAT_NEGATIVE_INFINITY -> return Double.NEGATIVE_INFINITY
+        }
+        var exponent = (raw and 0xF000) shr 12
+        var mantissa = raw and 0x0FFF
+        if (exponent and 0x8 != 0) exponent -= 0x10
+        if (mantissa and 0x800 != 0) mantissa -= 0x1000
+        return mantissa.toDouble() * POW10[exponent + EXPONENT_BIAS]
+    }
+
+    /**
+     * CRC-16/CCITT-FALSE over [data]: width 16, polynomial 0x1021, init 0xffff, no input/output
+     * reflection, zero final XOR. Mirrors `ValueConverter.e2e_crc`.
+     */
+    fun e2eCrc(data: ByteArray, length: Int = data.size): Int {
+        var crc = 0xFFFF
+        for (i in 0 until length) {
+            crc = crc xor ((data[i].toInt() and 0xFF) shl 8)
+            repeat(8) {
+                crc = if (crc and 0x8000 != 0) (crc shl 1) xor 0x1021 else crc shl 1
+                crc = crc and 0xFFFF
+            }
+        }
+        return crc
+    }
+
+    /**
+     * Verify the trailing 2-byte little-endian E2E-CRC of a packet: the CRC is computed over every
+     * byte except the last two and compared to those two. Mirrors `ValueConverter.check_crc`.
+     */
+    fun checkE2eCrc(message: ByteArray): Boolean {
+        if (message.size < CRC_SIZE) return false
+        val received = readUIntLe(message, message.size - CRC_SIZE, CRC_SIZE)
+        return e2eCrc(message, message.size - CRC_SIZE) == received
+    }
+
+    /** Number of trailing bytes holding the little-endian E2E-CRC. */
+    const val CRC_SIZE = 2
+
+    // Exponents seen on the wire span a single signed nibble (-8..7); precompute the powers of ten
+    // so decoding does no floating-point exponentiation per field.
+    private const val EXPONENT_BIAS = 8
+    private val POW10 = DoubleArray(16) { Math.pow(10.0, (it - EXPONENT_BIAS).toDouble()) }
+
+    // Reserved IEEE-11073 SFLOAT mantissa codes (12-bit field, exponent-independent).
+    private const val SFLOAT_POSITIVE_INFINITY = 0x07FE
+    private const val SFLOAT_NAN = 0x07FF
+    private const val SFLOAT_NRES = 0x0800
+    private const val SFLOAT_RESERVED = 0x0801
+    private const val SFLOAT_NEGATIVE_INFINITY = 0x0802
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicGattLink.kt
@@ -1,0 +1,52 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Transport seam for the Medtronic 700-series read layer.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import java.util.UUID
+
+/**
+ * The minimal GATT operations the read layer needs, abstracted so the readers and
+ * [MedtronicSessionReader] are transport-agnostic and unit-testable against canned frames.
+ *
+ * In the inverted topology the pump connects to the phone (peripheral) but exposes its CGM / IDD /
+ * Device-Info services as a GATT **server**; over that same link the phone acts as a GATT **client**
+ * to read them — exactly as OpenMinimed's PythonPumpConnector does over BlueZ (write the control
+ * point, subscribe for notifications, read static characteristics). The concrete Android
+ * `BluetoothGatt`-client implementation of this interface is wired in Milestone C3; the connection
+ * manager already owns the link and the post-handshake [com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession].
+ *
+ * All payloads cross this seam as raw bytes; SAKE encryption/decryption is applied above it
+ * ([MedtronicSessionReader]), and the 20-byte PDU cap is honored by fragmenting outbound writes via
+ * [com.glycemicgpt.mobile.ble.protocol.PduFramer] and reassembling inbound notifications
+ * ([NotificationReassembler]). Implementations never call `requestMtu()`.
+ *
+ * Per the project's BLE guideline, the implementation must time-bound every [read]/[write]/[subscribe]
+ * operation (the C3 wiring enforces this); this interface defines no timer of its own.
+ */
+interface MedtronicGattLink {
+
+    /** Read a static characteristic value (Device Info, Battery Level, CGM Feature). */
+    fun read(characteristic: UUID): ByteArray
+
+    /**
+     * Write [value] to a characteristic. The caller passes a payload already fragmented to <= 20-byte
+     * PDUs when oversized; control-point requests (RACP, SOCP) are small and fit one PDU.
+     */
+    fun write(characteristic: UUID, value: ByteArray)
+
+    /**
+     * Enable notifications/indications on [characteristic] and deliver each inbound PDU to [onPdu].
+     * Re-subscribing replaces the handler. Notifications must be effective before any subsequent
+     * control-point [write], so the request's response is not missed.
+     *
+     * **Threading contract:** all [onPdu] callbacks across every subscribed characteristic are
+     * delivered serialized on a single thread. [MedtronicSessionReader] relies on this to keep its
+     * per-exchange state lock-free; the on-device implementation (C3) must honor it (e.g. by hopping
+     * BLE callbacks onto one handler thread, as the connection manager already does).
+     */
+    fun subscribe(characteristic: UUID, onPdu: (ByteArray) -> Unit)
+
+    /** Disable notifications and drop the handler for [characteristic]. */
+    fun unsubscribe(characteristic: UUID)
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadException.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadException.kt
@@ -1,0 +1,14 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Failure type for the Medtronic 700-series read layer.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+/**
+ * Thrown when a Medtronic pump payload cannot be turned into a trustworthy domain value: a malformed
+ * or truncated frame, a failed E2E-CRC, an unexpected control-point response, or a reading that
+ * falls outside the configured [com.glycemicgpt.mobile.domain.pump.SafetyLimits].
+ *
+ * The read layer **rejects** rather than clamps: a value we cannot fully trust is never silently
+ * coerced into range, because a wrong glucose or battery number is worse than a missing one.
+ */
+class MedtronicReadException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -187,8 +187,12 @@ class MedtronicSessionReader(
         }
 
         link.subscribe(socp) { pdu ->
+            if (finished) return@subscribe
             try {
                 val frame = assembler.offer(pdu) ?: return@subscribe
+                // Decrypting advances the session's inbound sequence counter; only do it while the
+                // exchange is live so a late/duplicate notification after finish() cannot consume the
+                // next operation's frame or desync the session (mirrors reportLastRecord).
                 finish(Result.success(session.decryptFromPump(frame)))
             } catch (e: Exception) {
                 finish(Result.failure(asReadException(e, "SOCP response could not be decrypted")))

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -1,0 +1,230 @@
+/*
+ * Post-handshake session-read framework for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The control-point read choreography -- write a request, collect the
+ * (possibly fragmented, SAKE-encrypted) notifications, terminate on the response -- mirrors
+ * OpenMinimed's PythonPumpConnector `sg_reader.py` (SGReader) and `socp.py` (SocpController),
+ * GPL-3.0, used with the author's permission; the SAKE cipher itself lives in the vendored JavaSake
+ * behind MedtronicSakeSession (B1). See medtronic-ble-reverse-engineering.md Sec. 8.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.PduFramer
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import java.util.UUID
+import timber.log.Timber
+
+/**
+ * Accumulates inbound notification PDUs into a complete application frame.
+ *
+ * Application frames are fragmented into <= 20-byte PDUs ([PduFramer.fragment]); the standard BLE
+ * convention used here is "full PDUs until a short one ends the frame", so a frame is complete when
+ * a PDU smaller than [maxPduSize] arrives (a single short PDU completes immediately). This is the
+ * incremental inverse of [PduFramer.fragment] for any payload whose length is not an exact multiple
+ * of [maxPduSize].
+ *
+ * The exact-multiple ambiguity (a frame that fragments into all-full PDUs has no short terminator)
+ * does not arise for the small SAKE-encrypted CGM records this story handles; record-level,
+ * length-prefixed paging for the larger history reads lands with the history reader in 48.C2.
+ */
+internal class NotificationReassembler(
+    private val maxPduSize: Int = PduFramer.MAX_PDU_SIZE,
+    private val maxFrameSize: Int = MAX_FRAME_SIZE,
+) {
+    private val fragments = ArrayList<ByteArray>()
+    private var accumulated = 0
+
+    /**
+     * Offer one inbound PDU; returns the reassembled frame once complete, or `null` if more PDUs are
+     * expected. Empty PDUs are ignored (a real encrypted frame is never empty, so an empty
+     * notification is noise and must not falsely terminate a multi-PDU frame).
+     *
+     * @throws MedtronicReadException if the accumulated frame exceeds [maxFrameSize] -- a peer that
+     *     streams only full-size PDUs with no short terminator cannot grow memory without bound.
+     */
+    fun offer(pdu: ByteArray): ByteArray? {
+        if (pdu.isEmpty()) return null
+        // Defensive copy: the link may recycle the delivery buffer after the callback returns (the
+        // same discipline SakeHandshakeDriver uses on inbound writes).
+        fragments.add(pdu.copyOf())
+        accumulated += pdu.size
+        if (accumulated > maxFrameSize) {
+            reset()
+            throw MedtronicReadException("Reassembled frame exceeds $maxFrameSize bytes; aborting read")
+        }
+        if (pdu.size < maxPduSize) {
+            val frame = PduFramer.reassemble(fragments)
+            reset()
+            return frame
+        }
+        return null
+    }
+
+    /** Discard any partially-accumulated frame. */
+    fun reset() {
+        fragments.clear()
+        accumulated = 0
+    }
+
+    companion object {
+        /**
+         * Upper bound on a single reassembled application frame. Far above any CGM/SOCP record, it
+         * caps the memory a malfunctioning or hostile central can force by streaming full-size PDUs
+         * without a short terminator. Record-level paging for the larger history reads is 48.C2.
+         */
+        const val MAX_FRAME_SIZE = 512
+    }
+}
+
+/**
+ * Reusable read layer over a live [MedtronicSakeSession]: subscribes to a characteristic, reassembles
+ * fragmented notifications, decrypts pump->phone payloads, and orchestrates the control-point
+ * request -> notify -> response pattern shared by RACP and SOCP.
+ *
+ * **Read-only.** Only report/get-class requests are issued; no control or calibration opcode is ever
+ * written.
+ *
+ * The exchanges are event-driven and complete via the supplied callback. They assume the link
+ * delivers all notification callbacks serialized on a single thread (the contract on
+ * [MedtronicGattLink]); the per-exchange state is confined to that thread and not otherwise
+ * synchronized.
+ *
+ * **Timeout contract:** this framework carries no timers so it stays transport-agnostic and
+ * unit-testable; if the pump never responds, the callback is never invoked. Per the project's BLE
+ * guideline ("all BLE operations must have timeouts"), the on-device caller (the C3
+ * `BluetoothGatt`-client wiring) **must** bound every exchange with an operation timeout and surface
+ * expiry as a [MedtronicReadException] -- e.g. by wrapping these calls in a coroutine with
+ * `withTimeout`. The pure logic here is the request/decrypt/reassemble/terminate choreography only.
+ */
+class MedtronicSessionReader(
+    private val link: MedtronicGattLink,
+    private val session: MedtronicSakeSession,
+) {
+
+    /**
+     * RACP "Report Stored Records: Last Record": write the (plaintext) request to [controlPoint],
+     * collect the SAKE-encrypted measurement notification on [dataChar], decrypt it, and finish when
+     * the plaintext RACP response indication confirms success.
+     *
+     * Delivers the decrypted record bytes via [onResult]; a failure (CRC/MAC, an unsuccessful or
+     * unexpected RACP response, or a missing record) is delivered as [Result.failure]. [onResult] is
+     * invoked only when the pump responds (or errors); the caller must impose the operation timeout
+     * (see the class-level timeout contract).
+     */
+    fun reportLastRecord(
+        dataChar: UUID,
+        controlPoint: UUID,
+        onResult: (Result<ByteArray>) -> Unit,
+    ) {
+        val assembler = NotificationReassembler()
+        var record: ByteArray? = null
+        var finished = false
+
+        fun finish(result: Result<ByteArray>) {
+            if (finished) return
+            finished = true
+            link.unsubscribe(dataChar)
+            link.unsubscribe(controlPoint)
+            onResult(result)
+        }
+
+        link.subscribe(dataChar) { pdu ->
+            if (finished) return@subscribe
+            try {
+                val frame = assembler.offer(pdu) ?: return@subscribe
+                // Decrypting advances the session's inbound sequence counter, so only do it while the
+                // exchange is live; a late notification after finish() would desync the next read.
+                record = session.decryptFromPump(frame)
+            } catch (e: Exception) {
+                // Any decrypt/auth failure (MacFailureException) or session-state/length error
+                // (IllegalState/IllegalArgument from SeqCrypt) must fail the read cleanly rather than
+                // escape the delivery thread and leave the exchange hung, matching SakeHandshakeDriver.
+                finish(Result.failure(asReadException(e, "CGM measurement could not be decrypted")))
+            }
+        }
+
+        link.subscribe(controlPoint) { response ->
+            if (finished) return@subscribe
+            when {
+                response.contentEquals(RACP_REPORT_SUCCESS) -> {
+                    val r = record
+                    if (r == null) {
+                        finish(Result.failure(MedtronicReadException("RACP reported success but no record arrived")))
+                    } else {
+                        finish(Result.success(r))
+                    }
+                }
+                else -> finish(
+                    Result.failure(
+                        MedtronicReadException("Unexpected RACP response: ${response.toHex()}"),
+                    ),
+                )
+            }
+        }
+
+        Timber.d("RACP report-last-record request")
+        link.write(controlPoint, RACP_REPORT_LAST_RECORD)
+    }
+
+    /**
+     * SOCP read-only GET (e.g. sensor details): take a [requestOpcode] (a GET-class opcode, optionally
+     * followed by operands), append the E2E-CRC and SAKE-encrypt it for the pump exactly as
+     * `socp.py._trigger_opcode` does, write it to the [socp] characteristic, then reassemble + decrypt
+     * the SAKE-encrypted response and deliver the plaintext (its first byte is the response opcode; any
+     * E2E-CRC trailer is validated by the response parser in 48.C2). Only GET-class opcodes belong here
+     * -- no calibration or control opcode is ever issued. As with [reportLastRecord], the caller must
+     * impose the operation timeout (see the class-level timeout contract).
+     */
+    fun socpGet(socp: UUID, requestOpcode: ByteArray, onResult: (Result<ByteArray>) -> Unit) {
+        val assembler = NotificationReassembler()
+        var finished = false
+
+        fun finish(result: Result<ByteArray>) {
+            if (finished) return
+            finished = true
+            link.unsubscribe(socp)
+            onResult(result)
+        }
+
+        link.subscribe(socp) { pdu ->
+            try {
+                val frame = assembler.offer(pdu) ?: return@subscribe
+                finish(Result.success(session.decryptFromPump(frame)))
+            } catch (e: Exception) {
+                finish(Result.failure(asReadException(e, "SOCP response could not be decrypted")))
+            }
+        }
+
+        val request = appendE2eCrc(requestOpcode)
+        Timber.d("SOCP GET request (%d bytes)", request.size)
+        link.write(socp, session.encryptForPump(request))
+    }
+
+    /** Map any decrypt/parse failure to a [MedtronicReadException], preserving an already-typed one. */
+    private fun asReadException(e: Exception, message: String): MedtronicReadException =
+        e as? MedtronicReadException ?: MedtronicReadException(message, e)
+
+    /** Append the little-endian E2E-CRC over [payload], matching `socp.py`'s request framing. */
+    private fun appendE2eCrc(payload: ByteArray): ByteArray {
+        val crc = MedtronicCodec.e2eCrc(payload)
+        return payload + byteArrayOf((crc and 0xFF).toByte(), ((crc shr 8) and 0xFF).toByte())
+    }
+
+    companion object {
+        /**
+         * RACP request: Op Code 0x01 (Report Stored Records), Operator 0x06 (Last Record). Written in
+         * the clear -- the RACP itself is not SAKE-encrypted, only the measurement it triggers is
+         * (`sg_reader.py`). The 4-byte RACP response likewise fits a single notification PDU, so it is
+         * not run through the reassembler.
+         */
+        val RACP_REPORT_LAST_RECORD = byteArrayOf(0x01, 0x06)
+
+        /**
+         * Expected RACP response: Op Code 0x06 (Response Code), Operator 0x00 (Null), Operand =
+         * Request Op Code 0x01 + Response Code Value 0x01 (Success). GSS section 3.199.
+         */
+        val RACP_REPORT_SUCCESS = byteArrayOf(0x06, 0x00, 0x01, 0x01)
+
+        private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/BatteryReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/BatteryReaderTest.kt
@@ -1,0 +1,45 @@
+/*
+ * AC4: Battery Level read (plain SIG percentage byte, not SAKE-encrypted) into a BatteryStatus, with
+ * rejection of an out-of-range or empty value rather than clamping.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class BatteryReaderTest {
+
+    private val fixedNow = Instant.ofEpochSecond(1_700_000_000)
+
+    private fun reader(link: FakeGattLink) = BatteryReader(link) { fixedNow }
+
+    @Test
+    fun `reads a valid battery percentage`() {
+        val link = FakeGattLink()
+        link.reads[MedtronicProtocol.BATTERY_LEVEL_UUID] = byteArrayOf(72)
+
+        val status = reader(link).read()
+
+        assertEquals(72, status.percentage)
+        assertFalse(status.isCharging)
+        assertEquals(fixedNow, status.timestamp)
+    }
+
+    @Test
+    fun `rejects a percentage above 100`() {
+        val link = FakeGattLink()
+        link.reads[MedtronicProtocol.BATTERY_LEVEL_UUID] = byteArrayOf(0xFF.toByte())
+        assertThrows(MedtronicReadException::class.java) { reader(link).read() }
+    }
+
+    @Test
+    fun `rejects an empty battery value`() {
+        val link = FakeGattLink()
+        link.reads[MedtronicProtocol.BATTERY_LEVEL_UUID] = ByteArray(0)
+        assertThrows(MedtronicReadException::class.java) { reader(link).read() }
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/CgmFeatureTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/CgmFeatureTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Tests for CgmFeature: the E2E_CRC feature bit drives whether measurements carry a CRC (read per
+ * pump, never hard-coded for 780G), and the 0xffff sentinel marks E2E-safety unsupported.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CgmFeatureTest {
+
+    @Test
+    fun `reads E2E_CRC enabled from the captured feature vector`() {
+        // cgm_features.py __main__ vector: feature bits include bit 12 (E2E_CRC), CRC field present.
+        assertTrue(CgmFeature.parse(hex("009001591404")).e2eCrcEnabled)
+    }
+
+    @Test
+    fun `treats the 0xffff CRC sentinel as E2E unsupported and skips validation`() {
+        // feature bits 0x000091 (no bit 12), CRC field = 0xffff -> unsupported, CRC not validated.
+        val feature = CgmFeature.parse(hex("910000" + "14" + "ffff"))
+        assertFalse(feature.e2eCrcEnabled)
+    }
+
+    @Test
+    fun `rejects a wrong-length feature value`() {
+        assertThrows(MedtronicReadException::class.java) { CgmFeature.parse(hex("0090")) }
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/CgmMeasurementTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/CgmMeasurementTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Tests for CgmMeasurement parsing against OpenMinimed-captured CGM Measurement vectors
+ * (cgm_measurement.py), plus the E2E-CRC present/absent layouts and structural rejections.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class CgmMeasurementTest {
+
+    @Test
+    fun `parses the captured 249 mgdl rising vector with E2E-CRC`() {
+        val m = CgmMeasurement.parse(hex("0ec3f900f40b000074e00a00e0f1"), useCrc = true)
+        assertEquals(249.0, m.glucoseMgDl, 1e-9)
+        assertEquals(3060, m.timeOffsetMinutes)
+        assertEquals(1.16, m.trendMgDlPerMin!!, 1e-9)
+        assertEquals(10.0, m.quality!!, 1e-9)
+    }
+
+    @Test
+    fun `parses the captured 141 mgdl flat vector with E2E-CRC`() {
+        val m = CgmMeasurement.parse(hex("0ec38d00e803000010e00a00d9af"), useCrc = true)
+        assertEquals(141.0, m.glucoseMgDl, 1e-9)
+        assertEquals(1000, m.timeOffsetMinutes)
+        assertEquals(0.16, m.trendMgDlPerMin!!, 1e-9)
+    }
+
+    @Test
+    fun `parses a record without E2E-CRC when the feature flag is off`() {
+        // Same fields as the captured vector, CRC stripped and the size field adjusted to 12.
+        val m = CgmMeasurement.parse(hex("0cc3f900f40b000074e00a00"), useCrc = false)
+        assertEquals(249.0, m.glucoseMgDl, 1e-9)
+        assertEquals(1.16, m.trendMgDlPerMin!!, 1e-9)
+    }
+
+    @Test
+    fun `absent trend flag yields null trend`() {
+        // flags 0x00 -> no optional octets; size 6, glucose 100 (0x0064), offset 0.
+        val m = CgmMeasurement.parse(hex("060064000000"), useCrc = false)
+        assertEquals(100.0, m.glucoseMgDl, 1e-9)
+        assertNull(m.trendMgDlPerMin)
+        assertNull(m.quality)
+    }
+
+    @Test
+    fun `rejects a record shorter than the mandatory prefix`() {
+        assertThrows(MedtronicReadException::class.java) {
+            CgmMeasurement.parse(hex("0ec3f9"), useCrc = true)
+        }
+    }
+
+    @Test
+    fun `rejects a size field that disagrees with the buffer length`() {
+        assertThrows(MedtronicReadException::class.java) {
+            CgmMeasurement.parse(hex("0fc3f900f40b000074e00a00e0f1"), useCrc = true)
+        }
+    }
+
+    @Test
+    fun `rejects a failed E2E-CRC`() {
+        assertThrows(MedtronicReadException::class.java) {
+            CgmMeasurement.parse(hex("0ec3f900f40b000074e00a00e0f0"), useCrc = true)
+        }
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/CgmReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/CgmReaderTest.kt
@@ -1,0 +1,139 @@
+/*
+ * AC3 + AC5: end-to-end CGM read (feature-flag-driven E2E-CRC, RACP last-record, decrypt, parse to a
+ * mg/dL CgmReading with a mapped trend arrow) and the SafetyLimits rejection of an out-of-range SG.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CgmReaderTest {
+
+    private val feature = MedtronicProtocol.CGM_FEATURE_UUID
+    private val measurement = MedtronicProtocol.CGM_MEASUREMENT_UUID
+    private val racp = MedtronicProtocol.RACP_UUID
+    private val fixedNow = Instant.ofEpochSecond(1_700_000_000)
+
+    /** Append the little-endian E2E-CRC computed over [dataNoCrc] (whose size byte already includes it). */
+    private fun withCrc(dataNoCrc: ByteArray): ByteArray {
+        val crc = MedtronicCodec.e2eCrc(dataNoCrc, dataNoCrc.size)
+        return dataNoCrc + byteArrayOf((crc and 0xFF).toByte(), ((crc shr 8) and 0xFF).toByte())
+    }
+
+    private fun reader(link: FakeGattLink, two: TwoSidedSession, limits: SafetyLimits = SafetyLimits()) =
+        CgmReader(link, two.server, limits) { fixedNow }
+
+    @Test
+    fun `reads the latest SG in mg dL with a mapped trend when E2E-CRC is enabled`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[feature] = hex("009001591404") // E2E_CRC enabled
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(measurement, two.pumpEncrypt(hex("0ec3f900f40b000074e00a00e0f1")))
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.CgmReading>? = null
+        reader(link, two).readLatest { result = it }
+
+        val reading = result!!.getOrThrow()
+        assertEquals(249, reading.glucoseMgDl)
+        assertEquals(CgmTrend.FORTY_FIVE_UP, reading.trendArrow)
+        assertEquals(fixedNow, reading.timestamp)
+    }
+
+    @Test
+    fun `reads a measurement without a CRC when the feature flag is off`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[feature] = hex("910000" + "14" + "ffff") // E2E unsupported
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(measurement, two.pumpEncrypt(hex("0cc3f900f40b000074e00a00")))
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.CgmReading>? = null
+        reader(link, two).readLatest { result = it }
+
+        assertEquals(249, result!!.getOrThrow().glucoseMgDl)
+    }
+
+    @Test
+    fun `rejects an out-of-range SG rather than clamping it`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[feature] = hex("009001591404")
+        // Glucose 600 mg/dL (0x0258), no optional fields, with a valid E2E-CRC.
+        val record = withCrc(byteArrayOf(0x08, 0x00, 0x58, 0x02, 0x00, 0x00))
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(measurement, two.pumpEncrypt(record))
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.CgmReading>? = null
+        reader(link, two).readLatest { result = it }
+
+        assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull() is MedtronicReadException)
+    }
+
+    @Test
+    fun `rejects a non-finite SFLOAT glucose sentinel`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[feature] = hex("009001591404")
+        // Glucose mantissa 0x07FF (NaN sentinel), no optional fields, valid E2E-CRC.
+        val record = withCrc(byteArrayOf(0x08, 0x00, 0xFF.toByte(), 0x07, 0x00, 0x00))
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(measurement, two.pumpEncrypt(record))
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.CgmReading>? = null
+        reader(link, two).readLatest { result = it }
+
+        assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull() is MedtronicReadException)
+    }
+
+    @Test
+    fun `feature read failure surfaces without issuing an RACP request`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[feature] = hex("0090") // wrong length
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.CgmReading>? = null
+        reader(link, two).readLatest { result = it }
+
+        assertTrue(result!!.isFailure)
+        assertEquals(0, link.writes.size)
+    }
+
+    @Test
+    fun `trend rate maps onto the CgmTrend arrows`() {
+        assertEquals(CgmTrend.UNKNOWN, CgmReader.trendArrowFor(null))
+        assertEquals(CgmTrend.UNKNOWN, CgmReader.trendArrowFor(Double.NaN))
+        assertEquals(CgmTrend.UNKNOWN, CgmReader.trendArrowFor(Double.POSITIVE_INFINITY))
+        assertEquals(CgmTrend.FLAT, CgmReader.trendArrowFor(0.5))
+        assertEquals(CgmTrend.FLAT, CgmReader.trendArrowFor(-0.5))
+        assertEquals(CgmTrend.FORTY_FIVE_UP, CgmReader.trendArrowFor(1.5))
+        assertEquals(CgmTrend.SINGLE_UP, CgmReader.trendArrowFor(2.5))
+        assertEquals(CgmTrend.DOUBLE_UP, CgmReader.trendArrowFor(3.5))
+        assertEquals(CgmTrend.FORTY_FIVE_DOWN, CgmReader.trendArrowFor(-1.5))
+        assertEquals(CgmTrend.SINGLE_DOWN, CgmReader.trendArrowFor(-2.5))
+        assertEquals(CgmTrend.DOUBLE_DOWN, CgmReader.trendArrowFor(-3.5))
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/CipherDirectionConfirmationTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/CipherDirectionConfirmationTest.kt
@@ -1,0 +1,57 @@
+/*
+ * AC2: confirm the inbound-cipher binding for post-handshake pump->phone traffic.
+ *
+ * B1 left `decryptFromPump = clientCrypt` verified only against a simulated peer and flagged that
+ * PythonPumpConnector decrypts inbound pump traffic with `server_crypt` (sg_reader.py / socp.py).
+ * This test resolves the apparent conflict at the cipher level: after a server-role handshake both
+ * SeqCrypt instances share the same key and nonce and have rxSeq positioned at 2 (clientCrypt from
+ * decrypting the pump's msg5; serverCrypt from SakeServer's explicit reset). Since SeqCrypt.decrypt
+ * consumes only rxSeq, the two conventions recover identical plaintext -- so B1's binding is correct
+ * and equivalent to upstream's. Live over-the-air confirmation against a real pump is TODO(48.A2).
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.openminimed.sake.DeviceType
+import org.openminimed.sake.KeyDatabase
+import org.openminimed.sake.SakeClient
+import org.openminimed.sake.SakeServer
+import org.openminimed.sake.Session
+
+class CipherDirectionConfirmationTest {
+
+    @Test
+    fun `inbound pump traffic decrypts identically with clientCrypt and serverCrypt`() {
+        val server = SakeServer(KeyDatabase.fromBytes(hex(CUSTOM_SERVER_KEYDB_HEX)))
+        val client = SakeClient(KeyDatabase.fromBytes(hex(CUSTOM_CLIENT_KEYDB_HEX)), DeviceType.INSULIN_PUMP)
+
+        val msg0 = server.handshake(ByteArray(Session.MESSAGE_SIZE))
+        val msg1 = client.handshake(msg0)
+        val msg2 = server.handshake(msg1)
+        val msg3 = client.handshake(msg2)
+        val msg4 = server.handshake(msg3)
+        val msg5 = client.handshake(msg4)
+        assertNull(server.handshake(msg5))
+
+        // The crux of the equivalence: both inbound ciphers are positioned at the same sequence.
+        assertEquals(2L, server.session().clientCrypt().rxSeq)
+        assertEquals(2L, server.session().serverCrypt().rxSeq)
+
+        val payload = "from-pump-record".toByteArray()
+        val frame = client.session().clientCrypt().encrypt(payload)
+
+        // B1 (clientCrypt) and PythonPumpConnector (server_crypt) recover the same plaintext.
+        assertArrayEquals(payload, server.session().clientCrypt().decrypt(frame.copyOf()))
+        assertArrayEquals(payload, server.session().serverCrypt().decrypt(frame.copyOf()))
+    }
+
+    @Test
+    fun `wrapper decryptFromPump recovers a genuinely pump-encrypted frame`() {
+        val two = TwoSidedSession()
+        val payload = "sg-record".toByteArray()
+        assertArrayEquals(payload, two.server.decryptFromPump(two.pumpEncrypt(payload)))
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/DeviceInfoReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/DeviceInfoReaderTest.kt
@@ -1,0 +1,33 @@
+/*
+ * AC4: Device Information Service reads (plain SIG strings, not SAKE-encrypted) into a
+ * MedtronicDeviceInfo, including trailing-NUL trimming and the hex System ID.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeviceInfoReaderTest {
+
+    @Test
+    fun `reads device information strings and the system id`() {
+        val link = FakeGattLink()
+        link.reads[MedtronicProtocol.MODEL_NUMBER_UUID] = "MMT-1880".toByteArray()
+        // A NUL-terminated value, as some firmware reports DIS strings.
+        link.reads[MedtronicProtocol.SERIAL_NUMBER_UUID] = "NG1234567H".toByteArray() + 0x00
+        link.reads[MedtronicProtocol.HARDWARE_REVISION_UUID] = "1.0".toByteArray()
+        link.reads[MedtronicProtocol.FIRMWARE_REVISION_UUID] = "8.0.1".toByteArray()
+        link.reads[MedtronicProtocol.SOFTWARE_REVISION_UUID] = "BLE 4.2".toByteArray()
+        link.reads[MedtronicProtocol.SYSTEM_ID_UUID] = byteArrayOf(0x01, 0x02, 0x03, 0xAB.toByte())
+
+        val info = DeviceInfoReader(link).read()
+
+        assertEquals("MMT-1880", info.modelNumber)
+        assertEquals("NG1234567H", info.serialNumber)
+        assertEquals("1.0", info.hardwareRevision)
+        assertEquals("8.0.1", info.firmwareRevision)
+        assertEquals("BLE 4.2", info.softwareRevision)
+        assertEquals("010203ab", info.systemId)
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicCodecTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicCodecTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Tests for MedtronicCodec: little-endian decode, IEEE-11073 SFLOAT (medfloat16), and the E2E-CRC.
+ * Expected values are cross-checked against OpenMinimed value_converter.py / parse_utils.py.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MedtronicCodecTest {
+
+    @Test
+    fun `little-endian decode`() {
+        assertEquals(0x1234, MedtronicCodec.readUIntLe(byteArrayOf(0x34, 0x12), 0, 2))
+        assertEquals(0x00F9, MedtronicCodec.readUIntLe(byteArrayOf(0xF9.toByte(), 0x00), 0, 2))
+        assertEquals(0x019000, MedtronicCodec.readUIntLe(byteArrayOf(0x00, 0x90.toByte(), 0x01), 0, 3))
+    }
+
+    @Test
+    fun `medfloat16 integer glucose has exponent zero`() {
+        assertEquals(249.0, MedtronicCodec.decodeMedFloat16(0x00F9), 1e-9)
+    }
+
+    @Test
+    fun `medfloat16 trend uses a negative exponent`() {
+        // 0xe074: exponent nibble 0xe -> -2, mantissa 0x074 = 116 -> 1.16 mg/dL/min.
+        assertEquals(1.16, MedtronicCodec.decodeMedFloat16(0xE074), 1e-9)
+        // 0xe010: exponent -2, mantissa 16 -> 0.16 mg/dL/min.
+        assertEquals(0.16, MedtronicCodec.decodeMedFloat16(0xE010), 1e-9)
+    }
+
+    @Test
+    fun `medfloat16 sign-extends a negative mantissa`() {
+        // 0x0f9c: exponent 0, mantissa 0xf9c has bit 11 set -> 3996 - 4096 = -100.
+        assertEquals(-100.0, MedtronicCodec.decodeMedFloat16(0x0F9C), 1e-9)
+    }
+
+    @Test
+    fun `medfloat16 reserved codes decode to non-finite sentinels`() {
+        assertTrue(MedtronicCodec.decodeMedFloat16(0x07FF).isNaN()) // NaN
+        assertTrue(MedtronicCodec.decodeMedFloat16(0x0800).isNaN()) // NRes
+        assertTrue(MedtronicCodec.decodeMedFloat16(0x0801).isNaN()) // Reserved
+        assertEquals(Double.POSITIVE_INFINITY, MedtronicCodec.decodeMedFloat16(0x07FE), 0.0)
+        assertEquals(Double.NEGATIVE_INFINITY, MedtronicCodec.decodeMedFloat16(0x0802), 0.0)
+    }
+
+    @Test
+    fun `e2e crc validates an upstream-captured packet`() {
+        // value_converter.py __main__ asserts check_crc(...) is true for this vector.
+        assertTrue(MedtronicCodec.checkE2eCrc(hex("ea07031c0a1f2a80ff0873")))
+    }
+
+    @Test
+    fun `e2e crc validates the captured CGM measurement vector`() {
+        assertTrue(MedtronicCodec.checkE2eCrc(hex("0ec3f900f40b000074e00a00e0f1")))
+    }
+
+    @Test
+    fun `e2e crc rejects a corrupted packet`() {
+        val tampered = hex("0ec3f900f40b000074e00a00e0f1").also { it[2] = (it[2] + 1).toByte() }
+        assertFalse(MedtronicCodec.checkE2eCrc(tampered))
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
@@ -1,0 +1,145 @@
+/*
+ * AC1: the session-read framework subscribes, reassembles fragmented notifications via PduFramer,
+ * decrypts pump->phone payloads with the live SAKE session, and orchestrates the RACP/SOCP
+ * request -> notify -> response pattern. Driven by a fake link + frames minted by a real two-sided
+ * SAKE handshake (the pump role's client_crypt), so the decrypt path is genuinely exercised.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.protocol.PduFramer
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MedtronicSessionReaderTest {
+
+    private val dataChar = MedtronicProtocol.CGM_MEASUREMENT_UUID
+    private val racp = MedtronicProtocol.RACP_UUID
+    private val socp = MedtronicProtocol.CGM_SOCP_UUID
+
+    @Test
+    fun `reportLastRecord decrypts the measurement and completes on the RACP success response`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        val record = hex("0ec3f900f40b000074e00a00e0f1")
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.contentEquals(MedtronicSessionReader.RACP_REPORT_LAST_RECORD)) {
+                emit(dataChar, two.pumpEncrypt(record))
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<ByteArray>? = null
+        MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { result = it }
+
+        assertNotNull(result)
+        assertTrue(result!!.isSuccess)
+        assertArrayEquals(record, result!!.getOrNull())
+        // Subscriptions are released once the exchange finishes.
+        assertFalse(link.isSubscribed(dataChar))
+        assertFalse(link.isSubscribed(racp))
+    }
+
+    @Test
+    fun `reportLastRecord reassembles a fragmented measurement before decrypting`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        // A record large enough that its encrypted form exceeds one 20-byte PDU and must reassemble.
+        val record = ByteArray(25) { it.toByte() }
+        val encrypted = two.pumpEncrypt(record)
+        val pdus = PduFramer.fragment(encrypted)
+        assertTrue("expected fragmentation", pdus.size > 1)
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                pdus.forEach { emit(dataChar, it) }
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<ByteArray>? = null
+        MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { result = it }
+
+        assertArrayEquals(record, result!!.getOrThrow())
+    }
+
+    @Test
+    fun `reportLastRecord fails on an unsuccessful RACP response`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(dataChar, two.pumpEncrypt(hex("0ec3f900f40b000074e00a00e0f1")))
+                // Response Code / Null / req 0x01 / 0x06 (procedure not completed) -> not success.
+                emit(racp, byteArrayOf(0x06, 0x00, 0x01, 0x06))
+            }
+        }
+
+        var result: Result<ByteArray>? = null
+        MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { result = it }
+
+        assertTrue(result!!.isFailure)
+    }
+
+    @Test
+    fun `reportLastRecord fails when the measurement does not authenticate`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        val tampered = two.pumpEncrypt(hex("0ec3f900f40b000074e00a00e0f1")).also { it[0] = (it[0] + 1).toByte() }
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(dataChar, tampered)
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<ByteArray>? = null
+        MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { result = it }
+
+        assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull() is MedtronicReadException)
+    }
+
+    @Test
+    fun `reportLastRecord fails when a peer streams full PDUs past the frame cap`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                // Stream full-size PDUs with no short terminator past MAX_FRAME_SIZE (512).
+                repeat(30) { emit(dataChar, ByteArray(PduFramer.MAX_PDU_SIZE) { 0x41 }) }
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<ByteArray>? = null
+        MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { result = it }
+
+        assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull() is MedtronicReadException)
+    }
+
+    @Test
+    fun `socpGet encrypts the request and decrypts the response`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        val request = byteArrayOf(0x90.toByte()) // GET_SENSOR_DETAILS opcode
+        val responsePlain = hex("91071d00ffff60273420") // SENSOR_DETAILS_RESPONSE (sensor_details.py)
+        link.onWrite = { characteristic, value ->
+            if (characteristic == socp) {
+                // The request crossed the link encrypted, not in the clear.
+                assertFalse(value.contentEquals(request))
+                emit(socp, two.pumpEncrypt(responsePlain))
+            }
+        }
+
+        var result: Result<ByteArray>? = null
+        MedtronicSessionReader(link, two.server).socpGet(socp, request) { result = it }
+
+        assertArrayEquals(responsePlain, result!!.getOrThrow())
+        assertEquals(1, link.writes.size)
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
@@ -123,6 +123,45 @@ class MedtronicSessionReaderTest {
     }
 
     @Test
+    fun `socpGet ignores a notification delivered after the exchange finished`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        val results = mutableListOf<Result<ByteArray>>()
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == socp) emit(socp, two.pumpEncrypt(hex("9100")))
+        }
+
+        MedtronicSessionReader(link, two.server).socpGet(socp, byteArrayOf(0x90.toByte())) { results.add(it) }
+        assertEquals(1, results.size)
+        assertArrayEquals(hex("9100"), results[0].getOrThrow())
+
+        // A duplicate/late notification still in flight when the reader unsubscribed must be dropped:
+        // the post-finish guard stops a second decryptFromPump that would consume a sequence slot.
+        link.emitInFlight(socp, two.pumpEncrypt(hex("dead")))
+        assertEquals(1, results.size)
+    }
+
+    @Test
+    fun `reportLastRecord ignores a measurement delivered after the exchange finished`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        val results = mutableListOf<Result<ByteArray>>()
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(dataChar, two.pumpEncrypt(hex("0ec3f900f40b000074e00a00e0f1")))
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { results.add(it) }
+        assertEquals(1, results.size)
+        assertTrue(results[0].isSuccess)
+
+        link.emitInFlight(dataChar, two.pumpEncrypt(hex("0ec38d00e803000010e00a00d9af")))
+        assertEquals(1, results.size)
+    }
+
+    @Test
     fun `socpGet encrypts the request and decrypts the response`() {
         val two = TwoSidedSession()
         val link = FakeGattLink()

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
@@ -26,6 +26,9 @@ internal class FakeGattLink : MedtronicGattLink {
     val reads = mutableMapOf<UUID, ByteArray>()
     val writes = mutableListOf<Pair<UUID, ByteArray>>()
     private val handlers = mutableMapOf<UUID, (ByteArray) -> Unit>()
+    // The last handler ever registered per characteristic, retained across unsubscribe so a test can
+    // simulate a BLE notification already in flight when the reader unsubscribes (see [emitInFlight]).
+    private val retained = mutableMapOf<UUID, (ByteArray) -> Unit>()
 
     /** Invoked on every [write]; the receiver scripts notifications via [emit]. */
     var onWrite: (FakeGattLink.(characteristic: UUID, value: ByteArray) -> Unit)? = null
@@ -40,6 +43,7 @@ internal class FakeGattLink : MedtronicGattLink {
 
     override fun subscribe(characteristic: UUID, onPdu: (ByteArray) -> Unit) {
         handlers[characteristic] = onPdu
+        retained[characteristic] = onPdu
     }
 
     override fun unsubscribe(characteristic: UUID) {
@@ -49,6 +53,15 @@ internal class FakeGattLink : MedtronicGattLink {
     /** Deliver one inbound PDU to whatever handler is currently subscribed on [characteristic]. */
     fun emit(characteristic: UUID, pdu: ByteArray) {
         handlers[characteristic]?.invoke(pdu)
+    }
+
+    /**
+     * Deliver a PDU to the last-registered handler even after the reader has unsubscribed, simulating
+     * a BLE notification that was already in flight when the exchange finished. Used to exercise the
+     * reader's post-finish guard.
+     */
+    fun emitInFlight(characteristic: UUID, pdu: ByteArray) {
+        retained[characteristic]?.invoke(pdu)
     }
 
     fun isSubscribed(characteristic: UUID): Boolean = handlers.containsKey(characteristic)

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
@@ -1,0 +1,98 @@
+/*
+ * Shared test doubles and SAKE vectors for the Medtronic 700-series read-layer unit tests.
+ *
+ * The SAKE key databases are the same shared, published-upstream OpenMinimed protocol constants the
+ * B1/B2 suites use -- a synthetic matched key-DB pair, not session secrets and not unique per device
+ * (medtronic-ble-reverse-engineering.md Sec. 12). Driving a real two-sided JavaSake handshake here
+ * lets the reader tests decrypt genuinely pump-encrypted frames (the pump role uses its client_crypt),
+ * which is a stronger, protocol-faithful stand-in than a hand-mocked cipher while a captured live
+ * session frame is unavailable offline (TODO(48.A2)).
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import java.util.UUID
+import org.openminimed.sake.DeviceType
+import org.openminimed.sake.KeyDatabase
+import org.openminimed.sake.SakeClient
+import org.openminimed.sake.Session
+
+/**
+ * In-memory [MedtronicGattLink]. [reads] stubs static characteristic values; [subscribe] records a
+ * per-characteristic notification handler; [write] records the write and runs [onWrite] so a test
+ * can script the pump's notification/response in reaction to a control-point request.
+ */
+internal class FakeGattLink : MedtronicGattLink {
+    val reads = mutableMapOf<UUID, ByteArray>()
+    val writes = mutableListOf<Pair<UUID, ByteArray>>()
+    private val handlers = mutableMapOf<UUID, (ByteArray) -> Unit>()
+
+    /** Invoked on every [write]; the receiver scripts notifications via [emit]. */
+    var onWrite: (FakeGattLink.(characteristic: UUID, value: ByteArray) -> Unit)? = null
+
+    override fun read(characteristic: UUID): ByteArray =
+        reads[characteristic] ?: throw MedtronicReadException("no read stub for $characteristic")
+
+    override fun write(characteristic: UUID, value: ByteArray) {
+        writes.add(characteristic to value)
+        onWrite?.invoke(this, characteristic, value)
+    }
+
+    override fun subscribe(characteristic: UUID, onPdu: (ByteArray) -> Unit) {
+        handlers[characteristic] = onPdu
+    }
+
+    override fun unsubscribe(characteristic: UUID) {
+        handlers.remove(characteristic)
+    }
+
+    /** Deliver one inbound PDU to whatever handler is currently subscribed on [characteristic]. */
+    fun emit(characteristic: UUID, pdu: ByteArray) {
+        handlers[characteristic]?.invoke(pdu)
+    }
+
+    fun isSubscribed(characteristic: UUID): Boolean = handlers.containsKey(characteristic)
+}
+
+/**
+ * A completed two-sided SAKE session: [server] is the phone-side wrapper the readers consume;
+ * [pumpEncrypt] produces a frame the pump (client role) would send, so a test can feed a genuinely
+ * encrypted payload through [MedtronicSakeSession.decryptFromPump].
+ *
+ * Encrypt frames in the same order they are delivered to the server so the per-direction sequence
+ * counters stay aligned (the pump's client_crypt tx and the server's inbound rx both step 2,4,6,...).
+ */
+internal class TwoSidedSession {
+    val server = MedtronicSakeSession(KeyDatabase.fromBytes(hex(CUSTOM_SERVER_KEYDB_HEX)))
+    private val client = SakeClient(KeyDatabase.fromBytes(hex(CUSTOM_CLIENT_KEYDB_HEX)), DeviceType.INSULIN_PUMP)
+
+    init {
+        val msg0 = server.onPumpWrite(ByteArray(Session.MESSAGE_SIZE))
+        val msg1 = client.handshake(msg0)
+        val msg2 = server.onPumpWrite(msg1)
+        val msg3 = client.handshake(msg2)
+        val msg4 = server.onPumpWrite(msg3)
+        val msg5 = client.handshake(msg4)
+        check(server.onPumpWrite(msg5) == null) { "handshake did not complete" }
+    }
+
+    /** Encrypt [plaintext] as the pump (client role) would, for the server to decrypt as inbound traffic. */
+    fun pumpEncrypt(plaintext: ByteArray): ByteArray = client.session().clientCrypt().encrypt(plaintext)
+}
+
+internal fun hex(s: String): ByteArray {
+    require(s.length % 2 == 0) { "Hex string has odd length" }
+    return ByteArray(s.length / 2) { i -> s.substring(2 * i, 2 * i + 2).toInt(16).toByte() }
+}
+
+/** Server-side (MOBILE_APPLICATION) half of the matched synthetic two-sided test pair. */
+internal const val CUSTOM_SERVER_KEYDB_HEX =
+    "b079cdc504010144455249564154494f4e5f5f5f4b4559484e4453484b455f41" +
+        "5554485f4b455950484f4e455f5045524d49545f454e4350484f4e455f5045" +
+        "524d49545f4d4143ad14ad2780437db892d5650567d491b9"
+
+/** Client-side (INSULIN_PUMP) half of the matched synthetic two-sided test pair. */
+internal const val CUSTOM_CLIENT_KEYDB_HEX =
+    "db8c1f2801010444455249564154494f4e5f5f5f4b4559484e4453484b455f41" +
+        "5554485f4b455950554d505f5045524d49545f454e435250554d505f504552" +
+        "4d49545f434d4143f2f8dbbb51563d4fa98fdaff0042a432"


### PR DESCRIPTION
## Summary

Adds the post-handshake **session-read framework** for the read-only Medtronic MiniMed 700-series driver, plus the first concrete readers, consuming the live SAKE session held by the connection manager. No physical pump is required — the decrypt→parse path is proven against captured/synthesized frames. Over-the-air confirmation rides with later offline-spike follow-up work; nothing here is claimed live-verified.

This builds directly on the landed peripheral connection manager (#697) and the SAKE/protocol module (#694).

## What's included

- **`MedtronicSessionReader`** — transport-agnostic read layer over the SAKE session: subscribe to a characteristic, reassemble fragmented notifications (`PduFramer`), decrypt pump→phone payloads, and orchestrate the RACP/SOCP request→notify→response pattern. **Read-only**: only report/get-class opcodes are ever written — no control or calibration opcode.
- **`MedtronicGattLink`** — the GATT transport seam (the on-device `BluetoothGatt`-client wiring lands in a follow-up).
- **`CgmReader` → `CgmReading`** — sensor glucose in **mg/dL** with a mapped trend arrow. E2E-CRC presence is read from the CGM Feature characteristic **per pump** (bit 12), not hard-coded for one model.
- **`DeviceInfoReader` → `MedtronicDeviceInfo`** and **`BatteryReader` → `BatteryStatus`** over the standard SIG services (plain reads).
- **`MedtronicCodec`** — IEEE-11073 SFLOAT decode (incl. reserved-sentinel handling), little-endian helpers, and the E2E-CRC, ported from the upstream parsers.
- Every parsed value is **rejected (never clamped)** when out of physiological range or non-finite.

## Inbound-cipher confirmation

The reader/codec parsers are ported from the OpenMinimed `PythonPumpConnector` reference (GPL-3.0, used with permission), with in-source attribution headers on each ported file. The inbound decrypt binding (`clientCrypt`) left simulated-peer-verified previously is confirmed here against the upstream `server_crypt` convention: after a server handshake both ciphers share the same key/nonce and an `rxSeq` of 2, so they decrypt pump traffic byte-identically. A two-sided-handshake test locks this equivalence.

## Testing

- 36 new unit tests across the read layer (module total 145, all green): codec/SFLOAT/E2E-CRC, CGM measurement + feature parsing against captured vectors, the cipher-direction equivalence, RACP/SOCP orchestration with reassembly, safety-limit rejection, and the device-info/battery readers.
- `:medtronic-pump-driver:testDebugUnitTest`, `:lintDebug`, and `:assembleDebug` all pass.

## Out of scope (follow-ups)

- Insulin-delivery status (reservoir/IOB/basal) + history/event-log readers.
- Capability delegates, the device plugin, Hilt registration, and the `:app` dependency (which wire the on-device `MedtronicGattLink` and add the per-operation timeout the framework documents as a caller contract).
- Polling, persistence, backend push, and dashboard UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Medtronic 700-series BLE read support: CGM measurement parsing with trend mapping, safety-limit enforcement, E2E-CRC handling, and session/read protocols.
  * Added battery level reading and device information retrieval (model, serial, hardware/firmware/software revisions, system ID).

* **Tests**
  * Added extensive unit and integration tests covering codec, parsing, session exchanges, battery, device info, and encryption/decryption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->