### PR TITLE
feat(medtronic): render pump connection notes in settings card

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/plugin/PluginSettingsRenderer.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/plugin/PluginSettingsRenderer.kt
@@ -41,11 +41,15 @@ import kotlin.math.roundToInt
 /**
  * Renders a [PluginSettingsDescriptor] as Material 3 UI components.
  * Reads/writes values through the plugin's [PluginSettingsStore].
+ *
+ * [settingsStore] may be null for read-only/informational contexts (e.g. the pump settings card,
+ * which renders only [SettingDescriptor.InfoText] notes). Store-backed input items are omitted when
+ * no store is provided, since they cannot be read or persisted without one.
  */
 @Composable
 fun PluginSettingsRenderer(
     descriptor: PluginSettingsDescriptor,
-    settingsStore: PluginSettingsStore,
+    settingsStore: PluginSettingsStore? = null,
     onAction: (key: String) -> Unit = {},
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -70,14 +74,15 @@ fun PluginSettingsRenderer(
 @Composable
 internal fun SettingItem(
     descriptor: SettingDescriptor,
-    store: PluginSettingsStore,
+    store: PluginSettingsStore?,
     onAction: (String) -> Unit,
 ) {
     when (descriptor) {
-        is SettingDescriptor.TextInput -> TextInputSetting(descriptor, store)
-        is SettingDescriptor.Toggle -> ToggleSetting(descriptor, store)
-        is SettingDescriptor.Slider -> SliderSetting(descriptor, store)
-        is SettingDescriptor.Dropdown -> DropdownSetting(descriptor, store)
+        // Input items need a store to read/persist their value; skip them when none is available.
+        is SettingDescriptor.TextInput -> if (store != null) TextInputSetting(descriptor, store)
+        is SettingDescriptor.Toggle -> if (store != null) ToggleSetting(descriptor, store)
+        is SettingDescriptor.Slider -> if (store != null) SliderSetting(descriptor, store)
+        is SettingDescriptor.Dropdown -> if (store != null) DropdownSetting(descriptor, store)
         is SettingDescriptor.ActionButton -> ActionButtonSetting(descriptor, onAction)
         is SettingDescriptor.InfoText -> InfoTextSetting(descriptor)
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -80,6 +80,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.glycemicgpt.mobile.data.local.AlertSoundCategory
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
+import com.glycemicgpt.mobile.presentation.plugin.PluginSettingsRenderer
 import com.glycemicgpt.mobile.presentation.theme.ThemeMode
 import com.glycemicgpt.mobile.wear.WatchFaceVariant
 import java.io.File
@@ -986,6 +987,18 @@ private fun PumpSection(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                }
+            }
+
+            // Pump-specific connection notes (e.g. Medtronic's single-peer limitation) declared by the
+            // active plugin's settings descriptor. The card chrome above/below owns live pairing status
+            // and the pair/unpair actions; the ViewModel has already reduced this to informational
+            // notes only, so no settings store is needed here.
+            val pumpNotes = state.activePumpSettingsDescriptor
+            if (pumpNotes != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Column(modifier = Modifier.testTag("pump_settings_notes")) {
+                    PluginSettingsRenderer(descriptor = pumpNotes)
                 }
             }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -235,16 +235,27 @@ class SettingsViewModel @Inject constructor(
     /** Copy active pump plugin display fields from the registry into the state. */
     private fun SettingsUiState.withActivePumpFields(): SettingsUiState {
         val plugin = pluginRegistry.activePumpPlugin.value
-        val meta = plugin?.metadata
-        // A misbehaving (e.g. runtime) plugin must not crash settings; default to no notes.
-        val notes = plugin?.let {
+        // Both reads cross the plugin boundary, so a misbehaving (e.g. runtime) plugin must not crash
+        // settings via a throwing getter or a linkage Error (AbstractMethodError / NoClassDefFoundError);
+        // catch Throwable on each (mirrors the SentryInitializer init guard). They are guarded
+        // separately on purpose: a descriptor failure drops only the notes and keeps the pump card,
+        // whereas losing metadata necessarily drops the card (its id/name are required).
+        val meta = plugin?.let {
             try {
-                it.settingsDescriptor()
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to read settings descriptor for plugin %s", meta?.id)
+                it.metadata
+            } catch (t: Throwable) {
+                Timber.w(t, "Failed to read metadata for active pump plugin")
                 null
             }
-        }?.infoNotesOnly()
+        }
+        val notes = plugin?.let {
+            try {
+                it.settingsDescriptor().infoNotesOnly()
+            } catch (t: Throwable) {
+                Timber.w(t, "Failed to read settings descriptor for active pump plugin")
+                null
+            }
+        }
         return copy(
             activePumpPluginId = meta?.id,
             activePumpPluginName = meta?.name,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -15,6 +15,8 @@ import com.glycemicgpt.mobile.data.local.AlertSoundStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
+import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsDescriptor
+import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
 import com.glycemicgpt.mobile.plugin.PluginRegistry
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
@@ -147,6 +149,9 @@ data class SettingsUiState(
     val activePluginIds: Set<String> = emptySet(),
     val activePumpPluginName: String? = null,
     val activePumpProtocolDisplay: String? = null,
+    // Active pump plugin's informational connection notes (e.g. Medtronic's single-peer limitation),
+    // rendered under the pump card. Null when the active pump declares no notes.
+    val activePumpSettingsDescriptor: PluginSettingsDescriptor? = null,
     // Sync
     val backendSyncEnabled: Boolean = true,
     val dataRetentionDays: Int = 7,
@@ -229,14 +234,37 @@ class SettingsViewModel @Inject constructor(
 
     /** Copy active pump plugin display fields from the registry into the state. */
     private fun SettingsUiState.withActivePumpFields(): SettingsUiState {
-        val meta = pluginRegistry.activePumpPlugin.value?.metadata
+        val plugin = pluginRegistry.activePumpPlugin.value
+        val meta = plugin?.metadata
+        // A misbehaving (e.g. runtime) plugin must not crash settings; default to no notes.
+        val notes = plugin?.let {
+            try {
+                it.settingsDescriptor()
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to read settings descriptor for plugin %s", meta?.id)
+                null
+            }
+        }?.infoNotesOnly()
         return copy(
             activePumpPluginId = meta?.id,
             activePumpPluginName = meta?.name,
             activePumpProtocolDisplay = meta?.let { m ->
                 m.protocolName?.let { "$it v${m.version}" }
             },
+            activePumpSettingsDescriptor = notes,
         )
+    }
+
+    /**
+     * Reduce a plugin's settings descriptor to its informational notes (e.g. Medtronic's single-peer
+     * limitation). The generic pump card owns live pairing status and the pair/unpair actions, so
+     * interactive settings never belong on it; returns null when there are no notes to show.
+     */
+    private fun PluginSettingsDescriptor.infoNotesOnly(): PluginSettingsDescriptor? {
+        val noteSections = sections
+            .map { it.copy(items = it.items.filterIsInstance<SettingDescriptor.InfoText>()) }
+            .filter { it.items.isNotEmpty() }
+        return if (noteSections.isEmpty()) null else PluginSettingsDescriptor(noteSections)
     }
 
     /** Observable auth state for UI-level session expiry handling. */

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -24,6 +24,10 @@ import com.glycemicgpt.mobile.wear.WearDataSender
 import com.glycemicgpt.mobile.domain.plugin.DevicePlugin
 import com.glycemicgpt.mobile.domain.plugin.Plugin
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
+import com.glycemicgpt.mobile.domain.plugin.ui.ButtonStyle
+import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsDescriptor
+import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsSection
+import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
 import com.glycemicgpt.mobile.plugin.PluginRegistry
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
 import io.mockk.coEvery
@@ -586,6 +590,91 @@ class SettingsViewModelTest {
         val state = vm.uiState.value.watchAppUpdateState
         assertTrue(state is WatchAppUpdateState.Error)
         assertEquals("Watch version not available", (state as WatchAppUpdateState.Error).message)
+    }
+
+    @Test
+    fun `loadState reduces the active pump descriptor to informational notes only`() {
+        // Descriptor mixes an info note with an interactive action; the pump card must surface only
+        // the note (the generic card chrome owns pair/unpair actions), so the action is filtered out.
+        val descriptor = PluginSettingsDescriptor(
+            sections = listOf(
+                PluginSettingsSection(
+                    title = "Connection",
+                    items = listOf(
+                        SettingDescriptor.InfoText(key = "single_peer_note", text = "one phone at a time"),
+                        SettingDescriptor.ActionButton(
+                            key = "unpair",
+                            label = "Unpair Pump",
+                            style = ButtonStyle.DESTRUCTIVE,
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val pumpPlugin = mockk<DevicePlugin> {
+            every { metadata } returns PluginMetadata(
+                id = "com.glycemicgpt.medtronic",
+                name = "Medtronic MiniMed Pump",
+                version = "1.0.0",
+                apiVersion = 1,
+            )
+            every { settingsDescriptor() } returns descriptor
+        }
+        every { pluginRegistry.activePumpPlugin } returns MutableStateFlow<DevicePlugin?>(pumpPlugin)
+
+        val vm = createViewModel()
+        val items = vm.uiState.value.activePumpSettingsDescriptor?.sections?.single()?.items
+
+        assertEquals(1, items?.size)
+        assertTrue(items?.single() is SettingDescriptor.InfoText)
+        assertEquals("single_peer_note", (items?.single() as SettingDescriptor.InfoText).key)
+    }
+
+    @Test
+    fun `loadState exposes no pump notes when the descriptor has only interactive items`() {
+        val descriptor = PluginSettingsDescriptor(
+            sections = listOf(
+                PluginSettingsSection(
+                    title = "Connection",
+                    items = listOf(
+                        SettingDescriptor.ActionButton(key = "unpair", label = "Unpair Pump"),
+                    ),
+                ),
+            ),
+        )
+        val pumpPlugin = mockk<DevicePlugin> {
+            every { metadata } returns PluginMetadata(
+                id = "com.glycemicgpt.tandem",
+                name = "Tandem Insulin Pump",
+                version = "1.0.0",
+                apiVersion = 1,
+            )
+            every { settingsDescriptor() } returns descriptor
+        }
+        every { pluginRegistry.activePumpPlugin } returns MutableStateFlow<DevicePlugin?>(pumpPlugin)
+
+        val vm = createViewModel()
+
+        assertNull(vm.uiState.value.activePumpSettingsDescriptor)
+    }
+
+    @Test
+    fun `loadState tolerates a plugin whose settings descriptor throws`() {
+        val pumpPlugin = mockk<DevicePlugin> {
+            every { metadata } returns PluginMetadata(
+                id = "com.glycemicgpt.medtronic",
+                name = "Medtronic MiniMed Pump",
+                version = "1.0.0",
+                apiVersion = 1,
+            )
+            every { settingsDescriptor() } throws IllegalStateException("boom")
+        }
+        every { pluginRegistry.activePumpPlugin } returns MutableStateFlow<DevicePlugin?>(pumpPlugin)
+
+        val vm = createViewModel()
+
+        assertNull(vm.uiState.value.activePumpSettingsDescriptor)
+        assertEquals("com.glycemicgpt.medtronic", vm.uiState.value.activePumpPluginId)
     }
 
     @Test

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePlugin.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePlugin.kt
@@ -21,7 +21,6 @@ import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
 import com.glycemicgpt.mobile.domain.plugin.capabilities.GlucoseSource
 import com.glycemicgpt.mobile.domain.plugin.capabilities.InsulinSource
 import com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus
-import com.glycemicgpt.mobile.domain.plugin.ui.ButtonStyle
 import com.glycemicgpt.mobile.domain.plugin.ui.DashboardCardDescriptor
 import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsDescriptor
 import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsSection
@@ -105,27 +104,23 @@ class MedtronicDevicePlugin(
     override fun scan(): Flow<DiscoveredDevice> =
         connectionManager.scan()
 
+    /**
+     * Pump-specific connection notes surfaced under the generic pump settings card. The card chrome
+     * already renders live pairing status and the Unpair action for any active pump plugin, so the
+     * descriptor only contributes what is unique to this driver: the single-peer limitation.
+     */
     override fun settingsDescriptor(): PluginSettingsDescriptor = PluginSettingsDescriptor(
         sections = listOf(
             PluginSettingsSection(
                 title = "Connection",
                 items = listOf(
-                    SettingDescriptor.InfoText(
-                        key = "pairing_status",
-                        text = "Status: ${connectionManager.connectionState.value}",
-                    ),
                     // Single-peer limitation (medtronic-ble-reverse-engineering.md Sec. 7): a 700-series
                     // pump talks to one phone at a time, so pairing GlycemicGPT requires first removing
-                    // the pump from the official Medtronic app. Surfaced here for Milestone D's pairing UX.
+                    // the pump from the official Medtronic app. Surfaced here for the pairing UX.
                     SettingDescriptor.InfoText(
                         key = "single_peer_note",
                         text = "A MiniMed pump pairs with only one phone at a time. " +
                             "Remove the pump from the official Medtronic app before pairing it here.",
-                    ),
-                    SettingDescriptor.ActionButton(
-                        key = "unpair",
-                        label = "Unpair Pump",
-                        style = ButtonStyle.DESTRUCTIVE,
                     ),
                 ),
             ),

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePluginTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePluginTest.kt
@@ -1,7 +1,7 @@
 /*
  * AC2 / AC3 / AC5: the MedtronicDevicePlugin exposes the read-only capability contract, maps the
- * lifecycle onto the connection manager, and renders the settings descriptor (status + Unpair +
- * single-peer note) -- all without any write/PUMP_CONTROL surface.
+ * lifecycle onto the connection manager, and declares the pump-specific single-peer settings note
+ * -- all without any write/PUMP_CONTROL surface.
  */
 package com.glycemicgpt.mobile.plugin
 
@@ -15,7 +15,6 @@ import com.glycemicgpt.mobile.domain.plugin.capabilities.BgmSource
 import com.glycemicgpt.mobile.domain.plugin.capabilities.GlucoseSource
 import com.glycemicgpt.mobile.domain.plugin.capabilities.InsulinSource
 import com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus
-import com.glycemicgpt.mobile.domain.plugin.ui.ButtonStyle
 import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
 import io.mockk.every
 import io.mockk.mockk
@@ -135,18 +134,16 @@ class MedtronicDevicePluginTest {
     }
 
     @Test
-    fun `settings descriptor shows status, the single-peer note, and a destructive Unpair`() {
-        every { connectionManager.connectionState } returns MutableStateFlow(ConnectionState.DISCONNECTED)
-
+    fun `settings descriptor surfaces only the single-peer note`() {
         val items = plugin.settingsDescriptor().sections.single().items
-        val status = items.filterIsInstance<SettingDescriptor.InfoText>().first { it.key == "pairing_status" }
-        assertTrue(status.text.contains("DISCONNECTED"))
 
-        val singlePeer = items.filterIsInstance<SettingDescriptor.InfoText>().first { it.key == "single_peer_note" }
+        // The pump-specific note is present and explains the single-peer limitation.
+        val singlePeer = items.filterIsInstance<SettingDescriptor.InfoText>().single { it.key == "single_peer_note" }
         assertTrue(singlePeer.text.contains("one phone at a time"))
 
-        val unpair = items.filterIsInstance<SettingDescriptor.ActionButton>().single()
-        assertEquals("unpair", unpair.key)
-        assertEquals(ButtonStyle.DESTRUCTIVE, unpair.style)
+        // Live status and the Unpair action are owned by the generic pump settings card, so the
+        // descriptor must not duplicate them (no stale status snapshot, no second Unpair button).
+        assertNull(items.filterIsInstance<SettingDescriptor.InfoText>().firstOrNull { it.key == "pairing_status" })
+        assertTrue(items.none { it is SettingDescriptor.ActionButton })
     }
 }

--- a/plugins/shipped/tandem/src/main/java/com/glycemicgpt/mobile/plugin/TandemDevicePlugin.kt
+++ b/plugins/shipped/tandem/src/main/java/com/glycemicgpt/mobile/plugin/TandemDevicePlugin.kt
@@ -14,9 +14,6 @@ import com.glycemicgpt.mobile.domain.plugin.capabilities.InsulinSource
 import com.glycemicgpt.mobile.domain.plugin.capabilities.PumpStatus
 import com.glycemicgpt.mobile.domain.plugin.ui.DashboardCardDescriptor
 import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsDescriptor
-import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsSection
-import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
-import com.glycemicgpt.mobile.domain.plugin.ui.ButtonStyle
 import com.glycemicgpt.mobile.ble.connection.BleConnectionManager
 import com.glycemicgpt.mobile.ble.connection.BleScanner
 import com.glycemicgpt.mobile.ble.connection.TandemBleDriver
@@ -95,24 +92,12 @@ class TandemDevicePlugin(
             )
         }
 
-    override fun settingsDescriptor(): PluginSettingsDescriptor = PluginSettingsDescriptor(
-        sections = listOf(
-            PluginSettingsSection(
-                title = "Connection",
-                items = listOf(
-                    SettingDescriptor.InfoText(
-                        key = "pairing_status",
-                        text = "Status: ${connectionManager.connectionState.value}",
-                    ),
-                    SettingDescriptor.ActionButton(
-                        key = "unpair",
-                        label = "Unpair Pump",
-                        style = ButtonStyle.DESTRUCTIVE,
-                    ),
-                ),
-            ),
-        ),
-    )
+    /**
+     * Tandem contributes no pump-specific connection notes: the generic pump settings card already
+     * renders live pairing status and the Unpair action for any active pump plugin.
+     */
+    override fun settingsDescriptor(): PluginSettingsDescriptor =
+        PluginSettingsDescriptor(sections = emptyList())
 
     override fun observeDashboardCards(): Flow<List<DashboardCardDescriptor>> =
         flowOf(emptyList())


### PR DESCRIPTION
## Summary

Wires the active pump plugin's settings descriptor into the generic pump settings card so pump-specific connection notes render in-app. For Medtronic this surfaces the single-peer limitation during pairing: a MiniMed pump pairs with only one phone at a time, so the official Medtronic app must be removed from the pump before pairing here.

Previously each pump plugin declared a `settingsDescriptor()` that was never rendered anywhere. The generic pump card already owns live pairing status and the pair/unpair actions, so the descriptor is reduced to its informational notes before rendering:

- The ViewModel filters the active pump's descriptor to its informational text items only, so interactive items never produce dead/unwired controls on the card (the card renders for any active pump, including future ones).
- `PluginSettingsRenderer` now accepts a null settings store and omits store-backed input items when none is provided, supporting read-only informational rendering.
- The Medtronic descriptor declares only the single-peer note; Tandem declares none (its connection UX is fully covered by the card chrome).

This change is presentation-layer only and read-only — no pump write/control surface is added. It also removes a stale, non-reactive connection-status snapshot the descriptors previously carried.

## Testing

- `:app`, `:medtronic-pump-driver`, `:tandem-pump-driver` unit tests, `lintDebug`, and `assembleDebug` all green.
- New unit tests cover the descriptor-to-informational-notes reduction (interactive items filtered out), the no-notes case, throw-tolerance, and the trimmed Medtronic descriptor shape.
- Emulator visual verification: the single-peer note renders under the Medtronic pump card alongside live status and the Pair button; Tandem renders cleanly with no note section; dashboard empty/not-connected card states render correctly; single-instance plugin switching works with no regression.
- Ran the app under a monitoring-enabled build and confirmed no new runtime issues attributable to the driver and no sensitive data in any captured event.

Live data rendering and over-the-air pairing require a physical 700-series pump and remain a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings screen can show pump-specific informational notes; interactive controls are omitted in read-only contexts.
  * Medtronic settings now surface only the single-peer pairing note.
  * Tandem settings no longer show pump-specific connection content.

* **Bug Fixes**
  * Settings loading is more resilient: plugin note failures won’t break pump metadata display.

* **Tests**
  * Added tests covering informational descriptor extraction and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->