### PR TITLE
feat(medtronic): on-device BluetoothGatt-client read transport

### DIFF
--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -203,7 +203,8 @@ class AndroidMedtronicGattLink(
                 }
                 // Register the handler before enabling notifications so a PDU delivered the instant the
                 // CCCD takes effect is not lost. Re-subscribing replaces the handler (seam contract).
-                handlers[characteristic] = ActiveSubscription(resolved, onPdu)
+                // Record the owning client so a deferred unsubscribe can't disable a later connection.
+                handlers[characteristic] = ActiveSubscription(resolved, onPdu, link)
                 val enable = if (isIndication(char)) CCCD_ENABLE_INDICATION else CCCD_ENABLE_NOTIFICATION
                 // The CCCD write completes before this returns, so notifications are effective before
                 // the caller's subsequent control-point write (AC3).
@@ -402,6 +403,10 @@ class AndroidMedtronicGattLink(
         try {
             opLock.withLock {
                 val link = gatt ?: return
+                // This cleanup may be deferred (run off the worker / on the watchdog) and the client may
+                // have been replaced by a reconnect meanwhile. The old connection's subscriptions died
+                // with it, so skip rather than disable a characteristic on the new connection.
+                if (link !== sub.ownerGatt) return
                 val char = sub.resolved.characteristic
                 if (!link.setCharacteristicNotification(char, false)) {
                     Timber.w("Medtronic GATT %s: setCharacteristicNotification(false) was rejected", op)
@@ -589,7 +594,11 @@ class AndroidMedtronicGattLink(
 
     private data class ResolvedChar(val serviceUuid: UUID, val characteristic: BluetoothGattCharacteristic)
 
-    private class ActiveSubscription(val resolved: ResolvedChar, val onPdu: (ByteArray) -> Unit)
+    private class ActiveSubscription(
+        val resolved: ResolvedChar,
+        val onPdu: (ByteArray) -> Unit,
+        val ownerGatt: BluetoothGatt,
+    )
 
     private class GattOutcome(val status: Int, val value: ByteArray?)
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -132,6 +132,13 @@ class AndroidMedtronicGattLink(
     @Volatile
     private var connectPending: ArrayBlockingQueue<GattOutcome>? = null
 
+    // The BluetoothGatt of the in-flight connect attempt. Connect-phase callbacks are accepted only for
+    // this handle, so a late callback from a prior (timed-out) attempt can't complete a newer one. Null
+    // while no connect is in progress -- a callback arriving then is tolerated (the matching
+    // [connectPending] is also null, so the offer is a no-op).
+    @Volatile
+    private var connectingGatt: BluetoothGatt? = null
+
     @Volatile
     private var watchdogHandle: SubscriptionWatchdog.Handle? = null
 
@@ -217,10 +224,12 @@ class AndroidMedtronicGattLink(
 
     override fun unsubscribe(characteristic: UUID) {
         // Drop the handler first, lock-free: this is the AC4 correctness guarantee (no notification
-        // reaches a finished exchange) and must never block the worker thread on the CCCD round trip.
+        // reaches a finished exchange). A reader calls unsubscribe from inside its onPdu handler, which
+        // runs on the shared worker thread, so the blocking CCCD-disable round trip is run off that
+        // thread (the cleanup executor) -- otherwise it would stall connection-lifecycle events.
         val sub = handlers.remove(characteristic) ?: return
         if (handlers.isEmpty()) cancelWatchdog()
-        disableNotifications("unsubscribe", sub)
+        watchdog.execute { disableNotifications("unsubscribe", sub) }
     }
 
     // -- Connection / discovery ---------------------------------------------
@@ -245,8 +254,10 @@ class AndroidMedtronicGattLink(
             connectPending = null
             throw MedtronicReadException("Medtronic GATT connect returned no client")
         }
+        connectingGatt = opened
         val outcome = slot.poll(connectTimeoutMs, TimeUnit.MILLISECONDS)
         connectPending = null
+        connectingGatt = null
         if (outcome == null || outcome.status != BluetoothGatt.GATT_SUCCESS) {
             logGattWarning("connect", null, outcome?.status ?: SYNTHETIC_TIMEOUT_STATUS)
             closeClient(opened)
@@ -435,10 +446,18 @@ class AndroidMedtronicGattLink(
 
     // -- GATT callback (binder thread) --------------------------------------
 
+    // A connect-phase callback (CONNECTED / services-discovered / a disconnect of the connecting handle)
+    // is stale if it belongs to a BluetoothGatt other than the one the current attempt opened. While no
+    // connect is in progress [connectingGatt] is null and the callback is tolerated (connectPending is
+    // also null then, so any offer is a no-op).
+    private fun isStaleConnectCallback(g: BluetoothGatt): Boolean =
+        connectingGatt != null && g !== connectingGatt
+
     private val gattCallback = object : BluetoothGattCallback() {
         override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
             when (newState) {
                 BluetoothProfile.STATE_CONNECTED -> {
+                    if (isStaleConnectCallback(g)) return
                     if (status != BluetoothGatt.GATT_SUCCESS) {
                         connectPending?.offer(GattOutcome(status, null))
                         return
@@ -459,6 +478,7 @@ class AndroidMedtronicGattLink(
         }
 
         override fun onServicesDiscovered(g: BluetoothGatt, status: Int) {
+            if (isStaleConnectCallback(g)) return
             connectPending?.offer(GattOutcome(status, null))
         }
 
@@ -507,10 +527,10 @@ class AndroidMedtronicGattLink(
     }
 
     private fun teardownOnDisconnect(g: BluetoothGatt, status: Int) {
-        // Fail whatever blocking call is parked so it returns instead of waiting out its full timeout.
-        // (Offered regardless of identity: a disconnect of the in-progress connect arrives before [gatt]
-        // is published, and the connect awaiter must still be released.)
-        connectPending?.offer(GattOutcome(status, null))
+        // A disconnect of the handle a connect is currently waiting on (it fires before [gatt] is
+        // published) must release that connect awaiter -- but only for that handle, so a stale prior
+        // attempt's disconnect can't wake a newer connect's slot.
+        if (!isStaleConnectCallback(g)) connectPending?.offer(GattOutcome(status, null))
         if (gatt !== g) {
             // A stale handle disconnected (e.g. after a reconnect to a new device); just close it.
             closeClient(g)
@@ -521,6 +541,9 @@ class AndroidMedtronicGattLink(
         racpServiceUuids = emptySet()
         cancelWatchdog()
         handlers.clear()
+        // `gatt === g` here, so this disconnect is for the live connection: failing its in-flight op is
+        // correct. (A concurrent op-thread timeout would have already replaced [gatt], taking the early
+        // return above, so it can't be redirected to a newer op's slot.)
         pending?.offer(GattOutcome(status, null))
         closeClient(g)
         gatt = null
@@ -623,13 +646,18 @@ class AndroidMedtronicGattLink(
 }
 
 /**
- * One-shot delayed scheduler for the GATT-client subscription watchdog (AC4). Abstracted like
- * [SerialWorker] so the cleanup-on-timeout path is deterministically unit-testable without a real
+ * The off-thread mechanism for GATT-client subscription cleanup (AC4): a one-shot delayed timer (the
+ * dangling-subscription watchdog) plus immediate off-caller-thread execution (so an `unsubscribe`
+ * issued from a notification handler doesn't block the shared worker thread on its CCCD round trip).
+ * Abstracted like [SerialWorker] so both paths are deterministically unit-testable without a real
  * timer thread.
  */
 interface SubscriptionWatchdog {
     /** Run [task] after [delayMs]; the returned handle cancels it if the subscription is released first. */
     fun schedule(delayMs: Long, task: () -> Unit): Handle
+
+    /** Run [task] as soon as possible on the cleanup thread, off the calling thread. */
+    fun execute(task: () -> Unit)
 
     /** Release any resources (e.g. the executor thread). Default no-op for in-memory test doubles. */
     fun close() {}
@@ -649,6 +677,10 @@ class ScheduledSubscriptionWatchdog(
     override fun schedule(delayMs: Long, task: () -> Unit): SubscriptionWatchdog.Handle {
         val future = executor.schedule(task, delayMs, TimeUnit.MILLISECONDS)
         return SubscriptionWatchdog.Handle { future.cancel(false) }
+    }
+
+    override fun execute(task: () -> Unit) {
+        executor.execute(task)
     }
 
     override fun close() {

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -1,0 +1,657 @@
+/*
+ * On-device BluetoothGatt-CLIENT transport for the Medtronic MiniMed 700-series read-only driver.
+ *
+ * GlycemicGPT code (GPL-3.0). The concrete Android implementation of the [MedtronicGattLink] seam
+ * (Milestone D). In the inverted topology the pump connects to the phone (peripheral) for advertising
+ * + SAKE, but to read the pump's data the phone opens a GATT *client* connection back to the *pump's*
+ * GATT server over that same link -- exactly as OpenMinimed's PythonPumpConnector does over BlueZ
+ * (GPL-3.0, used with permission): write the control point, subscribe for notifications, read static
+ * characteristics. The connected pump [BluetoothDevice] is obtained from
+ * [MedtronicBleConnectionManager.connectedPumpDevice] (captured when the pump connected to our GATT
+ * server); this never starts a fresh scan/advertise cycle for it.
+ *
+ * READ-ONLY: only static reads and report/control-point writes (RACP / CGM SOCP / IDD SRCP, plus the
+ * CCCD descriptor) are issued; [write] refuses any characteristic outside that allow-list, so no
+ * therapeutic write opcode can be sent. MTU stays at 23 -- we never call `requestMtu()`; outbound
+ * payloads arrive pre-fragmented to <= 20-byte PDUs via
+ * [com.glycemicgpt.mobile.ble.protocol.PduFramer] and inbound reassembly stays above the seam.
+ *
+ * Over-the-air validation against a real pump rides with 48.A2 / Milestone F -- in particular that a
+ * second (client) GATT connection attaches to the existing link rather than opening a new one. Nothing
+ * here is claimed live-verified.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.BluetoothStatusCodes
+import android.content.Context
+import android.os.Build
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.read.MedtronicGattLink
+import com.glycemicgpt.mobile.ble.read.MedtronicReadException
+import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import timber.log.Timber
+import java.util.UUID
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * `BluetoothGatt`-client implementation of [MedtronicGattLink].
+ *
+ * **Blocking + serialized.** Android allows one outstanding GATT operation at a time, so every
+ * [read]/[write]/[subscribe]/[unsubscribe] -- and the watchdog cleanup -- runs under [opLock] and
+ * blocks the calling thread (the gateway's IO dispatcher) until the matching GATT callback fires,
+ * bounded by [operationTimeoutMs]. The connection is opened lazily on first use and reused until the
+ * pump disconnects. The link assumes **one exchange at a time**: the read gateway issues a single
+ * read per call and polling orchestration (Milestone D2) serializes across readers; concurrent
+ * exchanges over one BLE link are not a real pump scenario and are not supported here.
+ *
+ * **Stale-completion safety.** GATT callbacks for an operation can arrive after that operation's
+ * timeout. A request timeout therefore tears the client GATT down ([closeGatt]); the operational
+ * callbacks below reject any callback whose `BluetoothGatt` is not the current one ([gatt]), so a late
+ * completion from a timed-out op lands on a now-discarded handle and can never satisfy a later op's
+ * slot.
+ *
+ * **Threading contract (AC3).** Inbound notification PDUs are hopped onto [worker] -- the connection
+ * manager's existing single SAKE worker thread -- so every `onPdu` callback is delivered serialized on
+ * one thread, as [com.glycemicgpt.mobile.ble.read.MedtronicSessionReader] requires. No second thread
+ * is spun up for delivery.
+ *
+ * **RACP service-scoping (AC2).** The shared SIG `0x2A52` RACP characteristic lives under both the CGM
+ * and IDD services. It is resolved to the service whose data characteristic the current exchange is
+ * actively streaming (the reader subscribes the data char immediately before touching the control
+ * point), falling back to the most recently resolved RACP-bearing service -- never the bare UUID, and
+ * never poisoned by an unrelated Battery/Device-Info read.
+ *
+ * **Cancellation/cleanup (AC4).** A reader only [unsubscribe]s on a pump *response*; if the gateway's
+ * per-operation timeout cancels the driving coroutine first, the subscriptions would dangle. A
+ * [watchdog] armed while subscriptions are open releases them (drops handlers + disables CCCD) once
+ * the exchange can no longer succeed, so a timed-out read leaves no notifications that desync the next
+ * one.
+ *
+ * @param deviceProvider supplies the connected pump device, or `null` when no pump is connected.
+ * @param worker the connection manager's serial worker; inbound PDUs are delivered on it.
+ */
+@SuppressLint("MissingPermission")
+class AndroidMedtronicGattLink(
+    context: Context,
+    private val deviceProvider: () -> BluetoothDevice?,
+    private val worker: SerialWorker,
+    private val watchdog: SubscriptionWatchdog = ScheduledSubscriptionWatchdog(),
+    private val operationTimeoutMs: Long = DEFAULT_OPERATION_TIMEOUT_MS,
+    private val connectTimeoutMs: Long = DEFAULT_CONNECT_TIMEOUT_MS,
+    private val subscriptionTimeoutMs: Long = MedtronicReadGateway.DEFAULT_OPERATION_TIMEOUT_MS,
+) : MedtronicGattLink {
+
+    private val appContext = context.applicationContext
+
+    // Only one GATT operation may be in flight at a time; every operation serializes here.
+    private val opLock = ReentrantLock()
+
+    @Volatile
+    private var gatt: BluetoothGatt? = null
+
+    @Volatile
+    private var connectedAddress: String? = null
+
+    @Volatile
+    private var servicesReady = false
+
+    // Built once per connection from the discovered GATT table: bare characteristic UUID -> the
+    // (service, characteristic) pairs exposing it. The RACP UUID maps to more than one entry.
+    @Volatile
+    private var serviceIndex: Map<UUID, List<ResolvedChar>> = emptyMap()
+
+    // The services that expose the shared RACP characteristic (CGM + IDD). Only reads of characteristics
+    // in these services update [lastResolvedServiceUuid], so an unrelated Battery/Device-Info read can
+    // never poison RACP scoping.
+    @Volatile
+    private var racpServiceUuids: Set<UUID> = emptySet()
+
+    // The service of the most recently resolved RACP-bearing characteristic -- the fallback context for
+    // scoping the shared RACP UUID when no data subscription is active.
+    @Volatile
+    private var lastResolvedServiceUuid: UUID? = null
+
+    // The completion slot for the in-flight read/write/descriptor operation (set under [opLock]); the
+    // GATT callback offers the outcome here. A separate slot is used for connect/discover.
+    @Volatile
+    private var pending: ArrayBlockingQueue<GattOutcome>? = null
+
+    @Volatile
+    private var connectPending: ArrayBlockingQueue<GattOutcome>? = null
+
+    @Volatile
+    private var watchdogHandle: SubscriptionWatchdog.Handle? = null
+
+    // Active notification subscriptions keyed by the bare characteristic UUID the caller subscribed.
+    // Concurrent so the binder-thread teardown and the worker-thread delivery can read it safely.
+    private val handlers = ConcurrentHashMap<UUID, ActiveSubscription>()
+
+    // -- MedtronicGattLink ---------------------------------------------------
+
+    override fun read(characteristic: UUID): ByteArray =
+        opLock.withLock {
+            val link = ensureConnected()
+            val resolved = resolve(characteristic)
+            val outcome = awaitGatt("read", characteristic) { link.readCharacteristic(resolved.characteristic) }
+            if (outcome.status != BluetoothGatt.GATT_SUCCESS) {
+                logGattWarning("read", characteristic, outcome.status)
+                throw MedtronicReadException("Medtronic GATT read failed (status=${outcome.status})")
+            }
+            outcome.value ?: ByteArray(0)
+        }
+
+    override fun write(characteristic: UUID, value: ByteArray) {
+        if (characteristic !in WRITABLE_CONTROL_POINTS) {
+            // READ-ONLY defense-in-depth: only the report/control points are ever written, so a buggy
+            // caller can never issue a therapeutic write. Keep the UUID at DEBUG (not Sentry-eligible).
+            Timber.w("Medtronic GATT write refused: characteristic is not a permitted control point")
+            Timber.d("Medtronic GATT write refused for %s", characteristic)
+            return
+        }
+        // Best-effort: a failed control-point write degrades to the gateway's operation timeout (the
+        // pump simply never responds) rather than escaping the readers' Result<T> contract.
+        try {
+            opLock.withLock {
+                val link = ensureConnected()
+                val resolved = resolve(characteristic)
+                val outcome = awaitGatt("write", characteristic) { writeCharacteristic(link, resolved.characteristic, value) }
+                if (outcome.status != BluetoothGatt.GATT_SUCCESS) {
+                    logGattWarning("write", characteristic, outcome.status)
+                }
+            }
+        } catch (e: MedtronicReadException) {
+            logOperationFailure("write", characteristic, e)
+        }
+    }
+
+    override fun subscribe(characteristic: UUID, onPdu: (ByteArray) -> Unit) {
+        try {
+            opLock.withLock {
+                val link = ensureConnected()
+                val resolved = resolve(characteristic)
+                val char = resolved.characteristic
+                val cccd = char.getDescriptor(MedtronicProtocol.CCCD_UUID)
+                if (cccd == null) {
+                    Timber.w("Medtronic GATT subscribe: no CCCD on the target characteristic")
+                    return
+                }
+                if (!link.setCharacteristicNotification(char, true)) {
+                    // Android won't route notifications to our callback, so enabling the CCCD would only
+                    // make the reader wait out its timeout for data it can never receive. Abort now.
+                    Timber.w("Medtronic GATT subscribe: setCharacteristicNotification was rejected")
+                    return
+                }
+                // Register the handler before enabling notifications so a PDU delivered the instant the
+                // CCCD takes effect is not lost. Re-subscribing replaces the handler (seam contract).
+                handlers[characteristic] = ActiveSubscription(resolved, onPdu)
+                val enable = if (isIndication(char)) CCCD_ENABLE_INDICATION else CCCD_ENABLE_NOTIFICATION
+                // The CCCD write completes before this returns, so notifications are effective before
+                // the caller's subsequent control-point write (AC3).
+                val outcome = awaitGatt("subscribe", characteristic) { writeDescriptor(link, cccd, enable) }
+                if (outcome.status != BluetoothGatt.GATT_SUCCESS) {
+                    logGattWarning("subscribe", characteristic, outcome.status)
+                    // The CCCD never took effect; drop the handler so it isn't a phantom subscription.
+                    handlers.remove(characteristic)
+                    return
+                }
+                armWatchdog()
+            }
+        } catch (e: MedtronicReadException) {
+            // On a timeout [awaitGatt] already tore the connection down, clearing handlers; nothing to undo.
+            logOperationFailure("subscribe", characteristic, e)
+        }
+    }
+
+    override fun unsubscribe(characteristic: UUID) {
+        // Drop the handler first, lock-free: this is the AC4 correctness guarantee (no notification
+        // reaches a finished exchange) and must never block the worker thread on the CCCD round trip.
+        val sub = handlers.remove(characteristic) ?: return
+        if (handlers.isEmpty()) cancelWatchdog()
+        disableNotifications("unsubscribe", sub)
+    }
+
+    // -- Connection / discovery ---------------------------------------------
+
+    private fun ensureConnected(): BluetoothGatt {
+        val device = deviceProvider()
+            ?: throw MedtronicReadException("Medtronic GATT read skipped: pump not connected")
+        val existing = gatt
+        if (existing != null && servicesReady && connectedAddress == device.address) return existing
+
+        closeGatt()
+        val slot = ArrayBlockingQueue<GattOutcome>(1)
+        connectPending = slot
+        val opened =
+            try {
+                device.connectGatt(appContext, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+            } catch (e: SecurityException) {
+                connectPending = null
+                throw MedtronicReadException("Medtronic GATT connect failed: ${e.javaClass.simpleName}", e)
+            }
+        if (opened == null) {
+            connectPending = null
+            throw MedtronicReadException("Medtronic GATT connect returned no client")
+        }
+        val outcome = slot.poll(connectTimeoutMs, TimeUnit.MILLISECONDS)
+        connectPending = null
+        if (outcome == null || outcome.status != BluetoothGatt.GATT_SUCCESS) {
+            logGattWarning("connect", null, outcome?.status ?: SYNTHETIC_TIMEOUT_STATUS)
+            closeClient(opened)
+            throw MedtronicReadException("Medtronic GATT connect/discover failed (status=${outcome?.status ?: "timeout"})")
+        }
+        // Publish the handle only after connect + discovery succeeded, so a racing disconnect callback
+        // can't null a half-initialized connection out from under the next operation.
+        gatt = opened
+        connectedAddress = device.address
+        buildServiceIndex(opened)
+        servicesReady = true
+        return opened
+    }
+
+    private fun buildServiceIndex(link: BluetoothGatt) {
+        val index = HashMap<UUID, MutableList<ResolvedChar>>()
+        for (service in link.services) {
+            for (char in service.characteristics) {
+                index.getOrPut(char.uuid) { mutableListOf() }.add(ResolvedChar(service.uuid, char))
+            }
+        }
+        serviceIndex = index
+        racpServiceUuids = index[MedtronicProtocol.RACP_UUID].orEmpty().mapTo(HashSet()) { it.serviceUuid }
+    }
+
+    private fun closeGatt() {
+        cancelWatchdog()
+        handlers.clear()
+        serviceIndex = emptyMap()
+        racpServiceUuids = emptySet()
+        lastResolvedServiceUuid = null
+        servicesReady = false
+        gatt?.let { closeClient(it) }
+        gatt = null
+        connectedAddress = null
+    }
+
+    private fun closeClient(link: BluetoothGatt) {
+        try {
+            link.disconnect()
+            link.close()
+        } catch (e: SecurityException) {
+            Timber.w("Medtronic GATT close failed: %s", e.javaClass.simpleName)
+        }
+    }
+
+    // -- Characteristic resolution (AC2) ------------------------------------
+
+    private fun resolve(characteristic: UUID): ResolvedChar {
+        val candidates = serviceIndex[characteristic].orEmpty()
+        return when {
+            candidates.isEmpty() ->
+                throw MedtronicReadException("Medtronic GATT characteristic not found in the pump's services")
+            candidates.size == 1 -> candidates[0].also { rememberServiceContext(it.serviceUuid) }
+            else -> resolveAmbiguous(candidates)
+        }
+    }
+
+    /**
+     * Record the service context used to scope the shared RACP characteristic, but only for services
+     * that actually expose RACP (CGM + IDD). A Battery / Device-Info read must not move the CGM-vs-IDD
+     * fallback context.
+     */
+    private fun rememberServiceContext(serviceUuid: UUID) {
+        if (serviceUuid in racpServiceUuids) lastResolvedServiceUuid = serviceUuid
+    }
+
+    /**
+     * Scope a characteristic exposed by more than one service (the shared `0x2A52` RACP). Bind it to
+     * the service whose data characteristic this exchange is actively streaming -- the reader subscribes
+     * that data char (CGM Measurement / IDD History Data) immediately before the RACP write -- and fall
+     * back to the most recently resolved RACP-bearing service. Guessing here silently reads the wrong
+     * log, so an unresolvable case fails loudly rather than picking the first candidate.
+     */
+    private fun resolveAmbiguous(candidates: List<ResolvedChar>): ResolvedChar {
+        val activeServices = handlers.values.mapTo(HashSet()) { it.resolved.serviceUuid }
+        return candidates.firstOrNull { it.serviceUuid in activeServices }
+            ?: candidates.firstOrNull { it.serviceUuid == lastResolvedServiceUuid }
+            ?: throw MedtronicReadException("Medtronic GATT could not scope a shared characteristic to a service")
+    }
+
+    // -- Operation plumbing -------------------------------------------------
+
+    private fun awaitGatt(
+        op: String,
+        characteristic: UUID?,
+        tearDownOnTimeout: Boolean = true,
+        issue: () -> Boolean,
+    ): GattOutcome {
+        val slot = ArrayBlockingQueue<GattOutcome>(1)
+        pending = slot
+        val started =
+            try {
+                issue()
+            } catch (e: SecurityException) {
+                pending = null
+                throw MedtronicReadException("Medtronic GATT $op failed: ${e.javaClass.simpleName}", e)
+            }
+        if (!started) {
+            pending = null
+            throw MedtronicReadException("Medtronic GATT $op was rejected by the stack")
+        }
+        val outcome = slot.poll(operationTimeoutMs, TimeUnit.MILLISECONDS)
+        pending = null
+        return outcome ?: run {
+            logGattWarning(op, characteristic, SYNTHETIC_TIMEOUT_STATUS)
+            // Discard the desynchronized connection so the timed-out op's late callback lands on a
+            // stale handle (rejected by the identity guard) instead of a later op's slot.
+            if (tearDownOnTimeout) closeGatt()
+            throw MedtronicReadException("Medtronic GATT $op timed out after $operationTimeoutMs ms")
+        }
+    }
+
+    private fun writeCharacteristic(link: BluetoothGatt, char: BluetoothGattCharacteristic, value: ByteArray): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            link.writeCharacteristic(char, value, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) ==
+                BluetoothStatusCodes.SUCCESS
+        } else {
+            @Suppress("DEPRECATION")
+            char.value = value
+            @Suppress("DEPRECATION")
+            char.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+            @Suppress("DEPRECATION")
+            link.writeCharacteristic(char)
+        }
+
+    private fun writeDescriptor(link: BluetoothGatt, descriptor: BluetoothGattDescriptor, value: ByteArray): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            link.writeDescriptor(descriptor, value) == BluetoothStatusCodes.SUCCESS
+        } else {
+            @Suppress("DEPRECATION")
+            descriptor.value = value
+            @Suppress("DEPRECATION")
+            link.writeDescriptor(descriptor)
+        }
+
+    private fun isIndication(char: BluetoothGattCharacteristic): Boolean =
+        (char.properties and BluetoothGattCharacteristic.PROPERTY_INDICATE) != 0
+
+    /** Disable notifications for [sub], serialized under [opLock] so its CCCD write owns its own slot. */
+    private fun disableNotifications(op: String, sub: ActiveSubscription) {
+        try {
+            opLock.withLock {
+                val link = gatt ?: return
+                val char = sub.resolved.characteristic
+                if (!link.setCharacteristicNotification(char, false)) {
+                    Timber.w("Medtronic GATT %s: setCharacteristicNotification(false) was rejected", op)
+                }
+                val cccd = char.getDescriptor(MedtronicProtocol.CCCD_UUID) ?: return
+                // Best-effort: don't tear the connection down if the disable is lost.
+                val outcome = awaitGatt(op, char.uuid, tearDownOnTimeout = false) { writeDescriptor(link, cccd, CCCD_DISABLE) }
+                if (outcome.status != BluetoothGatt.GATT_SUCCESS) {
+                    logGattWarning(op, char.uuid, outcome.status)
+                }
+            }
+        } catch (e: MedtronicReadException) {
+            logOperationFailure(op, sub.resolved.characteristic.uuid, e)
+        }
+    }
+
+    // -- Watchdog (AC4) -----------------------------------------------------
+
+    private fun armWatchdog() {
+        watchdogHandle?.cancel()
+        watchdogHandle = watchdog.schedule(subscriptionTimeoutMs) { onWatchdogFire() }
+    }
+
+    private fun cancelWatchdog() {
+        watchdogHandle?.cancel()
+        watchdogHandle = null
+    }
+
+    private fun onWatchdogFire() {
+        if (handlers.isEmpty()) return
+        // The driving read's coroutine has been cancelled by the gateway's operation timeout without the
+        // reader unsubscribing (it only unsubscribes on a pump response). Release every dangling
+        // subscription so the timed-out read leaves no notifications that desync the next exchange.
+        Timber.w("Medtronic GATT subscription watchdog fired; releasing dangling subscriptions")
+        cancelWatchdog()
+        // Drop handlers first (lock-free): the no-dangling-notification guarantee. The CCCD disables
+        // then run serialized under [opLock] so each owns its own completion slot.
+        val orphaned = handlers.values.toList()
+        handlers.clear()
+        for (sub in orphaned) disableNotifications("watchdog-release", sub)
+    }
+
+    // -- GATT callback (binder thread) --------------------------------------
+
+    private val gattCallback = object : BluetoothGattCallback() {
+        override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
+            when (newState) {
+                BluetoothProfile.STATE_CONNECTED -> {
+                    if (status != BluetoothGatt.GATT_SUCCESS) {
+                        connectPending?.offer(GattOutcome(status, null))
+                        return
+                    }
+                    // Never requestMtu(): the pump only honors 23-byte PDUs (AC5). Go straight to
+                    // discovery.
+                    val started =
+                        try {
+                            g.discoverServices()
+                        } catch (e: SecurityException) {
+                            Timber.w("Medtronic GATT discoverServices failed: %s", e.javaClass.simpleName)
+                            false
+                        }
+                    if (!started) connectPending?.offer(GattOutcome(SYNTHETIC_REJECTED_STATUS, null))
+                }
+                BluetoothProfile.STATE_DISCONNECTED -> teardownOnDisconnect(g, status)
+            }
+        }
+
+        override fun onServicesDiscovered(g: BluetoothGatt, status: Int) {
+            connectPending?.offer(GattOutcome(status, null))
+        }
+
+        override fun onCharacteristicRead(
+            g: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray,
+            status: Int,
+        ) {
+            if (g !== gatt) return
+            pending?.offer(GattOutcome(status, value.copyOf()))
+        }
+
+        @Deprecated("Deprecated in API 33")
+        override fun onCharacteristicRead(g: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
+            if (g !== gatt) return
+            @Suppress("DEPRECATION")
+            pending?.offer(GattOutcome(status, characteristic.value?.copyOf()))
+        }
+
+        override fun onCharacteristicWrite(g: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
+            if (g !== gatt) return
+            pending?.offer(GattOutcome(status, null))
+        }
+
+        override fun onDescriptorWrite(g: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) {
+            if (g !== gatt) return
+            pending?.offer(GattOutcome(status, null))
+        }
+
+        override fun onCharacteristicChanged(
+            g: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray,
+        ) {
+            if (g !== gatt) return
+            deliverPdu(characteristic.uuid, value)
+        }
+
+        @Deprecated("Deprecated in API 33")
+        override fun onCharacteristicChanged(g: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
+            if (g !== gatt) return
+            @Suppress("DEPRECATION")
+            characteristic.value?.let { deliverPdu(characteristic.uuid, it) }
+        }
+    }
+
+    private fun teardownOnDisconnect(g: BluetoothGatt, status: Int) {
+        // Fail whatever blocking call is parked so it returns instead of waiting out its full timeout.
+        // (Offered regardless of identity: a disconnect of the in-progress connect arrives before [gatt]
+        // is published, and the connect awaiter must still be released.)
+        connectPending?.offer(GattOutcome(status, null))
+        if (gatt !== g) {
+            // A stale handle disconnected (e.g. after a reconnect to a new device); just close it.
+            closeClient(g)
+            return
+        }
+        servicesReady = false
+        serviceIndex = emptyMap()
+        racpServiceUuids = emptySet()
+        cancelWatchdog()
+        handlers.clear()
+        pending?.offer(GattOutcome(status, null))
+        closeClient(g)
+        gatt = null
+        connectedAddress = null
+    }
+
+    private fun deliverPdu(characteristic: UUID, value: ByteArray) {
+        // Hop onto the connection manager's single worker thread so all onPdu callbacks are serialized
+        // on one thread (AC3). Copy first: the API-33 callback may recycle its delivery buffer once this
+        // returns, and the copy is read later on the worker.
+        val copy = value.copyOf()
+        worker.post { handlers[characteristic]?.onPdu?.invoke(copy) }
+    }
+
+    // -- Lifecycle ----------------------------------------------------------
+
+    /**
+     * Release the client GATT and the watchdog executor. Not part of the singleton's normal lifecycle
+     * (the connection is reused across reads); provided for explicit teardown and tests.
+     */
+    fun close() {
+        opLock.withLock { closeGatt() }
+        watchdog.close()
+    }
+
+    // -- Logging ------------------------------------------------------------
+
+    private fun logGattWarning(op: String, characteristic: UUID?, status: Int) {
+        // AC7: WARN is forwarded to the glycemicgpt-mobile Sentry project, so it carries only the
+        // operation + GATT status -- never a characteristic payload/value. The (non-PHI) characteristic
+        // UUID and full detail stay at DEBUG (local logcat), below the Sentry threshold.
+        Timber.w("Medtronic GATT %s failed (status=%s)", op, gattStatusName(status))
+        Timber.d("Medtronic GATT %s detail: characteristic=%s status=%d", op, characteristic, status)
+    }
+
+    private fun logOperationFailure(op: String, characteristic: UUID, e: Throwable) {
+        Timber.w("Medtronic GATT %s failed: %s", op, e.javaClass.simpleName)
+        Timber.d(e, "Medtronic GATT %s failure detail: characteristic=%s", op, characteristic)
+    }
+
+    /** Number of live notification subscriptions; exposed for the transport's unit tests only. */
+    internal fun activeSubscriptionCount(): Int = handlers.size
+
+    private data class ResolvedChar(val serviceUuid: UUID, val characteristic: BluetoothGattCharacteristic)
+
+    private class ActiveSubscription(val resolved: ResolvedChar, val onPdu: (ByteArray) -> Unit)
+
+    private class GattOutcome(val status: Int, val value: ByteArray?)
+
+    companion object {
+        /** Per-GATT-operation timeout: a single read/write/CCCD round trip of 20-byte PDUs is quick. */
+        const val DEFAULT_OPERATION_TIMEOUT_MS = 10_000L
+
+        /** Connect + service-discovery timeout. */
+        const val DEFAULT_CONNECT_TIMEOUT_MS = 10_000L
+
+        /**
+         * The report/control-point characteristics the read layer is allowed to write to. Everything
+         * else is rejected by [write] -- the transport is READ-ONLY and never issues a therapeutic write.
+         */
+        private val WRITABLE_CONTROL_POINTS = setOf(
+            MedtronicProtocol.RACP_UUID,
+            MedtronicProtocol.CGM_SOCP_UUID,
+            MedtronicProtocol.IDD_SRCP_UUID,
+        )
+
+        // CCCD payloads per the Bluetooth Core spec (Client Characteristic Configuration). Defined
+        // here rather than via BluetoothGattDescriptor.* because those platform constants are null
+        // under the unit-test android.jar stub (this module uses mockk, not Robolectric).
+        private val CCCD_ENABLE_NOTIFICATION = byteArrayOf(0x01, 0x00)
+        private val CCCD_ENABLE_INDICATION = byteArrayOf(0x02, 0x00)
+        private val CCCD_DISABLE = byteArrayOf(0x00, 0x00)
+
+        /** Synthetic status for a local timeout (not a platform GATT status). */
+        private const val SYNTHETIC_TIMEOUT_STATUS = -1
+
+        /** Synthetic status for an op the stack refused to start. */
+        private const val SYNTHETIC_REJECTED_STATUS = -2
+
+        /** Human-readable GATT status for WARN logs (no PHI -- a numeric stack code). */
+        private fun gattStatusName(status: Int): String = when (status) {
+            BluetoothGatt.GATT_SUCCESS -> "SUCCESS"
+            0x02 -> "READ_NOT_PERMITTED"
+            0x03 -> "WRITE_NOT_PERMITTED"
+            0x05 -> "INSUFFICIENT_AUTHENTICATION"
+            0x06 -> "REQUEST_NOT_SUPPORTED"
+            0x07 -> "INVALID_OFFSET"
+            0x08 -> "INSUFFICIENT_ENCRYPTION"
+            0x0D -> "INVALID_ATTRIBUTE_LENGTH"
+            0x13 -> "CONN_TERMINATE_PEER_USER"
+            0x16 -> "CONN_TERMINATE_LOCAL_HOST"
+            0x22 -> "CONN_FAILED_ESTABLISHMENT"
+            0x3E -> "CONN_TIMEOUT"
+            0x85 -> "GATT_ERROR"
+            SYNTHETIC_TIMEOUT_STATUS -> "LOCAL_TIMEOUT"
+            SYNTHETIC_REJECTED_STATUS -> "LOCAL_REJECTED"
+            else -> "UNKNOWN_0x${status.toString(16)}"
+        }
+    }
+}
+
+/**
+ * One-shot delayed scheduler for the GATT-client subscription watchdog (AC4). Abstracted like
+ * [SerialWorker] so the cleanup-on-timeout path is deterministically unit-testable without a real
+ * timer thread.
+ */
+interface SubscriptionWatchdog {
+    /** Run [task] after [delayMs]; the returned handle cancels it if the subscription is released first. */
+    fun schedule(delayMs: Long, task: () -> Unit): Handle
+
+    /** Release any resources (e.g. the executor thread). Default no-op for in-memory test doubles. */
+    fun close() {}
+
+    /** Cancels a scheduled task. */
+    fun interface Handle {
+        fun cancel()
+    }
+}
+
+/** Production [SubscriptionWatchdog] backed by a single daemon scheduled-executor thread. */
+class ScheduledSubscriptionWatchdog(
+    private val executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "medtronic-gatt-watchdog").apply { isDaemon = true }
+    },
+) : SubscriptionWatchdog {
+    override fun schedule(delayMs: Long, task: () -> Unit): SubscriptionWatchdog.Handle {
+        val future = executor.schedule(task, delayMs, TimeUnit.MILLISECONDS)
+        return SubscriptionWatchdog.Handle { future.cancel(false) }
+    }
+
+    override fun close() {
+        executor.shutdownNow()
+    }
+}

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicPeripheral.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicPeripheral.kt
@@ -146,6 +146,8 @@ class AndroidMedtronicPeripheral(context: Context) : MedtronicPeripheral {
         }
     }
 
+    override fun connectedDevice(): BluetoothDevice? = peer
+
     override fun removeBond(address: String): Boolean {
         val device = adapter?.getRemoteDevice(address) ?: return false
         if (device.bondState != BluetoothDevice.BOND_BONDED) return false

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
@@ -15,6 +15,7 @@
  */
 package com.glycemicgpt.mobile.ble.connection
 
+import android.bluetooth.BluetoothDevice
 import android.content.Context
 import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
 import com.glycemicgpt.mobile.domain.model.ConnectionState
@@ -117,6 +118,15 @@ class MedtronicBleConnectionManager(
     @Volatile
     var sakeSession: MedtronicSakeSession? = null
         private set
+
+    /**
+     * The connected pump's [BluetoothDevice], captured by the peripheral when the pump connected to
+     * our GATT server. The Milestone D `BluetoothGatt`-client transport ([AndroidMedtronicGattLink])
+     * opens a client connection back to this device over the same link to read the pump's GATT server
+     * -- it must not start a fresh scan/advertise cycle. `null` until a pump is connected.
+     */
+    val connectedPumpDevice: BluetoothDevice?
+        get() = peripheral.connectedDevice()
 
     @Volatile
     private var autoReconnect = false

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicPeripheral.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicPeripheral.kt
@@ -10,6 +10,7 @@
  */
 package com.glycemicgpt.mobile.ble.connection
 
+import android.bluetooth.BluetoothDevice
 import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
 
 /**
@@ -93,6 +94,15 @@ interface MedtronicPeripheral {
 
     /** Best-effort removal of the OS-level BLE bond for [address] (used by unpair). */
     fun removeBond(address: String): Boolean
+
+    /**
+     * The pump's [BluetoothDevice] captured when it connected to our GATT server (as the BLE
+     * central), or `null` when no pump is connected. The Milestone D `BluetoothGatt`-client transport
+     * opens a client connection back to *this* device over the same link to read the pump's
+     * CGM / IDD / Device-Info GATT server; it must **not** start a fresh scan to obtain it. Defaults
+     * to `null` for the connection-only collaborators the B2 lifecycle tests exercise.
+     */
+    fun connectedDevice(): BluetoothDevice? = null
 
     /** Stop advertising and close the GATT server, releasing all BLE resources. */
     fun stop()

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/di/MedtronicPumpModule.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/di/MedtronicPumpModule.kt
@@ -9,12 +9,14 @@
 package com.glycemicgpt.mobile.di
 
 import android.content.Context
+import com.glycemicgpt.mobile.ble.connection.AndroidMedtronicGattLink
 import com.glycemicgpt.mobile.ble.connection.AndroidMedtronicPeripheral
 import com.glycemicgpt.mobile.ble.connection.HandlerThreadSerialWorker
 import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
 import com.glycemicgpt.mobile.ble.connection.MedtronicPeripheral
 import com.glycemicgpt.mobile.ble.connection.SerialWorker
 import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
+import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.plugin.PluginFactory
 import com.glycemicgpt.mobile.domain.pump.PumpCredentialProvider
 import com.glycemicgpt.mobile.plugin.MedtronicPluginFactory
@@ -64,17 +66,40 @@ abstract class MedtronicPumpModule {
                 scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
             )
 
+        /**
+         * The on-device `BluetoothGatt`-client transport. It opens a client connection back to the
+         * connected pump (captured by the connection manager when the pump connected to our GATT
+         * server) and reuses the same SAKE [worker] thread so inbound notifications stay serialized on
+         * one thread.
+         */
+        @Provides
+        @Singleton
+        fun provideGattLink(
+            @ApplicationContext context: Context,
+            connectionManager: MedtronicBleConnectionManager,
+            worker: SerialWorker,
+        ): AndroidMedtronicGattLink =
+            AndroidMedtronicGattLink(
+                context = context,
+                deviceProvider = { connectionManager.connectedPumpDevice },
+                worker = worker,
+            )
+
         @Provides
         @Singleton
         fun provideReadGateway(
             connectionManager: MedtronicBleConnectionManager,
+            gattLink: AndroidMedtronicGattLink,
         ): MedtronicReadGateway =
             MedtronicReadGateway(
                 sessionProvider = { connectionManager.sakeSession },
-                // TODO(48.D): supply the on-device BluetoothGatt-client MedtronicGattLink (scoping the
-                // shared SIG 0x2A52 RACP characteristic under the CGM vs IDD service). Until the
-                // transport lands the gateway reports "not connected"; pairing + handshake already work.
-                linkProvider = { null },
+                // Supply the transport only while a pump is authenticated; otherwise null so the
+                // gateway keeps reporting the clean "not connected" failure rather than reading a dead
+                // link. The shared SIG 0x2A52 RACP characteristic is scoped to the CGM vs IDD service
+                // inside the link itself (TODO(48.C3) closed).
+                linkProvider = {
+                    if (connectionManager.connectionState.value == ConnectionState.CONNECTED) gattLink else null
+                },
             )
 
         private const val SAKE_WORKER_THREAD_NAME = "medtronic-sake"

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
@@ -1,0 +1,414 @@
+/*
+ * AC1-AC8: unit tests for the on-device BluetoothGatt-client transport against a mocked BluetoothGatt /
+ * BluetoothGattCallback (mockk -- no Robolectric, mirroring the rest of this module). The mocked GATT
+ * fires its callbacks synchronously from each operation so the transport's blocking, latch-based
+ * operation model completes deterministically on the test thread; a queueing worker lets a test prove
+ * inbound PDUs are hopped onto the worker rather than delivered inline. No real pump and no Android BLE
+ * stack are involved -- over-the-air validation is 48.A2 / Milestone F.
+ */
+package com.glycemicgpt.mobile.ble.connection
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.util.Log
+import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
+import com.glycemicgpt.mobile.ble.read.MedtronicReadException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.util.UUID
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import timber.log.Timber
+
+class AndroidMedtronicGattLinkTest {
+
+    private val context = mockk<Context>(relaxed = true)
+    private val device = mockk<BluetoothDevice>(relaxed = true)
+    private val gatt = mockk<BluetoothGatt>(relaxed = true)
+    private val callbackSlot = slot<BluetoothGattCallback>()
+    private val callback: BluetoothGattCallback get() = callbackSlot.captured
+
+    private val readValues = mutableMapOf<UUID, ByteArray>()
+    private val events = mutableListOf<String>()
+    private val watchdog = ManualWatchdog()
+
+    // -- GATT table the mocked pump exposes ---------------------------------
+
+    private val cgmFeature = characteristic(MedtronicProtocol.CGM_FEATURE_UUID, withCccd = false)
+    private val cgmMeasurement = characteristic(MedtronicProtocol.CGM_MEASUREMENT_UUID, BluetoothGattCharacteristic.PROPERTY_NOTIFY)
+    private val cgmRacp = characteristic(MedtronicProtocol.RACP_UUID, BluetoothGattCharacteristic.PROPERTY_INDICATE)
+    private val iddFeatures = characteristic(MedtronicProtocol.IDD_FEATURES_UUID, withCccd = false)
+    private val iddHistory = characteristic(MedtronicProtocol.IDD_HISTORY_DATA_UUID, BluetoothGattCharacteristic.PROPERTY_NOTIFY)
+    private val iddRacp = characteristic(MedtronicProtocol.RACP_UUID, BluetoothGattCharacteristic.PROPERTY_INDICATE)
+    private val batteryLevel = characteristic(MedtronicProtocol.BATTERY_LEVEL_UUID, withCccd = false)
+
+    private val cgmService = service(MedtronicProtocol.CGM_SERVICE_UUID, cgmFeature, cgmMeasurement, cgmRacp)
+    private val iddService = service(MedtronicProtocol.IDD_SERVICE_UUID, iddFeatures, iddHistory, iddRacp)
+    private val batteryService = service(MedtronicProtocol.BATTERY_SERVICE_UUID, batteryLevel)
+
+    /** GATT statuses the mock reports; overridden per test to exercise the failure paths. */
+    private var readStatus = BluetoothGatt.GATT_SUCCESS
+    private var writeStatus = BluetoothGatt.GATT_SUCCESS
+    private var descriptorStatus = BluetoothGatt.GATT_SUCCESS
+
+    init {
+        every { device.address } returns PUMP_ADDRESS
+        every { device.connectGatt(any(), any(), capture(callbackSlot), any()) } answers {
+            // Simulate the stack connecting + discovering synchronously off the connectGatt call.
+            callback.onConnectionStateChange(gatt, BluetoothGatt.GATT_SUCCESS, BluetoothProfile.STATE_CONNECTED)
+            gatt
+        }
+        every { gatt.services } returns listOf(cgmService, iddService, batteryService)
+        every { gatt.discoverServices() } answers {
+            callback.onServicesDiscovered(gatt, BluetoothGatt.GATT_SUCCESS)
+            true
+        }
+        every { gatt.setCharacteristicNotification(any(), any()) } returns true
+        every { gatt.readCharacteristic(any()) } answers {
+            val char = firstArg<BluetoothGattCharacteristic>()
+            callback.onCharacteristicRead(gatt, char, readValues[char.uuid] ?: ByteArray(0), readStatus)
+            true
+        }
+        @Suppress("DEPRECATION")
+        every { gatt.writeCharacteristic(any<BluetoothGattCharacteristic>()) } answers {
+            val char = firstArg<BluetoothGattCharacteristic>()
+            events.add("write-char:${char.uuid}")
+            callback.onCharacteristicWrite(gatt, char, writeStatus)
+            true
+        }
+        @Suppress("DEPRECATION")
+        every { gatt.writeDescriptor(any<BluetoothGattDescriptor>()) } answers {
+            events.add("write-cccd")
+            callback.onDescriptorWrite(gatt, firstArg(), descriptorStatus)
+            true
+        }
+    }
+
+    private fun newLink(worker: SerialWorker = DirectSerialWorker()) = AndroidMedtronicGattLink(
+        context = context,
+        deviceProvider = { device },
+        worker = worker,
+        watchdog = watchdog,
+    )
+
+    @After
+    fun tearDown() = Timber.uprootAll()
+
+    // -- AC1 / AC5: connect, discover, read; never requestMtu ---------------
+
+    @Test
+    fun `connects discovers and reads a static characteristic`() {
+        readValues[MedtronicProtocol.BATTERY_LEVEL_UUID] = byteArrayOf(85)
+
+        val value = newLink().read(MedtronicProtocol.BATTERY_LEVEL_UUID)
+
+        assertArrayEquals(byteArrayOf(85), value)
+        verify { device.connectGatt(any(), false, any(), BluetoothDevice.TRANSPORT_LE) }
+        verify { gatt.discoverServices() }
+        verify(exactly = 0) { gatt.requestMtu(any()) }
+    }
+
+    @Test
+    fun `opens the client connection only once across reads`() {
+        readValues[MedtronicProtocol.BATTERY_LEVEL_UUID] = byteArrayOf(85)
+        val link = newLink()
+
+        link.read(MedtronicProtocol.BATTERY_LEVEL_UUID)
+        link.read(MedtronicProtocol.BATTERY_LEVEL_UUID)
+
+        verify(exactly = 1) { device.connectGatt(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `read skips cleanly when no pump device is available`() {
+        val link = AndroidMedtronicGattLink(context, deviceProvider = { null }, worker = DirectSerialWorker(), watchdog = watchdog)
+
+        val error = assertThrows(MedtronicReadException::class.java) {
+            link.read(MedtronicProtocol.BATTERY_LEVEL_UUID)
+        }
+        assertTrue(error.message!!.contains("not connected"))
+    }
+
+    // -- AC3: notifications effective (CCCD written) before the control-point write --
+
+    @Test
+    fun `subscribe enables the CCCD before the subsequent control-point write`() {
+        val link = newLink()
+
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {}
+        link.write(MedtronicProtocol.RACP_UUID, byteArrayOf(0x01, 0x06))
+
+        assertEquals(listOf("write-cccd", "write-char:${MedtronicProtocol.RACP_UUID}"), events)
+    }
+
+    // -- AC3: inbound PDUs are delivered serialized on the connection manager's worker thread --
+
+    @Test
+    fun `inbound notifications are delivered on the worker thread not inline`() {
+        val queueingWorker = QueueingWorker()
+        val link = newLink(worker = queueingWorker)
+        val received = mutableListOf<ByteArray>()
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) { received.add(it) }
+
+        callback.onCharacteristicChanged(gatt, cgmMeasurement, byteArrayOf(0x0e, 0x01))
+        assertTrue("delivery must be posted to the worker, not run inline on the binder thread", received.isEmpty())
+
+        queueingWorker.runQueued()
+        assertEquals(1, received.size)
+        assertArrayEquals(byteArrayOf(0x0e, 0x01), received[0])
+    }
+
+    // -- AC2: the shared 0x2A52 RACP is scoped to the right service ----------
+
+    @Test
+    fun `RACP is scoped to the CGM service for a CGM exchange`() {
+        val link = newLink()
+
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {}
+        link.write(MedtronicProtocol.RACP_UUID, byteArrayOf(0x01, 0x06))
+
+        @Suppress("DEPRECATION")
+        verify { gatt.writeCharacteristic(cgmRacp) }
+        @Suppress("DEPRECATION")
+        verify(exactly = 0) { gatt.writeCharacteristic(iddRacp) }
+    }
+
+    @Test
+    fun `RACP is scoped to the IDD service for a history exchange`() {
+        val link = newLink()
+
+        link.subscribe(MedtronicProtocol.IDD_HISTORY_DATA_UUID) {}
+        link.write(MedtronicProtocol.RACP_UUID, byteArrayOf(0x33, 0x69, 0x0f))
+
+        @Suppress("DEPRECATION")
+        verify { gatt.writeCharacteristic(iddRacp) }
+        @Suppress("DEPRECATION")
+        verify(exactly = 0) { gatt.writeCharacteristic(cgmRacp) }
+    }
+
+    @Test
+    fun `RACP falls back to the most recently read RACP-bearing service, unpoisoned by a battery read`() {
+        val link = newLink()
+
+        // IDD read establishes IDD context; a Battery read (no RACP) must NOT move it; a bare RACP
+        // write with no active data subscription then still resolves to the IDD service's RACP.
+        link.read(MedtronicProtocol.IDD_FEATURES_UUID)
+        link.read(MedtronicProtocol.BATTERY_LEVEL_UUID)
+        link.write(MedtronicProtocol.RACP_UUID, byteArrayOf(0x5a, 0x33, 0x0f))
+
+        @Suppress("DEPRECATION")
+        verify { gatt.writeCharacteristic(iddRacp) }
+        @Suppress("DEPRECATION")
+        verify(exactly = 0) { gatt.writeCharacteristic(cgmRacp) }
+    }
+
+    // -- READ-ONLY: writes are confined to the report/control points ---------
+
+    @Test
+    fun `write to a non-control-point characteristic is refused`() {
+        val link = newLink()
+
+        link.write(MedtronicProtocol.CGM_MEASUREMENT_UUID, byteArrayOf(0x01))
+
+        @Suppress("DEPRECATION")
+        verify(exactly = 0) { gatt.writeCharacteristic(any<BluetoothGattCharacteristic>()) }
+        verify(exactly = 0) { device.connectGatt(any(), any(), any(), any()) }
+    }
+
+    // -- Connection-state failure edges --------------------------------------
+
+    @Test
+    fun `a GATT error on connect surfaces as a failed read and leaves no stale link`() {
+        every { device.connectGatt(any(), any(), capture(callbackSlot), any()) } answers {
+            // Connection establishment failed (e.g. GATT 133): the stack reports DISCONNECTED with the
+            // error status rather than CONNECTED.
+            callback.onConnectionStateChange(gatt, GATT_ERROR_133, BluetoothProfile.STATE_DISCONNECTED)
+            gatt
+        }
+        val link = newLink()
+
+        assertThrows(MedtronicReadException::class.java) {
+            link.read(MedtronicProtocol.BATTERY_LEVEL_UUID)
+        }
+        assertEquals(0, link.activeSubscriptionCount())
+    }
+
+    @Test
+    fun `an unexpected disconnect invalidates the cached link so the next read reconnects`() {
+        readValues[MedtronicProtocol.BATTERY_LEVEL_UUID] = byteArrayOf(85)
+        val link = newLink()
+
+        link.read(MedtronicProtocol.BATTERY_LEVEL_UUID) // opens connection #1
+        // The pump drops the link mid-session.
+        callback.onConnectionStateChange(gatt, GATT_CONN_TERMINATE_PEER_USER, BluetoothProfile.STATE_DISCONNECTED)
+        link.read(MedtronicProtocol.BATTERY_LEVEL_UUID) // must re-establish, not reuse the dead link
+
+        verify(exactly = 2) { device.connectGatt(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `subscribe aborts without writing the CCCD when setCharacteristicNotification is rejected`() {
+        every { gatt.setCharacteristicNotification(any(), any()) } returns false
+        val link = newLink()
+
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {}
+
+        assertEquals(0, link.activeSubscriptionCount())
+        @Suppress("DEPRECATION")
+        verify(exactly = 0) { gatt.writeDescriptor(any<BluetoothGattDescriptor>()) }
+    }
+
+    // -- AC4: a timed-out (cancelled) subscribe leaves no dangling subscription --
+
+    @Test
+    fun `the watchdog releases dangling subscriptions and stops delivering notifications`() {
+        val link = newLink()
+        val received = mutableListOf<ByteArray>()
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) { received.add(it) }
+        link.subscribe(MedtronicProtocol.RACP_UUID) { received.add(it) }
+        assertEquals(2, link.activeSubscriptionCount())
+
+        // The driving coroutine was cancelled by the gateway timeout without the reader unsubscribing.
+        watchdog.fire()
+
+        assertEquals(0, link.activeSubscriptionCount())
+        callback.onCharacteristicChanged(gatt, cgmMeasurement, byteArrayOf(0x0e))
+        assertTrue("a released subscription must not deliver notifications", received.isEmpty())
+    }
+
+    @Test
+    fun `unsubscribe cancels the watchdog once the last subscription is released`() {
+        val link = newLink()
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {}
+
+        link.unsubscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID)
+
+        assertEquals(0, link.activeSubscriptionCount())
+        assertTrue(watchdog.cancelled)
+    }
+
+    @Test
+    fun `a failed CCCD enable leaves no phantom subscription`() {
+        descriptorStatus = GATT_INSUFFICIENT_AUTHENTICATION
+        val link = newLink()
+
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {}
+
+        assertEquals(0, link.activeSubscriptionCount())
+    }
+
+    // -- AC7: BLE/GATT failures route through Timber.w with op + status, never payload --
+
+    @Test
+    fun `a read failure throws and surfaces the GATT status without the payload`() {
+        val tree = RecordingTree().also { Timber.plant(it) }
+        readStatus = GATT_INSUFFICIENT_AUTHENTICATION
+
+        assertThrows(MedtronicReadException::class.java) {
+            newLink().read(MedtronicProtocol.CGM_FEATURE_UUID)
+        }
+
+        assertTrue(tree.warns.any { it.contains("read") && it.contains("INSUFFICIENT_AUTHENTICATION") })
+    }
+
+    @Test
+    fun `a write failure logs op and status at WARN but never the written payload`() {
+        val tree = RecordingTree().also { Timber.plant(it) }
+        writeStatus = GATT_INSUFFICIENT_AUTHENTICATION
+        val payload = byteArrayOf(0x01, 0x06, 0x42)
+
+        val link = newLink()
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {}
+        link.write(MedtronicProtocol.RACP_UUID, payload)
+
+        assertTrue(tree.warns.any { it.contains("write") && it.contains("INSUFFICIENT_AUTHENTICATION") })
+        val payloadFragments = listOf("0106", "01 06", "[1,", "010642")
+        assertFalse(
+            "WARN logs must not embed the characteristic payload",
+            tree.warns.any { warn -> payloadFragments.any { warn.contains(it) } },
+        )
+    }
+
+    // -- Test doubles --------------------------------------------------------
+
+    private fun characteristic(
+        uuid: UUID,
+        properties: Int = 0,
+        withCccd: Boolean = true,
+    ): BluetoothGattCharacteristic {
+        val char = mockk<BluetoothGattCharacteristic>(relaxed = true)
+        every { char.uuid } returns uuid
+        every { char.properties } returns properties
+        every { char.getDescriptor(MedtronicProtocol.CCCD_UUID) } returns
+            if (withCccd) mockk(relaxed = true) else null
+        return char
+    }
+
+    private fun service(uuid: UUID, vararg chars: BluetoothGattCharacteristic): BluetoothGattService {
+        val service = mockk<BluetoothGattService>(relaxed = true)
+        every { service.uuid } returns uuid
+        every { service.characteristics } returns chars.toList()
+        return service
+    }
+
+    /** A [SerialWorker] that defers posted tasks so a test can prove delivery is not run inline. */
+    private class QueueingWorker : SerialWorker {
+        private val queued = ArrayDeque<() -> Unit>()
+
+        override fun post(task: () -> Unit) {
+            queued.add(task)
+        }
+
+        override fun stop() = queued.clear()
+
+        fun runQueued() {
+            while (queued.isNotEmpty()) queued.removeFirst().invoke()
+        }
+    }
+
+    /** A [SubscriptionWatchdog] whose scheduled task the test fires on demand (no real timer). */
+    private class ManualWatchdog : SubscriptionWatchdog {
+        private var task: (() -> Unit)? = null
+        var cancelled = false
+            private set
+
+        override fun schedule(delayMs: Long, task: () -> Unit): SubscriptionWatchdog.Handle {
+            this.task = task
+            return SubscriptionWatchdog.Handle {
+                cancelled = true
+                this.task = null
+            }
+        }
+
+        fun fire() = task?.invoke() ?: Unit
+    }
+
+    /** Records emitted Timber logs so a test can assert the WARN discipline (AC7). */
+    private class RecordingTree : Timber.Tree() {
+        val warns = mutableListOf<String>()
+
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            if (priority == Log.WARN) warns.add(message)
+        }
+    }
+
+    private companion object {
+        const val PUMP_ADDRESS = "AA:BB:CC:DD:EE:FF"
+        const val GATT_INSUFFICIENT_AUTHENTICATION = 0x05
+        const val GATT_CONN_TERMINATE_PEER_USER = 0x13
+        const val GATT_ERROR_133 = 0x85
+    }
+}

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
@@ -64,35 +64,44 @@ class AndroidMedtronicGattLinkTest {
     private var writeStatus = BluetoothGatt.GATT_SUCCESS
     private var descriptorStatus = BluetoothGatt.GATT_SUCCESS
 
+    // The client(s) `connectGatt` hands back, in order; defaults to the single shared [gatt].
+    private val connectQueue = ArrayDeque<BluetoothGatt>()
+
     init {
         every { device.address } returns PUMP_ADDRESS
         every { device.connectGatt(any(), any(), capture(callbackSlot), any()) } answers {
             // Simulate the stack connecting + discovering synchronously off the connectGatt call.
-            callback.onConnectionStateChange(gatt, BluetoothGatt.GATT_SUCCESS, BluetoothProfile.STATE_CONNECTED)
-            gatt
+            val client = if (connectQueue.isEmpty()) gatt else connectQueue.removeFirst()
+            callback.onConnectionStateChange(client, BluetoothGatt.GATT_SUCCESS, BluetoothProfile.STATE_CONNECTED)
+            client
         }
-        every { gatt.services } returns listOf(cgmService, iddService, batteryService)
-        every { gatt.discoverServices() } answers {
-            callback.onServicesDiscovered(gatt, BluetoothGatt.GATT_SUCCESS)
+        stubGattClient(gatt)
+    }
+
+    /** Stub a `BluetoothGatt` client so its callbacks fire synchronously off each operation. */
+    private fun stubGattClient(client: BluetoothGatt) {
+        every { client.services } returns listOf(cgmService, iddService, batteryService)
+        every { client.discoverServices() } answers {
+            callback.onServicesDiscovered(client, BluetoothGatt.GATT_SUCCESS)
             true
         }
-        every { gatt.setCharacteristicNotification(any(), any()) } returns true
-        every { gatt.readCharacteristic(any()) } answers {
+        every { client.setCharacteristicNotification(any(), any()) } returns true
+        every { client.readCharacteristic(any()) } answers {
             val char = firstArg<BluetoothGattCharacteristic>()
-            callback.onCharacteristicRead(gatt, char, readValues[char.uuid] ?: ByteArray(0), readStatus)
+            callback.onCharacteristicRead(client, char, readValues[char.uuid] ?: ByteArray(0), readStatus)
             true
         }
         @Suppress("DEPRECATION")
-        every { gatt.writeCharacteristic(any<BluetoothGattCharacteristic>()) } answers {
+        every { client.writeCharacteristic(any<BluetoothGattCharacteristic>()) } answers {
             val char = firstArg<BluetoothGattCharacteristic>()
             events.add("write-char:${char.uuid}")
-            callback.onCharacteristicWrite(gatt, char, writeStatus)
+            callback.onCharacteristicWrite(client, char, writeStatus)
             true
         }
         @Suppress("DEPRECATION")
-        every { gatt.writeDescriptor(any<BluetoothGattDescriptor>()) } answers {
+        every { client.writeDescriptor(any<BluetoothGattDescriptor>()) } answers {
             events.add("write-cccd")
-            callback.onDescriptorWrite(gatt, firstArg(), descriptorStatus)
+            callback.onDescriptorWrite(client, firstArg(), descriptorStatus)
             true
         }
     }
@@ -317,6 +326,28 @@ class AndroidMedtronicGattLinkTest {
     }
 
     @Test
+    fun `a deferred unsubscribe does not disable a characteristic on a reconnected client`() {
+        val gattB = mockk<BluetoothGatt>(relaxed = true)
+        stubGattClient(gattB)
+        readValues[MedtronicProtocol.BATTERY_LEVEL_UUID] = byteArrayOf(85)
+        connectQueue.addAll(listOf(gatt, gattB)) // connection A then, after reconnect, B
+        val deferring = DeferringWatchdog()
+        val link = AndroidMedtronicGattLink(context, deviceProvider = { device }, worker = DirectSerialWorker(), watchdog = deferring)
+
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {} // connects to A; CCCD enable on A; owner = A
+        link.unsubscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) // queues the disable, deferred
+        // A drops; the next read reconnects to B.
+        callback.onConnectionStateChange(gatt, GATT_CONN_TERMINATE_PEER_USER, BluetoothProfile.STATE_DISCONNECTED)
+        link.read(MedtronicProtocol.BATTERY_LEVEL_UUID)
+
+        deferring.runDeferred() // the queued disable now runs against the live client (B)
+
+        @Suppress("DEPRECATION")
+        verify(exactly = 0) { gattB.writeDescriptor(any<BluetoothGattDescriptor>()) }
+        verify(exactly = 0) { gattB.setCharacteristicNotification(any(), false) }
+    }
+
+    @Test
     fun `a failed CCCD enable leaves no phantom subscription`() {
         descriptorStatus = GATT_INSUFFICIENT_AUTHENTICATION
         val link = newLink()
@@ -412,6 +443,25 @@ class AndroidMedtronicGattLinkTest {
         override fun execute(task: () -> Unit) = task()
 
         fun fire() = task?.invoke() ?: Unit
+    }
+
+    /** A [SubscriptionWatchdog] that defers `execute` work so a test can run it after a reconnect. */
+    private class DeferringWatchdog : SubscriptionWatchdog {
+        private var timerTask: (() -> Unit)? = null
+        private val deferred = ArrayDeque<() -> Unit>()
+
+        override fun schedule(delayMs: Long, task: () -> Unit): SubscriptionWatchdog.Handle {
+            timerTask = task
+            return SubscriptionWatchdog.Handle { timerTask = null }
+        }
+
+        override fun execute(task: () -> Unit) {
+            deferred.add(task)
+        }
+
+        fun runDeferred() {
+            while (deferred.isNotEmpty()) deferred.removeFirst().invoke()
+        }
     }
 
     /** Records emitted Timber logs so a test can assert the WARN discipline (AC7). */

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
@@ -301,6 +301,22 @@ class AndroidMedtronicGattLinkTest {
     }
 
     @Test
+    fun `unsubscribe disables the CCCD off the worker thread`() {
+        // A reader calls unsubscribe from inside its onPdu handler on the worker; the blocking CCCD
+        // disable must not run on that worker. With a worker whose queue is never drained, the disable
+        // still happens -- via the cleanup executor -- so it cannot have gone through the worker.
+        val queueingWorker = QueueingWorker()
+        val link = newLink(worker = queueingWorker)
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {} // writeDescriptor #1 = CCCD enable
+
+        link.unsubscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) // writeDescriptor #2 = CCCD disable
+
+        assertEquals(0, link.activeSubscriptionCount())
+        @Suppress("DEPRECATION")
+        verify(exactly = 2) { gatt.writeDescriptor(any<BluetoothGattDescriptor>()) }
+    }
+
+    @Test
     fun `a failed CCCD enable leaves no phantom subscription`() {
         descriptorStatus = GATT_INSUFFICIENT_AUTHENTICATION
         val link = newLink()
@@ -392,6 +408,8 @@ class AndroidMedtronicGattLinkTest {
                 this.task = null
             }
         }
+
+        override fun execute(task: () -> Unit) = task()
 
         fun fire() = task?.invoke() ?: Unit
     }


### PR DESCRIPTION
## Summary

Implements the on-device `BluetoothGatt`-client transport for the Medtronic 700-series read-only driver and wires it into the read gateway, so the CGM / IDD / Device-Info readers now read a connected pump instead of always reporting "not connected". This was the one deferred piece left after the plugin became discoverable and activatable — the gateway's `linkProvider` previously returned `null`.

### Topology

The phone is a BLE **peripheral** while advertising and running the SAKE handshake, but to read the pump's data it acts as a GATT **client** to the pump's GATT server over that same link. The connected pump's `BluetoothDevice` is taken from the connection manager (captured when the pump connected to our server) — no fresh scan is started.

## What's included

- **`AndroidMedtronicGattLink`** — opens a client connection to the connected pump, discovers services, and implements `read` / `write` / `subscribe` / `unsubscribe`. The connection is opened lazily and reused across reads; every operation is serialized (one GATT op in flight at a time) and time-bounded.
- **Shared RACP characteristic scoping** — the SIG `0x2A52` Record Access Control Point exists under both the CGM and the IDD service. The transport binds it to the service whose data characteristic the exchange is actively streaming (sensor glucose → CGM, history → IDD), with a fallback to the most recently read RACP-bearing service. Battery / Device-Info reads cannot move that context.
- **Serialized notification delivery** — inbound notification fragments are delivered on the connection manager's existing worker thread (one serialized callback thread), and the CCCD is made effective before the control-point write so a fast response isn't missed.
- **Timeout cleanup** — an injectable watchdog releases any still-open subscriptions when an operation times out, so a timed-out read leaves no dangling notifications behind to desync the next read. Stale post-timeout GATT callbacks are rejected by handle identity, and a request timeout tears the client connection down so it is re-established cleanly on the next read.
- **Read-only + PDU discipline** — `requestMtu()` is never called (MTU stays at 23; payloads are pre-fragmented above the seam). Writes are confined to an allow-list of report/control-point characteristics, so no therapeutic write can be issued.
- **Observability** — caught BLE/GATT failures are routed through `Timber.w` carrying only the operation name and GATT status; characteristic payloads/values and identifiers stay at debug level (below the monitoring threshold).

## Testing

- New `AndroidMedtronicGattLinkTest` (19 tests) against a mocked `BluetoothGatt` / `BluetoothGattCallback`, covering connect→discover→read, CCCD-before-write ordering, worker-thread delivery, RACP CGM-vs-IDD scoping (and context not being poisoned by unrelated reads), read-only write rejection, timeout/cancellation cleanup, unexpected-disconnect and connect-error edges, and the error-logging discipline.
- `./gradlew :medtronic-pump-driver:testDebugUnitTest :app:assembleDebug :medtronic-pump-driver:lintDebug` all green.

Over-the-air verification against real hardware is tracked separately and is not claimed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native Bluetooth GATT support for Medtronic MiniMed 700-series with on-device transport enabled when a pump is connected.
  * Exposes the currently connected pump device to the connection layer.

* **Bug Fixes / Reliability**
  * Improved subscription handling, timeouts, watchdog-driven cleanup, and CCCD management to avoid stale callbacks and improve stability.

* **Tests**
  * Added comprehensive unit tests for connection, subscription, scoping, and lifecycle behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->