### PR TITLE
feat(medtronic): poll/persist/push pipeline integration with single-flight reads

### DIFF
--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/PluginRegistryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/PluginRegistryTest.kt
@@ -169,6 +169,51 @@ class PluginRegistryTest {
     }
 
     @Test
+    fun `activating Medtronic excludes an active Tandem across all single-instance capabilities`() {
+        // AC5: a pump driver declares GLUCOSE_SOURCE / INSULIN_SOURCE / PUMP_STATUS -- all single-instance
+        // -- so activating Medtronic must evict an already-active Tandem from every one of those slots.
+        val singleInstanceCaps = setOf(
+            PluginCapability.GLUCOSE_SOURCE,
+            PluginCapability.INSULIN_SOURCE,
+            PluginCapability.PUMP_STATUS,
+        )
+        val tandem: DevicePlugin = mockk(relaxed = true) {
+            every { metadata } returns PluginMetadata(
+                id = "com.glycemicgpt.tandem",
+                name = "Tandem",
+                version = "1.0.0",
+                apiVersion = PLUGIN_API_VERSION,
+            )
+            every { capabilities } returns singleInstanceCaps
+        }
+        val medtronic: DevicePlugin = mockk(relaxed = true) {
+            every { metadata } returns PluginMetadata(
+                id = "com.glycemicgpt.medtronic",
+                name = "Medtronic",
+                version = "1.0.0",
+                apiVersion = PLUGIN_API_VERSION,
+            )
+            every { capabilities } returns singleInstanceCaps
+        }
+        val registry = createRegistry(setOf(createFactory(tandem), createFactory(medtronic)))
+        registry.initialize()
+
+        registry.activatePlugin("com.glycemicgpt.tandem")
+        // Tandem now owns every single-instance slot.
+        every { preferences.getActivePluginId(any()) } returns "com.glycemicgpt.tandem"
+
+        val result = registry.activatePlugin("com.glycemicgpt.medtronic")
+
+        assertTrue(result.isSuccess)
+        verify { tandem.onDeactivated() }
+        verify { medtronic.onActivated() }
+        // Exactly one pump is active, and Medtronic occupies the pump + glucose slots.
+        assertEquals(1, registry.allActivePlugins.value.size)
+        assertEquals("com.glycemicgpt.medtronic", registry.activePumpPlugin.value?.metadata?.id)
+        assertEquals("com.glycemicgpt.medtronic", registry.activeGlucoseSource.value?.metadata?.id)
+    }
+
+    @Test
     fun `deactivatePlugin removes from active and clears preferences`() {
         val plugin = createPlugin(
             "test.plugin",

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/PluginRegistryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/PluginRegistryTest.kt
@@ -207,6 +207,12 @@ class PluginRegistryTest {
         assertTrue(result.isSuccess)
         verify { tandem.onDeactivated() }
         verify { medtronic.onActivated() }
+        // The single-instance ownership bookkeeping moved from Tandem to Medtronic for every slot:
+        // Medtronic claims each capability and Tandem's is cleared.
+        for (cap in singleInstanceCaps) {
+            verify { preferences.setActivePluginId(cap, "com.glycemicgpt.medtronic") }
+            verify { preferences.clearActivePlugin(cap) }
+        }
         // Exactly one pump is active, and Medtronic occupies the pump + glucose slots.
         assertEquals(1, registry.allActivePlugins.value.size)
         assertEquals("com.glycemicgpt.medtronic", registry.activePumpPlugin.value?.metadata?.id)

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -4,25 +4,27 @@
  *
  * This is the Medtronic analog of Tandem's `TandemBleDriver`: a single seam the capability delegates
  * (MedtronicGlucoseSource / MedtronicInsulinSource / MedtronicPumpStatus) forward to, so the delegates
- * stay thin. It owns three cross-cutting concerns the individual C1/C2 readers deliberately left to
+ * stay thin. It owns four cross-cutting concerns the individual C1/C2 readers deliberately left to
  * their caller (see MedtronicSessionReader's timeout contract):
  *   1. resolving the live SAKE session + the GATT-client transport, failing cleanly when not connected;
  *   2. bounding every read with a per-operation timeout (the readers carry no timers);
- *   3. routing caught failures through Timber so they are observable in the glycemicgpt-mobile Sentry
+ *   3. serializing every read so no two exchanges overlap on the single one-exchange-at-a-time link
+ *      (the polling orchestrator drives the fast/medium/slow tiers as independent coroutines, so this
+ *      seam is where they coalesce into single-flight -- see [readMutex]);
+ *   4. routing caught failures through Timber so they are observable in the glycemicgpt-mobile Sentry
  *      project once this runs in :app (Story AC7).
  *
  * It adds no parsing of its own -- the readers (CgmReader / IddStatusReader / HistoryReader /
  * DeviceInfoReader / BatteryReader) own that. READ-ONLY: only report/get-class reads are issued.
  *
- * **Transport seam (Milestone D).** The on-device [MedtronicGattLink] (a `BluetoothGatt` client to the
- * connected pump's CGM / IDD / Device-Info GATT server) is wired with the polling/orchestration slice
- * in Milestone D; [linkProvider] returns `null` until then, so reads report "not connected" rather
- * than fabricate data. Pairing, the SAKE handshake and connection state already work end-to-end
- * (Milestone B2), so the plugin is fully discoverable/activatable now; data lights up when the link
- * provider is supplied. `TODO(48.D)`: provide a real `BluetoothGatt`-client link, scoping the shared
- * SIG `0x2A52` [MedtronicProtocol.RACP_UUID] under the CGM service for [getCgmReading] and under the
- * IDD service for [getHistoryLogs] (the readers reuse the same characteristic UUID across both
- * services; the on-device link must resolve it by service -- `TODO(48.C3)` carried forward).
+ * **Transport seam.** The on-device `AndroidMedtronicGattLink` (a `BluetoothGatt` client to the
+ * connected pump's CGM / IDD / Device-Info GATT server) implements [MedtronicGattLink] and is supplied
+ * by the DI module's [linkProvider], which returns the link while a pump is `CONNECTED` and `null`
+ * otherwise -- so reads report "not connected" rather than fabricate data when no pump is authenticated.
+ * The link resolves the shared SIG `0x2A52` [MedtronicProtocol.RACP_UUID] under the CGM service for
+ * [getCgmReading] and under the IDD service for [getHistoryLogs] (the readers reuse the same
+ * characteristic UUID across both services). The link is strictly one-exchange-at-a-time; this gateway
+ * owns the cross-exchange serialization (see [readMutex]).
  */
 package com.glycemicgpt.mobile.ble.read
 
@@ -38,6 +40,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resume
@@ -48,8 +52,8 @@ import timber.log.Timber
  *
  * @param sessionProvider supplies the live post-handshake session (the connection manager's
  *     `sakeSession`), or `null` when no pump is authenticated.
- * @param linkProvider supplies the GATT-client transport to the connected pump, or `null` when the
- *     transport is unavailable (the deferred Milestone D seam; see the class header).
+ * @param linkProvider supplies the GATT-client transport to the connected pump, or `null` when no pump
+ *     is connected (see the class header).
  * @param ioDispatcher dispatcher for the blocking SIG reads (Device Info / Battery).
  * @param operationTimeoutMs hard upper bound on every read; expiry surfaces as a failed [Result].
  */
@@ -59,6 +63,21 @@ class MedtronicReadGateway(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val operationTimeoutMs: Long = DEFAULT_OPERATION_TIMEOUT_MS,
 ) {
+
+    /**
+     * Single-flight guard. The Medtronic link is strictly one-exchange-at-a-time: a read is a stateful
+     * subscribe -> control-point write -> await-indication -> unsubscribe choreography on characteristics
+     * the CGM and IDD services *share* (the SIG `0x2A52` RACP), with no transaction id to demultiplex
+     * overlapping exchanges. The polling orchestrator runs the fast/medium/slow tiers as independent
+     * coroutines, so two reads can be issued concurrently; this mutex serializes them into single-flight
+     * so a slow exchange never interleaves with -- or stacks on top of -- the next one on the wire. The
+     * lock is held for the whole exchange (including the per-operation timeout), so a queued read waits
+     * its turn rather than spending its timeout budget racing for the link. The mutex is fair (FIFO), so
+     * a waiting keep-alive read is admitted as soon as the in-flight exchange releases the link. Keeping
+     * each exchange short enough to protect the pump's idle-timeout budget is the orchestrator's job (it
+     * releases the link between history-backfill batches); this seam only guarantees non-overlap.
+     */
+    private val readMutex = Mutex()
 
     /** Latest sensor glucose (CGM RACP "report last record"). */
     suspend fun getCgmReading(): Result<CgmReading> =
@@ -109,22 +128,28 @@ class MedtronicReadGateway(
      * **Cancellation/cleanup contract.** On a timeout this coroutine is cancelled while the reader may
      * still hold notification subscriptions on the link (the reader only unsubscribes when the pump
      * responds). The gateway cannot drop them here -- it does not know which characteristics the reader
-     * subscribed. The on-device [MedtronicGattLink] (Milestone D) MUST therefore release all
-     * outstanding subscriptions for an operation when that operation's coroutine is cancelled, so a
-     * timed-out read leaves no dangling notifications. `TODO(48.D)`.
+     * subscribed. The on-device `AndroidMedtronicGattLink` satisfies this: a subscription watchdog
+     * releases all outstanding subscriptions when an operation can no longer complete, so a timed-out
+     * read leaves no dangling notifications that would desync the next exchange.
      */
     private suspend fun <T> sessionRead(
         op: String,
         start: (MedtronicGattLink, MedtronicSakeSession, (Result<T>) -> Unit) -> Unit,
     ): Result<T> {
+        // Resolve the transport before queuing on [readMutex]: when no pump is connected this fails fast
+        // (a clean "not connected" Result) instead of blocking behind any in-flight exchange.
         val link = linkProvider() ?: return notConnected(op, "transport unavailable")
         val session = sessionProvider() ?: return notConnected(op, "no authenticated session")
-        return withOperationTimeout(op) {
-            // The readers issue blocking GATT read/write before registering their callback, so offload
-            // to [ioDispatcher] (as [blockingRead] does); the callback resume is dispatcher-agnostic.
-            withContext(ioDispatcher) {
-                suspendCancellableCoroutine { cont ->
-                    start(link, session) { result -> if (cont.isActive) cont.resume(result) }
+        // Hold the single-flight lock for the entire exchange so no other read touches the shared link
+        // until this one's await-indication completes (or its timeout tears it down).
+        return readMutex.withLock {
+            withOperationTimeout(op) {
+                // The readers issue blocking GATT read/write before registering their callback, so offload
+                // to [ioDispatcher] (as [blockingRead] does); the callback resume is dispatcher-agnostic.
+                withContext(ioDispatcher) {
+                    suspendCancellableCoroutine { cont ->
+                        start(link, session) { result -> if (cont.isActive) cont.resume(result) }
+                    }
                 }
             }
         }
@@ -138,22 +163,26 @@ class MedtronicReadGateway(
      * on its own. [runInterruptible] turns the operation timeout's cancellation into a thread interrupt,
      * so an interruptible blocking read (e.g. one parked on a latch / interruptible I/O) aborts at the
      * deadline. A read that ignores interruption still cannot be force-unwound here; the on-device
-     * [MedtronicGattLink] (Milestone D) must therefore also enforce its own per-read timeout, as its
-     * interface contract requires.
+     * `AndroidMedtronicGattLink` therefore also enforces its own per-operation timeout, as the
+     * [MedtronicGattLink] contract requires.
      */
     private suspend fun <T> blockingRead(op: String, read: (MedtronicGattLink) -> T): Result<T> {
         val link = linkProvider() ?: return notConnected(op, "transport unavailable")
-        return withOperationTimeout(op) {
-            runInterruptible(ioDispatcher) {
-                @Suppress("TooGenericExceptionCaught")
-                try {
-                    Result.success(read(link))
-                } catch (e: InterruptedException) {
-                    // A timeout interrupt: rethrow so it surfaces as cancellation and the operation
-                    // timeout reports it, rather than being swallowed into a Result.failure.
-                    throw e
-                } catch (e: Exception) {
-                    Result.failure(e)
+        // Single-flight: a SIG battery/device-info read shares the same one-op-at-a-time link as the
+        // session reads, so it queues behind any in-flight exchange rather than racing it.
+        return readMutex.withLock {
+            withOperationTimeout(op) {
+                runInterruptible(ioDispatcher) {
+                    @Suppress("TooGenericExceptionCaught")
+                    try {
+                        Result.success(read(link))
+                    } catch (e: InterruptedException) {
+                        // A timeout interrupt: rethrow so it surfaces as cancellation and the operation
+                        // timeout reports it, rather than being swallowed into a Result.failure.
+                        throw e
+                    } catch (e: Exception) {
+                        Result.failure(e)
+                    }
                 }
             }
         }
@@ -178,8 +207,8 @@ class MedtronicReadGateway(
         }
 
     private fun <T> notConnected(op: String, reason: String): Result<T> {
-        // Expected before Milestone D wires the transport; debug (not warn) so it never reads as a
-        // Sentry-worthy error while the driver is inert.
+        // Expected whenever no pump is connected; debug (not warn) so a poll that fires between sessions
+        // never reads as a Sentry-worthy error.
         Timber.d("Medtronic %s read skipped: %s", op, reason)
         return Result.failure(MedtronicReadException("Medtronic $op read skipped: pump not connected ($reason)"))
     }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
@@ -11,6 +11,8 @@ import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.plugin.capabilities.InsulinSource
 import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.time.Instant
 
 /**
@@ -28,12 +30,20 @@ class MedtronicInsulinSource(
         gateway.getBasalRate()
 
     /**
+     * Serializes the [bolusCursor] read-fetch-advance so a fetch and its cursor update are atomic.
+     * Capability methods can be called from background dispatchers, so even though the orchestrator
+     * polls boluses from a single loop today, two concurrent [getBolusHistory] calls must not both read
+     * the same cursor, fetch overlapping windows, and then write back out of order (which would regress
+     * the cursor). The gateway's own mutex only serializes one wire exchange, not this read-modify-write.
+     */
+    private val bolusSyncMutex = Mutex()
+
+    /**
      * Sequence cursor for the medium-tier bolus poll: the highest history sequence already fetched by
      * *this* path. Each poll asks the pump only for records newer than it, so the poll is an incremental
-     * delta rather than a full-window rescan. Single-writer -- only the orchestrator's medium loop calls
-     * [getBolusHistory] and the gateway serializes wire access, so the volatile here is for restart
-     * visibility, not concurrent read-modify-write safety (mirrors [com.glycemicgpt.mobile.ble.connection]'s
-     * single-writer `@Volatile` cursors).
+     * delta rather than a full-window rescan. Guarded by [bolusSyncMutex] -- only read/written while that
+     * lock is held -- so the read-modify-write is safe regardless of how many coroutines call
+     * [getBolusHistory].
      *
      * Best-effort, not the durable bolus record: it advances on a successful fetch, before the
      * orchestrator persists, so a transient save failure could skip a bolus on this path. That is
@@ -43,14 +53,15 @@ class MedtronicInsulinSource(
      * IDD stream. Persisted bolus rows are de-duplicated by the repository's insert-conflict key, so the
      * one-time full re-read after a restart (cursor 0) yields no duplicate rows.
      */
-    @Volatile
     private var bolusCursor: Int = 0
 
     /**
      * Boluses delivered at or after [since]. Fetches only the history records newer than [bolusCursor]
      * (the pump's RACP range query), advances the cursor past the records seen, extracts delivered
      * boluses via [MedtronicHistoryParser] applying [limits] (over-cap boluses are dropped, not
-     * clamped), and filters by [since] as a defensive lower bound.
+     * clamped), and filters by [since] as a defensive lower bound. The whole read-fetch-advance runs
+     * under [bolusSyncMutex] so concurrent calls can never regress the cursor or fetch overlapping
+     * windows.
      *
      * This replaces the earlier O(all-history) `getHistoryLogs(sinceSequence = 0)` full-window scan
      * (closing the C3 cost note): each medium poll is now an incremental delta over the same IDD stream
@@ -60,9 +71,11 @@ class MedtronicInsulinSource(
         since: Instant,
         limits: SafetyLimits,
     ): Result<List<BolusEvent>> =
-        gateway.getHistoryLogs(sinceSequence = bolusCursor).map { records ->
-            bolusCursor = records.maxOfOrNull { it.sequenceNumber } ?: bolusCursor
-            MedtronicHistoryParser.extractBolusesFromHistoryLogs(records, limits)
-                .filter { !it.timestamp.isBefore(since) }
+        bolusSyncMutex.withLock {
+            gateway.getHistoryLogs(sinceSequence = bolusCursor).map { records ->
+                bolusCursor = records.maxOfOrNull { it.sequenceNumber } ?: bolusCursor
+                MedtronicHistoryParser.extractBolusesFromHistoryLogs(records, limits)
+                    .filter { !it.timestamp.isBefore(since) }
+            }
         }
 }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
@@ -7,6 +7,7 @@ import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
 import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.plugin.capabilities.InsulinSource
 import com.glycemicgpt.mobile.domain.pump.SafetyLimits
@@ -27,22 +28,40 @@ class MedtronicInsulinSource(
         gateway.getBasalRate()
 
     /**
-     * Boluses delivered at or after [since]. Reads the available history log and extracts delivered
-     * boluses via [MedtronicHistoryParser], applying [limits] (over-cap boluses are dropped, not
-     * clamped).
+     * Sequence cursor for the medium-tier bolus poll: the highest history sequence already fetched by
+     * *this* path. Each poll asks the pump only for records newer than it, so the poll is an incremental
+     * delta rather than a full-window rescan. Single-writer -- only the orchestrator's medium loop calls
+     * [getBolusHistory] and the gateway serializes wire access, so the volatile here is for restart
+     * visibility, not concurrent read-modify-write safety (mirrors [com.glycemicgpt.mobile.ble.connection]'s
+     * single-writer `@Volatile` cursors).
      *
-     * This scans from the start of the available window (sequence 0) and filters by time, so it is
-     * O(all-history) per call. `TODO(48.D)`: the polling orchestrator should drive incremental bolus
-     * sync through the sequence cursor on
-     * [com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus.getHistoryLogs] +
-     * [com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus.extractBolusesFromHistoryLogs]
-     * rather than this full-window convenience path.
+     * Best-effort, not the durable bolus record: it advances on a successful fetch, before the
+     * orchestrator persists, so a transient save failure could skip a bolus on this path. That is
+     * tolerated because the **slow loop's raw-history sync is the durable, self-healing bolus path** --
+     * it persists each raw [HistoryLogRecord] to Room (keyed by sequence) before advancing its own
+     * cursor, restores that cursor from Room on restart, and re-extracts the same boluses from the same
+     * IDD stream. Persisted bolus rows are de-duplicated by the repository's insert-conflict key, so the
+     * one-time full re-read after a restart (cursor 0) yields no duplicate rows.
+     */
+    @Volatile
+    private var bolusCursor: Int = 0
+
+    /**
+     * Boluses delivered at or after [since]. Fetches only the history records newer than [bolusCursor]
+     * (the pump's RACP range query), advances the cursor past the records seen, extracts delivered
+     * boluses via [MedtronicHistoryParser] applying [limits] (over-cap boluses are dropped, not
+     * clamped), and filters by [since] as a defensive lower bound.
+     *
+     * This replaces the earlier O(all-history) `getHistoryLogs(sinceSequence = 0)` full-window scan
+     * (closing the C3 cost note): each medium poll is now an incremental delta over the same IDD stream
+     * the slow loop backfills. See [bolusCursor] for the durability / dedup model.
      */
     override suspend fun getBolusHistory(
         since: Instant,
         limits: SafetyLimits,
     ): Result<List<BolusEvent>> =
-        gateway.getHistoryLogs(sinceSequence = 0).map { records ->
+        gateway.getHistoryLogs(sinceSequence = bolusCursor).map { records ->
+            bolusCursor = records.maxOfOrNull { it.sequenceNumber } ?: bolusCursor
             MedtronicHistoryParser.extractBolusesFromHistoryLogs(records, limits)
                 .filter { !it.timestamp.isBefore(since) }
         }

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
@@ -10,6 +10,7 @@ import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -81,10 +82,10 @@ class MedtronicReadGatewayTest {
     fun `getCgmReading drives the full session read to a parsed reading`() = runTest {
         val two = TwoSidedSession()
         val link = FakeGattLink()
-        link.reads[feature] = hex("009001591404") // E2E-CRC enabled
+        link.reads[feature] = hex(CGM_FEATURE_E2E_ENABLED_HEX)
         link.onWrite = { characteristic, _ ->
             if (characteristic == racp) {
-                emit(measurement, two.pumpEncrypt(hex("0ec3f900f40b000074e00a00e0f1")))
+                emit(measurement, two.pumpEncrypt(hex(CGM_MEASUREMENT_249_HEX)))
                 emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
             }
         }
@@ -98,7 +99,7 @@ class MedtronicReadGatewayTest {
     fun `a hung read is bounded by the operation timeout`() = runTest {
         val two = TwoSidedSession()
         val link = FakeGattLink()
-        link.reads[feature] = hex("009001591404")
+        link.reads[feature] = hex(CGM_FEATURE_E2E_ENABLED_HEX)
         // The pump never responds to the RACP request, so the reader's callback never fires.
 
         val result = gateway(link = link, session = two.server, timeoutMs = 5_000L).getCgmReading()
@@ -137,5 +138,83 @@ class MedtronicReadGatewayTest {
 
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull()!!.message!!.contains("timed out"))
+    }
+
+    /**
+     * Single-flight (Story AC1): the Medtronic link is one-exchange-at-a-time, but the polling
+     * orchestrator drives the fast/medium/slow tiers as independent coroutines, so the gateway must
+     * serialize them. Two concurrent reads are launched eagerly; the first holds the link awaiting its
+     * (deferred) response, so the second must park on the gateway's mutex and reach the wire only after
+     * the first finishes -- exactly one RACP write is outstanding at a time, never two overlapping.
+     */
+    @Test
+    fun `concurrent reads are serialized single-flight on the one link`() = runTest {
+        val two = TwoSidedSession()
+        val link = SerializingProbeLink(two)
+        val io = UnconfinedTestDispatcher(testScheduler)
+        val gw = MedtronicReadGateway(
+            sessionProvider = { two.server },
+            linkProvider = { link },
+            ioDispatcher = io,
+            operationTimeoutMs = 30_000L,
+        )
+
+        // Eagerly dispatched (Unconfined): each runs until it suspends. The first parks awaiting the
+        // pump's deferred response while holding the mutex; the second parks on the mutex itself.
+        val first = async(io) { gw.getCgmReading() }
+        val second = async(io) { gw.getCgmReading() }
+
+        // The proof: only the first exchange has reached the wire. Without single-flight the second
+        // would already have written its own RACP request (racpWrites == 2).
+        assertEquals("second read must not touch the link while the first holds it", 1, link.racpWrites)
+
+        link.releaseNext() // complete the first; releasing the mutex lets the second proceed
+        assertEquals("second read reaches the wire only after the first finishes", 2, link.racpWrites)
+
+        link.releaseNext() // complete the second
+
+        assertEquals(249, first.await().getOrThrow().glucoseMgDl)
+        assertEquals(249, second.await().getOrThrow().glucoseMgDl)
+    }
+
+    /**
+     * A [MedtronicGattLink] that defers each RACP exchange's response until [releaseNext], so a read
+     * stays in flight (holding the single-flight lock) until the test chooses to complete it. Counts
+     * RACP writes so a test can prove that a second exchange does not reach the wire while a first is
+     * outstanding. Only valid under single-flight (one set of handlers registered at a time).
+     */
+    private class SerializingProbeLink(private val two: TwoSidedSession) : MedtronicGattLink {
+        private val handlers = mutableMapOf<UUID, (ByteArray) -> Unit>()
+        private val pendingResponses = ArrayDeque<() -> Unit>()
+
+        var racpWrites = 0
+            private set
+
+        override fun read(characteristic: UUID): ByteArray =
+            if (characteristic == MedtronicProtocol.CGM_FEATURE_UUID) hex(CGM_FEATURE_E2E_ENABLED_HEX)
+            else throw MedtronicReadException("no read stub for $characteristic")
+
+        override fun write(characteristic: UUID, value: ByteArray) {
+            if (characteristic != MedtronicProtocol.RACP_UUID) return
+            racpWrites++
+            // Defer the pump's response so the exchange stays in flight, holding the single-flight lock
+            // until releaseNext() delivers it.
+            pendingResponses.addLast {
+                handlers[MedtronicProtocol.CGM_MEASUREMENT_UUID]
+                    ?.invoke(two.pumpEncrypt(hex(CGM_MEASUREMENT_249_HEX)))
+                handlers[MedtronicProtocol.RACP_UUID]?.invoke(MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        override fun subscribe(characteristic: UUID, onPdu: (ByteArray) -> Unit) {
+            handlers[characteristic] = onPdu
+        }
+
+        override fun unsubscribe(characteristic: UUID) {
+            handlers.remove(characteristic)
+        }
+
+        /** Deliver the next deferred pump response, completing the oldest in-flight exchange. */
+        fun releaseNext() = pendingResponses.removeFirst().invoke()
     }
 }

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
@@ -98,6 +98,12 @@ internal fun hex(s: String): ByteArray {
     return ByteArray(s.length / 2) { i -> s.substring(2 * i, 2 * i + 2).toInt(16).toByte() }
 }
 
+/** CGM Feature characteristic value with the E2E-CRC bit (12) set. */
+internal const val CGM_FEATURE_E2E_ENABLED_HEX = "009001591404"
+
+/** A captured plaintext CGM measurement frame that parses to 249 mg/dL, rising. */
+internal const val CGM_MEASUREMENT_249_HEX = "0ec3f900f40b000074e00a00e0f1"
+
 /** Server-side (MOBILE_APPLICATION) half of the matched synthetic two-sided test pair. */
 internal const val CUSTOM_SERVER_KEYDB_HEX =
     "b079cdc504010144455249564154494f4e5f5f5f4b4559484e4453484b455f41" +

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSourceTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSourceTest.kt
@@ -51,8 +51,8 @@ class MedtronicInsulinSourceTest {
     }
 
     @Test
-    fun `getBolusHistory fetches history from the start of the window`() = runTest {
-        // No records -> no boluses; this asserts the wiring (full-window fetch + empty extraction),
+    fun `the first bolus poll fetches from sequence 0`() = runTest {
+        // No records -> no boluses; this asserts the wiring (the initial cursor is 0 + empty extraction),
         // not the parser internals (covered by MedtronicHistoryParserTest).
         coEvery { gateway.getHistoryLogs(0) } returns Result.success(emptyList())
 
@@ -61,6 +61,28 @@ class MedtronicInsulinSourceTest {
         assertTrue(result.isSuccess)
         assertEquals(emptyList<Any>(), result.getOrThrow())
         coVerify { gateway.getHistoryLogs(0) }
+    }
+
+    @Test
+    fun `bolus polling advances the sequence cursor so the next poll is incremental`() = runTest {
+        // First poll returns records up to sequence 111; the cursor must advance there so the second
+        // poll requests only newer records (the AC4 incremental cursor path) instead of rescanning the
+        // full window from sequence 0.
+        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+        val firstBatch = listOf(
+            rawRecord(0xF00E, seq = 100, offsetSec = 0, bodyHex = "3cea0706010c0000"),
+            rawRecord(0x0069, seq = 110, offsetSec = 600, bodyHex = "010033190000ff000000000000"),
+            rawRecord(0x0096, seq = 111, offsetSec = 600, bodyHex = "01000000005a"),
+        )
+        coEvery { gateway.getHistoryLogs(0) } returns Result.success(firstBatch)
+        coEvery { gateway.getHistoryLogs(111) } returns Result.success(emptyList())
+
+        source.getBolusHistory(reference, SafetyLimits()).getOrThrow()
+        val second = source.getBolusHistory(reference, SafetyLimits()).getOrThrow()
+
+        assertTrue(second.isEmpty())
+        coVerify(exactly = 1) { gateway.getHistoryLogs(0) }
+        coVerify(exactly = 1) { gateway.getHistoryLogs(111) }
     }
 
     @Test
@@ -85,13 +107,16 @@ class MedtronicInsulinSourceTest {
         )
         coEvery { gateway.getHistoryLogs(0) } returns Result.success(records)
 
+        // Fresh sources per assertion so each exercises the since filter from a clean cursor (the
+        // incremental cursor advance is covered separately above).
         // since at the reference -> the bolus (at +600s) is included.
-        val included = source.getBolusHistory(reference, SafetyLimits()).getOrThrow()
+        val included = MedtronicInsulinSource(gateway).getBolusHistory(reference, SafetyLimits()).getOrThrow()
         assertEquals(1, included.size)
         assertEquals(2.5f, included[0].units, 1e-4f)
 
         // since after the bolus -> filtered out.
-        val excluded = source.getBolusHistory(reference.plusSeconds(601), SafetyLimits()).getOrThrow()
+        val excluded = MedtronicInsulinSource(gateway)
+            .getBolusHistory(reference.plusSeconds(601), SafetyLimits()).getOrThrow()
         assertTrue(excluded.isEmpty())
     }
 


### PR DESCRIPTION
## Summary

Wires the read-only Medtronic MiniMed BLE driver into the shared pump polling, persistence, and backend-push pipeline, so Medtronic pump data flows through exactly the same path as Tandem.

The footprint is intentionally small: the polling orchestrator, event mapper, DTOs, Room schema, and backend are all reused unchanged. The driver registers like any other pump plugin; the only Medtronic-specific concern is isolated to the read gateway.

## Changes

- **Single-flight read serialization.** The Medtronic GATT link is strictly one-exchange-at-a-time (a stateful subscribe -> control-point write -> await-indication sequence on a shared, transaction-id-less characteristic). The polling loops run as independent coroutines, so a `Mutex` in `MedtronicReadGateway` now serializes every read: overlapping reads from the fast/medium/slow tiers coalesce instead of interleaving on the wire. (Tandem needs no equivalent because it multiplexes responses by transaction id.)
- **Incremental bolus history.** `MedtronicInsulinSource.getBolusHistory` now reads from a monotonic sequence cursor instead of rescanning the full history window on every poll. This removes an O(all-history) scan every 5 minutes and fixes a latent duplicate-row insert.
- **Docs.** Refreshed the read-gateway transport documentation to reflect the now-wired client link.

## Reused unchanged (verified)

- **Persistence:** the Medtronic readers already emit the platform domain models, so data persists through the existing repository/DAO with no schema change.
- **Backend push:** the event mapper is pump-agnostic; events ingest identically (channel `source = "mobile"` plus hardware serial/model), so no backend schema change.
- **Single-instance:** activating Medtronic evicts any other active glucose/insulin/pump-status source via the existing registry enforcement.

## Tests

- Single-flight serialization (proves only one control-point write reaches the wire while an exchange is in flight).
- Incremental cursor advance.
- Single-instance exclusion across all single-instance capabilities.
- Full module + app unit tests, lint, and debug build pass.

Not live-verified against a physical pump; on-device verification is tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure only one plugin remains active for single-instance capabilities; deactivation of prior plugins is enforced.
  * Prevent overlapping Bluetooth read exchanges to avoid data conflicts and speed up connection failure reporting.

* **Improvements**
  * Bolus history polling now advances a sequence cursor and fetches only new records since the last poll.

* **Tests**
  * Added and expanded tests for plugin activation, Bluetooth read serialization, and bolus polling behavior; updated test fixtures/constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->