### PR TITLE
feat(medtronic): capability delegates + DevicePlugin + Hilt/:app wiring

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
     // Pump driver modules
     implementation(project(":pump-driver-api"))
     implementation(project(":tandem-pump-driver"))
+    implementation(project(":medtronic-pump-driver"))
 
     // AndroidX Core
     implementation(libs.androidx.core.ktx)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -715,9 +715,10 @@ private fun PluginsSection(
     onShowRemovePlugin: (String) -> Unit,
     onClearPluginInstallError: () -> Unit,
 ) {
-    // Only show pump pairing card when the Tandem plugin is active.
-    // Uses literal ID to avoid importing TandemDevicePlugin into the UI layer.
-    if ("com.glycemicgpt.tandem" in state.activePluginIds) {
+    // Show the pump pairing card whenever any pump DevicePlugin is active (the registry resolves the
+    // active PUMP_STATUS/INSULIN_SOURCE plugin generically into activePumpPluginId), so it works for
+    // every pump driver -- Tandem, Medtronic, or a future one -- without hardcoding a vendor id.
+    if (state.activePumpPluginId != null) {
         PumpSection(
             state = state,
             onNavigateToPairing = onNavigateToPairing,

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -51,12 +51,15 @@ id = "GHSA-qx2v-qp2m-jg93"
 reason = "Nested only inside next; build-time CSS pipeline does not process untrusted CSS; top-level postcss is patched to 8.5.13"
 
 # vitest 3.2.4 -- dev-only test runner in the sidecar (sidecar/package.json devDependencies).
-# GHSA-5xrq-8626-4rwp: arbitrary file read/exec only when the Vitest *UI server* is listening and
-# exposed to the network (--api.host / api.host), or Vitest UI/Browser Mode on Windows. We never run
-# the UI server -- CI runs vitest headless on Linux, no --api.host -- so the vulnerable surface is
-# never enabled, and vitest is not in any production build. Fix = bump vitest to >= 4.1.0 (major),
-# tracked separately; ignoreUntil forces re-evaluation.
+# GHSA-5xrq-8626-4rwp (alias CVE-2026-47429): "When Vitest UI server is listening, arbitrary file can
+# be read and executed." Affected vitest < 4.1.0 (fixed 4.1.0). The vulnerable surface is the Vitest
+# UI / Browser Mode server (packages/browser RPC fs endpoint); it requires the UI server to be
+# listening and reachable. We never start it -- the sidecar runs vitest headless in CI (no `vitest
+# --ui`, no `--api.host`), and vitest is not in any production build. Sources:
+#   * https://osv.dev/vulnerability/GHSA-5xrq-8626-4rwp
+#   * https://github.com/vitest-dev/vitest/security/advisories/GHSA-5xrq-8626-4rwp
+# Real fix = bump vitest to >= 4.1.0 (major), tracked separately; ignoreUntil forces re-evaluation.
 [[IgnoredVulns]]
 id = "GHSA-5xrq-8626-4rwp"
 ignoreUntil = 2026-09-01T00:00:00Z
-reason = "Dev-only test dependency (sidecar vitest); not exploitable -- the affected Vitest UI server is never started/exposed (headless Linux CI, no --api.host); not in production. Fix = bump vitest >= 4.1.0 (major), tracked separately."
+reason = "Dev-only test dependency (sidecar vitest, CVE-2026-47429); not exploitable -- the affected Vitest UI/Browser-Mode server is never started/exposed (headless Linux CI, no --ui/--api.host); not in production. Fixed in vitest 4.1.0; bump tracked separately. Refs: https://osv.dev/vulnerability/GHSA-5xrq-8626-4rwp , https://github.com/vitest-dev/vitest/security/advisories/GHSA-5xrq-8626-4rwp"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -49,3 +49,14 @@ reason = "Dev-only transitive dependency (jest/eslint toolchain); fix requires b
 [[IgnoredVulns]]
 id = "GHSA-qx2v-qp2m-jg93"
 reason = "Nested only inside next; build-time CSS pipeline does not process untrusted CSS; top-level postcss is patched to 8.5.13"
+
+# vitest 3.2.4 -- dev-only test runner in the sidecar (sidecar/package.json devDependencies).
+# GHSA-5xrq-8626-4rwp: arbitrary file read/exec only when the Vitest *UI server* is listening and
+# exposed to the network (--api.host / api.host), or Vitest UI/Browser Mode on Windows. We never run
+# the UI server -- CI runs vitest headless on Linux, no --api.host -- so the vulnerable surface is
+# never enabled, and vitest is not in any production build. Fix = bump vitest to >= 4.1.0 (major),
+# tracked separately; ignoreUntil forces re-evaluation.
+[[IgnoredVulns]]
+id = "GHSA-5xrq-8626-4rwp"
+ignoreUntil = 2026-09-01T00:00:00Z
+reason = "Dev-only test dependency (sidecar vitest); not exploitable -- the affected Vitest UI server is never started/exposed (headless Linux CI, no --api.host); not in production. Fix = bump vitest >= 4.1.0 (major), tracked separately."

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
@@ -426,8 +426,13 @@ class MedtronicBleConnectionManager(
         /** Default advertised local name. Must match `Mobile .{0,7}`. TODO(48.A2/D): per-install identity. */
         const val DEFAULT_LOCAL_NAME = "Mobile 000001"
 
-        /** Plugin id stamped on discovered devices. The MedtronicDevicePlugin (Milestone C) owns the canonical id. */
-        const val PLUGIN_ID = "medtronic"
+        /**
+         * Canonical reverse-domain plugin id, stamped on discovered devices and reused as the
+         * [com.glycemicgpt.mobile.domain.plugin.PluginMetadata.id] by `MedtronicDevicePlugin`/
+         * `MedtronicPluginFactory` so there is a single source of truth (B2 shipped a `"medtronic"`
+         * placeholder; Milestone C set the canonical id here).
+         */
+        const val PLUGIN_ID = "com.glycemicgpt.medtronic"
 
         private const val SAKE_WORKER_THREAD_NAME = "medtronic-sake"
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicGattLink.kt
@@ -42,8 +42,15 @@ interface MedtronicGattLink {
      *
      * **Threading contract:** all [onPdu] callbacks across every subscribed characteristic are
      * delivered serialized on a single thread. [MedtronicSessionReader] relies on this to keep its
-     * per-exchange state lock-free; the on-device implementation (C3) must honor it (e.g. by hopping
-     * BLE callbacks onto one handler thread, as the connection manager already does).
+     * per-exchange state lock-free; the on-device implementation (Milestone D) must honor it (e.g. by
+     * hopping BLE callbacks onto one handler thread, as the connection manager already does).
+     *
+     * **Cancellation/cleanup contract:** the caller bounds each exchange with an operation timeout and
+     * cancels the coroutine on expiry, but a reader only calls [unsubscribe] when the pump *responds*.
+     * The implementation MUST therefore release every outstanding subscription/notification when the
+     * driving operation's coroutine is cancelled, so a timed-out read leaves no dangling notifications
+     * that could desync the next exchange. See the matching "Cancellation/cleanup contract" /
+     * `TODO(48.D)` on [MedtronicReadGateway] for the full semantics.
      */
     fun subscribe(characteristic: UUID, onPdu: (ByteArray) -> Unit)
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -1,0 +1,186 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Capability-facing read bundle for the Medtronic MiniMed 700-series
+ * read-only driver.
+ *
+ * This is the Medtronic analog of Tandem's `TandemBleDriver`: a single seam the capability delegates
+ * (MedtronicGlucoseSource / MedtronicInsulinSource / MedtronicPumpStatus) forward to, so the delegates
+ * stay thin. It owns three cross-cutting concerns the individual C1/C2 readers deliberately left to
+ * their caller (see MedtronicSessionReader's timeout contract):
+ *   1. resolving the live SAKE session + the GATT-client transport, failing cleanly when not connected;
+ *   2. bounding every read with a per-operation timeout (the readers carry no timers);
+ *   3. routing caught failures through Timber so they are observable in the glycemicgpt-mobile Sentry
+ *      project once this runs in :app (Story AC7).
+ *
+ * It adds no parsing of its own -- the readers (CgmReader / IddStatusReader / HistoryReader /
+ * DeviceInfoReader / BatteryReader) own that. READ-ONLY: only report/get-class reads are issued.
+ *
+ * **Transport seam (Milestone D).** The on-device [MedtronicGattLink] (a `BluetoothGatt` client to the
+ * connected pump's CGM / IDD / Device-Info GATT server) is wired with the polling/orchestration slice
+ * in Milestone D; [linkProvider] returns `null` until then, so reads report "not connected" rather
+ * than fabricate data. Pairing, the SAKE handshake and connection state already work end-to-end
+ * (Milestone B2), so the plugin is fully discoverable/activatable now; data lights up when the link
+ * provider is supplied. `TODO(48.D)`: provide a real `BluetoothGatt`-client link, scoping the shared
+ * SIG `0x2A52` [MedtronicProtocol.RACP_UUID] under the CGM service for [getCgmReading] and under the
+ * IDD service for [getHistoryLogs] (the readers reuse the same characteristic UUID across both
+ * services; the on-device link must resolve it by service -- `TODO(48.C3)` carried forward).
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.coroutines.resume
+import timber.log.Timber
+
+/**
+ * Bundles the Medtronic read layer behind suspend `Result<T>` calls for the capability delegates.
+ *
+ * @param sessionProvider supplies the live post-handshake session (the connection manager's
+ *     `sakeSession`), or `null` when no pump is authenticated.
+ * @param linkProvider supplies the GATT-client transport to the connected pump, or `null` when the
+ *     transport is unavailable (the deferred Milestone D seam; see the class header).
+ * @param ioDispatcher dispatcher for the blocking SIG reads (Device Info / Battery).
+ * @param operationTimeoutMs hard upper bound on every read; expiry surfaces as a failed [Result].
+ */
+class MedtronicReadGateway(
+    private val sessionProvider: () -> MedtronicSakeSession?,
+    private val linkProvider: () -> MedtronicGattLink?,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val operationTimeoutMs: Long = DEFAULT_OPERATION_TIMEOUT_MS,
+) {
+
+    /** Latest sensor glucose (CGM RACP "report last record"). */
+    suspend fun getCgmReading(): Result<CgmReading> =
+        sessionRead("CGM") { link, session, onResult ->
+            CgmReader(link, session).readLatest(onResult)
+        }
+
+    /** Insulin on board (IDD SRCP). PROVISIONAL until live-validated (the reader logs the marker). */
+    suspend fun getIoB(): Result<IoBReading> =
+        sessionRead("IOB") { link, session, onResult ->
+            IddStatusReader(link, session).readIoB(onResult)
+        }
+
+    /** Active basal rate currently delivered, with closed-loop (SmartGuard) detection. */
+    suspend fun getBasalRate(): Result<BasalReading> =
+        sessionRead("basal") { link, session, onResult ->
+            IddStatusReader(link, session).readActiveBasalRate(onResult)
+        }
+
+    /** Reservoir units remaining. */
+    suspend fun getReservoirLevel(): Result<ReservoirReading> =
+        sessionRead("reservoir") { link, session, onResult ->
+            IddStatusReader(link, session).readReservoir(onResult)
+        }
+
+    /** Incremental history fetch: every record newer than [sinceSequence] (raw, preserved for dedup). */
+    suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        sessionRead("history") { link, session, onResult ->
+            HistoryReader(link, session).readSinceSequence(sinceSequence, onResult)
+        }
+
+    /** Battery percentage (plain SIG Battery Level read; no session required). */
+    suspend fun getBatteryStatus(): Result<BatteryStatus> =
+        blockingRead("battery") { link -> BatteryReader(link).read() }
+
+    /** Device Information strings (model/serial/firmware/...); plain SIG reads, no session required. */
+    suspend fun getDeviceInfo(): Result<MedtronicDeviceInfo> =
+        blockingRead("device-info") { link -> DeviceInfoReader(link).read() }
+
+    // -- Internals ----------------------------------------------------------
+
+    /**
+     * Run a callback-style reader that needs both the live session and the transport, bridged to a
+     * suspend `Result<T>` under [operationTimeoutMs]. The readers invoke [onResult] exactly once on the
+     * link's single delivery thread; the timeout is the caller-side bound their timeout contract
+     * requires.
+     *
+     * **Cancellation/cleanup contract.** On a timeout this coroutine is cancelled while the reader may
+     * still hold notification subscriptions on the link (the reader only unsubscribes when the pump
+     * responds). The gateway cannot drop them here -- it does not know which characteristics the reader
+     * subscribed. The on-device [MedtronicGattLink] (Milestone D) MUST therefore release all
+     * outstanding subscriptions for an operation when that operation's coroutine is cancelled, so a
+     * timed-out read leaves no dangling notifications. `TODO(48.D)`.
+     */
+    private suspend fun <T> sessionRead(
+        op: String,
+        start: (MedtronicGattLink, MedtronicSakeSession, (Result<T>) -> Unit) -> Unit,
+    ): Result<T> {
+        val link = linkProvider() ?: return notConnected(op, "transport unavailable")
+        val session = sessionProvider() ?: return notConnected(op, "no authenticated session")
+        return withOperationTimeout(op) {
+            // The readers issue blocking GATT read/write before registering their callback, so offload
+            // to [ioDispatcher] (as [blockingRead] does); the callback resume is dispatcher-agnostic.
+            withContext(ioDispatcher) {
+                suspendCancellableCoroutine { cont ->
+                    start(link, session) { result -> if (cont.isActive) cont.resume(result) }
+                }
+            }
+        }
+    }
+
+    /**
+     * Run a synchronous (blocking) SIG reader off the caller thread, bounded by the operation timeout.
+     *
+     * Uses [runInterruptible] rather than plain [withContext]: a blocking GATT read is not a suspension
+     * point, so `withTimeout` could not cancel it -- structured concurrency would wait for it to return
+     * on its own. [runInterruptible] turns the operation timeout's cancellation into a thread interrupt,
+     * so an interruptible blocking read (e.g. one parked on a latch / interruptible I/O) aborts at the
+     * deadline. A read that ignores interruption still cannot be force-unwound here; the on-device
+     * [MedtronicGattLink] (Milestone D) must therefore also enforce its own per-read timeout, as its
+     * interface contract requires.
+     */
+    private suspend fun <T> blockingRead(op: String, read: (MedtronicGattLink) -> T): Result<T> {
+        val link = linkProvider() ?: return notConnected(op, "transport unavailable")
+        return withOperationTimeout(op) {
+            runInterruptible(ioDispatcher) {
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    Result.success(read(link))
+                } catch (e: InterruptedException) {
+                    // A timeout interrupt: rethrow so it surfaces as cancellation and the operation
+                    // timeout reports it, rather than being swallowed into a Result.failure.
+                    throw e
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
+            }
+        }
+    }
+
+    private suspend fun <T> withOperationTimeout(op: String, block: suspend () -> Result<T>): Result<T> =
+        try {
+            withTimeout(operationTimeoutMs) { block() }
+                .onFailure { Timber.w(it, "Medtronic %s read failed", op) }
+        } catch (e: TimeoutCancellationException) {
+            Timber.w(e, "Medtronic %s read timed out after %d ms", op, operationTimeoutMs)
+            Result.failure(MedtronicReadException("Medtronic $op read timed out after $operationTimeoutMs ms", e))
+        }
+
+    private fun <T> notConnected(op: String, reason: String): Result<T> {
+        // Expected before Milestone D wires the transport; debug (not warn) so it never reads as a
+        // Sentry-worthy error while the driver is inert.
+        Timber.d("Medtronic %s read skipped: %s", op, reason)
+        return Result.failure(MedtronicReadException("Medtronic $op read skipped: pump not connected ($reason)"))
+    }
+
+    companion object {
+        /**
+         * Per-operation timeout. A single read is a few BLE round trips of 20-byte PDUs; history fetches
+         * page more but each record still arrives promptly. 30s matches the handshake timeout and the
+         * 30s connect timeout the [com.glycemicgpt.mobile.domain.plugin.DevicePlugin] contract documents.
+         */
+        const val DEFAULT_OPERATION_TIMEOUT_MS = 30_000L
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -162,9 +162,18 @@ class MedtronicReadGateway(
     private suspend fun <T> withOperationTimeout(op: String, block: suspend () -> Result<T>): Result<T> =
         try {
             withTimeout(operationTimeoutMs) { block() }
-                .onFailure { Timber.w(it, "Medtronic %s read failed", op) }
+                .onFailure { e ->
+                    // WARN is forwarded to the glycemicgpt-mobile Sentry project, so it must NOT carry
+                    // the exception message/stacktrace: reader failures embed health values (e.g.
+                    // "SG 142 mg/dL outside ...", IOB/basal/reservoir) and raw pump bytes. Log only the
+                    // operation + exception type at WARN; keep the full detail at DEBUG (local logcat).
+                    Timber.w("Medtronic %s read failed: %s", op, e.javaClass.simpleName)
+                    Timber.d(e, "Medtronic %s read failure detail", op)
+                }
         } catch (e: TimeoutCancellationException) {
-            Timber.w(e, "Medtronic %s read timed out after %d ms", op, operationTimeoutMs)
+            // No PHI in a timeout, but keep the same WARN discipline (message only, throwable at DEBUG).
+            Timber.w("Medtronic %s read timed out after %d ms", op, operationTimeoutMs)
+            Timber.d(e, "Medtronic %s read timeout detail", op)
             Result.failure(MedtronicReadException("Medtronic $op read timed out after $operationTimeoutMs ms", e))
         }
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/di/MedtronicPumpModule.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/di/MedtronicPumpModule.kt
@@ -1,0 +1,82 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Hilt wiring for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * Mirrors TandemPumpModule: binds the factory into the platform's `Set<PluginFactory>` multibinding so
+ * PluginRegistry discovers it. Additionally assembles the B2 peripheral-mode connection manager from
+ * the Android peripheral + the dedicated SAKE worker thread, and the C3 read gateway over the
+ * post-handshake session.
+ */
+package com.glycemicgpt.mobile.di
+
+import android.content.Context
+import com.glycemicgpt.mobile.ble.connection.AndroidMedtronicPeripheral
+import com.glycemicgpt.mobile.ble.connection.HandlerThreadSerialWorker
+import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
+import com.glycemicgpt.mobile.ble.connection.MedtronicPeripheral
+import com.glycemicgpt.mobile.ble.connection.SerialWorker
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.plugin.PluginFactory
+import com.glycemicgpt.mobile.domain.pump.PumpCredentialProvider
+import com.glycemicgpt.mobile.plugin.MedtronicPluginFactory
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MedtronicPumpModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindMedtronicFactory(impl: MedtronicPluginFactory): PluginFactory
+
+    companion object {
+
+        @Provides
+        @Singleton
+        fun providePeripheral(@ApplicationContext context: Context): MedtronicPeripheral =
+            AndroidMedtronicPeripheral(context)
+
+        @Provides
+        @Singleton
+        fun provideSerialWorker(): SerialWorker =
+            HandlerThreadSerialWorker(SAKE_WORKER_THREAD_NAME)
+
+        @Provides
+        @Singleton
+        fun provideConnectionManager(
+            peripheral: MedtronicPeripheral,
+            worker: SerialWorker,
+            credentialStore: PumpCredentialProvider,
+        ): MedtronicBleConnectionManager =
+            MedtronicBleConnectionManager(
+                peripheral = peripheral,
+                credentialStore = credentialStore,
+                worker = worker,
+                scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+            )
+
+        @Provides
+        @Singleton
+        fun provideReadGateway(
+            connectionManager: MedtronicBleConnectionManager,
+        ): MedtronicReadGateway =
+            MedtronicReadGateway(
+                sessionProvider = { connectionManager.sakeSession },
+                // TODO(48.D): supply the on-device BluetoothGatt-client MedtronicGattLink (scoping the
+                // shared SIG 0x2A52 RACP characteristic under the CGM vs IDD service). Until the
+                // transport lands the gateway reports "not connected"; pairing + handshake already work.
+                linkProvider = { null },
+            )
+
+        private const val SAKE_WORKER_THREAD_NAME = "medtronic-sake"
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDeviceInfoMapper.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDeviceInfoMapper.kt
@@ -1,0 +1,69 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Adapts the Medtronic-native device-info shape onto the shared,
+ * Tandem-derived capability models.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.read.MedtronicDeviceInfo
+import com.glycemicgpt.mobile.domain.model.PumpHardwareInfo
+import com.glycemicgpt.mobile.domain.model.PumpSettings
+
+/**
+ * Maps the alphanumeric [MedtronicDeviceInfo] onto the shared [PumpSettings], which is string-typed
+ * and a clean fit: firmware/serial/model carry across verbatim.
+ */
+internal fun MedtronicDeviceInfo.toPumpSettings(): PumpSettings =
+    PumpSettings(
+        firmwareVersion = firmwareRevision,
+        serialNumber = serialNumber,
+        modelNumber = modelNumber,
+    )
+
+/**
+ * Maps [MedtronicDeviceInfo] onto the shared [PumpHardwareInfo].
+ *
+ * [PumpHardwareInfo] is Tandem-shaped: its identity fields ([PumpHardwareInfo.serialNumber],
+ * [PumpHardwareInfo.modelNumber]) are `Long`, whereas Medtronic's are alphanumeric (model "MMT-1880",
+ * serial "NG..."). The faithful, lossless representation of pump identity is [toPumpSettings] (and the
+ * native [MedtronicDeviceInfo]); this `Long`-keyed view is a best-effort adaptation for the shared
+ * surface:
+ *  - the numeric run is extracted from each identifier ([numericId]) for the `Long` slots, so a
+ *    "MMT-1880" model still yields a stable, comparable `1880`;
+ *  - the firmware/hardware revision strings map onto the revision slots;
+ *  - [PumpHardwareInfo.pumpFeatures] is left empty: it is a feature-flag map (uploaded verbatim to the
+ *    backend as `pump_features`), so it must not be repurposed to smuggle identity strings -- the DIS
+ *    exposes no genuine feature flags, and the identity is already carried losslessly by
+ *    [toPumpSettings];
+ *  - fields the Device Information Service does not expose (part number, PCBA serial, config bit
+ *    masks, ARM/MSP split) are left `0`/empty rather than invented.
+ *
+ * `TODO(48.D)`: prefer surfacing [MedtronicDeviceInfo] / [toPumpSettings] directly to the dashboard
+ * once the UI consumes pump identity, rather than round-tripping through this lossy `Long`-keyed view.
+ */
+internal fun MedtronicDeviceInfo.toPumpHardwareInfo(): PumpHardwareInfo =
+    PumpHardwareInfo(
+        serialNumber = numericId(serialNumber),
+        modelNumber = numericId(modelNumber),
+        partNumber = 0,
+        pumpRev = firmwareRevision,
+        armSwVer = numericId(softwareRevision),
+        mspSwVer = 0,
+        configABits = 0,
+        configBBits = 0,
+        pcbaSn = 0,
+        pcbaRev = hardwareRevision,
+        pumpFeatures = emptyMap(),
+    )
+
+/**
+ * The numeric value of the longest run of digits in [raw] (e.g. "MMT-1880" -> 1880, "NG1234567H" ->
+ * 1234567), or `0` when there are no digits. Longs are bounded; a pathologically long digit run is
+ * truncated to the trailing 18 digits to stay within [Long] range without overflowing.
+ */
+private fun numericId(raw: String): Long {
+    val digits = Regex("\\d+").findAll(raw).maxByOrNull { it.value.length }?.value ?: return 0L
+    return digits.takeLast(MAX_LONG_DIGITS).toLongOrNull() ?: 0L
+}
+
+/** 18 digits always fit in a signed 64-bit Long (max is 19 digits); avoids a parse overflow. */
+private const val MAX_LONG_DIGITS = 18

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePlugin.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePlugin.kt
@@ -53,7 +53,11 @@ class MedtronicDevicePlugin(
     }
 
     override fun shutdown() {
-        connectionManager.disconnect()
+        // Terminal teardown: fully release the connection manager's worker thread + coroutine scope
+        // (not just the BLE session). shutdown() is the destroy hook -- distinct from onDeactivated(),
+        // which only disconnects so the plugin can be reactivated. close() is safe here because the
+        // plugin is being discarded and is not re-created against the same manager.
+        connectionManager.close()
     }
 
     override fun onActivated() {
@@ -62,7 +66,9 @@ class MedtronicDevicePlugin(
     }
 
     override fun onDeactivated() {
-        // Drop the live session but keep the pairing, so reactivating reconnects without re-pairing.
+        // Drop the live session but keep the pairing (and the manager alive), so reactivating
+        // reconnects without re-pairing. Use disconnect(), not close(): close() is reserved for
+        // terminal shutdown().
         connectionManager.disconnect()
     }
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePlugin.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePlugin.kt
@@ -1,0 +1,147 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Read-only DevicePlugin for the Medtronic MiniMed 700-series.
+ *
+ * The first :app runtime surface of the Medtronic driver: it exposes the B2 peripheral-mode
+ * connection manager and the C1/C2 readers (via MedtronicReadGateway) through the same capability
+ * contract as Tandem. READ-ONLY -- it declares GLUCOSE_SOURCE / INSULIN_SOURCE / PUMP_STATUS only;
+ * there is no PUMP_CONTROL capability in the platform and no method here writes to the pump.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.DiscoveredDevice
+import com.glycemicgpt.mobile.domain.plugin.DevicePlugin
+import com.glycemicgpt.mobile.domain.plugin.PLUGIN_API_VERSION
+import com.glycemicgpt.mobile.domain.plugin.PluginCapability
+import com.glycemicgpt.mobile.domain.plugin.PluginCapabilityInterface
+import com.glycemicgpt.mobile.domain.plugin.PluginContext
+import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
+import com.glycemicgpt.mobile.domain.plugin.capabilities.GlucoseSource
+import com.glycemicgpt.mobile.domain.plugin.capabilities.InsulinSource
+import com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus
+import com.glycemicgpt.mobile.domain.plugin.ui.ButtonStyle
+import com.glycemicgpt.mobile.domain.plugin.ui.DashboardCardDescriptor
+import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsDescriptor
+import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsSection
+import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlin.reflect.KClass
+
+class MedtronicDevicePlugin(
+    private val connectionManager: MedtronicBleConnectionManager,
+    private val gateway: MedtronicReadGateway,
+) : DevicePlugin {
+
+    override val metadata = METADATA
+
+    override val capabilities: Set<PluginCapability> = setOf(
+        PluginCapability.GLUCOSE_SOURCE,
+        PluginCapability.INSULIN_SOURCE,
+        PluginCapability.PUMP_STATUS,
+    )
+
+    private val glucoseSource = MedtronicGlucoseSource(gateway)
+    private val insulinSource = MedtronicInsulinSource(gateway)
+    private val pumpStatus = MedtronicPumpStatus(gateway, connectionManager)
+
+    override fun initialize(context: PluginContext) {
+        // BLE components are injected ready-to-use; no additional setup needed.
+    }
+
+    override fun shutdown() {
+        connectionManager.disconnect()
+    }
+
+    override fun onActivated() {
+        // Reconnect to an already-paired pump when the user selects this driver.
+        connectionManager.reconnectIfPaired()
+    }
+
+    override fun onDeactivated() {
+        // Drop the live session but keep the pairing, so reactivating reconnects without re-pairing.
+        connectionManager.disconnect()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : PluginCapabilityInterface> getCapability(type: KClass<T>): T? = when (type) {
+        GlucoseSource::class -> glucoseSource as? T
+        InsulinSource::class -> insulinSource as? T
+        PumpStatus::class -> pumpStatus as? T
+        else -> null
+    }
+
+    override fun observeConnectionState(): StateFlow<ConnectionState> =
+        connectionManager.connectionState
+
+    /**
+     * Begin a connection. In the inverted (phone-as-peripheral) topology there is no pump address to
+     * dial -- the phone advertises and the pump connects to it -- so [address] is unused; the connection
+     * manager drives advertising + the SAKE handshake. Pass `config["forceFirstPair"] = "true"` to force
+     * first-pair advertising when re-pairing instead of reconnecting to a remembered pump.
+     */
+    override fun connect(address: String, config: Map<String, String>) {
+        connectionManager.startSession(forceFirstPair = config["forceFirstPair"].toBoolean())
+    }
+
+    override fun disconnect() {
+        connectionManager.disconnect()
+    }
+
+    /**
+     * Discovery is advertise-and-wait in the inverted topology (the pump finds us); the connection
+     * manager emits a [DiscoveredDevice] when a pump connects, already stamped with the canonical
+     * [PLUGIN_ID].
+     */
+    override fun scan(): Flow<DiscoveredDevice> =
+        connectionManager.scan()
+
+    override fun settingsDescriptor(): PluginSettingsDescriptor = PluginSettingsDescriptor(
+        sections = listOf(
+            PluginSettingsSection(
+                title = "Connection",
+                items = listOf(
+                    SettingDescriptor.InfoText(
+                        key = "pairing_status",
+                        text = "Status: ${connectionManager.connectionState.value}",
+                    ),
+                    // Single-peer limitation (medtronic-ble-reverse-engineering.md Sec. 7): a 700-series
+                    // pump talks to one phone at a time, so pairing GlycemicGPT requires first removing
+                    // the pump from the official Medtronic app. Surfaced here for Milestone D's pairing UX.
+                    SettingDescriptor.InfoText(
+                        key = "single_peer_note",
+                        text = "A MiniMed pump pairs with only one phone at a time. " +
+                            "Remove the pump from the official Medtronic app before pairing it here.",
+                    ),
+                    SettingDescriptor.ActionButton(
+                        key = "unpair",
+                        label = "Unpair Pump",
+                        style = ButtonStyle.DESTRUCTIVE,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    override fun observeDashboardCards(): Flow<List<DashboardCardDescriptor>> =
+        flowOf(emptyList())
+
+    companion object {
+        /** Canonical plugin id; single source of truth is [MedtronicBleConnectionManager.PLUGIN_ID]. */
+        const val PLUGIN_ID = MedtronicBleConnectionManager.PLUGIN_ID
+
+        /** Shared metadata -- used by both [MedtronicDevicePlugin] and [MedtronicPluginFactory]. */
+        val METADATA = PluginMetadata(
+            id = PLUGIN_ID,
+            name = "Medtronic MiniMed Pump",
+            version = "1.0.0",
+            apiVersion = PLUGIN_API_VERSION,
+            description = "Medtronic MiniMed 700-series pumps (680G / 770G / 780G) over Bluetooth (read-only, BETA)",
+            author = "GlycemicGPT",
+            protocolName = "Medtronic",
+        )
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicGlucoseSource.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicGlucoseSource.kt
@@ -1,0 +1,38 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Read-only glucose capability for the Medtronic 700-series driver.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.plugin.capabilities.GlucoseSource
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Exposes the pump's sensor glucose as the platform [GlucoseSource], delegating to
+ * [MedtronicReadGateway]. Read-only: no method writes to the pump.
+ */
+class MedtronicGlucoseSource(
+    private val gateway: MedtronicReadGateway,
+) : GlucoseSource {
+
+    /**
+     * Poll the latest reading on a fixed interval (mirrors Tandem; the real-time stream is polling, not
+     * pump-pushed). Cadence ownership moves to the polling orchestrator in Milestone D.
+     */
+    override fun observeReadings(): Flow<CgmReading> = flow {
+        while (true) {
+            gateway.getCgmReading().onSuccess { emit(it) }
+            delay(POLL_INTERVAL_MS)
+        }
+    }
+
+    override suspend fun getCurrentReading(): Result<CgmReading> =
+        gateway.getCgmReading()
+
+    private companion object {
+        const val POLL_INTERVAL_MS = 60_000L
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
@@ -1,0 +1,49 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Read-only insulin capability for the Medtronic 700-series driver.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.plugin.capabilities.InsulinSource
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import java.time.Instant
+
+/**
+ * Exposes IOB, active basal rate and bolus history as the platform [InsulinSource], delegating to
+ * [MedtronicReadGateway]. Read-only: no method writes to the pump.
+ */
+class MedtronicInsulinSource(
+    private val gateway: MedtronicReadGateway,
+) : InsulinSource {
+
+    override suspend fun getIoB(): Result<IoBReading> =
+        gateway.getIoB()
+
+    override suspend fun getBasalRate(): Result<BasalReading> =
+        gateway.getBasalRate()
+
+    /**
+     * Boluses delivered at or after [since]. Reads the available history log and extracts delivered
+     * boluses via [MedtronicHistoryParser], applying [limits] (over-cap boluses are dropped, not
+     * clamped).
+     *
+     * This scans from the start of the available window (sequence 0) and filters by time, so it is
+     * O(all-history) per call. `TODO(48.D)`: the polling orchestrator should drive incremental bolus
+     * sync through the sequence cursor on
+     * [com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus.getHistoryLogs] +
+     * [com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus.extractBolusesFromHistoryLogs]
+     * rather than this full-window convenience path.
+     */
+    override suspend fun getBolusHistory(
+        since: Instant,
+        limits: SafetyLimits,
+    ): Result<List<BolusEvent>> =
+        gateway.getHistoryLogs(sinceSequence = 0).map { records ->
+            MedtronicHistoryParser.extractBolusesFromHistoryLogs(records, limits)
+                .filter { !it.timestamp.isBefore(since) }
+        }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicPluginFactory.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicPluginFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * GlycemicGPT code (GPL-3.0). PluginFactory for the Medtronic MiniMed 700-series read-only driver.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.plugin.Plugin
+import com.glycemicgpt.mobile.domain.plugin.PluginContext
+import com.glycemicgpt.mobile.domain.plugin.PluginFactory
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MedtronicPluginFactory @Inject constructor(
+    private val connectionManager: MedtronicBleConnectionManager,
+    private val gateway: MedtronicReadGateway,
+) : PluginFactory {
+
+    override val metadata = MedtronicDevicePlugin.METADATA
+
+    override fun create(context: PluginContext): Plugin {
+        return MedtronicDevicePlugin(connectionManager, gateway)
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicPumpStatus.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicPumpStatus.kt
@@ -1,0 +1,73 @@
+/*
+ * GlycemicGPT code (GPL-3.0). Read-only pump-status capability for the Medtronic 700-series driver.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
+import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import com.glycemicgpt.mobile.domain.model.PumpHardwareInfo
+import com.glycemicgpt.mobile.domain.model.PumpSettings
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
+import com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+
+/**
+ * Exposes battery, reservoir, settings, hardware info and the event-log history as the platform
+ * [PumpStatus], delegating reads to [MedtronicReadGateway] and pairing lifecycle to
+ * [MedtronicBleConnectionManager]. Read-only: no method writes to the pump.
+ *
+ * Settings and hardware info both derive from the Device Information Service (Medtronic exposes no
+ * dedicated settings characteristic); [toPumpSettings] / [toPumpHardwareInfo] adapt the native shape.
+ * The `extract*FromHistoryLogs` helpers are pure functions on [MedtronicHistoryParser] and run on
+ * already-fetched raw records, so they need no live session.
+ */
+class MedtronicPumpStatus(
+    private val gateway: MedtronicReadGateway,
+    private val connectionManager: MedtronicBleConnectionManager,
+) : PumpStatus {
+
+    override suspend fun getBatteryStatus(): Result<BatteryStatus> =
+        gateway.getBatteryStatus()
+
+    override suspend fun getReservoirLevel(): Result<ReservoirReading> =
+        gateway.getReservoirLevel()
+
+    override suspend fun getPumpSettings(): Result<PumpSettings> =
+        gateway.getDeviceInfo().map { it.toPumpSettings() }
+
+    override suspend fun getPumpHardwareInfo(): Result<PumpHardwareInfo> =
+        gateway.getDeviceInfo().map { it.toPumpHardwareInfo() }
+
+    override suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        gateway.getHistoryLogs(sinceSequence)
+
+    override fun extractCgmFromHistoryLogs(
+        records: List<HistoryLogRecord>,
+        limits: SafetyLimits,
+    ): List<CgmReading> =
+        MedtronicHistoryParser.extractCgmFromHistoryLogs(records, limits)
+
+    override fun extractBolusesFromHistoryLogs(
+        records: List<HistoryLogRecord>,
+        limits: SafetyLimits,
+    ): List<BolusEvent> =
+        MedtronicHistoryParser.extractBolusesFromHistoryLogs(records, limits)
+
+    override fun extractBasalFromHistoryLogs(
+        records: List<HistoryLogRecord>,
+        limits: SafetyLimits,
+    ): List<BasalReading> =
+        MedtronicHistoryParser.extractBasalFromHistoryLogs(records, limits)
+
+    override fun unpair() =
+        connectionManager.unpair()
+
+    override fun autoReconnectIfPaired() =
+        connectionManager.reconnectIfPaired()
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
@@ -1,0 +1,141 @@
+/*
+ * AC1 / AC6 / AC7: the read gateway resolves the live session + transport, bridges the callback/blocking
+ * readers to suspend Result<T>, fails cleanly when not connected, and bounds a hung read with the
+ * per-operation timeout.
+ */
+package com.glycemicgpt.mobile.ble.read
+
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MedtronicReadGatewayTest {
+
+    private val feature = MedtronicProtocol.CGM_FEATURE_UUID
+    private val measurement = MedtronicProtocol.CGM_MEASUREMENT_UUID
+    private val racp = MedtronicProtocol.RACP_UUID
+
+    private fun TestScope.gateway(
+        link: MedtronicGattLink?,
+        session: MedtronicSakeSession?,
+        timeoutMs: Long = 30_000L,
+    ) = MedtronicReadGateway(
+        sessionProvider = { session },
+        linkProvider = { link },
+        ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+        operationTimeoutMs = timeoutMs,
+    )
+
+    @Test
+    fun `a session read fails cleanly when no session is held`() = runTest {
+        val result = gateway(link = FakeGattLink(), session = null).getCgmReading()
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is MedtronicReadException)
+    }
+
+    @Test
+    fun `a blocking read fails cleanly when the transport is unavailable`() = runTest {
+        val result = gateway(link = null, session = TwoSidedSession().server).getBatteryStatus()
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is MedtronicReadException)
+    }
+
+    @Test
+    fun `getBatteryStatus reads the SIG battery level`() = runTest {
+        val link = FakeGattLink()
+        link.reads[MedtronicProtocol.BATTERY_LEVEL_UUID] = byteArrayOf(85)
+
+        val result = gateway(link = link, session = TwoSidedSession().server).getBatteryStatus()
+
+        assertEquals(85, result.getOrThrow().percentage)
+    }
+
+    @Test
+    fun `getDeviceInfo reads the Device Information Service`() = runTest {
+        val link = FakeGattLink()
+        link.reads[MedtronicProtocol.MODEL_NUMBER_UUID] = "MMT-1880".toByteArray()
+        link.reads[MedtronicProtocol.SERIAL_NUMBER_UUID] = "NG1234567H".toByteArray()
+        link.reads[MedtronicProtocol.HARDWARE_REVISION_UUID] = "RevA".toByteArray()
+        link.reads[MedtronicProtocol.FIRMWARE_REVISION_UUID] = "4.2.1".toByteArray()
+        link.reads[MedtronicProtocol.SOFTWARE_REVISION_UUID] = "10.5".toByteArray()
+        link.reads[MedtronicProtocol.SYSTEM_ID_UUID] = byteArrayOf(0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77)
+
+        val info = gateway(link = link, session = TwoSidedSession().server).getDeviceInfo().getOrThrow()
+
+        assertEquals("MMT-1880", info.modelNumber)
+        assertEquals("NG1234567H", info.serialNumber)
+        assertEquals("0011223344556677", info.systemId)
+    }
+
+    @Test
+    fun `getCgmReading drives the full session read to a parsed reading`() = runTest {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[feature] = hex("009001591404") // E2E-CRC enabled
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(measurement, two.pumpEncrypt(hex("0ec3f900f40b000074e00a00e0f1")))
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        val result = gateway(link = link, session = two.server).getCgmReading()
+
+        assertEquals(249, result.getOrThrow().glucoseMgDl)
+    }
+
+    @Test
+    fun `a hung read is bounded by the operation timeout`() = runTest {
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[feature] = hex("009001591404")
+        // The pump never responds to the RACP request, so the reader's callback never fires.
+
+        val result = gateway(link = link, session = two.server, timeoutMs = 5_000L).getCgmReading()
+
+        assertTrue(result.isFailure)
+        val error = result.exceptionOrNull()
+        assertTrue(error is MedtronicReadException)
+        assertTrue("expected a timeout failure", error!!.message!!.contains("timed out"))
+    }
+
+    /**
+     * The blocking-read path (battery / device info) must also be bounded: a synchronous GATT read
+     * that blocks is not a suspension point, so the gateway uses runInterruptible to make the operation
+     * timeout interrupt it. Uses a real IO dispatcher + real (short) timeout so the interrupt actually
+     * fires; with a plain withContext this would hang past the deadline.
+     */
+    @Test
+    fun `a hung blocking read is bounded by the operation timeout`() = runBlocking {
+        val blockingLink = object : MedtronicGattLink {
+            override fun read(characteristic: UUID): ByteArray {
+                Thread.sleep(30_000) // never completes within the test budget; only the interrupt ends it
+                return ByteArray(0)
+            }
+            override fun write(characteristic: UUID, value: ByteArray) = error("unused")
+            override fun subscribe(characteristic: UUID, onPdu: (ByteArray) -> Unit) = error("unused")
+            override fun unsubscribe(characteristic: UUID) = error("unused")
+        }
+        val gateway = MedtronicReadGateway(
+            sessionProvider = { TwoSidedSession().server },
+            linkProvider = { blockingLink },
+            ioDispatcher = Dispatchers.IO,
+            operationTimeoutMs = 200L,
+        )
+
+        val result = gateway.getBatteryStatus()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("timed out"))
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDeviceInfoMapperTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDeviceInfoMapperTest.kt
@@ -1,0 +1,61 @@
+/*
+ * AC1: the MedtronicDeviceInfo -> PumpSettings / PumpHardwareInfo adaptation (string fields carry
+ * verbatim; the Long-keyed hardware view extracts numeric ids and preserves the strings as features).
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.read.MedtronicDeviceInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MedtronicDeviceInfoMapperTest {
+
+    private fun info(
+        model: String = "MMT-1880",
+        serial: String = "NG1234567H",
+        hw: String = "RevA",
+        fw: String = "4.2.1",
+        sw: String = "10.5",
+        systemId: String = "0011223344556677",
+    ) = MedtronicDeviceInfo(model, serial, hw, fw, sw, systemId)
+
+    @Test
+    fun `toPumpSettings carries the strings verbatim`() {
+        val settings = info().toPumpSettings()
+        assertEquals("4.2.1", settings.firmwareVersion)
+        assertEquals("NG1234567H", settings.serialNumber)
+        assertEquals("MMT-1880", settings.modelNumber)
+    }
+
+    @Test
+    fun `toPumpHardwareInfo extracts numeric ids and maps revisions`() {
+        val hw = info().toPumpHardwareInfo()
+        assertEquals(1880L, hw.modelNumber)
+        assertEquals(1234567L, hw.serialNumber)
+        assertEquals("4.2.1", hw.pumpRev)
+        assertEquals("RevA", hw.pcbaRev)
+        assertEquals(0L, hw.partNumber)
+    }
+
+    @Test
+    fun `toPumpHardwareInfo leaves the feature-flag map empty`() {
+        // pumpFeatures is a genuine feature-flag map (uploaded as pump_features); it must not be
+        // repurposed for identity strings. Identity is carried losslessly by toPumpSettings.
+        assertTrue(info().toPumpHardwareInfo().pumpFeatures.isEmpty())
+    }
+
+    @Test
+    fun `numeric id is zero when an identifier has no digits`() {
+        val hw = info(model = "UNKNOWN", serial = "NONE").toPumpHardwareInfo()
+        assertEquals(0L, hw.modelNumber)
+        assertEquals(0L, hw.serialNumber)
+    }
+
+    @Test
+    fun `numeric id picks the longest digit run`() {
+        // "AB12-3456789" -> longest run 3456789, not 12.
+        val hw = info(serial = "AB12-3456789").toPumpHardwareInfo()
+        assertEquals(3456789L, hw.serialNumber)
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePluginTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePluginTest.kt
@@ -1,0 +1,152 @@
+/*
+ * AC2 / AC3 / AC5: the MedtronicDevicePlugin exposes the read-only capability contract, maps the
+ * lifecycle onto the connection manager, and renders the settings descriptor (status + Unpair +
+ * single-peer note) -- all without any write/PUMP_CONTROL surface.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.DiscoveredDevice
+import com.glycemicgpt.mobile.domain.plugin.PLUGIN_API_VERSION
+import com.glycemicgpt.mobile.domain.plugin.PluginCapability
+import com.glycemicgpt.mobile.domain.plugin.capabilities.BgmSource
+import com.glycemicgpt.mobile.domain.plugin.capabilities.GlucoseSource
+import com.glycemicgpt.mobile.domain.plugin.capabilities.InsulinSource
+import com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus
+import com.glycemicgpt.mobile.domain.plugin.ui.ButtonStyle
+import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MedtronicDevicePluginTest {
+
+    private val connectionManager: MedtronicBleConnectionManager = mockk(relaxed = true)
+    private val gateway: MedtronicReadGateway = mockk(relaxed = true)
+
+    private val plugin = MedtronicDevicePlugin(connectionManager, gateway)
+
+    @Test
+    fun `declares exactly the three read-only capabilities`() {
+        val caps = plugin.capabilities
+        assertEquals(3, caps.size)
+        assertTrue(caps.contains(PluginCapability.GLUCOSE_SOURCE))
+        assertTrue(caps.contains(PluginCapability.INSULIN_SOURCE))
+        assertTrue(caps.contains(PluginCapability.PUMP_STATUS))
+    }
+
+    @Test
+    fun `does not declare BOLUS_CATEGORY_PROVIDER`() {
+        assertFalse(plugin.capabilities.contains(PluginCapability.BOLUS_CATEGORY_PROVIDER))
+    }
+
+    @Test
+    fun `getCapability returns GlucoseSource`() {
+        val source = plugin.getCapability(GlucoseSource::class)
+        assertNotNull(source)
+        assertTrue(source is GlucoseSource)
+    }
+
+    @Test
+    fun `getCapability returns InsulinSource`() {
+        val source = plugin.getCapability(InsulinSource::class)
+        assertNotNull(source)
+        assertTrue(source is InsulinSource)
+    }
+
+    @Test
+    fun `getCapability returns PumpStatus`() {
+        val status = plugin.getCapability(PumpStatus::class)
+        assertNotNull(status)
+        assertTrue(status is PumpStatus)
+    }
+
+    @Test
+    fun `getCapability returns null for an unsupported type`() {
+        assertNull(plugin.getCapability(BgmSource::class))
+    }
+
+    @Test
+    fun `metadata uses the canonical id and protocol name`() {
+        assertEquals("com.glycemicgpt.medtronic", plugin.metadata.id)
+        assertEquals(PLUGIN_API_VERSION, plugin.metadata.apiVersion)
+        assertEquals("Medtronic MiniMed Pump", plugin.metadata.name)
+        assertEquals("Medtronic", plugin.metadata.protocolName)
+    }
+
+    @Test
+    fun `connect starts a session (first-pair when forced)`() {
+        plugin.connect(address = "ignored", config = emptyMap())
+        verify { connectionManager.startSession(false) }
+
+        plugin.connect(address = "ignored", config = mapOf("forceFirstPair" to "true"))
+        verify { connectionManager.startSession(true) }
+    }
+
+    @Test
+    fun `disconnect delegates to the connection manager`() {
+        plugin.disconnect()
+        verify { connectionManager.disconnect() }
+    }
+
+    @Test
+    fun `onActivated reconnects to a paired pump`() {
+        plugin.onActivated()
+        verify { connectionManager.reconnectIfPaired() }
+    }
+
+    @Test
+    fun `onDeactivated disconnects but preserves pairing`() {
+        plugin.onDeactivated()
+        verify { connectionManager.disconnect() }
+        verify(exactly = 0) { connectionManager.unpair() }
+    }
+
+    @Test
+    fun `shutdown disconnects`() {
+        plugin.shutdown()
+        verify { connectionManager.disconnect() }
+    }
+
+    @Test
+    fun `observeConnectionState exposes the manager state flow`() {
+        val state = MutableStateFlow(ConnectionState.CONNECTED)
+        every { connectionManager.connectionState } returns state
+        assertEquals(ConnectionState.CONNECTED, plugin.observeConnectionState().value)
+    }
+
+    @Test
+    fun `scan passes through the manager's advertise-and-wait discovery`() = runTest {
+        val device = DiscoveredDevice(name = "Mobile 000001", address = "AA:BB", pluginId = "com.glycemicgpt.medtronic")
+        every { connectionManager.scan() } returns flowOf(device)
+        assertEquals(device, plugin.scan().first())
+    }
+
+    @Test
+    fun `settings descriptor shows status, the single-peer note, and a destructive Unpair`() {
+        every { connectionManager.connectionState } returns MutableStateFlow(ConnectionState.DISCONNECTED)
+
+        val items = plugin.settingsDescriptor().sections.single().items
+        val status = items.filterIsInstance<SettingDescriptor.InfoText>().first { it.key == "pairing_status" }
+        assertTrue(status.text.contains("DISCONNECTED"))
+
+        val singlePeer = items.filterIsInstance<SettingDescriptor.InfoText>().first { it.key == "single_peer_note" }
+        assertTrue(singlePeer.text.contains("one phone at a time"))
+
+        val unpair = items.filterIsInstance<SettingDescriptor.ActionButton>().single()
+        assertEquals("unpair", unpair.key)
+        assertEquals(ButtonStyle.DESTRUCTIVE, unpair.style)
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePluginTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePluginTest.kt
@@ -115,9 +115,9 @@ class MedtronicDevicePluginTest {
     }
 
     @Test
-    fun `shutdown disconnects`() {
+    fun `shutdown fully closes the connection manager`() {
         plugin.shutdown()
-        verify { connectionManager.disconnect() }
+        verify { connectionManager.close() }
     }
 
     @Test

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicGlucoseSourceTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicGlucoseSourceTest.kt
@@ -1,0 +1,71 @@
+/*
+ * AC1: MedtronicGlucoseSource forwards to the read gateway and surfaces the Result verbatim.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class MedtronicGlucoseSourceTest {
+
+    private val gateway: MedtronicReadGateway = mockk(relaxed = true)
+    private val source = MedtronicGlucoseSource(gateway)
+
+    private val reading = CgmReading(
+        glucoseMgDl = 142,
+        trendArrow = CgmTrend.FLAT,
+        timestamp = Instant.ofEpochSecond(1_700_000_000),
+    )
+
+    @Test
+    fun `getCurrentReading delegates to the gateway`() = runTest {
+        coEvery { gateway.getCgmReading() } returns Result.success(reading)
+
+        val result = source.getCurrentReading()
+
+        assertTrue(result.isSuccess)
+        assertEquals(reading, result.getOrThrow())
+        coVerify { gateway.getCgmReading() }
+    }
+
+    @Test
+    fun `getCurrentReading surfaces a failure verbatim`() = runTest {
+        val failure = IllegalStateException("boom")
+        coEvery { gateway.getCgmReading() } returns Result.failure(failure)
+
+        val result = source.getCurrentReading()
+
+        assertTrue(result.isFailure)
+        assertEquals(failure, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `observeReadings emits each successful poll`() = runTest {
+        coEvery { gateway.getCgmReading() } returns Result.success(reading)
+
+        // first() cancels collection after one emission, ending the polling loop.
+        assertEquals(reading, source.observeReadings().first())
+    }
+
+    @Test
+    fun `observeReadings skips a failed poll and emits the next success`() = runTest {
+        val later = reading.copy(glucoseMgDl = 156)
+        // First poll fails (no emission), the next succeeds -> only the success reaches the collector.
+        coEvery { gateway.getCgmReading() } returnsMany listOf(
+            Result.failure(IllegalStateException("not connected")),
+            Result.success(later),
+        )
+
+        assertEquals(later, source.observeReadings().first())
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSourceTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSourceTest.kt
@@ -1,0 +1,118 @@
+/*
+ * AC1: MedtronicInsulinSource forwards IOB / basal to the gateway, and builds bolus history by
+ * extracting delivered boluses from the fetched raw records and filtering by the requested instant.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.model.PumpActivityMode
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+class MedtronicInsulinSourceTest {
+
+    private val gateway: MedtronicReadGateway = mockk(relaxed = true)
+    private val source = MedtronicInsulinSource(gateway)
+
+    @Test
+    fun `getIoB delegates to the gateway`() = runTest {
+        val iob = IoBReading(iob = 1.2f, timestamp = Instant.ofEpochSecond(1_700_000_000))
+        coEvery { gateway.getIoB() } returns Result.success(iob)
+
+        assertEquals(iob, source.getIoB().getOrThrow())
+        coVerify { gateway.getIoB() }
+    }
+
+    @Test
+    fun `getBasalRate delegates to the gateway`() = runTest {
+        val basal = BasalReading(
+            rate = 0.8f,
+            isAutomated = true,
+            activityMode = PumpActivityMode.NONE,
+            timestamp = Instant.ofEpochSecond(1_700_000_000),
+        )
+        coEvery { gateway.getBasalRate() } returns Result.success(basal)
+
+        assertEquals(basal, source.getBasalRate().getOrThrow())
+        coVerify { gateway.getBasalRate() }
+    }
+
+    @Test
+    fun `getBolusHistory fetches history from the start of the window`() = runTest {
+        // No records -> no boluses; this asserts the wiring (full-window fetch + empty extraction),
+        // not the parser internals (covered by MedtronicHistoryParserTest).
+        coEvery { gateway.getHistoryLogs(0) } returns Result.success(emptyList())
+
+        val result = source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits())
+
+        assertTrue(result.isSuccess)
+        assertEquals(emptyList<Any>(), result.getOrThrow())
+        coVerify { gateway.getHistoryLogs(0) }
+    }
+
+    @Test
+    fun `getBolusHistory propagates a history fetch failure`() = runTest {
+        val failure = IllegalStateException("not connected")
+        coEvery { gateway.getHistoryLogs(0) } returns Result.failure(failure)
+
+        val result = source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits())
+
+        assertTrue(result.isFailure)
+        assertEquals(failure, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `getBolusHistory extracts delivered boluses and filters by the since instant`() = runTest {
+        // One delivered 2.5 IU bolus at reference + 600s, plus the reference-time anchor record.
+        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+        val records = listOf(
+            rawRecord(0xF00E, seq = 100, offsetSec = 0, bodyHex = "3cea0706010c0000"),
+            rawRecord(0x0069, seq = 110, offsetSec = 600, bodyHex = "010033190000ff000000000000"),
+            rawRecord(0x0096, seq = 111, offsetSec = 600, bodyHex = "01000000005a"),
+        )
+        coEvery { gateway.getHistoryLogs(0) } returns Result.success(records)
+
+        // since at the reference -> the bolus (at +600s) is included.
+        val included = source.getBolusHistory(reference, SafetyLimits()).getOrThrow()
+        assertEquals(1, included.size)
+        assertEquals(2.5f, included[0].units, 1e-4f)
+
+        // since after the bolus -> filtered out.
+        val excluded = source.getBolusHistory(reference.plusSeconds(601), SafetyLimits()).getOrThrow()
+        assertTrue(excluded.isEmpty())
+    }
+
+    // -- IDD history record builder (documented layout: history_data.py; see MedtronicHistoryParserTest) --
+
+    private fun rawRecord(typeId: Int, seq: Int, offsetSec: Int, bodyHex: String): HistoryLogRecord =
+        MedtronicHistoryParser.toHistoryLogRecord(
+            le16(typeId) + le32(seq) + le16(offsetSec) + hex(bodyHex),
+            useE2e = false,
+        )!!
+
+    private fun le16(v: Int): ByteArray =
+        byteArrayOf((v and 0xFF).toByte(), ((v shr 8) and 0xFF).toByte())
+
+    private fun le32(v: Int): ByteArray = byteArrayOf(
+        (v and 0xFF).toByte(),
+        ((v shr 8) and 0xFF).toByte(),
+        ((v shr 16) and 0xFF).toByte(),
+        ((v shr 24) and 0xFF).toByte(),
+    )
+
+    private fun hex(s: String): ByteArray =
+        ByteArray(s.length / 2) { i -> s.substring(2 * i, 2 * i + 2).toInt(16).toByte() }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicPumpStatusTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicPumpStatusTest.kt
@@ -1,0 +1,158 @@
+/*
+ * AC1: MedtronicPumpStatus forwards reads to the gateway, adapts Device Info onto PumpSettings /
+ * PumpHardwareInfo, runs the pure extract* helpers, and routes pairing lifecycle to the manager.
+ */
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
+import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
+import com.glycemicgpt.mobile.ble.read.MedtronicDeviceInfo
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+class MedtronicPumpStatusTest {
+
+    private val gateway: MedtronicReadGateway = mockk(relaxed = true)
+    private val connectionManager: MedtronicBleConnectionManager = mockk(relaxed = true)
+    private val pumpStatus = MedtronicPumpStatus(gateway, connectionManager)
+
+    private val deviceInfo = MedtronicDeviceInfo(
+        modelNumber = "MMT-1880",
+        serialNumber = "NG1234567H",
+        hardwareRevision = "RevA",
+        firmwareRevision = "4.2.1",
+        softwareRevision = "10.5",
+        systemId = "0011223344556677",
+    )
+
+    @Test
+    fun `getBatteryStatus delegates to the gateway`() = runTest {
+        val battery = BatteryStatus(percentage = 80, isCharging = false, timestamp = Instant.ofEpochSecond(1))
+        coEvery { gateway.getBatteryStatus() } returns Result.success(battery)
+
+        assertEquals(battery, pumpStatus.getBatteryStatus().getOrThrow())
+        coVerify { gateway.getBatteryStatus() }
+    }
+
+    @Test
+    fun `getReservoirLevel delegates to the gateway`() = runTest {
+        val reservoir = ReservoirReading(unitsRemaining = 120f, timestamp = Instant.ofEpochSecond(1))
+        coEvery { gateway.getReservoirLevel() } returns Result.success(reservoir)
+
+        assertEquals(reservoir, pumpStatus.getReservoirLevel().getOrThrow())
+        coVerify { gateway.getReservoirLevel() }
+    }
+
+    @Test
+    fun `getPumpSettings maps the Device Information strings`() = runTest {
+        coEvery { gateway.getDeviceInfo() } returns Result.success(deviceInfo)
+
+        val settings = pumpStatus.getPumpSettings().getOrThrow()
+
+        assertEquals("4.2.1", settings.firmwareVersion)
+        assertEquals("NG1234567H", settings.serialNumber)
+        assertEquals("MMT-1880", settings.modelNumber)
+    }
+
+    @Test
+    fun `getPumpHardwareInfo adapts Device Info onto the shared shape`() = runTest {
+        coEvery { gateway.getDeviceInfo() } returns Result.success(deviceInfo)
+
+        val hw = pumpStatus.getPumpHardwareInfo().getOrThrow()
+
+        assertEquals(1880L, hw.modelNumber)
+        assertEquals(1234567L, hw.serialNumber)
+        assertEquals("4.2.1", hw.pumpRev)
+        assertEquals("RevA", hw.pcbaRev)
+        assertTrue(hw.pumpFeatures.isEmpty())
+    }
+
+    @Test
+    fun `getPumpSettings propagates a read failure`() = runTest {
+        val failure = IllegalStateException("not connected")
+        coEvery { gateway.getDeviceInfo() } returns Result.failure(failure)
+
+        assertEquals(failure, pumpStatus.getPumpSettings().exceptionOrNull())
+    }
+
+    @Test
+    fun `getHistoryLogs delegates to the gateway`() = runTest {
+        coEvery { gateway.getHistoryLogs(7) } returns Result.success(emptyList())
+
+        assertTrue(pumpStatus.getHistoryLogs(7).getOrThrow().isEmpty())
+        coVerify { gateway.getHistoryLogs(7) }
+    }
+
+    @Test
+    fun `extract helpers return empty for no records`() {
+        val none = emptyList<HistoryLogRecord>()
+        val limits = SafetyLimits()
+        assertTrue(pumpStatus.extractCgmFromHistoryLogs(none, limits).isEmpty())
+        assertTrue(pumpStatus.extractBolusesFromHistoryLogs(none, limits).isEmpty())
+        assertTrue(pumpStatus.extractBasalFromHistoryLogs(none, limits).isEmpty())
+    }
+
+    @Test
+    fun `extractCgmFromHistoryLogs actually routes raw records through the parser`() {
+        // A reference-time record + one SG record (120 mg/dL at +300s) -- proves the delegate runs the
+        // real MedtronicHistoryParser, not a stub that would also pass the empty-list case above.
+        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+        val records = listOf(
+            rawRecord(0xF00E, seq = 100, offsetSec = 0, bodyHex = "3cea0706010c0000"),
+            rawRecord(0xF00C, seq = 101, offsetSec = 300, bodyHex = "0000780000000000"),
+        )
+
+        val cgm = pumpStatus.extractCgmFromHistoryLogs(records, SafetyLimits())
+
+        assertEquals(1, cgm.size)
+        assertEquals(120, cgm[0].glucoseMgDl)
+        assertEquals(reference.plusSeconds(300), cgm[0].timestamp)
+    }
+
+    @Test
+    fun `unpair routes to the connection manager`() {
+        pumpStatus.unpair()
+        verify { connectionManager.unpair() }
+    }
+
+    @Test
+    fun `autoReconnectIfPaired routes to the connection manager`() {
+        pumpStatus.autoReconnectIfPaired()
+        verify { connectionManager.reconnectIfPaired() }
+    }
+
+    // -- IDD history record builders (documented layout: history_data.py; see MedtronicHistoryParserTest) --
+
+    private fun rawRecord(typeId: Int, seq: Int, offsetSec: Int, bodyHex: String): HistoryLogRecord =
+        MedtronicHistoryParser.toHistoryLogRecord(
+            le16(typeId) + le32(seq) + le16(offsetSec) + hex(bodyHex),
+            useE2e = false,
+        )!!
+
+    private fun le16(v: Int): ByteArray =
+        byteArrayOf((v and 0xFF).toByte(), ((v shr 8) and 0xFF).toByte())
+
+    private fun le32(v: Int): ByteArray = byteArrayOf(
+        (v and 0xFF).toByte(),
+        ((v shr 8) and 0xFF).toByte(),
+        ((v shr 16) and 0xFF).toByte(),
+        ((v shr 24) and 0xFF).toByte(),
+    )
+
+    private fun hex(s: String): ByteArray =
+        ByteArray(s.length / 2) { i -> s.substring(2 * i, 2 * i + 2).toInt(16).toByte() }
+}


### PR DESCRIPTION
## Summary

Makes the read-only Medtronic MiniMed 700-series BLE driver a discoverable, activatable plugin that exposes glucose / insulin / pump-status through the same capability contract as the Tandem driver. This is the first time the driver runs as a real app plugin.

## What's included

- **Capability delegates** — `MedtronicGlucoseSource`, `MedtronicInsulinSource`, `MedtronicPumpStatus` over the existing readers; all return `Result<T>` and never write to the pump.
- **`MedtronicReadGateway`** — bundles the readers behind suspend `Result<T>` calls (the analog of `TandemBleDriver`): resolves the live session, bounds every read with a per-operation timeout, and routes caught failures through Timber. The on-device `BluetoothGatt`-client transport is supplied in a follow-up change, so reads cleanly report "not connected" until then.
- **`MedtronicDevicePlugin`** — maps connect/disconnect/scan onto the peripheral connection manager; declares `GLUCOSE_SOURCE` / `INSULIN_SOURCE` / `PUMP_STATUS` only (read-only — there is no pump-control capability); canonical id `com.glycemicgpt.medtronic`; settings card with connection status + Unpair.
- **Device-info adaptation** — `MedtronicDeviceInfo` → `PumpSettings` / `PumpHardwareInfo`.
- **Hilt wiring** — `MedtronicPluginFactory` + `MedtronicPumpModule` (`@Binds @IntoSet`); `:medtronic-pump-driver` added as an app dependency so the factory is discovered.
- **Settings screen** — the pump pairing/status/Unpair card was hardcoded to the Tandem plugin id; generalized to render for any active pump plugin (resolved generically by the registry), so the Medtronic card shows.

## Testing

- 46 new unit tests for the delegates, plugin, read gateway, and device-info mapper (driver module total 232, all passing).
- `:medtronic-pump-driver:testDebugUnitTest`, `:app:assembleDebug`, `:app:testDebugUnitTest`, and lint all green.
- On-device (emulator): the plugin appears as a selectable source, activates with the correct lifecycle, and its pump settings card renders. No data flows yet (the BLE-client transport lands in a follow-up); live-pump verification is tracked separately.

## Scope

Read-only and BLE / on-device only. No pump-control surface. No backend changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only Medtronic MiniMed 700-series support (CGM, IOB, basal rates, reservoir, battery, history); settings now show pump pairing when any pump plugin is active and include a Connection section with pairing status and "Unpair Pump" action. Medtronic plugin registered and enabled.

* **Tests**
  * Added comprehensive unit and integration tests covering reads, mapping, plugin behavior, polling, timeouts, and lifecycle.

* **Documentation**
  * Clarified GATT threading/cancellation semantics.

* **Chores**
  * Updated mobile module to include the Medtronic pump driver and added an OSV suppression entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->