### PR TITLE
feat(medtronic): IDD status + history/RACP read-only readers

### DIFF
--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
@@ -1,0 +1,600 @@
+/*
+ * IDD history event-log parser for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * Ported to Kotlin from OpenMinimed PythonPumpConnector `history_data.py` (HistoryData and its event
+ * data classes) and `history_reader.py` (HistoryReader record framing), https://github.com/OpenMinimed,
+ * GPL-3.0, used with the author's permission. Copyright (C) OpenMinimed contributors: palmarci
+ * (Pal Marci), drfubar, Morten Fyhn Amundsen, Stenium; original medtronic-bt-decrypt PoC by
+ * @planiitis. GlycemicGPT is itself GPL-3.0, so this is redistributed under the same license.
+ *
+ * READ-ONLY: this parses records the pump reports; it never constructs a write/control message. See
+ * medtronic-ble-reverse-engineering.md Sec. 8.
+ */
+package com.glycemicgpt.mobile.ble.messages
+
+import com.glycemicgpt.mobile.ble.read.MedtronicCodec
+import com.glycemicgpt.mobile.ble.read.MedtronicReadException
+import com.glycemicgpt.mobile.ble.read.stripIddE2e
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import com.glycemicgpt.mobile.domain.model.PumpActivityMode
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.Base64
+import kotlin.math.roundToInt
+import timber.log.Timber
+
+/** Medtronic IDD history event types (`history_data.py` HistoryEventType). */
+enum class MedtronicHistoryEventType(val id: Int) {
+    REFERENCE_TIME(0x000F),
+    BOLUS_PROGRAMMED_P1(0x005A),
+    BOLUS_PROGRAMMED_P2(0x0066),
+    BOLUS_DELIVERED_P1(0x0069),
+    BOLUS_DELIVERED_P2(0x0096),
+    DELIVERED_BASAL_RATE_CHANGED(0x0099),
+    MAX_BOLUS_AMOUNT_CHANGED(0x03FC),
+    AUTO_BASAL_DELIVERY(0xF001),
+    CL1_TRANSITION(0xF002),
+    THERAPY_CONTEXT(0xF004),
+    MEAL(0xF005),
+    BG_READING(0xF007),
+    CALIBRATION_COMPLETE(0xF008),
+    CALIBRATION_REJECTED(0xF009),
+    INSULIN_DELIVERY_STOPPED(0xF00A),
+    INSULIN_DELIVERY_RESTARTED(0xF00B),
+    SG_MEASUREMENT(0xF00C),
+    CGM_ANALYTICS_DATA_BACKFILL(0xF00D),
+    NGP_REFERENCE_TIME(0xF00E),
+    ANNUNCIATION_CLEARED(0xF00F),
+    ANNUNCIATION_CONSOLIDATED(0xF010),
+    MAX_AUTO_BASAL_RATE_CHANGED(0xF01A),
+    UNDEFINED(0xFFFF),
+    ;
+
+    companion object {
+        fun from(id: Int): MedtronicHistoryEventType = entries.firstOrNull { it.id == id } ?: UNDEFINED
+    }
+}
+
+/** Bolus delivery activation (`history_data.py` BolusActivationType). COMMANDED = closed-loop/SmartGuard. */
+enum class BolusActivationType(val raw: Int) {
+    UNDETERMINED(0x0F),
+    MANUAL(0x33),
+    RECOMMENDED(0x3C),
+    MANUALLY_CHANGED_RECOMMENDED(0x55),
+    COMMANDED(0x5A),
+    UNKNOWN(-1),
+    ;
+
+    companion object {
+        fun from(raw: Int): BolusActivationType = entries.firstOrNull { it.raw == raw } ?: UNKNOWN
+    }
+}
+
+/** Basal delivery context inside a history record (`history_data.py` BasalDeliveryContext). */
+enum class HistoryBasalDeliveryContext(val raw: Int) {
+    UNDETERMINED(0x0F),
+    DEVICE_BASED(0x33),
+    REMOTE_CONTROL(0x3C),
+    ARTIFICIAL_PANCREAS_CONTROLLER(0x55),
+    UNKNOWN(-1),
+    ;
+
+    companion object {
+        fun from(raw: Int): HistoryBasalDeliveryContext = entries.firstOrNull { it.raw == raw } ?: UNKNOWN
+    }
+}
+
+/** Typed event payload of a history record. [Unparsed] preserves any type we do not decode. */
+sealed interface MedtronicHistoryEvent {
+    /** Bolus programmed or delivered, part 1: amounts. [delivered] distinguishes delivered vs programmed. */
+    data class BolusAmounts(
+        val delivered: Boolean,
+        val bolusId: Int,
+        val fastIu: Double,
+        val extendedIu: Double,
+        val durationMin: Int,
+    ) : MedtronicHistoryEvent
+
+    /** Bolus programmed, part 2: delivery-reason flags (correction/meal) + activation type. */
+    data class BolusProgrammedDetail(
+        val isCorrection: Boolean,
+        val isMeal: Boolean,
+        val activationType: BolusActivationType?,
+    ) : MedtronicHistoryEvent
+
+    /** Bolus delivered, part 2: activation type (automated detection). */
+    data class BolusDeliveredDetail(
+        val activationType: BolusActivationType?,
+    ) : MedtronicHistoryEvent
+
+    /** A basal rate change; [context] = AP_CONTROLLER means SmartGuard drove it. */
+    data class BasalRateChanged(
+        val oldRateIuPerHour: Double,
+        val newRateIuPerHour: Double,
+        val context: HistoryBasalDeliveryContext?,
+    ) : MedtronicHistoryEvent
+
+    /** SmartGuard auto-basal micro-bolus -- see the mapping caveat in [extractBolusesFromHistoryLogs]. */
+    data class AutoBasalMicroBolus(val bolusNumber: Int, val amountIu: Double) : MedtronicHistoryEvent
+
+    /** Sensor glucose measurement; [sgValueRaw] may be a sentinel (see [SG_SENTINELS]). */
+    data class SgMeasurement(val timeOffsetMin: Int, val sgValueRaw: Int) : MedtronicHistoryEvent
+
+    /** Fingerstick BG reading / calibration BG, in mg/dL. */
+    data class BgReading(val mgDl: Double, val calibration: Boolean, val accepted: Boolean) :
+        MedtronicHistoryEvent
+
+    /** Insulin delivery stopped (suspend) or restarted (resume); [reason] is the raw reason code. */
+    data class InsulinDelivery(val stopped: Boolean, val reason: Int) : MedtronicHistoryEvent
+
+    /**
+     * Pump annunciation: alarms, alerts, and cartridge/battery events (low reservoir, low battery, ...).
+     *
+     * Two encodings share this type, distinguished by [statusRaw]:
+     * - **Consolidated** (`ANNUNCIATION_CONSOLIDATED`): [annunciationType] is the `& 0x0FFF`-masked
+     *   type, [statusRaw] is the pump annunciation status, [timestamp] is set.
+     * - **Cleared** (`ANNUNCIATION_CLEARED`): [annunciationType] is the raw 16-bit fault type,
+     *   [statusRaw] is [CLEARED_NO_STATUS] (a cleared event carries no status), [timestamp] is null.
+     */
+    data class Annunciation(
+        val annunciationType: Int,
+        val statusRaw: Int,
+        val timestamp: Instant?,
+    ) : MedtronicHistoryEvent {
+        /** True when this is a "cleared" annunciation (raw fault type, no status, no timestamp). */
+        val cleared: Boolean get() = statusRaw == CLEARED_NO_STATUS
+
+        companion object {
+            /** [statusRaw] sentinel marking a cleared annunciation that carries no status field. */
+            const val CLEARED_NO_STATUS = -1
+        }
+    }
+
+    /** NGP reference time anchoring the relative offsets of following records to wall-clock time. */
+    data class ReferenceTime(val time: Instant?) : MedtronicHistoryEvent
+
+    /** Any event type not individually decoded; the raw bytes are still preserved on the record. */
+    object Unparsed : MedtronicHistoryEvent
+}
+
+/**
+ * A parsed history record: its sequence number, type, relative offset, and typed [event] payload.
+ * The raw bytes are preserved separately as a [HistoryLogRecord] for dedup/backfill (see
+ * [toHistoryLogRecord]).
+ */
+data class MedtronicHistoryRecord(
+    val sequenceNumber: Int,
+    val eventType: MedtronicHistoryEventType,
+    val relativeOffsetSeconds: Int,
+    val event: MedtronicHistoryEvent,
+)
+
+/**
+ * Parses Medtronic IDD history-data records (decrypted by the C1 framework) into typed events and the
+ * shared [HistoryLogRecord] raw-preservation shape, and extracts CGM / bolus / basal domain models.
+ *
+ * **Record framing & timestamps.** Each record's header is `event_type(u16) seq(u32) offset(u16)`
+ * followed by the event body, optionally wrapped in the Medtronic E2E trailer. Records carry only a
+ * relative offset; absolute time is resolved against the most recent [MedtronicHistoryEventType.NGP_REFERENCE_TIME]
+ * record (interpreted as UTC -- timezone handling is a Milestone D concern). Events before any
+ * reference are dropped (and counted) rather than mis-timestamped. Over-the-air behavior rides with
+ * 48.A2; nothing here is claimed live-verified.
+ */
+object MedtronicHistoryParser {
+
+    /** Header: event_type(2) + sequence(4) + relative_offset(2). */
+    private const val HEADER_SIZE = 8
+
+    /** Sensor-glucose sentinel values that are not real mg/dL (`SGMeasurementData.__str__`). */
+    val SG_SENTINELS = setOf(0x0301, 0x0303, 0x030D)
+
+    private const val ANNUNCIATION_TYPE_TAG = 0xF000
+
+    /** Pump annunciation timestamps are seconds since 2000-01-01T00:00:00Z. */
+    private val MEDTRONIC_EPOCH_2000: Instant = Instant.parse("2000-01-01T00:00:00Z")
+
+    // -- Raw preservation ---------------------------------------------------
+
+    /**
+     * Convert a decrypted raw history record into the shared [HistoryLogRecord] (raw bytes base64'd,
+     * mirroring Tandem's `RawHistoryLog`) for dedup/backfill, or `null` if it is too short to carry a
+     * header. [pumpTimeSeconds] holds the record's raw relative offset in seconds (the pump emits no
+     * absolute per-record time; absolute resolution via the reference-time event is done at extraction).
+     */
+    fun toHistoryLogRecord(raw: ByteArray, useE2e: Boolean): HistoryLogRecord? {
+        val body =
+            try {
+                stripIddE2e(raw, useE2e)
+            } catch (e: MedtronicReadException) {
+                Timber.w(e, "Dropping history record with bad E2E trailer")
+                return null
+            }
+        if (body.size < HEADER_SIZE) {
+            Timber.w("Dropping history record shorter than header: %d bytes", body.size)
+            return null
+        }
+        val eventTypeId = MedtronicCodec.readUIntLe(body, 0, 2)
+        val sequence = MedtronicCodec.readULongLe(body, 2, 4)
+        val relativeOffset = MedtronicCodec.readUIntLe(body, 6, 2)
+        // HistoryLogRecord.sequenceNumber is a signed Int by platform convention (PumpModels.kt notes
+        // current pump sequence values are ~1.3M, well inside Int range). Preserve the E2E-stripped
+        // body, not the wrapped frame, so the base64 round-trips back to the bytes the parser expects.
+        return HistoryLogRecord(
+            sequenceNumber = sequence.toInt(),
+            rawBytesB64 = Base64.getEncoder().encodeToString(body),
+            eventTypeId = eventTypeId,
+            pumpTimeSeconds = relativeOffset.toLong(),
+        )
+    }
+
+    /** Distinct records by sequence number (keeping the first seen), for paged-read dedup/backfill. */
+    fun dedupBySequence(records: List<HistoryLogRecord>): List<HistoryLogRecord> =
+        records.distinctBy { it.sequenceNumber }
+
+    // -- Typed record parsing -----------------------------------------------
+
+    /**
+     * Parse one decrypted history record body (already E2E-stripped; pass the [HistoryLogRecord.rawBytesB64]
+     * bytes) into a [MedtronicHistoryRecord], or `null` if the header is malformed. An event body that
+     * cannot be decoded is preserved as [MedtronicHistoryEvent.Unparsed] rather than dropping the record.
+     */
+    fun parseRecordBody(body: ByteArray): MedtronicHistoryRecord? {
+        if (body.size < HEADER_SIZE) return null
+        val eventTypeId = MedtronicCodec.readUIntLe(body, 0, 2)
+        val sequence = MedtronicCodec.readULongLe(body, 2, 4).toInt()
+        val relativeOffset = MedtronicCodec.readUIntLe(body, 6, 2)
+        val type = MedtronicHistoryEventType.from(eventTypeId)
+        val payload = body.copyOfRange(HEADER_SIZE, body.size)
+        // Narrow to the decode failures the per-type parsers actually raise (require -> IAE; field/CRC
+        // checks -> MedtronicReadException). A broader catch would mask programming errors as bad data.
+        val event =
+            try {
+                parseEvent(type, payload)
+            } catch (e: MedtronicReadException) {
+                Timber.w(e, "Unparseable %s event body; preserving raw", type)
+                MedtronicHistoryEvent.Unparsed
+            } catch (e: IllegalArgumentException) {
+                Timber.w(e, "Unparseable %s event body; preserving raw", type)
+                MedtronicHistoryEvent.Unparsed
+            }
+        return MedtronicHistoryRecord(sequence, type, relativeOffset, event)
+    }
+
+    private fun parseEvent(type: MedtronicHistoryEventType, p: ByteArray): MedtronicHistoryEvent =
+        when (type) {
+            MedtronicHistoryEventType.BOLUS_PROGRAMMED_P1 -> bolusAmounts(p, delivered = false)
+            MedtronicHistoryEventType.BOLUS_DELIVERED_P1 -> bolusAmounts(p, delivered = true)
+            MedtronicHistoryEventType.BOLUS_PROGRAMMED_P2 -> bolusProgrammedDetail(p)
+            MedtronicHistoryEventType.BOLUS_DELIVERED_P2 -> bolusDeliveredDetail(p)
+            MedtronicHistoryEventType.DELIVERED_BASAL_RATE_CHANGED -> basalRateChanged(p)
+            MedtronicHistoryEventType.AUTO_BASAL_DELIVERY -> autoBasalMicroBolus(p)
+            MedtronicHistoryEventType.SG_MEASUREMENT -> sgMeasurement(p)
+            MedtronicHistoryEventType.BG_READING -> bgReading(p, calibration = false, accepted = true)
+            MedtronicHistoryEventType.CALIBRATION_COMPLETE -> bgReading(p, calibration = true, accepted = true)
+            MedtronicHistoryEventType.CALIBRATION_REJECTED -> bgReading(p, calibration = true, accepted = false)
+            MedtronicHistoryEventType.INSULIN_DELIVERY_STOPPED -> insulinDelivery(p, stopped = true)
+            MedtronicHistoryEventType.INSULIN_DELIVERY_RESTARTED -> insulinDelivery(p, stopped = false)
+            MedtronicHistoryEventType.ANNUNCIATION_CONSOLIDATED -> annunciation(p)
+            MedtronicHistoryEventType.ANNUNCIATION_CLEARED -> annunciationCleared(p)
+            MedtronicHistoryEventType.NGP_REFERENCE_TIME -> referenceTime(p)
+            else -> MedtronicHistoryEvent.Unparsed
+        }
+
+    private fun bolusAmounts(p: ByteArray, delivered: Boolean): MedtronicHistoryEvent {
+        // bolus_id(2) type(1) fast f32(4) extended f32(4) duration(2)
+        require(p.size >= 13) { "bolus amounts body too short: ${p.size}" }
+        return MedtronicHistoryEvent.BolusAmounts(
+            delivered = delivered,
+            bolusId = MedtronicCodec.readUIntLe(p, 0, 2),
+            fastIu = MedtronicCodec.decodeMedFloat32(MedtronicCodec.readULongLe(p, 3, 4)),
+            extendedIu = MedtronicCodec.decodeMedFloat32(MedtronicCodec.readULongLe(p, 7, 4)),
+            durationMin = MedtronicCodec.readUIntLe(p, 11, 2),
+        )
+    }
+
+    private fun bolusProgrammedDetail(p: ByteArray): MedtronicHistoryEvent {
+        require(p.isNotEmpty()) { "bolus programmed P2 body empty" }
+        val flags = MedtronicCodec.readUIntLe(p, 0, 1)
+        var offset = 1
+        fun consume(n: Int): Int {
+            require(offset + n <= p.size) { "bolus programmed P2 truncated" }
+            return MedtronicCodec.readUIntLe(p, offset, n).also { offset += n }
+        }
+        if (flags and BOLUS_DELAY_TIME_PRESENT != 0) consume(2)
+        if (flags and BOLUS_TEMPLATE_NUMBER_PRESENT != 0) consume(1)
+        val activation =
+            if (flags and BOLUS_ACTIVATION_TYPE_PRESENT != 0) BolusActivationType.from(consume(1)) else null
+        return MedtronicHistoryEvent.BolusProgrammedDetail(
+            isCorrection = flags and BOLUS_DELIVERY_REASON_CORRECTION != 0,
+            isMeal = flags and BOLUS_DELIVERY_REASON_MEAL != 0,
+            activationType = activation,
+        )
+    }
+
+    private fun bolusDeliveredDetail(p: ByteArray): MedtronicHistoryEvent {
+        // flags(1) start_time_offset(4) [activation(1)] [end_reason(1)] [annunciation_id(2)]
+        require(p.size >= 5) { "bolus delivered P2 body too short: ${p.size}" }
+        val flags = MedtronicCodec.readUIntLe(p, 0, 1)
+        var offset = 5
+        fun consume(n: Int): Int {
+            require(offset + n <= p.size) { "bolus delivered P2 truncated" }
+            return MedtronicCodec.readUIntLe(p, offset, n).also { offset += n }
+        }
+        val activation =
+            if (flags and BOLUS_ACTIVATION_TYPE_PRESENT_DELIVERED != 0) BolusActivationType.from(consume(1)) else null
+        // bolus_id is not in the delivered-P2 body; correlation back to P1 is by sequence adjacency.
+        return MedtronicHistoryEvent.BolusDeliveredDetail(activationType = activation)
+    }
+
+    private fun basalRateChanged(p: ByteArray): MedtronicHistoryEvent {
+        // flags(1) old f32(4) new f32(4) [context(1)]
+        require(p.size >= 9) { "basal-rate-changed body too short: ${p.size}" }
+        val flags = MedtronicCodec.readUIntLe(p, 0, 1)
+        val context =
+            if (flags and BASAL_DELIVERY_CONTEXT_PRESENT != 0 && p.size >= 10) {
+                HistoryBasalDeliveryContext.from(MedtronicCodec.readUIntLe(p, 9, 1))
+            } else {
+                null
+            }
+        return MedtronicHistoryEvent.BasalRateChanged(
+            oldRateIuPerHour = MedtronicCodec.decodeMedFloat32(MedtronicCodec.readULongLe(p, 1, 4)),
+            newRateIuPerHour = MedtronicCodec.decodeMedFloat32(MedtronicCodec.readULongLe(p, 5, 4)),
+            context = context,
+        )
+    }
+
+    private fun autoBasalMicroBolus(p: ByteArray): MedtronicHistoryEvent {
+        require(p.size >= 5) { "auto-basal micro-bolus body too short: ${p.size}" }
+        return MedtronicHistoryEvent.AutoBasalMicroBolus(
+            bolusNumber = MedtronicCodec.readUIntLe(p, 0, 1),
+            amountIu = MedtronicCodec.decodeMedFloat32(MedtronicCodec.readULongLe(p, 1, 4)),
+        )
+    }
+
+    private fun sgMeasurement(p: ByteArray): MedtronicHistoryEvent {
+        // time_offset i16, sg u16, isig u16, v_counter i16
+        require(p.size >= 8) { "SG measurement body too short: ${p.size}" }
+        return MedtronicHistoryEvent.SgMeasurement(
+            timeOffsetMin = MedtronicCodec.signExtend(MedtronicCodec.readUIntLe(p, 0, 2), 16),
+            sgValueRaw = MedtronicCodec.readUIntLe(p, 2, 2),
+        )
+    }
+
+    private fun bgReading(p: ByteArray, calibration: Boolean, accepted: Boolean): MedtronicHistoryEvent {
+        // time_offset i16, bg f16 (kg/L); mg/dL = 1e5 * kg/L (ValueConverter.kgl_to_mgdl)
+        require(p.size >= 4) { "BG reading body too short: ${p.size}" }
+        val bgKgL = MedtronicCodec.decodeMedFloat16(MedtronicCodec.readUIntLe(p, 2, 2))
+        return MedtronicHistoryEvent.BgReading(mgDl = bgKgL * 1e5, calibration = calibration, accepted = accepted)
+    }
+
+    private fun insulinDelivery(p: ByteArray, stopped: Boolean): MedtronicHistoryEvent {
+        require(p.isNotEmpty()) { "insulin-delivery body empty" }
+        return MedtronicHistoryEvent.InsulinDelivery(stopped = stopped, reason = MedtronicCodec.readUIntLe(p, 0, 1))
+    }
+
+    private fun annunciation(p: ByteArray): MedtronicHistoryEvent {
+        // event_flags(1) annunciation_id(2) type(2) status(1) timestamp(4)
+        require(p.size >= 10) { "annunciation body too short: ${p.size}" }
+        val typeRaw = MedtronicCodec.readUIntLe(p, 3, 2)
+        if (typeRaw and 0xF000 != ANNUNCIATION_TYPE_TAG) {
+            throw MedtronicReadException("Unknown annunciation type 0x%04x".format(typeRaw))
+        }
+        val status = MedtronicCodec.readUIntLe(p, 5, 1)
+        val seconds = MedtronicCodec.readULongLe(p, 6, 4)
+        return MedtronicHistoryEvent.Annunciation(
+            annunciationType = typeRaw and 0x0FFF,
+            statusRaw = status,
+            timestamp = MEDTRONIC_EPOCH_2000.plusSeconds(seconds),
+        )
+    }
+
+    private fun annunciationCleared(p: ByteArray): MedtronicHistoryEvent {
+        require(p.size >= 4) { "annunciation-cleared body too short: ${p.size}" }
+        return MedtronicHistoryEvent.Annunciation(
+            annunciationType = MedtronicCodec.readUIntLe(p, 0, 2),
+            statusRaw = MedtronicHistoryEvent.Annunciation.CLEARED_NO_STATUS,
+            timestamp = null,
+        )
+    }
+
+    private fun referenceTime(p: ByteArray): MedtronicHistoryEvent {
+        // recording_reason(1) then datetime(7): year u16, month, day, hour, min, sec
+        require(p.size >= 8) { "reference-time body too short: ${p.size}" }
+        val time =
+            try {
+                LocalDateTime.of(
+                    MedtronicCodec.readUIntLe(p, 1, 2), // year
+                    MedtronicCodec.readUIntLe(p, 3, 1), // month
+                    MedtronicCodec.readUIntLe(p, 4, 1), // day
+                    MedtronicCodec.readUIntLe(p, 5, 1), // hour
+                    MedtronicCodec.readUIntLe(p, 6, 1), // minute
+                    MedtronicCodec.readUIntLe(p, 7, 1), // second
+                ).toInstant(ZoneOffset.UTC)
+            } catch (e: java.time.DateTimeException) {
+                Timber.w(e, "Invalid reference-time datetime; offsets after it cannot be anchored")
+                null
+            }
+        return MedtronicHistoryEvent.ReferenceTime(time)
+    }
+
+    // -- Domain extraction (consumed by the C3 capability delegates) --------
+
+    /**
+     * Each parsed record paired with its resolved absolute timestamp, walking [records] in sequence
+     * order and carrying the most recent reference time forward (mirrors `history_data.py`'s `ref_time`
+     * tracking). Records seen before any reference time, or whose body fails to parse, are dropped (and
+     * counted in a debug log) rather than mis-timestamped.
+     */
+    private fun timedRecords(records: List<HistoryLogRecord>): List<Pair<MedtronicHistoryRecord, Instant>> {
+        val sorted = records.sortedBy { it.sequenceNumber }
+        var reference: Instant? = null
+        var droppedNoReference = 0
+        val out = ArrayList<Pair<MedtronicHistoryRecord, Instant>>(sorted.size)
+        for (record in sorted) {
+            val body = Base64.getDecoder().decode(record.rawBytesB64)
+            val parsed = parseRecordBody(body) ?: continue
+            val event = parsed.event
+            if (event is MedtronicHistoryEvent.ReferenceTime) {
+                event.time?.let { reference = it }
+                continue
+            }
+            val ref = reference
+            if (ref == null) {
+                droppedNoReference++
+                continue
+            }
+            out += parsed to ref.plusSeconds(parsed.relativeOffsetSeconds.toLong())
+        }
+        if (droppedNoReference > 0) {
+            Timber.d("Dropped %d history record(s) with no preceding reference time", droppedNoReference)
+        }
+        return out
+    }
+
+    /**
+     * Extract CGM readings from [records] (event type SG_MEASUREMENT). Sentinel SG values
+     * ([SG_SENTINELS]) and any reading outside [limits] are dropped, never clamped. Trend is
+     * [CgmTrend.UNKNOWN]: the SG history record carries no rate of change.
+     */
+    fun extractCgmFromHistoryLogs(
+        records: List<HistoryLogRecord>,
+        limits: SafetyLimits = SafetyLimits(),
+    ): List<CgmReading> =
+        timedRecords(records)
+            .mapNotNull { (record, time) ->
+                val event = record.event as? MedtronicHistoryEvent.SgMeasurement ?: return@mapNotNull null
+                val mgDl = event.sgValueRaw
+                if (mgDl in SG_SENTINELS) return@mapNotNull null
+                if (mgDl < limits.minGlucoseMgDl || mgDl > limits.maxGlucoseMgDl) return@mapNotNull null
+                CgmReading(glucoseMgDl = mgDl, trendArrow = CgmTrend.UNKNOWN, timestamp = time)
+            }
+            .sortedBy { it.timestamp }
+
+    /**
+     * Extract delivered boluses from [records] (event type BOLUS_DELIVERED_P1), enriched by the
+     * adjacent BOLUS_DELIVERED_P2 (activation type) and the matching BOLUS_PROGRAMMED_P2
+     * (correction/meal reason, by bolus id). Boluses exceeding [SafetyLimits.maxBolusDoseMilliunits]
+     * are dropped, never clamped.
+     *
+     * **SmartGuard micro-boluses excluded (known nuance, AC5 / Medtronic Connect open item).** The
+     * `AUTO_BASAL_DELIVERY` auto-correction micro-boluses (770G/780G) are *not* mapped to bolus events
+     * here: how they should be attributed (bolus vs. basal, double-count risk) is unresolved without
+     * live validation, so they are counted and logged rather than guessed. `TODO(48.A2)`.
+     */
+    fun extractBolusesFromHistoryLogs(
+        records: List<HistoryLogRecord>,
+        limits: SafetyLimits = SafetyLimits(),
+    ): List<BolusEvent> {
+        val timed = timedRecords(records)
+        // Correction/meal reason lives in the programmed-P2 record, keyed by bolus id from programmed-P1.
+        // Pair each programmed-P1 (id) with the programmed-P2 that immediately follows it in sequence.
+        val sortedRecords = timed.map { it.first }
+        val reasonByBolusId = HashMap<Int, MedtronicHistoryEvent.BolusProgrammedDetail>()
+        var pendingProgrammedId: Int? = null
+        for (r in sortedRecords) {
+            when (val e = r.event) {
+                is MedtronicHistoryEvent.BolusAmounts ->
+                    if (!e.delivered) pendingProgrammedId = e.bolusId
+                is MedtronicHistoryEvent.BolusProgrammedDetail -> {
+                    pendingProgrammedId?.let { reasonByBolusId[it] = e }
+                    pendingProgrammedId = null
+                }
+                else -> Unit
+            }
+        }
+
+        var droppedMicroBoluses = 0
+        val result =
+            timed.mapIndexedNotNull { index, (record, time) ->
+                val amounts = record.event as? MedtronicHistoryEvent.BolusAmounts ?: run {
+                    if (record.event is MedtronicHistoryEvent.AutoBasalMicroBolus) droppedMicroBoluses++
+                    return@mapIndexedNotNull null
+                }
+                if (!amounts.delivered) return@mapIndexedNotNull null
+
+                val totalIu = amounts.fastIu + amounts.extendedIu
+                if (!totalIu.isFinite() || totalIu < 0.0) return@mapIndexedNotNull null
+                val milliunits = (totalIu * 1000.0).roundToInt()
+                if (milliunits > limits.maxBolusDoseMilliunits) return@mapIndexedNotNull null
+                // BolusEvent's own init caps units at MAX_BOLUS_UNITS; the limits check above already
+                // guards it, but a configured limit looser than the hard cap would still throw -- so
+                // skip rather than construct an out-of-cap event.
+                if (totalIu > BolusEvent.MAX_BOLUS_UNITS) return@mapIndexedNotNull null
+
+                // Activation type comes from the delivered-P2 that immediately follows this delivered-P1.
+                // This positional correlation is a best-effort heuristic: if a record is dropped or
+                // interleaved between the P1 and its P2, the join misses and the bolus degrades to
+                // manual/non-correction rather than failing. Tolerated for this read-only, not-yet-live
+                // slice -- the whole bolus mapping is TODO(48.A2).
+                val deliveredDetail =
+                    sortedRecords.getOrNull(index + 1)?.event as? MedtronicHistoryEvent.BolusDeliveredDetail
+                val automated = deliveredDetail?.activationType == BolusActivationType.COMMANDED
+                val reason = reasonByBolusId[amounts.bolusId]
+                val isCorrection = reason?.isCorrection == true
+                val isMeal = reason?.isMeal == true
+                // Medtronic reports only the delivered total, with no numeric correction/meal split.
+                // Attribute the whole amount to the single indicated reason; leave both 0 when neither
+                // (or both) reasons are set, since the split is then unknown.
+                val correctionUnits = if (isCorrection && !isMeal) totalIu.toFloat() else 0f
+                val mealUnits = if (isMeal && !isCorrection) totalIu.toFloat() else 0f
+
+                BolusEvent(
+                    units = totalIu.toFloat(),
+                    isAutomated = automated,
+                    isCorrection = isCorrection,
+                    correctionUnits = correctionUnits,
+                    mealUnits = mealUnits,
+                    timestamp = time,
+                )
+            }
+        if (droppedMicroBoluses > 0) {
+            Timber.d(
+                "Excluded %d SmartGuard auto-basal micro-bolus event(s) from bolus history (TODO(48.A2))",
+                droppedMicroBoluses,
+            )
+        }
+        return result.sortedBy { it.timestamp }
+    }
+
+    /**
+     * Extract basal-rate changes from [records] (event type DELIVERED_BASAL_RATE_CHANGED). The new
+     * rate is reported; an AP-controller delivery context marks it automated (SmartGuard, 770G/780G).
+     * Rates exceeding [SafetyLimits.maxBasalRateMilliunits] are dropped, never clamped.
+     */
+    fun extractBasalFromHistoryLogs(
+        records: List<HistoryLogRecord>,
+        limits: SafetyLimits = SafetyLimits(),
+    ): List<BasalReading> =
+        timedRecords(records)
+            .mapNotNull { (record, time) ->
+                val event = record.event as? MedtronicHistoryEvent.BasalRateChanged ?: return@mapNotNull null
+                val rate = event.newRateIuPerHour
+                if (!rate.isFinite() || rate < 0.0) return@mapNotNull null
+                if ((rate * 1000.0).roundToInt() > limits.maxBasalRateMilliunits) return@mapNotNull null
+                BasalReading(
+                    rate = rate.toFloat(),
+                    isAutomated = event.context == HistoryBasalDeliveryContext.ARTIFICIAL_PANCREAS_CONTROLLER,
+                    activityMode = PumpActivityMode.NONE,
+                    timestamp = time,
+                )
+            }
+            .sortedBy { it.timestamp }
+
+    // Bolus P2 flag bits (history_data.py BolusFlag for programmed; BolusDeliveredP2Data.Flag for delivered).
+    private const val BOLUS_DELAY_TIME_PRESENT = 1 shl 0
+    private const val BOLUS_TEMPLATE_NUMBER_PRESENT = 1 shl 1
+    private const val BOLUS_ACTIVATION_TYPE_PRESENT = 1 shl 2
+    private const val BOLUS_DELIVERY_REASON_CORRECTION = 1 shl 3
+    private const val BOLUS_DELIVERY_REASON_MEAL = 1 shl 4
+
+    // Delivered-P2 has its own flag layout: activation-type present is bit 0 there.
+    private const val BOLUS_ACTIVATION_TYPE_PRESENT_DELIVERED = 1 shl 0
+
+    private const val BASAL_DELIVERY_CONTEXT_PRESENT = 1 shl 0
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
@@ -1,0 +1,163 @@
+/*
+ * IDD history/event-log reader for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The RACP record-fetch choreography -- query the record count, request
+ * the last record or a sequence range, collect the SAKE-encrypted records on the IDD History Data
+ * characteristic, and terminate on the (plaintext) RACP indication -- is ported from OpenMinimed
+ * PythonPumpConnector `history_reader.py` (HistoryReader), GPL-3.0, used with the author's
+ * permission. Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar, Morten Fyhn
+ * Amundsen, Stenium; original medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is itself GPL-3.0.
+ *
+ * READ-ONLY: only RACP report/count opcodes are issued; never delete/abort or any write/control
+ * opcode. See medtronic-ble-reverse-engineering.md Sec. 8.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+
+/**
+ * Reads the pump's IDD event-log (bolus / basal / sensor / alarm / cartridge-battery events) over the
+ * C1 session-read framework, preserving each record raw ([HistoryLogRecord], the Tandem `RawHistoryLog`
+ * analog) for dedup/backfill. Parsing into typed events + domain models is [MedtronicHistoryParser].
+ *
+ * **History uses the IDD service's RACP**, not the CGM RACP: upstream's working history path is
+ * `history_reader.py` over the IDD Record Access Control Point + IDD History Data (`0x108`); the HAT
+ * service (`0x300`) RACP is stubbed/unsupported upstream (`hats.py` -- every request returns
+ * "Not Supported" / "No Records Found"), so it is intentionally not used here. The IDD RACP shares the
+ * SIG `0x2A52` UUID with the CGM RACP but lives under a different service; the C3 `BluetoothGatt`-client
+ * wiring must address [MedtronicProtocol.RACP_UUID] under the IDD service for these reads
+ * (`TODO(48.C3)` for the on-device service scoping).
+ *
+ * **Record framing caveat.** Records are delimited by the short-PDU rule of the C1 reassembler
+ * (multi-byte records fragment at the 23-byte MTU and the trailing short PDU ends each one). Upstream's
+ * Linux client negotiated a larger MTU and so received one record per notification; on Android we hold
+ * MTU 23 (never `requestMtu()`) and must reassemble. A record whose encrypted length is an exact
+ * multiple of the PDU size has no short terminator -- the documented [NotificationReassembler]
+ * ambiguity. The exact on-wire delimiting is unconfirmed offline; `TODO(48.A2)` to verify against a
+ * live capture. As with the other readers the caller (C3) imposes the per-operation timeout.
+ */
+class HistoryReader(
+    private val link: MedtronicGattLink,
+    session: MedtronicSakeSession,
+) {
+    private val sessionReader = MedtronicSessionReader(link, session)
+
+    /** Available history record count (RACP "report number of records"). */
+    fun readRecordCount(onResult: (Result<Int>) -> Unit) {
+        sessionReader.controlPointQuery(MedtronicProtocol.RACP_UUID, REQUEST_REPORT_NUMBER_OF_RECORDS) { result ->
+            onResult(result.mapCatching { parseCount(it) })
+        }
+    }
+
+    /** The most recent history record, or `null` if the log is empty / no record arrives. */
+    fun readLastRecord(onResult: (Result<HistoryLogRecord?>) -> Unit) {
+        val e2e = e2eFlagOr(onResult) ?: return
+        fetchRecords(REQUEST_REPORT_LAST_RECORD, e2e) { result ->
+            onResult(result.mapCatching { it.firstOrNull() })
+        }
+    }
+
+    /** All records with sequence number in [firstSeq]..[lastSeq] inclusive. */
+    fun readRecordsInRange(firstSeq: Int, lastSeq: Int, onResult: (Result<List<HistoryLogRecord>>) -> Unit) {
+        val e2e = e2eFlagOr(onResult) ?: return
+        fetchRecords(rangeRequest(firstSeq, lastSeq), e2e, onResult)
+    }
+
+    /**
+     * Incremental backfill: every record newer than [sinceSequence]. Reads the last record to learn
+     * the newest sequence, then ranges from `sinceSequence + 1` to it. Empty when the log is already
+     * caught up. Matches the `getHistoryLogs(sinceSequence)` contract the C3 PumpStatus capability uses.
+     */
+    fun readSinceSequence(sinceSequence: Int, onResult: (Result<List<HistoryLogRecord>>) -> Unit) {
+        val e2e = e2eFlagOr(onResult) ?: return
+        fetchRecords(REQUEST_REPORT_LAST_RECORD, e2e) { lastResult ->
+            val last = lastResult.getOrElse { onResult(Result.failure(it)); return@fetchRecords }.firstOrNull()
+            when {
+                last == null -> onResult(Result.success(emptyList()))
+                last.sequenceNumber <= sinceSequence -> onResult(Result.success(emptyList()))
+                else -> fetchRecords(rangeRequest(sinceSequence + 1, last.sequenceNumber), e2e, onResult)
+            }
+        }
+    }
+
+    /** Read the IDD Features E2E flag, routing a read/parse failure to [onResult]; null = abort. */
+    private fun <T> e2eFlagOr(onResult: (Result<T>) -> Unit): Boolean? =
+        try {
+            IddFeatures.parse(sessionReader.decryptedRead(MedtronicProtocol.IDD_FEATURES_UUID)).e2eProtectionEnabled
+        } catch (e: MedtronicReadException) {
+            onResult(Result.failure(e))
+            null
+        }
+
+    private fun fetchRecords(request: ByteArray, useE2e: Boolean, onResult: (Result<List<HistoryLogRecord>>) -> Unit) {
+        sessionReader.reportRecords(
+            dataChar = MedtronicProtocol.IDD_HISTORY_DATA_UUID,
+            controlPoint = MedtronicProtocol.RACP_UUID,
+            request = request,
+            isSuccess = ::isReportSuccess,
+        ) { result ->
+            onResult(
+                result.mapCatching { frames ->
+                    MedtronicHistoryParser.dedupBySequence(
+                        frames.mapNotNull { MedtronicHistoryParser.toHistoryLogRecord(it, useE2e) },
+                    )
+                },
+            )
+        }
+    }
+
+    private fun parseCount(response: ByteArray): Int {
+        if (response.size < 4) {
+            throw MedtronicReadException("RACP count response too short: ${response.size} bytes")
+        }
+        if (response[0].toInt() and 0xFF != NUMBER_OF_RECORDS_RESPONSE ||
+            response[1].toInt() and 0xFF != FILTER_SEQUENCE_NUMBER
+        ) {
+            throw MedtronicReadException("Unexpected RACP count response: ${response.toHex()}")
+        }
+        return MedtronicCodec.readUIntLe(response, 2, 2)
+    }
+
+    /** True when the terminating RACP indication is the IDD "report records: success" response code. */
+    private fun isReportSuccess(response: ByteArray): Boolean =
+        response.size >= EXPECTED_REPORT_SUCCESS.size &&
+            EXPECTED_REPORT_SUCCESS.indices.all { response[it] == EXPECTED_REPORT_SUCCESS[it] }
+
+    private fun rangeRequest(firstSeq: Int, lastSeq: Int): ByteArray =
+        REQUEST_REPORT_WITHIN_RANGE_PREFIX + MedtronicCodec.u32Le(firstSeq) + MedtronicCodec.u32Le(lastSeq)
+
+    private fun ByteArray.toHex(): String = MedtronicCodec.toHex(this)
+
+    companion object {
+        // IDD RACP op codes / operators / filter types (history_reader.py IddRacpOpCode/Operator/FilterType).
+        private const val OP_REPORT_RECORDS = 51 // 0x33
+        private const val OP_REPORT_NUMBER_OF_RECORDS = 90 // 0x5A
+        private const val NUMBER_OF_RECORDS_RESPONSE = 102 // 0x66
+        private const val RESPONSE_CODE = 15 // 0x0F
+        private const val OPERATOR_NULL = 15 // 0x0F
+        private const val OPERATOR_ALL_RECORDS = 51 // 0x33
+        private const val OPERATOR_WITHIN_RANGE = 90 // 0x5A
+        private const val OPERATOR_LAST_RECORD = 105 // 0x69
+        private const val FILTER_SEQUENCE_NUMBER = 15 // 0x0F
+        private const val RESPONSE_SUCCESS = 240 // 0xF0
+
+        /** RACP: report stored records, last record, by sequence number. */
+        val REQUEST_REPORT_LAST_RECORD =
+            byteArrayOf(OP_REPORT_RECORDS.toByte(), OPERATOR_LAST_RECORD.toByte(), FILTER_SEQUENCE_NUMBER.toByte())
+
+        /** RACP: report the number of stored records, all records, by sequence number. */
+        val REQUEST_REPORT_NUMBER_OF_RECORDS =
+            byteArrayOf(OP_REPORT_NUMBER_OF_RECORDS.toByte(), OPERATOR_ALL_RECORDS.toByte(), FILTER_SEQUENCE_NUMBER.toByte())
+
+        /** RACP: report stored records within a sequence-number range; followed by min/max u32 LE. */
+        val REQUEST_REPORT_WITHIN_RANGE_PREFIX =
+            byteArrayOf(OP_REPORT_RECORDS.toByte(), OPERATOR_WITHIN_RANGE.toByte(), FILTER_SEQUENCE_NUMBER.toByte())
+
+        /** Terminating success indication: response-code / null / report-records / success. */
+        val EXPECTED_REPORT_SUCCESS =
+            byteArrayOf(RESPONSE_CODE.toByte(), OPERATOR_NULL.toByte(), OP_REPORT_RECORDS.toByte(), RESPONSE_SUCCESS.toByte())
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddFeatures.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddFeatures.kt
@@ -1,0 +1,86 @@
+/*
+ * IDD Features characteristic parser for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * Ported to Kotlin from OpenMinimed PythonPumpConnector `idd/features/pump_features.py` (PumpFeatures)
+ * and `idd/features/reader.py` (IDDFeaturesReader), https://github.com/OpenMinimed, GPL-3.0, used
+ * with the author's permission. Copyright (C) OpenMinimed contributors: palmarci (Pal Marci),
+ * drfubar, Morten Fyhn Amundsen, Stenium; original medtronic-bt-decrypt PoC by @planiitis.
+ * GlycemicGPT is itself GPL-3.0, so this is redistributed under the same license.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+/**
+ * Decoded IDD Features characteristic (`0x104`, SAKE-encrypted; the caller decrypts before parsing).
+ *
+ * Two things this driver acts on: [e2eProtectionEnabled] (whether the IDD Status/SRCP/history records
+ * carry the Medtronic E2E-Counter + E2E-CRC trailer -- read per pump rather than the upstream
+ * 780G-hardcoded assumption that it is off), and [model] (the SmartGuard capability tier inferred from
+ * the feature bits, see [MedtronicPumpModel]).
+ *
+ * @property insulinConcentration insulin concentration in IU/mL (medfloat16).
+ * @property featureFlags the variable-width feature bit word (extension bytes folded in).
+ */
+data class IddFeatures(
+    val insulinConcentration: Double,
+    val featureFlags: Long,
+    val e2eProtectionEnabled: Boolean,
+    val model: MedtronicPumpModel,
+) {
+    companion object {
+        /** Mandatory prefix: e2e-crc(2) + e2e-counter(1) + concentration SFLOAT(2) + flags(3). */
+        private const val MANDATORY_SIZE = 8
+
+        /** E2E Protection Supported feature bit (bit 0): when set the IDD service uses E2E framing. */
+        private const val E2E_PROTECTION_SUPPORTED = 1L shl 0
+
+        /** Feature Extension bit (bit 23): another flags byte follows, folded in at shift 24. */
+        private const val FEATURE_EXTENSION = 1L shl 23
+
+        private const val FLAGS_FIELD_SIZE = 3
+        private const val EXTENSION_CONTINUE_BIT = 0x80
+
+        /**
+         * Decode the decrypted IDD Features value.
+         *
+         * @throws MedtronicReadException if the value is shorter than the mandatory prefix or a
+         *     promised feature-extension byte is missing.
+         */
+        fun parse(decrypted: ByteArray): IddFeatures {
+            if (decrypted.size < MANDATORY_SIZE) {
+                throw MedtronicReadException(
+                    "IDD Features too short: need >= $MANDATORY_SIZE bytes, got ${decrypted.size}",
+                )
+            }
+            // bytes 0-1 e2e-crc, byte 2 e2e-counter -- only meaningful when E2E is enabled (the bit
+            // below); upstream asserts they are 0xffff/0 because the 780G leaves E2E off. We read the
+            // bit and don't hard-assert, so a model that does enable E2E is not misparsed here.
+            val concentration = MedtronicCodec.decodeMedFloat16(MedtronicCodec.readUIntLe(decrypted, 3, 2))
+            var flags = MedtronicCodec.readUIntLe(decrypted, 5, FLAGS_FIELD_SIZE).toLong()
+
+            var offset = MANDATORY_SIZE
+            fun nextExtensionByte(): Int {
+                if (offset >= decrypted.size) {
+                    throw MedtronicReadException("IDD Features missing a promised feature-extension byte")
+                }
+                return MedtronicCodec.readUIntLe(decrypted, offset++, 1)
+            }
+            if (flags and FEATURE_EXTENSION != 0L) {
+                var shift = 24
+                var ext = nextExtensionByte()
+                flags = flags or (ext.toLong() shl shift)
+                while (ext and EXTENSION_CONTINUE_BIT != 0) {
+                    shift += 8
+                    ext = nextExtensionByte()
+                    flags = flags or (ext.toLong() shl shift)
+                }
+            }
+
+            return IddFeatures(
+                insulinConcentration = concentration,
+                featureFlags = flags,
+                e2eProtectionEnabled = flags and E2E_PROTECTION_SUPPORTED != 0L,
+                model = MedtronicPumpModel.fromFeatureFlags(flags),
+            )
+        }
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatus.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatus.kt
@@ -1,0 +1,262 @@
+/*
+ * IDD status payload parsers for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * Ported to Kotlin from OpenMinimed PythonPumpConnector `idd/status/pump_status.py` (PumpStatus),
+ * `idd/status/iob.py` (InsulinOnBoardData) and `idd/status/active_basal_rate_delivery.py`
+ * (ActiveBasalRateDelivery), https://github.com/OpenMinimed, GPL-3.0, used with the author's
+ * permission. Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar, Morten Fyhn
+ * Amundsen, Stenium; original medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is itself GPL-3.0,
+ * so this is redistributed under the same license.
+ *
+ * Each value is SAKE-encrypted on the wire; the caller (MedtronicSessionReader) decrypts before
+ * parsing here. All amounts are medfloat32 IU. See medtronic-ble-reverse-engineering.md Sec. 8.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+/** Pump therapy control state (`pump_status.py` TherapyControlState). */
+enum class TherapyControlState(val raw: Int) {
+    UNDETERMINED(0x0F),
+    STOP(0x33),
+    PAUSE(0x3C),
+    RUN(0x55),
+    UNKNOWN(-1),
+    ;
+
+    companion object {
+        fun from(raw: Int): TherapyControlState = entries.firstOrNull { it.raw == raw } ?: UNKNOWN
+    }
+}
+
+/** Pump operational state (`pump_status.py` OperationalState). */
+enum class OperationalState(val raw: Int) {
+    UNDETERMINED(0x0F),
+    OFF(0x33),
+    STANDBY(0x3C),
+    PREPARING(0x55),
+    PRIMING(0x5A),
+    WAITING(0x66),
+    READY(0x96),
+    UNKNOWN(-1),
+    ;
+
+    companion object {
+        fun from(raw: Int): OperationalState = entries.firstOrNull { it.raw == raw } ?: UNKNOWN
+    }
+}
+
+/** Sensor message / annunciation state surfaced in the IDD status (`pump_status.py` SensorMessageState). */
+enum class SensorMessageState(val raw: Int) {
+    NO_MESSAGE(0x00),
+    WAIT_TO_CALIBRATE(0x01),
+    DO_NOT_CALIBRATE(0x02),
+    CALIBRATION_REQUIRED(0x03),
+    CALIBRATING(0x04),
+    SEARCHING_FOR_SENSOR_SIGNAL(0x05),
+    NO_SENSOR_SIGNAL(0x06),
+    CHANGE_SENSOR(0x07),
+    WARM_UP(0x08),
+    SG_BELOW_LOWER_LIMIT(0x09),
+    SG_ABOVE_UPPER_LIMIT(0x0A),
+    GST_BATTERY_DEPLETED(0x0B),
+    SENSOR_CONNECTED(0x0C),
+    WAITING_WARM_UP(0x0D),
+    NO_PAIRED_SENSOR(0x0E),
+    UNKNOWN(-1),
+    ;
+
+    companion object {
+        fun from(raw: Int): SensorMessageState = entries.firstOrNull { it.raw == raw } ?: UNKNOWN
+    }
+}
+
+/**
+ * Decoded IDD Status record (`0x102`): therapy/operational state, reservoir units, and sensor state.
+ *
+ * @property reservoirRemainingIu reservoir units remaining (IU).
+ * @property reservoirAttached IDD status flag bit 0 (reservoir attached).
+ * @property sensorConnectivityFlags raw sensor-connectivity flag byte (bit0 on, bit1 paired, ...).
+ */
+data class IddStatusRecord(
+    val therapyControlState: TherapyControlState,
+    val operationalState: OperationalState,
+    val reservoirRemainingIu: Double,
+    val reservoirAttached: Boolean,
+    val sensorConnectivityFlags: Int,
+    val sensorMessageState: SensorMessageState,
+) {
+    companion object {
+        private const val BODY_SIZE = 9
+        private const val RESERVOIR_ATTACHED_BIT = 1 shl 0
+
+        /**
+         * Parse a decrypted IDD Status value. When [useE2e] the trailing E2E-Counter (1) + E2E-CRC (2)
+         * are validated and stripped first (read [IddFeatures.e2eProtectionEnabled] per pump rather
+         * than assuming, the upstream caveat).
+         *
+         * @throws MedtronicReadException on a length mismatch or failed E2E-CRC.
+         */
+        fun parse(decrypted: ByteArray, useE2e: Boolean): IddStatusRecord {
+            val body = stripIddE2e(decrypted, useE2e)
+            if (body.size != BODY_SIZE) {
+                throw MedtronicReadException("IDD Status length ${body.size} != expected $BODY_SIZE")
+            }
+            val therapy = TherapyControlState.from(MedtronicCodec.readUIntLe(body, 0, 1))
+            val operational = OperationalState.from(MedtronicCodec.readUIntLe(body, 1, 1))
+            val reservoir = MedtronicCodec.decodeMedFloat32(MedtronicCodec.readULongLe(body, 2, 4))
+            val flags = MedtronicCodec.readUIntLe(body, 6, 1)
+            val sensorConnectivity = MedtronicCodec.readUIntLe(body, 7, 1)
+            val sensorMessage = SensorMessageState.from(MedtronicCodec.readUIntLe(body, 8, 1))
+            return IddStatusRecord(
+                therapyControlState = therapy,
+                operationalState = operational,
+                reservoirRemainingIu = reservoir,
+                reservoirAttached = flags and RESERVOIR_ATTACHED_BIT != 0,
+                sensorConnectivityFlags = sensorConnectivity,
+                sensorMessageState = sensorMessage,
+            )
+        }
+    }
+}
+
+/**
+ * Decoded Insulin-On-Board response (SRCP opcode `0x03F3` -> response `0x03FC`).
+ *
+ * ⚠️ **PROVISIONAL.** Upstream marks IOB parsing "not tested" (`iob.py`); this is implemented
+ * faithfully but must be validated against a real pump before it is trusted. `TODO(48.A2)`.
+ *
+ * @property insulinOnBoardIu active insulin on board (IU, medfloat32).
+ */
+data class IddInsulinOnBoard(
+    val insulinOnBoardIu: Double,
+    val remainingDurationMin: Int?,
+) {
+    companion object {
+        private const val RESPONSE_OPCODE = 0x03FC
+        private const val REMAINING_DURATION_PRESENT = 1 shl 0
+        private const val IOB_PARTIAL_STATUS_PRESENT = 1 shl 1
+        private const val MIN_BODY_SIZE = 7 // opcode(2) + flags(1) + IOB f32(4)
+
+        /** @throws MedtronicReadException on a length mismatch, wrong opcode, or failed E2E-CRC. */
+        fun parse(decrypted: ByteArray, useE2e: Boolean): IddInsulinOnBoard {
+            val body = stripIddE2e(decrypted, useE2e)
+            if (body.size < MIN_BODY_SIZE) {
+                throw MedtronicReadException("IDD IOB too short: need >= $MIN_BODY_SIZE bytes, got ${body.size}")
+            }
+            val opcode = MedtronicCodec.readUIntLe(body, 0, 2)
+            if (opcode != RESPONSE_OPCODE) {
+                throw MedtronicReadException("IDD IOB wrong opcode 0x%04x, wanted 0x%04x".format(opcode, RESPONSE_OPCODE))
+            }
+            val flags = MedtronicCodec.readUIntLe(body, 2, 1)
+            val iob = MedtronicCodec.decodeMedFloat32(MedtronicCodec.readULongLe(body, 3, 4))
+            var offset = MIN_BODY_SIZE
+            fun consume(n: Int, field: String): Int {
+                if (offset + n > body.size) throw MedtronicReadException("IDD IOB missing $field field")
+                return MedtronicCodec.readUIntLe(body, offset, n).also { offset += n }
+            }
+            val remainingDuration = if (flags and REMAINING_DURATION_PRESENT != 0) consume(2, "remaining-duration") else null
+            if (flags and IOB_PARTIAL_STATUS_PRESENT != 0) {
+                consume(2, "iob-partial-duration")
+                consume(2, "iob-partial-remaining")
+            }
+            if (offset != body.size) {
+                throw MedtronicReadException("IDD IOB has ${body.size - offset} trailing byte(s) after declared fields")
+            }
+            return IddInsulinOnBoard(insulinOnBoardIu = iob, remainingDurationMin = remainingDuration)
+        }
+    }
+}
+
+/** Basal delivery context (`active_basal_rate_delivery.py` BasalDeliveryContext). */
+enum class BasalDeliveryContext(val raw: Int) {
+    UNDETERMINED(0x0F),
+    DEVICE_BASED(0x33),
+    REMOTE_CONTROL(0x3C),
+    AP_CONTROLLER(0x55),
+    UNKNOWN(-1),
+    ;
+
+    companion object {
+        fun from(raw: Int): BasalDeliveryContext = entries.firstOrNull { it.raw == raw } ?: UNKNOWN
+    }
+}
+
+/**
+ * Decoded Active Basal Rate Delivery response (SRCP opcode `0x0365` -> response `0x036A`).
+ *
+ * @property rateIuPerHour the active basal rate currently being delivered (IU/h, medfloat32).
+ * @property basalDeliveryContext present only when the pump reports it; [BasalDeliveryContext.AP_CONTROLLER]
+ *     means the closed-loop algorithm (SmartGuard) is driving the rate (770G/780G).
+ */
+data class IddActiveBasalRate(
+    val rateIuPerHour: Double,
+    val templateNumber: Int,
+    val basalDeliveryContext: BasalDeliveryContext?,
+) {
+    companion object {
+        private const val RESPONSE_OPCODE = 0x036A
+        private const val TBR_PRESENT = 1 shl 0
+        private const val TBR_TEMPLATE_NUMBER_PRESENT = 1 shl 1
+        private const val BASAL_DELIVERY_CONTEXT_PRESENT = 1 shl 2
+        private const val MIN_BODY_SIZE = 8 // opcode(2) + flags(1) + template(1) + rate f32(4)
+
+        /** @throws MedtronicReadException on a length mismatch, wrong opcode, or failed E2E-CRC. */
+        fun parse(decrypted: ByteArray, useE2e: Boolean): IddActiveBasalRate {
+            val body = stripIddE2e(decrypted, useE2e)
+            if (body.size < MIN_BODY_SIZE) {
+                throw MedtronicReadException("IDD basal too short: need >= $MIN_BODY_SIZE bytes, got ${body.size}")
+            }
+            val opcode = MedtronicCodec.readUIntLe(body, 0, 2)
+            if (opcode != RESPONSE_OPCODE) {
+                throw MedtronicReadException("IDD basal wrong opcode 0x%04x, wanted 0x%04x".format(opcode, RESPONSE_OPCODE))
+            }
+            val flags = MedtronicCodec.readUIntLe(body, 2, 1)
+            val template = MedtronicCodec.readUIntLe(body, 3, 1)
+            val rate = MedtronicCodec.decodeMedFloat32(MedtronicCodec.readULongLe(body, 4, 4))
+            var offset = MIN_BODY_SIZE
+            fun consume(n: Int, field: String): Int {
+                if (offset + n > body.size) throw MedtronicReadException("IDD basal missing $field field")
+                return MedtronicCodec.readUIntLe(body, offset, n).also { offset += n }
+            }
+            // TBR block (type, adjustment f32, programmed dur, remaining dur) -- read past it; the active
+            // delivered rate is the mandatory field above, which already reflects any TBR adjustment.
+            if (flags and TBR_PRESENT != 0) {
+                consume(1, "tbr-type")
+                consume(4, "tbr-adjustment")
+                consume(2, "tbr-duration-programmed")
+                consume(2, "tbr-duration-remaining")
+            }
+            if (flags and TBR_TEMPLATE_NUMBER_PRESENT != 0) consume(1, "tbr-template-number")
+            val context =
+                if (flags and BASAL_DELIVERY_CONTEXT_PRESENT != 0) {
+                    BasalDeliveryContext.from(consume(1, "basal-delivery-context"))
+                } else {
+                    null
+                }
+            if (offset != body.size) {
+                throw MedtronicReadException("IDD basal has ${body.size - offset} trailing byte(s) after declared fields")
+            }
+            return IddActiveBasalRate(rateIuPerHour = rate, templateNumber = template, basalDeliveryContext = context)
+        }
+    }
+}
+
+/**
+ * Validate and strip the optional Medtronic E2E trailer (E2E-Counter byte + 2-byte E2E-CRC) the IDD
+ * service appends when [useE2e]. The CRC covers everything up to and including the counter; on a
+ * match the counter and CRC are dropped, leaving the bare record body. Shared by every IDD payload
+ * parser (matches the `if self.use_e2e:` block repeated across the upstream IDD parsers).
+ *
+ * @throws MedtronicReadException if the value is too short to hold the trailer or the CRC mismatches.
+ */
+internal fun stripIddE2e(value: ByteArray, useE2e: Boolean): ByteArray {
+    if (!useE2e) return value
+    // counter(1) + crc(2)
+    val trailer = 1 + MedtronicCodec.CRC_SIZE
+    if (value.size < trailer) {
+        throw MedtronicReadException("IDD record too short for E2E trailer: ${value.size} bytes")
+    }
+    if (!MedtronicCodec.checkE2eCrc(value)) {
+        throw MedtronicReadException("IDD record E2E-CRC mismatch")
+    }
+    return value.copyOf(value.size - trailer)
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatusReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatusReader.kt
@@ -1,0 +1,200 @@
+/*
+ * IDD status reader for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The read choreography -- read the IDD Features for the per-model E2E
+ * flag, read+decrypt the IDD Status characteristic, and drive the SRCP control point for IOB and
+ * active-basal opcodes -- is ported from OpenMinimed PythonPumpConnector `idd/status/reader.py`
+ * (IDDStatusReader) and `idd/features/reader.py` (IDDFeaturesReader), GPL-3.0, used with the
+ * author's permission. Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
+ * Morten Fyhn Amundsen, Stenium; original medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is
+ * itself GPL-3.0. See medtronic-ble-reverse-engineering.md Sec. 8.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.model.PumpActivityMode
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import java.time.Instant
+import kotlin.math.roundToInt
+import timber.log.Timber
+
+/**
+ * The non-history IDD status surface bundled from one IDD Status read: therapy/operational state,
+ * reservoir-attached flag, sensor state, and the inferred per-model capability tier.
+ */
+data class MedtronicIddStatusState(
+    val therapyControlState: TherapyControlState,
+    val operationalState: OperationalState,
+    val reservoirAttached: Boolean,
+    val sensorMessageState: SensorMessageState,
+    val sensorConnectivityFlags: Int,
+    val model: MedtronicPumpModel,
+)
+
+/**
+ * Reads the pump's Insulin Delivery (IDD) status surface over the C1 session-read framework into the
+ * shared domain models: reservoir ([ReservoirReading]), IOB ([IoBReading], **provisional**), active
+ * basal ([BasalReading]) and the therapy/sensor [MedtronicIddStatusState].
+ *
+ * Every numeric value is gated by [safetyLimits]: an out-of-physiological-range reservoir/IOB/basal
+ * is **rejected** (a [MedtronicReadException]), never clamped, matching [CgmReader]. Over-the-air
+ * behavior rides with 48.A2; nothing here is claimed live-verified.
+ *
+ * The IDD Features read supplies two per-model facts (avoiding the upstream 780G hard-codes): the
+ * E2E-protection flag (whether records carry the E2E trailer) and the SmartGuard capability tier
+ * ([MedtronicPumpModel]). It is re-read per call for these single-shot reads; caching belongs with
+ * polling in Milestone D (as on [CgmReader]).
+ *
+ * @param now clock for stamping "current" readings; report time approximates capture time for these
+ *     live status reads.
+ */
+class IddStatusReader(
+    private val link: MedtronicGattLink,
+    session: MedtronicSakeSession,
+    private val safetyLimits: SafetyLimits = SafetyLimits(),
+    private val now: () -> Instant = Instant::now,
+) {
+    private val sessionReader = MedtronicSessionReader(link, session)
+
+    /** Reservoir units remaining, gated by the reservoir hardware bound. */
+    fun readReservoir(onResult: (Result<ReservoirReading>) -> Unit) {
+        onResult(
+            runCatching {
+                val features = readFeatures()
+                val status = readStatusRecord(features)
+                toReservoirReading(status.reservoirRemainingIu)
+            },
+        )
+    }
+
+    /** Therapy/operational/sensor state plus the inferred model tier. */
+    fun readStatusState(onResult: (Result<MedtronicIddStatusState>) -> Unit) {
+        onResult(
+            runCatching {
+                val features = readFeatures()
+                val status = readStatusRecord(features)
+                MedtronicIddStatusState(
+                    therapyControlState = status.therapyControlState,
+                    operationalState = status.operationalState,
+                    reservoirAttached = status.reservoirAttached,
+                    sensorMessageState = status.sensorMessageState,
+                    sensorConnectivityFlags = status.sensorConnectivityFlags,
+                    model = features.model,
+                )
+            },
+        )
+    }
+
+    /**
+     * Active insulin on board.
+     *
+     * ⚠️ **PROVISIONAL** -- upstream marks IOB parsing "not tested" (`iob.py`). It is parsed faithfully
+     * and safety-gated, but emitted with a warning marker and **must not be presented as trusted**
+     * until a live pump confirms the layout. `TODO(48.A2)`.
+     */
+    fun readIoB(onResult: (Result<IoBReading>) -> Unit) {
+        val features =
+            try {
+                readFeatures()
+            } catch (e: MedtronicReadException) {
+                onResult(Result.failure(e))
+                return
+            }
+        sessionReader.srcpGet(MedtronicProtocol.IDD_SRCP_UUID, REQUEST_GET_INSULIN_ON_BOARD) { result ->
+            onResult(result.mapCatching { decrypted -> toIoBReading(decrypted, features.e2eProtectionEnabled) })
+        }
+    }
+
+    /** Active basal rate currently being delivered, with automated (closed-loop) detection. */
+    fun readActiveBasalRate(onResult: (Result<BasalReading>) -> Unit) {
+        val features =
+            try {
+                readFeatures()
+            } catch (e: MedtronicReadException) {
+                onResult(Result.failure(e))
+                return
+            }
+        sessionReader.srcpGet(MedtronicProtocol.IDD_SRCP_UUID, REQUEST_GET_ACTIVE_BASAL_RATE) { result ->
+            onResult(result.mapCatching { decrypted -> toBasalReading(decrypted, features) })
+        }
+    }
+
+    private fun readFeatures(): IddFeatures =
+        IddFeatures.parse(sessionReader.decryptedRead(MedtronicProtocol.IDD_FEATURES_UUID))
+
+    private fun readStatusRecord(features: IddFeatures): IddStatusRecord =
+        IddStatusRecord.parse(
+            sessionReader.decryptedRead(MedtronicProtocol.IDD_STATUS_UUID),
+            features.e2eProtectionEnabled,
+        )
+
+    private fun toReservoirReading(reservoirIu: Double): ReservoirReading {
+        if (!reservoirIu.isFinite() || reservoirIu < 0.0 || reservoirIu > MAX_RESERVOIR_UNITS) {
+            throw MedtronicReadException(
+                "Reservoir $reservoirIu IU outside safe range 0..$MAX_RESERVOIR_UNITS",
+            )
+        }
+        return ReservoirReading(unitsRemaining = reservoirIu.toFloat(), timestamp = now())
+    }
+
+    private fun toIoBReading(decrypted: ByteArray, useE2e: Boolean): IoBReading {
+        val iob = IddInsulinOnBoard.parse(decrypted, useE2e).insulinOnBoardIu
+        // PROVISIONAL: upstream never validated IOB parsing. Emit a marker so this value is never
+        // silently trusted, and reject implausible amounts rather than surface a wrong IOB.
+        Timber.w("Medtronic IOB is PROVISIONAL (upstream untested); needs live validation TODO(48.A2)")
+        if (!iob.isFinite() || iob < 0.0 || iob > MAX_IOB_UNITS) {
+            throw MedtronicReadException("IOB $iob IU outside plausible range 0..$MAX_IOB_UNITS")
+        }
+        return IoBReading(iob = iob.toFloat(), timestamp = now())
+    }
+
+    private fun toBasalReading(decrypted: ByteArray, features: IddFeatures): BasalReading {
+        val parsed = IddActiveBasalRate.parse(decrypted, features.e2eProtectionEnabled)
+        val rate = parsed.rateIuPerHour
+        if (!rate.isFinite() || rate < 0.0) {
+            throw MedtronicReadException("Basal rate $rate IU/h is not a valid non-negative number")
+        }
+        val milliunits = (rate * 1000.0).roundToInt()
+        if (milliunits > safetyLimits.maxBasalRateMilliunits) {
+            throw MedtronicReadException(
+                "Basal rate $rate IU/h ($milliunits mU/h) exceeds safe max ${safetyLimits.maxBasalRateMilliunits} mU/h",
+            )
+        }
+        // Closed-loop (SmartGuard) delivery is reported via the AP-controller basal context, which the
+        // 680G never sets. Treat an AP-controller context as automated; flag the model mismatch if a
+        // non-SmartGuard tier somehow reports it (data-shape sanity per AC5, not a hard failure).
+        val automated = parsed.basalDeliveryContext == BasalDeliveryContext.AP_CONTROLLER
+        if (automated && !features.model.supportsSmartGuard) {
+            Timber.w(
+                "AP-controller basal context on a non-SmartGuard tier (%s); treating as automated",
+                features.model,
+            )
+        }
+        return BasalReading(
+            rate = rate.toFloat(),
+            isAutomated = automated,
+            activityMode = PumpActivityMode.NONE, // pump activity mode is not in the IDD basal payload
+            timestamp = now(),
+        )
+    }
+
+    companion object {
+        // SRCP request opcodes, little-endian (idd/status/opcodes.py IddStatusReaderOpCode).
+        private val REQUEST_GET_INSULIN_ON_BOARD = byteArrayOf(0xF3.toByte(), 0x03) // 0x03F3
+        private val REQUEST_GET_ACTIVE_BASAL_RATE = byteArrayOf(0x65, 0x03) // 0x0365
+
+        /** 700-series reservoir hardware maximum (IU); a reading above this is rejected, not clamped. */
+        const val MAX_RESERVOIR_UNITS = 300.0
+
+        /**
+         * Plausible upper bound on insulin-on-board (IU). Real IOB rarely exceeds the low tens of
+         * units; this generous ceiling rejects a garbled/misaligned PROVISIONAL IOB read rather than
+         * surfacing a wrong value. `TODO(48.A2)`: revisit once IOB is validated on a real pump.
+         */
+        const val MAX_IOB_UNITS = 100.0
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicCodec.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicCodec.kt
@@ -2,11 +2,12 @@
  * Low-level value decoding for the Medtronic MiniMed 700-series read-only driver.
  *
  * Ported to Kotlin from OpenMinimed PythonPumpConnector (https://github.com/OpenMinimed),
- * GPL-3.0, used with the author's permission: the IEEE-11073 SFLOAT decode and the little-endian
- * field consumers from `parse_utils.py` (ParseUtils) and the E2E-CRC / medfloat helpers from
- * `value_converter.py` (ValueConverter). Copyright (C) OpenMinimed contributors: palmarci
- * (Pal Marci), drfubar, Morten Fyhn Amundsen, Stenium; original medtronic-bt-decrypt PoC by
- * @planiitis. GlycemicGPT is itself GPL-3.0, so this is redistributed under the same license.
+ * GPL-3.0, used with the author's permission: the IEEE-11073 SFLOAT/FLOAT decode, the sign-extend,
+ * and the little-endian field consumers from `parse_utils.py` (ParseUtils) and the E2E-CRC /
+ * medfloat helpers from `value_converter.py` (ValueConverter). Copyright (C) OpenMinimed
+ * contributors: palmarci (Pal Marci), drfubar, Morten Fyhn Amundsen, Stenium; original
+ * medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is itself GPL-3.0, so this is redistributed
+ * under the same license.
  *
  * See medtronic-ble-reverse-engineering.md Sec. 8-9.
  */
@@ -39,6 +40,74 @@ internal object MedtronicCodec {
             value = value or ((data[offset + i].toInt() and 0xFF) shl (8 * i))
         }
         return value
+    }
+
+    /**
+     * Read [n] bytes of [data] starting at [offset] as a little-endian unsigned integer, widened into
+     * a [Long]. Bounded to 1..4 bytes: the IDD/history records carry unsigned 32-bit fields (record
+     * sequence number, bolus start-time offset, annunciation timestamp) that overflow a signed [Int];
+     * [readUIntLe] stays the right tool for the 1..3-byte fields. Mirrors `ParseUtils.consume_u32`.
+     */
+    fun readULongLe(data: ByteArray, offset: Int, n: Int): Long {
+        require(n in 1..4) { "n must be in 1..4, was $n" }
+        require(offset >= 0 && offset + n <= data.size) {
+            "range [$offset, ${offset + n}) out of bounds for ${data.size} bytes"
+        }
+        var value = 0L
+        for (i in 0 until n) {
+            value = value or ((data[offset + i].toLong() and 0xFF) shl (8 * i))
+        }
+        return value
+    }
+
+    /** Lower-case hex of [data], for diagnostic/error messages. */
+    fun toHex(data: ByteArray): String = data.joinToString("") { "%02x".format(it) }
+
+    /** Encode [value] as a 4-byte little-endian unsigned 32-bit field (the RACP sequence operands). */
+    fun u32Le(value: Int): ByteArray =
+        byteArrayOf(
+            (value and 0xFF).toByte(),
+            ((value ushr 8) and 0xFF).toByte(),
+            ((value ushr 16) and 0xFF).toByte(),
+            ((value ushr 24) and 0xFF).toByte(),
+        )
+
+    /**
+     * Sign-extend the low [bits] of [value] to a signed [Int]. Mirrors `ValueConverter.sign_extend`;
+     * used for the signed time-offset fields in the history records (`consume_i16`).
+     */
+    fun signExtend(value: Int, bits: Int): Int {
+        require(bits in 1..32) { "bits must be in 1..32, was $bits" }
+        // A full-width Int needs no extension, and `1 shl 32` would wrap (Kotlin masks the shift count
+        // to the low 5 bits, so `1 shl 32 == 1`) and corrupt the result.
+        if (bits == 32) return value
+        val signBit = 1 shl (bits - 1)
+        return if (value and signBit != 0) value - (1 shl bits) else value
+    }
+
+    /**
+     * Decode a 32-bit IEEE-11073 FLOAT ("medfloat32"): an 8-bit signed exponent in the high byte and
+     * a 24-bit signed mantissa, valued as `mantissa * 10^exponent`. Mirrors
+     * `ValueConverter.decode_medfloat32`; used for the insulin amounts (reservoir, IOB, basal rate,
+     * bolus units) the IDD/history records carry in IU.
+     *
+     * Takes the raw value as a [Long] (from [readULongLe] with n=4) so the unsigned 32-bit field is
+     * not misread as a negative [Int]. Computed with [Math.pow] rather than the [decodeMedFloat16]
+     * lookup table because the signed-byte exponent spans -128..127 and these fields are read only a
+     * few times per status read, not per CGM sample.
+     *
+     * Unlike [decodeMedFloat16] this does not special-case the IEEE-11073 reserved/NaN/Inf mantissa
+     * codes (upstream's `decode_medfloat32` does not either, and the 32-bit reserved codes differ).
+     * A reserved/garbled insulin field therefore decodes to a bogus finite number or a non-finite
+     * value; callers gate it with `isFinite()` + a physiological range check and reject it, so a
+     * sentinel never surfaces as a real reservoir/IOB/basal/bolus amount.
+     */
+    fun decodeMedFloat32(raw: Long): Double {
+        var exponent = ((raw ushr 24) and 0xFF).toInt()
+        var mantissa = (raw and 0x00FFFFFF).toInt()
+        if (exponent and 0x80 != 0) exponent -= 0x100
+        if (mantissa and 0x800000 != 0) mantissa -= 0x1000000
+        return mantissa.toDouble() * Math.pow(10.0, exponent.toDouble())
     }
 
     /**

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicPumpModel.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicPumpModel.kt
@@ -1,0 +1,74 @@
+/*
+ * Per-model capability tiering for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The capability bits are read from the IDD Features characteristic as
+ * mapped by OpenMinimed PythonPumpConnector `idd/features/pump_features.py` (PumpFeatureFlags),
+ * https://github.com/OpenMinimed, GPL-3.0, used with the author's permission. Copyright (C)
+ * OpenMinimed contributors: palmarci (Pal Marci), drfubar, Morten Fyhn Amundsen, Stenium; original
+ * medtronic-bt-decrypt PoC by @planiitis. GlycemicGPT is itself GPL-3.0.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+/**
+ * The MiniMed 700-series model this driver supports, inferred from the IDD Features capability bits.
+ *
+ * **Why capability flags and not the model-number string:** the marketing model name (680G/770G/780G)
+ * is not on the wire -- the Device Information model characteristic carries an MMT part number
+ * (e.g. "MMT-1885") that OpenMinimed never mapped to a marketing name, so substring-matching it is
+ * unreliable. The reverse-engineering findings instead prescribe driving per-model behavior off the
+ * features flag (the same fix applied to E2E-CRC: read the flag, never hardcode 780G). So this enum
+ * is a coarse **capability tier** derived from the closed-loop feature bits, used to decide whether
+ * SmartGuard / auto-basal data is expected -- not a precise hardware identifier.
+ *
+ * The single data-shape consequence that matters for C2 is [supportsSmartGuard]: 770G/780G run a
+ * hybrid closed loop (auto-basal, auto-mode therapy state, AP-controller basal context, and on the
+ * 780G auto-correction micro-boluses), while the 680G does not. The individual records remain
+ * flag-driven and parse safely regardless; this tier only governs interpretation/labeling and the
+ * "is this expected for this model?" sanity logging.
+ *
+ * `TODO(48.A2)`: confirm the exact feature-bit-to-model boundary against a real 680G/770G/780G; the
+ * inference here is the best that can be done offline.
+ */
+enum class MedtronicPumpModel {
+    /** No hybrid closed loop: manual/PLGM/suspend-before-low only. No SmartGuard auto-basal. */
+    MINIMED_680G,
+
+    /** Hybrid closed loop (SmartGuard auto-basal + auto-mode), without auto-correction boluses. */
+    MINIMED_770G,
+
+    /** Hybrid closed loop with auto-correction (SmartGuard + Meal Detection / auto-correction boluses). */
+    MINIMED_780G,
+
+    /** Features unavailable or unrecognized; treat conservatively (parse defensively, no assumptions). */
+    UNKNOWN,
+    ;
+
+    /** True for the closed-loop models (770G/780G) that produce SmartGuard / auto-basal data. */
+    val supportsSmartGuard: Boolean
+        get() = this == MINIMED_770G || this == MINIMED_780G
+
+    /** True only for the 780G tier, which adds SmartGuard auto-correction (Meal Detection) boluses. */
+    val supportsAutoCorrectionBolus: Boolean
+        get() = this == MINIMED_780G
+
+    companion object {
+        // IDD Features bits (pump_features.py PumpFeatureFlags). Hybrid Closed Loop ("SmartGuard")
+        // distinguishes 770G/780G from 680G; Smart Settings (Meal Detection / auto-correction) is the
+        // 780G addition on top.
+        private const val HCL_FEATURE_SUPPORTED = 1L shl 28
+        private const val SMART_SETTINGS_SUPPORTED = 1L shl 29
+
+        /**
+         * Infer the capability tier from the IDD Features flag word. With no closed loop -> 680G; with
+         * closed loop but no smart settings -> 770G; with both -> 780G. [featureFlags] of 0 (features
+         * unread/unavailable) maps to [UNKNOWN].
+         */
+        fun fromFeatureFlags(featureFlags: Long): MedtronicPumpModel =
+            when {
+                featureFlags == 0L -> UNKNOWN
+                featureFlags and HCL_FEATURE_SUPPORTED == 0L -> MINIMED_680G
+                featureFlags and SMART_SETTINGS_SUPPORTED != 0L -> MINIMED_780G
+                else -> MINIMED_770G
+            }
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -265,6 +265,7 @@ class MedtronicSessionReader(
                             ),
                         ),
                     )
+                    return@subscribe
                 }
             } catch (e: Exception) {
                 finish(Result.failure(asReadException(e, "History record could not be decrypted")))

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -79,7 +79,8 @@ internal class NotificationReassembler(
 /**
  * Reusable read layer over a live [MedtronicSakeSession]: subscribes to a characteristic, reassembles
  * fragmented notifications, decrypts pump->phone payloads, and orchestrates the control-point
- * request -> notify -> response pattern shared by RACP and SOCP.
+ * request -> notify -> response pattern shared by the RACP (CGM single-record + IDD multi-record),
+ * SOCP and IDD SRCP exchanges, plus encrypted static reads (IDD Status/Features).
  *
  * **Read-only.** Only report/get-class requests are issued; no control or calibration opcode is ever
  * written.
@@ -176,32 +177,173 @@ class MedtronicSessionReader(
      * impose the operation timeout (see the class-level timeout contract).
      */
     fun socpGet(socp: UUID, requestOpcode: ByteArray, onResult: (Result<ByteArray>) -> Unit) {
+        val request = appendE2eCrc(requestOpcode)
+        Timber.d("SOCP GET request (%d bytes)", request.size)
+        encryptedGet(socp, session.encryptForPump(request), "SOCP response could not be decrypted", onResult)
+    }
+
+    /**
+     * IDD Status Reader Control Point (SRCP) read-only GET: SAKE-encrypt the (little-endian)
+     * [requestOpcode], write it to the [srcp] characteristic, then reassemble + decrypt the
+     * SAKE-encrypted indication and deliver the plaintext, exactly as `idd/status/reader.py`'s
+     * `_send_and_receive_opcode` does. Only GET-class opcodes (IOB, active basal, therapy state, ...)
+     * belong here -- no reset or control opcode is ever issued.
+     *
+     * Unlike [socpGet] the request is **not** E2E-CRC-wrapped: the 780G does not enable E2E
+     * protection in the IDD service, and upstream reads the IDD Features E2E bit to decide rather than
+     * assuming. `TODO(48.A2)`: honor that features flag per model once a live pump confirms it. As
+     * with the other exchanges the caller must impose the operation timeout.
+     */
+    fun srcpGet(srcp: UUID, requestOpcode: ByteArray, onResult: (Result<ByteArray>) -> Unit) {
+        Timber.d("IDD SRCP GET request (%d bytes)", requestOpcode.size)
+        encryptedGet(srcp, session.encryptForPump(requestOpcode), "IDD SRCP response could not be decrypted", onResult)
+    }
+
+    /**
+     * Read a SAKE-encrypted static characteristic (e.g. IDD Status `0x102`) and decrypt it. Unlike the
+     * plain [MedtronicGattLink.read] used for SIG characteristics, the IDD Status/Features values are
+     * encrypted, so they are decrypted here exactly as `idd/status/reader.py`'s `get_pump_status`
+     * does (`server_crypt.decrypt` of the raw read).
+     *
+     * Decrypting advances the session's inbound sequence counter, so this must be ordered with the
+     * other reads against the same session. Synchronous: the underlying [MedtronicGattLink.read] is.
+     *
+     * @throws MedtronicReadException if the read fails or the value does not authenticate/decrypt.
+     */
+    fun decryptedRead(characteristic: UUID): ByteArray =
+        try {
+            session.decryptFromPump(link.read(characteristic))
+        } catch (e: Exception) {
+            throw asReadException(e, "Encrypted characteristic $characteristic could not be decrypted")
+        }
+
+    /**
+     * Multi-record RACP report: write the (plaintext) [request] to [controlPoint], collect the stream
+     * of SAKE-encrypted record notifications on [dataChar] -- decrypting each -- and terminate when the
+     * plaintext RACP indication arrives. [isSuccess] decides whether that terminating indication is a
+     * success (deliver the collected records) or a failure (e.g. an IDD RACP error code).
+     *
+     * Mirrors `history_reader.py` (`get_records_between` / `get_last_record`): the RACP itself is not
+     * encrypted, only the IDD History Data records it triggers are, and the RACP indication follows
+     * after all records. Records are delimited by the same short-PDU rule [NotificationReassembler]
+     * uses; see the record-framing caveat on [HistoryReader]. The caller imposes the operation
+     * timeout (class-level contract).
+     */
+    fun reportRecords(
+        dataChar: UUID,
+        controlPoint: UUID,
+        request: ByteArray,
+        isSuccess: (ByteArray) -> Boolean,
+        onResult: (Result<List<ByteArray>>) -> Unit,
+    ) {
+        val assembler = NotificationReassembler()
+        val records = ArrayList<ByteArray>()
+        var finished = false
+
+        fun finish(result: Result<List<ByteArray>>) {
+            if (finished) return
+            finished = true
+            link.unsubscribe(dataChar)
+            link.unsubscribe(controlPoint)
+            onResult(result)
+        }
+
+        link.subscribe(dataChar) { pdu ->
+            if (finished) return@subscribe
+            try {
+                val frame = assembler.offer(pdu) ?: return@subscribe
+                records.add(session.decryptFromPump(frame))
+                // Defense-in-depth: a misbehaving (but authenticated) pump that streams records but
+                // never sends the terminating RACP indication must not grow memory without bound. The
+                // ceiling is far above any realistic single-fetch window; the operation timeout the C3
+                // caller imposes is the primary bound (mirrors NotificationReassembler's frame cap).
+                if (records.size > MAX_RECORDS_PER_REPORT) {
+                    finish(
+                        Result.failure(
+                            MedtronicReadException(
+                                "History report exceeded $MAX_RECORDS_PER_REPORT records without a terminating response",
+                            ),
+                        ),
+                    )
+                }
+            } catch (e: Exception) {
+                finish(Result.failure(asReadException(e, "History record could not be decrypted")))
+            }
+        }
+
+        link.subscribe(controlPoint) { response ->
+            if (finished) return@subscribe
+            if (isSuccess(response)) {
+                finish(Result.success(records.toList()))
+            } else {
+                finish(
+                    Result.failure(MedtronicReadException("Unexpected/failed RACP response: ${response.toHex()}")),
+                )
+            }
+        }
+
+        Timber.d("RACP report-records request (%d bytes)", request.size)
+        link.write(controlPoint, request)
+    }
+
+    /**
+     * Single plaintext control-point query (no encrypted data records): write [request] to
+     * [controlPoint] and deliver the first RACP indication verbatim. Used for the IDD "report number
+     * of records" query (`history_reader.py`'s `get_available_record_count`), where the count rides in
+     * the RACP indication itself and the IDD History Data characteristic is not involved.
+     */
+    fun controlPointQuery(controlPoint: UUID, request: ByteArray, onResult: (Result<ByteArray>) -> Unit) {
+        var finished = false
+
+        fun finish(result: Result<ByteArray>) {
+            if (finished) return
+            finished = true
+            link.unsubscribe(controlPoint)
+            onResult(result)
+        }
+
+        link.subscribe(controlPoint) { response ->
+            if (finished) return@subscribe
+            finish(Result.success(response.copyOf()))
+        }
+
+        Timber.d("RACP control-point query (%d bytes)", request.size)
+        link.write(controlPoint, request)
+    }
+
+    /**
+     * Shared body for the encrypted request -> single encrypted response exchanges ([socpGet],
+     * [srcpGet]): subscribe to [char], reassemble + decrypt the first complete response frame, and
+     * finish. Decrypting only while the exchange is live keeps a late/duplicate notification after
+     * finish() from consuming the next operation's sequence slot and desyncing the session.
+     */
+    private fun encryptedGet(
+        char: UUID,
+        encryptedRequest: ByteArray,
+        failMessage: String,
+        onResult: (Result<ByteArray>) -> Unit,
+    ) {
         val assembler = NotificationReassembler()
         var finished = false
 
         fun finish(result: Result<ByteArray>) {
             if (finished) return
             finished = true
-            link.unsubscribe(socp)
+            link.unsubscribe(char)
             onResult(result)
         }
 
-        link.subscribe(socp) { pdu ->
+        link.subscribe(char) { pdu ->
             if (finished) return@subscribe
             try {
                 val frame = assembler.offer(pdu) ?: return@subscribe
-                // Decrypting advances the session's inbound sequence counter; only do it while the
-                // exchange is live so a late/duplicate notification after finish() cannot consume the
-                // next operation's frame or desync the session (mirrors reportLastRecord).
                 finish(Result.success(session.decryptFromPump(frame)))
             } catch (e: Exception) {
-                finish(Result.failure(asReadException(e, "SOCP response could not be decrypted")))
+                finish(Result.failure(asReadException(e, failMessage)))
             }
         }
 
-        val request = appendE2eCrc(requestOpcode)
-        Timber.d("SOCP GET request (%d bytes)", request.size)
-        link.write(socp, session.encryptForPump(request))
+        link.write(char, encryptedRequest)
     }
 
     /** Map any decrypt/parse failure to a [MedtronicReadException], preserving an already-typed one. */
@@ -229,6 +371,13 @@ class MedtronicSessionReader(
          */
         val RACP_REPORT_SUCCESS = byteArrayOf(0x06, 0x00, 0x01, 0x01)
 
-        private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+        /**
+         * Upper bound on records collected in a single [reportRecords] call before the read is failed.
+         * Generous (far above any realistic incremental/backfill window) -- it only bounds memory when
+         * a pump streams records but never terminates the RACP procedure.
+         */
+        const val MAX_RECORDS_PER_REPORT = 50_000
+
+        private fun ByteArray.toHex(): String = MedtronicCodec.toHex(this)
     }
 }

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParserTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParserTest.kt
@@ -1,0 +1,149 @@
+/*
+ * AC2/AC3/AC4/AC5: the IDD history parser turns synthesized records into typed events + domain
+ * models, preserves raw records for dedup/backfill, resolves absolute time from the reference-time
+ * event, drops sentinel/out-of-range readings, and excludes SmartGuard micro-boluses (the flagged
+ * nuance). Frames are synthesized to the documented record layout (history_data.py); no pump needed.
+ */
+package com.glycemicgpt.mobile.ble.messages
+
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MedtronicHistoryParserTest {
+
+    private val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+
+    // NGP_REFERENCE_TIME at seq 100: recording_reason 0x3c + datetime 2026-06-01 12:00:00 UTC.
+    private val referenceRecord = record(0xF00E, 100, 0, "3c" + "ea07" + "06" + "01" + "0c" + "00" + "00")
+
+    private fun record(typeId: Int, seq: Int, offsetSec: Int, bodyHex: String): HistoryLogRecord =
+        MedtronicHistoryParser.toHistoryLogRecord(le16(typeId) + le32(seq) + le16(offsetSec) + hex(bodyHex), useE2e = false)!!
+
+    @Test
+    fun `toHistoryLogRecord preserves sequence, event type and relative offset`() {
+        val raw = le16(0xF00C) + le32(101) + le16(300) + hex("0000780000000000")
+        val log = MedtronicHistoryParser.toHistoryLogRecord(raw, useE2e = false)!!
+        assertEquals(101, log.sequenceNumber)
+        assertEquals(0xF00C, log.eventTypeId)
+        assertEquals(300L, log.pumpTimeSeconds)
+    }
+
+    @Test
+    fun `dedupBySequence keeps one record per sequence number`() {
+        val a = record(0xF00C, 101, 300, "0000780000000000")
+        val dup = record(0xF00C, 101, 300, "0000780000000000")
+        val b = record(0xF00C, 102, 360, "0000820000000000")
+        assertEquals(2, MedtronicHistoryParser.dedupBySequence(listOf(a, dup, b)).size)
+    }
+
+    @Test
+    fun `extractCgm resolves absolute time and drops sentinels, out-of-range and pre-reference records`() {
+        val records = listOf(
+            referenceRecord,
+            record(0xF00C, 50, 0, "0000820000000000"), // SG 130 BEFORE reference -> dropped
+            record(0xF00C, 101, 300, "0000780000000000"), // SG 120 mg/dL at +300s
+            record(0xF00C, 102, 360, "0000010300000000"), // sentinel 0x0301 -> dropped
+            record(0xF00C, 103, 420, "0000580200000000"), // SG 600 mg/dL -> out of range, dropped
+        )
+        val cgm = MedtronicHistoryParser.extractCgmFromHistoryLogs(records)
+        assertEquals(1, cgm.size)
+        assertEquals(120, cgm[0].glucoseMgDl)
+        assertEquals(CgmTrend.UNKNOWN, cgm[0].trendArrow)
+        assertEquals(reference.plusSeconds(300), cgm[0].timestamp)
+    }
+
+    @Test
+    fun `extractBoluses maps a delivered bolus as automated + correction and excludes micro-boluses`() {
+        val records = listOf(
+            referenceRecord,
+            record(0x005A, 108, 0, "010033190000ff000000000000"), // programmed P1, id 1, fast 2.5
+            record(0x0066, 109, 0, "08"), // programmed P2: delivery reason = correction
+            record(0x0069, 110, 600, "010033190000ff000000000000"), // delivered P1, id 1, fast 2.5
+            record(0x0096, 111, 600, "01000000005a"), // delivered P2: activation COMMANDED (auto)
+            record(0xF001, 112, 660, "01010000ff"), // SmartGuard auto-basal micro-bolus -> excluded
+        )
+        val boluses = MedtronicHistoryParser.extractBolusesFromHistoryLogs(records)
+        assertEquals(1, boluses.size)
+        assertEquals(2.5f, boluses[0].units, 1e-4f)
+        assertTrue(boluses[0].isAutomated)
+        assertTrue(boluses[0].isCorrection)
+        // Correction-only reason -> whole delivered amount attributed to correction, meal 0.
+        assertEquals(2.5f, boluses[0].correctionUnits, 1e-4f)
+        assertEquals(0f, boluses[0].mealUnits, 0f)
+        assertEquals(reference.plusSeconds(600), boluses[0].timestamp)
+    }
+
+    @Test
+    fun `extractBoluses rejects a bolus over the safety limit`() {
+        // delivered P1: bolusId(2)=1, type(1)=0, fast f32 = 1e000000 (30 IU), extended(4)=0,
+        // duration(2)=0 -> 13-byte body. 30000 mU > 25000 default cap, so it is dropped by the safety
+        // gate (not by a parse/length failure).
+        val records = listOf(
+            referenceRecord,
+            record(0x0069, 110, 600, "0100001e000000000000000000"),
+        )
+        assertTrue(MedtronicHistoryParser.extractBolusesFromHistoryLogs(records).isEmpty())
+    }
+
+    @Test
+    fun `extractBasal maps the new rate and flags AP-controller delivery as automated`() {
+        val records = listOf(
+            referenceRecord,
+            // flags 0x01 (context present), old 1.0, new 0.5 IU/h, context 0x55 (AP controller).
+            record(0x0099, 120, 0, "01" + "0a0000ff" + "050000ff" + "55"),
+        )
+        val basal = MedtronicHistoryParser.extractBasalFromHistoryLogs(records)
+        assertEquals(1, basal.size)
+        assertEquals(0.5f, basal[0].rate, 1e-4f)
+        assertTrue(basal[0].isAutomated)
+    }
+
+    @Test
+    fun `extractBasal rejects a rate over the safety limit`() {
+        val records = listOf(
+            referenceRecord,
+            // new rate 20 IU/h (0x00000014) -> 20000 mU/h > 15000 default cap.
+            record(0x0099, 120, 0, "00" + "0a0000ff" + "14000000"),
+        )
+        assertTrue(MedtronicHistoryParser.extractBasalFromHistoryLogs(records).isEmpty())
+    }
+
+    @Test
+    fun `parseRecordBody decodes a low-reservoir annunciation (cartridge event)`() {
+        // event_flags 03, ann_id 0001, type 0xf069 (low reservoir), status 0x33, timestamp 0.
+        val body = le16(0xF010) + le32(130) + le16(0) + hex("03" + "0100" + "69f0" + "33" + "00000000")
+        val parsed = MedtronicHistoryParser.parseRecordBody(body)!!
+        assertEquals(MedtronicHistoryEventType.ANNUNCIATION_CONSOLIDATED, parsed.eventType)
+        val event = parsed.event as MedtronicHistoryEvent.Annunciation
+        assertEquals(0x069, event.annunciationType)
+    }
+
+    @Test
+    fun `parseRecordBody preserves an unrecognized event type as Unparsed`() {
+        val body = le16(0x1234) + le32(140) + le16(0) + hex("deadbeef")
+        val parsed = MedtronicHistoryParser.parseRecordBody(body)!!
+        assertEquals(MedtronicHistoryEventType.UNDEFINED, parsed.eventType)
+        assertEquals(MedtronicHistoryEvent.Unparsed, parsed.event)
+    }
+
+    private fun le16(v: Int): ByteArray = byteArrayOf((v and 0xFF).toByte(), ((v shr 8) and 0xFF).toByte())
+
+    private fun le32(v: Int): ByteArray =
+        byteArrayOf(
+            (v and 0xFF).toByte(),
+            ((v shr 8) and 0xFF).toByte(),
+            ((v shr 16) and 0xFF).toByte(),
+            ((v shr 24) and 0xFF).toByte(),
+        )
+
+    private fun hex(s: String): ByteArray {
+        val clean = s.replace(" ", "")
+        return ByteArray(clean.length / 2) { clean.substring(2 * it, 2 * it + 2).toInt(16).toByte() }
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
@@ -75,6 +75,8 @@ class HistoryReaderTest {
                 value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
             ) {
                 PduFramer.fragment(two.pumpEncrypt(rec1)).forEach { emit(data, it) }
+                // Emit rec1 again (same sequence 118) so dedup is actually exercised end to end.
+                PduFramer.fragment(two.pumpEncrypt(rec1)).forEach { emit(data, it) }
                 PduFramer.fragment(two.pumpEncrypt(rec2)).forEach { emit(data, it) }
                 emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
             }

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
@@ -1,0 +1,131 @@
+/*
+ * AC2: the history reader drives the IDD RACP over the C1 framework -- the plaintext count query, and
+ * the multi-record report that collects SAKE-encrypted records on the IDD History Data characteristic
+ * and terminates on the RACP success indication. Records are encrypted by a genuine two-sided SAKE
+ * session and fragmented through PduFramer (MTU 23 discipline), in decrypt order.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.protocol.PduFramer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HistoryReaderTest {
+
+    private val racp = MedtronicProtocol.RACP_UUID
+    private val data = MedtronicProtocol.IDD_HISTORY_DATA_UUID
+    private val features = MedtronicProtocol.IDD_FEATURES_UUID
+    private val featuresPlain = hex("ffff006400fede801f") // E2E disabled
+
+    // A small basal-rate-changed record (18 bytes): type 0x0099, seq 120, offset 0, new rate 0.5 IU/h.
+    private val basalRecord = le16(0x0099) + le32(120) + le16(0) + hex("01" + "0a0000ff" + "050000ff" + "55")
+
+    @Test
+    fun `readRecordCount parses the RACP number-of-records response`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.contentEquals(HistoryReader.REQUEST_REPORT_NUMBER_OF_RECORDS)) {
+                // 66 0f <count u16 LE> -> NUMBER_OF_RECORDS_RESPONSE / SEQUENCE_NUMBER / count=5.
+                emit(racp, hex("660f0500"))
+            }
+        }
+
+        var result: Result<Int>? = null
+        HistoryReader(link, two.server).readRecordCount { result = it }
+        assertEquals(5, result!!.getOrThrow())
+    }
+
+    @Test
+    fun `readLastRecord collects one encrypted record and terminates on RACP success`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.contentEquals(HistoryReader.REQUEST_REPORT_LAST_RECORD)) {
+                PduFramer.fragment(two.pumpEncrypt(basalRecord)).forEach { emit(data, it) }
+                emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.HistoryLogRecord?>? = null
+        HistoryReader(link, two.server).readLastRecord { result = it }
+
+        val record = result!!.getOrThrow()
+        assertNotNull(record)
+        assertEquals(120, record!!.sequenceNumber)
+        assertEquals(0x0099, record.eventTypeId)
+    }
+
+    @Test
+    fun `readRecordsInRange collects multiple records, deduped`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        // Each record carries the optional context byte so it is 18 bytes (like basalRecord) and its
+        // encrypted form has a short terminating PDU rather than landing on an exact PDU multiple.
+        val rec1 = le16(0x0099) + le32(118) + le16(0) + hex("01" + "0a0000ff" + "050000ff" + "55")
+        val rec2 = le16(0x0099) + le32(119) + le16(0) + hex("01" + "050000ff" + "0a0000ff" + "55")
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.size > 3 &&
+                value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
+            ) {
+                PduFramer.fragment(two.pumpEncrypt(rec1)).forEach { emit(data, it) }
+                PduFramer.fragment(two.pumpEncrypt(rec2)).forEach { emit(data, it) }
+                emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
+        HistoryReader(link, two.server).readRecordsInRange(100, 120) { result = it }
+
+        val records = result!!.getOrThrow()
+        assertEquals(2, records.size)
+        assertEquals(listOf(118, 119), records.map { it.sequenceNumber }.sorted())
+    }
+
+    @Test
+    fun `readSinceSequence returns empty when already caught up`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.contentEquals(HistoryReader.REQUEST_REPORT_LAST_RECORD)) {
+                PduFramer.fragment(two.pumpEncrypt(basalRecord)).forEach { emit(data, it) } // seq 120
+                emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
+        HistoryReader(link, two.server).readSinceSequence(sinceSequence = 200) { result = it }
+
+        assertTrue(result!!.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `readRecordCount fails on an unexpected RACP response`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) emit(racp, hex("0f0f5a06")) // an error response code
+        }
+
+        var result: Result<Int>? = null
+        HistoryReader(link, two.server).readRecordCount { result = it }
+        assertTrue(result!!.isFailure)
+    }
+
+    private fun le16(v: Int): ByteArray = byteArrayOf((v and 0xFF).toByte(), ((v shr 8) and 0xFF).toByte())
+
+    private fun le32(v: Int): ByteArray =
+        byteArrayOf(
+            (v and 0xFF).toByte(),
+            ((v shr 8) and 0xFF).toByte(),
+            ((v shr 16) and 0xFF).toByte(),
+            ((v shr 24) and 0xFF).toByte(),
+        )
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/IddParsersTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/IddParsersTest.kt
@@ -1,0 +1,109 @@
+/*
+ * AC1/AC5: IDD payload parsers (status / IOB / active-basal / features) decoded against the published
+ * upstream PythonPumpConnector test vectors, the per-model feature tiering, and the optional Medtronic
+ * E2E trailer. These vectors are the shared, published-upstream protocol examples from the modules'
+ * __main__ blocks (not session secrets).
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IddParsersTest {
+
+    @Test
+    fun `IDD status parses the published vector`() {
+        // pump_status.py: 5596e80d28fb010300
+        val status = IddStatusRecord.parse(hex("5596e80d28fb010300"), useE2e = false)
+        assertEquals(TherapyControlState.RUN, status.therapyControlState)
+        assertEquals(OperationalState.READY, status.operationalState)
+        assertEquals(26.25, status.reservoirRemainingIu, 1e-9)
+        assertTrue(status.reservoirAttached)
+        assertEquals(SensorMessageState.NO_MESSAGE, status.sensorMessageState)
+    }
+
+    @Test
+    fun `IDD status validates and strips the E2E trailer when enabled`() {
+        val body = hex("5596e80d28fb010300")
+        val counter = byteArrayOf(0x01)
+        val protectedPrefix = body + counter
+        val crc = MedtronicCodec.e2eCrc(protectedPrefix)
+        val withE2e = protectedPrefix + byteArrayOf((crc and 0xFF).toByte(), ((crc shr 8) and 0xFF).toByte())
+
+        val status = IddStatusRecord.parse(withE2e, useE2e = true)
+        assertEquals(TherapyControlState.RUN, status.therapyControlState)
+        assertEquals(26.25, status.reservoirRemainingIu, 1e-9)
+    }
+
+    @Test
+    fun `IDD status rejects a corrupt E2E-CRC`() {
+        val withBadCrc = hex("5596e80d28fb010300") + hex("01dead")
+        assertThrows(MedtronicReadException::class.java) {
+            IddStatusRecord.parse(withBadCrc, useE2e = true)
+        }
+    }
+
+    @Test
+    fun `IDD status rejects a wrong-length body`() {
+        assertThrows(MedtronicReadException::class.java) {
+            IddStatusRecord.parse(hex("5596e80d28fb0103"), useE2e = false)
+        }
+    }
+
+    @Test
+    fun `IOB parses the published vector`() {
+        // iob.py: fc0300c05c15fa
+        val iob = IddInsulinOnBoard.parse(hex("fc0300c05c15fa"), useE2e = false)
+        assertEquals(1.4, iob.insulinOnBoardIu, 1e-9)
+        assertNull(iob.remainingDurationMin)
+    }
+
+    @Test
+    fun `IOB rejects a wrong response opcode`() {
+        assertThrows(MedtronicReadException::class.java) {
+            IddInsulinOnBoard.parse(hex("0000" + "00" + "c05c15fa"), useE2e = false)
+        }
+    }
+
+    @Test
+    fun `active basal parses the published vector`() {
+        // active_basal_rate_delivery.py: 6a03000200000000
+        val basal = IddActiveBasalRate.parse(hex("6a03000200000000"), useE2e = false)
+        assertEquals(0.0, basal.rateIuPerHour, 0.0)
+        assertEquals(2, basal.templateNumber)
+        assertNull(basal.basalDeliveryContext)
+    }
+
+    @Test
+    fun `active basal reads an AP-controller delivery context`() {
+        // opcode 036a, flags 0x04 (context present), template 0, rate 0, context 0x55 (AP controller).
+        val basal = IddActiveBasalRate.parse(hex("6a0304000000000055"), useE2e = false)
+        assertEquals(BasalDeliveryContext.AP_CONTROLLER, basal.basalDeliveryContext)
+    }
+
+    @Test
+    fun `IDD features parses the published vector`() {
+        // pump_features.py: ffff006400fede801f
+        val features = IddFeatures.parse(hex("ffff006400fede801f"))
+        assertEquals(100.0, features.insulinConcentration, 1e-6) // U-100 insulin
+        assertFalse(features.e2eProtectionEnabled)
+        // Real 700-series dump: closed loop supported. Assert the robust capability fact, not the exact
+        // 770-vs-780 tier (that boundary is verified deterministically below with synthesized flags).
+        assertTrue(features.model.supportsSmartGuard)
+    }
+
+    @Test
+    fun `pump model tiers from the closed-loop feature bits`() {
+        assertEquals(MedtronicPumpModel.UNKNOWN, MedtronicPumpModel.fromFeatureFlags(0L))
+        assertEquals(MedtronicPumpModel.MINIMED_680G, MedtronicPumpModel.fromFeatureFlags(0x0000_0002L))
+        assertEquals(MedtronicPumpModel.MINIMED_770G, MedtronicPumpModel.fromFeatureFlags(0x1000_0000L))
+        assertEquals(MedtronicPumpModel.MINIMED_780G, MedtronicPumpModel.fromFeatureFlags(0x3000_0000L))
+        assertFalse(MedtronicPumpModel.MINIMED_680G.supportsSmartGuard)
+        assertTrue(MedtronicPumpModel.MINIMED_780G.supportsAutoCorrectionBolus)
+        assertFalse(MedtronicPumpModel.MINIMED_770G.supportsAutoCorrectionBolus)
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/IddStatusReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/IddStatusReaderTest.kt
@@ -1,0 +1,135 @@
+/*
+ * AC1/AC4: the IDD status reader drives the C1 framework end to end -- decrypts the encrypted IDD
+ * Features + Status reads and the SRCP IOB/basal exchanges through a genuine two-sided SAKE session,
+ * maps them to the shared domain models, and rejects (never clamps) out-of-range values.
+ *
+ * Inbound frames are encrypted in the order the reader decrypts them so the SAKE sequence counters
+ * stay aligned (features read first, then the status read or the SRCP response).
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IddStatusReaderTest {
+
+    private val features = MedtronicProtocol.IDD_FEATURES_UUID
+    private val status = MedtronicProtocol.IDD_STATUS_UUID
+    private val srcp = MedtronicProtocol.IDD_SRCP_UUID
+
+    // E2E-disabled features (matches the published pump_features.py vector: e2e bit clear).
+    private val featuresPlain = hex("ffff006400fede801f")
+
+    @Test
+    fun `readReservoir decrypts the status read and maps units remaining`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.reads[status] = two.pumpEncrypt(hex("5596e80d28fb010300"))
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.ReservoirReading>? = null
+        IddStatusReader(link, two.server).readReservoir { result = it }
+
+        assertEquals(26.25f, result!!.getOrThrow().unitsRemaining, 1e-3f)
+    }
+
+    @Test
+    fun `readStatusState surfaces therapy, sensor and model`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.reads[status] = two.pumpEncrypt(hex("5596e80d28fb010300"))
+
+        var result: Result<MedtronicIddStatusState>? = null
+        IddStatusReader(link, two.server).readStatusState { result = it }
+
+        val state = result!!.getOrThrow()
+        assertEquals(TherapyControlState.RUN, state.therapyControlState)
+        assertEquals(OperationalState.READY, state.operationalState)
+        assertEquals(SensorMessageState.NO_MESSAGE, state.sensorMessageState)
+        assertTrue(state.reservoirAttached)
+        assertTrue(state.model.supportsSmartGuard)
+    }
+
+    @Test
+    fun `readReservoir rejects an out-of-range reservoir`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        // reservoir medfloat32 9999 IU (0x0000270f) -> above the 300 IU hardware bound.
+        link.reads[status] = two.pumpEncrypt(hex("55960f270000010300"))
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.ReservoirReading>? = null
+        IddStatusReader(link, two.server).readReservoir { result = it }
+
+        assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull() is MedtronicReadException)
+    }
+
+    @Test
+    fun `readIoB decrypts the SRCP exchange and maps IOB`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == srcp) emit(srcp, two.pumpEncrypt(hex("fc0300c05c15fa")))
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.IoBReading>? = null
+        IddStatusReader(link, two.server).readIoB { result = it }
+
+        assertEquals(1.4f, result!!.getOrThrow().iob, 1e-5f)
+    }
+
+    @Test
+    fun `readIoB rejects an implausible provisional IOB`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        // IOB medfloat32 200 IU (0x000000c8) -> above the plausible ceiling.
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == srcp) emit(srcp, two.pumpEncrypt(hex("fc0300c8000000")))
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.IoBReading>? = null
+        IddStatusReader(link, two.server).readIoB { result = it }
+
+        assertTrue(result!!.isFailure)
+    }
+
+    @Test
+    fun `readActiveBasalRate maps the rate and is manual without an AP context`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == srcp) emit(srcp, two.pumpEncrypt(hex("6a03000200000000")))
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.BasalReading>? = null
+        IddStatusReader(link, two.server).readActiveBasalRate { result = it }
+
+        val basal = result!!.getOrThrow()
+        assertEquals(0.0f, basal.rate, 0.0f)
+        assertEquals(false, basal.isAutomated)
+    }
+
+    @Test
+    fun `readActiveBasalRate rejects a basal rate over the safety limit`() {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        // rate medfloat32 20 IU/h (0x00000014) -> 20000 mU/h, above the 15000 mU/h default cap.
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == srcp) emit(srcp, two.pumpEncrypt(hex("6a03000014000000")))
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.BasalReading>? = null
+        IddStatusReader(link, two.server, SafetyLimits()).readActiveBasalRate { result = it }
+
+        assertTrue(result!!.isFailure)
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicCodecMedFloat32Test.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicCodecMedFloat32Test.kt
@@ -1,0 +1,53 @@
+/*
+ * AC1: the medfloat32 / uint32 / sign-extend additions to MedtronicCodec the IDD and history records
+ * rely on, checked against values decoded from the published upstream test vectors.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MedtronicCodecMedFloat32Test {
+
+    @Test
+    fun `decodeMedFloat32 decodes the reservoir vector to IU`() {
+        // From pump_status.py example 5596e80d28fb010300: reservoir bytes e8 0d 28 fb (LE) -> medfloat32
+        // = mantissa 0x280de8 (2,625,000) x 10^(exp 0xfb = -5) = 26.25 IU.
+        val raw = MedtronicCodec.readULongLe(hex("e80d28fb"), 0, 4)
+        assertEquals(26.25, MedtronicCodec.decodeMedFloat32(raw), 1e-9)
+    }
+
+    @Test
+    fun `decodeMedFloat32 decodes the IOB vector to IU`() {
+        // From iob.py example fc0300c05c15fa: IOB f32 bytes c0 5c 15 fa (LE)
+        // = mantissa 0x155cc0 (1,400,000) x 10^(exp 0xfa = -6) = 1.4 IU.
+        val raw = MedtronicCodec.readULongLe(hex("c05c15fa"), 0, 4)
+        assertEquals(1.4, MedtronicCodec.decodeMedFloat32(raw), 1e-9)
+    }
+
+    @Test
+    fun `decodeMedFloat32 decodes a zero rate as zero`() {
+        assertEquals(0.0, MedtronicCodec.decodeMedFloat32(0L), 0.0)
+    }
+
+    @Test
+    fun `readULongLe reads a full unsigned 32-bit value without sign loss`() {
+        assertEquals(0xFFFFFFFFL, MedtronicCodec.readULongLe(hex("ffffffff"), 0, 4))
+        assertEquals(0x0014D6L, MedtronicCodec.readULongLe(hex("d6140000"), 0, 4))
+    }
+
+    @Test
+    fun `signExtend turns a negative i16 into a negative Int`() {
+        assertEquals(-1, MedtronicCodec.signExtend(0xFFFF, 16))
+        assertEquals(-2, MedtronicCodec.signExtend(0xFFFE, 16))
+        assertEquals(5, MedtronicCodec.signExtend(0x0005, 16))
+    }
+
+    @Test
+    fun `signExtend on a full 32-bit width is the identity`() {
+        // 1 shl 32 would wrap (Kotlin masks the shift to low 5 bits); a full-width Int needs no extension.
+        assertEquals(-1, MedtronicCodec.signExtend(-1, 32))
+        assertEquals(Int.MIN_VALUE, MedtronicCodec.signExtend(Int.MIN_VALUE, 32))
+        assertEquals(42, MedtronicCodec.signExtend(42, 32))
+    }
+}


### PR DESCRIPTION
## Summary

Adds the data-heavy read layer for the read-only Medtronic MiniMed 700-series (680G / 770G / 780G) BLE driver, layered on the existing session-read framework. Kotlin port of the GPL-3.0 OpenMinimed `PythonPumpConnector` reference (used with the author's permission; GlycemicGPT is itself GPL-3.0, so the ported readers carry upstream attribution headers).

Strictly **read-only** — only RACP/SRCP/SOCP report/get opcodes are ever issued; no bolus, basal-set, suspend, or calibration-write opcode exists anywhere.

## What's included

**IDD status reader** (`IddStatusReader`, ported from `idd/status/*`)
- Reservoir → `ReservoirReading`, active basal → `BasalReading` (AP-controller delivery context ⇒ automated/closed-loop), therapy/operational/sensor state → `MedtronicIddStatusState`.
- Insulin-on-board → `IoBReading`, surfaced as **PROVISIONAL** (upstream marks IOB parsing untested) with a runtime warning marker — never presented as trusted.
- Per-pump E2E flag and SmartGuard capability tier are read from the IDD Features characteristic (`MedtronicPumpModel`, `IddFeatures`) rather than assuming one model's layout.

**History / RACP reader + parser** (`HistoryReader` + `MedtronicHistoryParser`, ported from `history_reader.py` / `history_data.py`)
- IDD-service RACP count / last-record / range / since-sequence fetch over the read framework.
- Typed parsing of bolus (programmed + delivered, P1/P2), basal-rate changes, sensor/calibration, insulin stop/restart, alarms and cartridge/battery annunciations, and SmartGuard auto-basal micro-boluses.
- Raw records preserved (base64, dedup by sequence number) for backfill/idempotency, mirroring the Tandem raw-history approach.
- Reference-time-anchored `extractCgm` / `extractBoluses` / `extractBasal` extraction helpers for the downstream capability layer.

**Shared**
- Codec gains medfloat32 / unsigned-32 / sign-extend decoders.
- Every parsed reservoir / IOB / basal / bolus value is routed through `SafetyLimits` and **rejected (never clamped)** when out of physiological range.

## Validation

- New reader/parser unit tests (module total 187, 0 failures) decode against the published upstream protocol vectors and synthesized frames, exercising decrypt through a genuine two-sided SAKE session, E2E-trailer handling, per-model tiering, safety-limit rejection, raw-record dedup, sensor-sentinel/out-of-range drop, and SmartGuard micro-bolus exclusion.
- `./gradlew :medtronic-pump-driver:testDebugUnitTest :medtronic-pump-driver:lintDebug :medtronic-pump-driver:assembleDebug` all green.
- Not claimed live-verified — over-the-air confirmation against a real pump is tracked as a follow-up.

## Scope / notes

- No app-side wiring, capability delegates, plugin class, or Hilt/`:app` dependency here — those are the next slice. CGM/device/battery readers already landed previously.
- The HAT service (`0x300`) RACP is stubbed/unsupported upstream and is intentionally not used; history goes through the IDD-service RACP, which shares the SIG `0x2A52` UUID with the CGM RACP (service-scoping is a follow-up concern for the on-device GATT client).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read full Medtronic MiniMed 700-series history over Bluetooth: CGM readings, boluses, and basal changes with proper timestamp anchoring, deduplication, and safety filtering.
  * Real-time IDD status reads: reservoir, insulin-on-board, active basal rate, and inferred automation status.
  * Automatic pump model detection to interpret capabilities (SmartGuard/auto-correction).

* **Bug Fixes / Reliability**
  * Improved parsing robustness, end-to-end integrity checks, and bounds/safety validations to reduce malformed or unsafe data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->