### PR TITLE
feat(medtronic): advertise-and-wait pairing UX + driver kill-switch

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -58,12 +58,19 @@ android {
         }
     }
 
+    // Medtronic read-only BLE driver kill switch. Default ON (the driver ships BETA, flag-gated);
+    // build with MEDTRONIC_DRIVER_ENABLED=false to make the plugin invisible/inert (not selectable,
+    // no pairing, no polling) without a code change -- the mobile analogue of the backend's
+    // MEDTRONIC_CONNECT_ENABLED operator kill switch. Anything other than "false" keeps it enabled.
+    val medtronicDriverEnabled = System.getenv("MEDTRONIC_DRIVER_ENABLED")?.lowercase() != "false"
+
     buildTypes {
         debug {
             isDebuggable = true
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
             buildConfigField("String", "UPDATE_CHANNEL", "\"dev\"")
+            buildConfigField("boolean", "MEDTRONIC_DRIVER_ENABLED", medtronicDriverEnabled.toString())
             val devBuildNumber = (project.findProperty("devBuildNumber") as? String)?.toIntOrNull() ?: 0
             buildConfigField("int", "DEV_BUILD_NUMBER", devBuildNumber.toString())
 
@@ -108,6 +115,7 @@ android {
             }
             buildConfigField("String", "UPDATE_CHANNEL", "\"stable\"")
             buildConfigField("int", "DEV_BUILD_NUMBER", "0")
+            buildConfigField("boolean", "MEDTRONIC_DRIVER_ENABLED", medtronicDriverEnabled.toString())
 
             // Never embed a Sentry DSN in a distributed/downloadable APK (it is client-extractable).
             buildConfigField("String", "SENTRY_DSN", "\"\"")

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/PluginModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/PluginModule.kt
@@ -5,7 +5,9 @@ import com.glycemicgpt.mobile.domain.pump.HistoryLogParser
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
 import com.glycemicgpt.mobile.domain.pump.PumpDriver
 import com.glycemicgpt.mobile.domain.pump.PumpScanner
+import com.glycemicgpt.mobile.plugin.BuildConfigPluginFeatureGate
 import com.glycemicgpt.mobile.plugin.PluginEventBusImpl
+import com.glycemicgpt.mobile.plugin.PluginFeatureGate
 import com.glycemicgpt.mobile.plugin.adapter.HistoryLogParserAdapter
 import com.glycemicgpt.mobile.plugin.adapter.PumpConnectionAdapter
 import com.glycemicgpt.mobile.plugin.adapter.PumpDriverAdapter
@@ -47,4 +49,8 @@ abstract class PluginModule {
     @Binds
     @Singleton
     abstract fun bindHistoryLogParser(impl: HistoryLogParserAdapter): HistoryLogParser
+
+    @Binds
+    @Singleton
+    abstract fun bindPluginFeatureGate(impl: BuildConfigPluginFeatureGate): PluginFeatureGate
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/PluginFeatureGate.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/PluginFeatureGate.kt
@@ -1,0 +1,31 @@
+package com.glycemicgpt.mobile.plugin
+
+import com.glycemicgpt.mobile.BuildConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Decides whether a compile-time plugin may be registered. A gated-off plugin is never created, so it
+ * is absent from Available Plugins (not selectable), has no pairing entry, and is never polled --
+ * fully invisible and inert. This is the mobile analogue of the backend's per-integration kill
+ * switches (e.g. `MEDTRONIC_CONNECT_ENABLED`): default-on, only an explicitly-disabled plugin is
+ * gated out.
+ */
+fun interface PluginFeatureGate {
+    fun isEnabled(pluginId: String): Boolean
+}
+
+/**
+ * [PluginFeatureGate] backed by build-time flags. The Medtronic read-only BLE driver ships BETA and
+ * is gated by [BuildConfig.MEDTRONIC_DRIVER_ENABLED] (default true; build with
+ * `MEDTRONIC_DRIVER_ENABLED=false` to ship it off). Every other plugin is always enabled.
+ */
+@Singleton
+class BuildConfigPluginFeatureGate @Inject constructor() : PluginFeatureGate {
+    override fun isEnabled(pluginId: String): Boolean = when (pluginId) {
+        // Reference the canonical id directly so the gate can never silently drift off the driver's
+        // own id (which would leave the kill switch matching nothing -> always enabled).
+        MedtronicDevicePlugin.PLUGIN_ID -> BuildConfig.MEDTRONIC_DRIVER_ENABLED
+        else -> true
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/PluginRegistry.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/PluginRegistry.kt
@@ -51,6 +51,7 @@ class PluginRegistry @Inject constructor(
     private val credentialProvider: PumpCredentialProvider,
     private val debugLogger: DebugLogger,
     private val safetyLimitsStore: SafetyLimitsStore,
+    private val featureGate: PluginFeatureGate,
 ) {
     // Thread-safe maps: activation/deactivation can be triggered from
     // multiple coroutine dispatchers or UI callbacks concurrently.
@@ -114,6 +115,15 @@ class PluginRegistry @Inject constructor(
                     "Plugin %s has API version %d, expected %d -- skipping",
                     meta.id, meta.apiVersion, PLUGIN_API_VERSION,
                 )
+                continue
+            }
+            // Feature gate / kill switch: a disabled plugin is never created, so it stays invisible in
+            // Available Plugins, has no pairing entry, and is never polled. Default-on. A persisted
+            // active-plugin preference is intentionally left untouched: this is an operator toggle, so
+            // re-enabling restores the user's prior selection (restoreActivePlugins skips an absent
+            // plugin without disturbing the empty slot).
+            if (!featureGate.isEnabled(meta.id)) {
+                Timber.i("Plugin %s disabled by feature gate -- skipping", meta.id)
                 continue
             }
             try {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/adapter/PumpConnectionAdapter.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/adapter/PumpConnectionAdapter.kt
@@ -1,6 +1,8 @@
 package com.glycemicgpt.mobile.plugin.adapter
 
 import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingProfile
 import com.glycemicgpt.mobile.domain.plugin.asPumpStatus
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
 import com.glycemicgpt.mobile.plugin.PluginRegistry
@@ -12,6 +14,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import timber.log.Timber
 import javax.inject.Inject
@@ -33,6 +36,16 @@ class PumpConnectionAdapter @Inject constructor(
         registry.activePumpPlugin.flatMapLatest { plugin ->
             plugin?.observeConnectionState() ?: flowOf(ConnectionState.DISCONNECTED)
         }.stateIn(scope, SharingStarted.Eagerly, ConnectionState.DISCONNECTED)
+
+    override val pairingProfile: StateFlow<PairingProfile> =
+        registry.activePumpPlugin.map { plugin ->
+            plugin?.pairingProfile ?: PairingProfile()
+        }.stateIn(scope, SharingStarted.Eagerly, PairingProfile())
+
+    override val pairingFault: StateFlow<PairingFault?> =
+        registry.activePumpPlugin.flatMapLatest { plugin ->
+            plugin?.observePairingFault() ?: flowOf(null)
+        }.stateIn(scope, SharingStarted.Eagerly, null)
 
     override fun connect(address: String, pairingCode: String?) {
         val plugin = registry.activePumpPlugin.value

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingScreen.kt
@@ -580,16 +580,17 @@ private fun AdvertiseAndWaitContent(
 
     // The phase is driven off the manager's connection state, not the advertise job's liveness: the
     // scan flow stays open across terminal faults and a completed handshake, so it can't be the source
-    // of truth. A pending fault is excluded from the advertising phase so terminal faults
-    // (advertise/handshake/auth) fall through to the idle branch and surface their message + Try Again
-    // instead of an endless "Waiting" spinner.
+    // of truth. Only TERMINAL faults route to the idle branch (so they surface their message + Try
+    // Again instead of an endless "Waiting" spinner); BOUND_ELSEWHERE means "still advertising, nothing
+    // has connected yet", so it stays in the waiting state where the Cancel action is shown.
+    val terminalFault = fault != null && fault != PairingFault.BOUND_ELSEWHERE
     when {
         connectionState == ConnectionState.CONNECTING ||
             connectionState == ConnectionState.AUTHENTICATING ->
             ConnectingCard(connectionState)
 
         connectionState == ConnectionState.SCANNING ||
-            (isAdvertising && fault == null && connectionState == ConnectionState.DISCONNECTED) ->
+            (isAdvertising && !terminalFault && connectionState == ConnectionState.DISCONNECTED) ->
             AdvertisingCard(
                 advertisedName = advertisedName,
                 fault = fault,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingScreen.kt
@@ -52,6 +52,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.DiscoveredPump
 import com.glycemicgpt.mobile.domain.model.TandemPumpModel
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingStyle
 
 @Composable
 fun PairingScreen(
@@ -60,9 +62,12 @@ fun PairingScreen(
 ) {
     val discoveredPumps by viewModel.discoveredPumps.collectAsState()
     val isScanning by viewModel.isScanning.collectAsState()
+    val isAdvertising by viewModel.isAdvertising.collectAsState()
     val selectedPump by viewModel.selectedPump.collectAsState()
     val pairingCode by viewModel.pairingCode.collectAsState()
     val connectionState by viewModel.connectionState.collectAsState()
+    val pairingProfile by viewModel.pairingProfile.collectAsState()
+    val pairingFault by viewModel.pairingFault.collectAsState()
 
     LaunchedEffect(connectionState) {
         if (connectionState == ConnectionState.CONNECTED) {
@@ -92,47 +97,94 @@ fun PairingScreen(
             Spacer(modifier = Modifier.height(16.dp))
         }
 
-        when {
-            // Connecting/authenticating state
-            connectionState == ConnectionState.CONNECTING ||
-                connectionState == ConnectionState.AUTHENTICATING -> {
-                ConnectingCard(connectionState)
-            }
+        // The active plugin's topology decides the flow: central-scan (phone scans, lists devices) vs
+        // advertise-and-wait (phone advertises, the device connects to it). Generalized off the plugin
+        // so each pump drives its own pairing UX through the same screen.
+        when (pairingProfile.style) {
+            PairingStyle.CENTRAL_SCAN -> CentralScanContent(
+                discoveredPumps = discoveredPumps,
+                isScanning = isScanning,
+                selectedPump = selectedPump,
+                pairingCode = pairingCode,
+                connectionState = connectionState,
+                onStartScan = { viewModel.startScan() },
+                onStopScan = { viewModel.stopScan() },
+                onSelectPump = { viewModel.selectPump(it) },
+                onCodeChanged = { viewModel.updatePairingCode(it) },
+                onPair = { viewModel.pair() },
+                onCancelSelection = { viewModel.clearSelection() },
+            )
 
-            // Auth failed -- show error with retry option
-            connectionState == ConnectionState.AUTH_FAILED && selectedPump != null -> {
-                AuthFailedCard(onRetry = { viewModel.pair() })
-                Spacer(modifier = Modifier.height(16.dp))
-                PairingCodeInput(
-                    pump = selectedPump!!,
-                    pairingCode = pairingCode,
-                    onCodeChanged = { viewModel.updatePairingCode(it) },
-                    onPair = { viewModel.pair() },
-                    onCancel = { viewModel.clearSelection() },
-                )
-            }
+            PairingStyle.ADVERTISE_AND_WAIT -> AdvertiseAndWaitContent(
+                advertisedName = pairingProfile.advertisedName,
+                isAdvertising = isAdvertising,
+                connectionState = connectionState,
+                fault = pairingFault,
+                onStartAdvertising = { viewModel.startAdvertising() },
+                onStopAdvertising = { viewModel.stopAdvertising() },
+            )
+        }
+    }
+}
 
-            // Pump selected, show pairing code input
-            selectedPump != null -> {
-                PairingCodeInput(
-                    pump = selectedPump!!,
-                    pairingCode = pairingCode,
-                    onCodeChanged = { viewModel.updatePairingCode(it) },
-                    onPair = { viewModel.pair() },
-                    onCancel = { viewModel.clearSelection() },
-                )
-            }
+/**
+ * Central-scan pairing (phone is the BLE central): scan, list nearby pumps, tap one, enter the code.
+ * Unchanged Tandem flow, lifted into its own composable so the screen can branch by [PairingStyle].
+ */
+@Composable
+private fun CentralScanContent(
+    discoveredPumps: List<DiscoveredPump>,
+    isScanning: Boolean,
+    selectedPump: DiscoveredPump?,
+    pairingCode: String,
+    connectionState: ConnectionState,
+    onStartScan: () -> Unit,
+    onStopScan: () -> Unit,
+    onSelectPump: (DiscoveredPump) -> Unit,
+    onCodeChanged: (String) -> Unit,
+    onPair: () -> Unit,
+    onCancelSelection: () -> Unit,
+) {
+    when {
+        // Connecting/authenticating state
+        connectionState == ConnectionState.CONNECTING ||
+            connectionState == ConnectionState.AUTHENTICATING -> {
+            ConnectingCard(connectionState)
+        }
 
-            // Scan mode
-            else -> {
-                ScanSection(
-                    pumps = discoveredPumps,
-                    isScanning = isScanning,
-                    onStartScan = { viewModel.startScan() },
-                    onStopScan = { viewModel.stopScan() },
-                    onSelectPump = { viewModel.selectPump(it) },
-                )
-            }
+        // Auth failed -- show error with retry option
+        connectionState == ConnectionState.AUTH_FAILED && selectedPump != null -> {
+            AuthFailedCard(onRetry = onPair)
+            Spacer(modifier = Modifier.height(16.dp))
+            PairingCodeInput(
+                pump = selectedPump,
+                pairingCode = pairingCode,
+                onCodeChanged = onCodeChanged,
+                onPair = onPair,
+                onCancel = onCancelSelection,
+            )
+        }
+
+        // Pump selected, show pairing code input
+        selectedPump != null -> {
+            PairingCodeInput(
+                pump = selectedPump,
+                pairingCode = pairingCode,
+                onCodeChanged = onCodeChanged,
+                onPair = onPair,
+                onCancel = onCancelSelection,
+            )
+        }
+
+        // Scan mode
+        else -> {
+            ScanSection(
+                pumps = discoveredPumps,
+                isScanning = isScanning,
+                onStartScan = onStartScan,
+                onStopScan = onStopScan,
+                onSelectPump = onSelectPump,
+            )
         }
     }
 }
@@ -468,4 +520,255 @@ private fun PumpCard(pump: DiscoveredPump, onClick: () -> Unit) {
             )
         }
     }
+}
+
+private fun requiredAdvertisePermissions(): Array<String> =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        arrayOf(
+            Manifest.permission.BLUETOOTH_ADVERTISE,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        )
+    } else {
+        // Pre-Android-12: advertising uses the auto-granted legacy BLUETOOTH/BLUETOOTH_ADMIN
+        // install-time permissions. ACCESS_FINE_LOCATION is a *scanning* requirement, not an
+        // advertising one, so requesting it here would pop a needless dialog that, if denied, blocks
+        // pairing even though advertising would work.
+        emptyArray()
+    }
+
+/**
+ * Advertise-and-wait pairing (phone is the BLE peripheral): the phone advertises as [advertisedName]
+ * and the pump connects to it -- there is no scan and no device list. The user triggers pairing from
+ * the pump's own menu. States are driven off the connection manager's [connectionState] and [fault]:
+ * idle (with the single-peer instruction) -> advertising/waiting -> connecting (SAKE) -> connected
+ * (handled by the caller) or failed.
+ */
+@Composable
+private fun AdvertiseAndWaitContent(
+    advertisedName: String?,
+    isAdvertising: Boolean,
+    connectionState: ConnectionState,
+    fault: PairingFault?,
+    onStartAdvertising: () -> Unit,
+    onStopAdvertising: () -> Unit,
+) {
+    val context = LocalContext.current
+    var permissionDenied by remember { mutableStateOf(false) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+    ) { results ->
+        if (results.values.all { it }) {
+            permissionDenied = false
+            onStartAdvertising()
+        } else {
+            permissionDenied = true
+        }
+    }
+
+    fun startWithPermissions() {
+        val granted = requiredAdvertisePermissions().all { perm ->
+            ContextCompat.checkSelfPermission(context, perm) == PackageManager.PERMISSION_GRANTED
+        }
+        if (granted) {
+            permissionDenied = false
+            onStartAdvertising()
+        } else {
+            permissionLauncher.launch(requiredAdvertisePermissions())
+        }
+    }
+
+    // The phase is driven off the manager's connection state, not the advertise job's liveness: the
+    // scan flow stays open across terminal faults and a completed handshake, so it can't be the source
+    // of truth. A pending fault is excluded from the advertising phase so terminal faults
+    // (advertise/handshake/auth) fall through to the idle branch and surface their message + Try Again
+    // instead of an endless "Waiting" spinner.
+    when {
+        connectionState == ConnectionState.CONNECTING ||
+            connectionState == ConnectionState.AUTHENTICATING ->
+            ConnectingCard(connectionState)
+
+        connectionState == ConnectionState.SCANNING ||
+            (isAdvertising && fault == null && connectionState == ConnectionState.DISCONNECTED) ->
+            AdvertisingCard(
+                advertisedName = advertisedName,
+                fault = fault,
+                onCancel = onStopAdvertising,
+            )
+
+        else -> AdvertiseIdleContent(
+            fault = fault,
+            permissionDenied = permissionDenied,
+            onStart = { startWithPermissions() },
+        )
+    }
+}
+
+@Composable
+private fun AdvertiseIdleContent(
+    fault: PairingFault?,
+    permissionDenied: Boolean,
+    onStart: () -> Unit,
+) {
+    // Single-peer limitation surfaced in the pairing flow (not just the settings card): a pump pairs
+    // with one phone at a time, so the official app must release it first.
+    Card(
+        modifier = Modifier.fillMaxWidth().testTag("single_peer_instruction"),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Before you start",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "A pump pairs with only one phone at a time. If this pump is currently " +
+                    "paired with the manufacturer's official app, remove it there first or it " +
+                    "will not connect here.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+    Spacer(modifier = Modifier.height(16.dp))
+
+    if (fault != null) {
+        FaultCard(fault)
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+
+    if (permissionDenied) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+            ),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = "Bluetooth permissions required",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "GlycemicGPT needs Bluetooth permissions to make your phone " +
+                        "discoverable to the pump. Please grant the permissions when prompted, " +
+                        "or enable them in your device settings.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+
+    Button(
+        onClick = onStart,
+        modifier = Modifier.fillMaxWidth().testTag("start_pairing_button"),
+    ) {
+        Icon(
+            imageVector = Icons.Default.Bluetooth,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(if (fault != null) "Try Again" else "Start Pairing")
+    }
+}
+
+@Composable
+private fun AdvertisingCard(
+    advertisedName: String?,
+    fault: PairingFault?,
+    onCancel: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().testTag("advertising_status")) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Waiting for your pump",
+                    style = MaterialTheme.typography.titleSmall,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = if (advertisedName != null) {
+                    "Your phone is now discoverable as \"$advertisedName\". On your pump, open the " +
+                        "pairing menu (Add/Pair new device) and select \"$advertisedName\" to connect."
+                } else {
+                    "Your phone is now discoverable. On your pump, open the pairing menu and select " +
+                        "this phone to connect."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // Single-peer fault while waiting is informational, not terminal -- the user can keep
+            // waiting or cancel and free the pump from the official app.
+            if (fault == PairingFault.BOUND_ELSEWHERE) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = faultMessage(fault),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag("pairing_fault"),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedButton(
+                onClick = onCancel,
+                modifier = Modifier.fillMaxWidth().testTag("cancel_advertising_button"),
+            ) {
+                Text("Cancel")
+            }
+        }
+    }
+}
+
+@Composable
+private fun FaultCard(fault: PairingFault) {
+    Card(
+        modifier = Modifier.fillMaxWidth().testTag("pairing_fault"),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Pairing did not complete",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = faultMessage(fault),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+        }
+    }
+}
+
+private fun faultMessage(fault: PairingFault): String = when (fault) {
+    PairingFault.PERIPHERAL_UNSUPPORTED ->
+        "This phone can't act as a Bluetooth accessory, so it can't pair with this pump. " +
+            "A different phone may be required."
+    PairingFault.ADVERTISE_FAILED ->
+        "Couldn't start Bluetooth advertising. Close other Bluetooth apps and try again."
+    PairingFault.HANDSHAKE_TIMEOUT ->
+        "The pump connected but the secure handshake timed out. Try again."
+    PairingFault.AUTH_FAILED ->
+        "The pump rejected the secure handshake. Try again."
+    PairingFault.BOUND_ELSEWHERE ->
+        "No pump has connected yet. If this pump is still paired with the manufacturer's " +
+            "official app, remove it there first."
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingViewModel.kt
@@ -117,7 +117,12 @@ class PairingViewModel @Inject constructor(
                 // the manager owns the lifecycle. We only need to hold the flow open here.
                 pumpScanner.scan().collect { }
             } finally {
-                _isAdvertising.value = false
+                // Reset the flag only when the flow ended on its own (e.g. PERIPHERAL_UNSUPPORTED closed
+                // it). On cancellation -- stopAdvertising() or a superseding startAdvertising() -- that
+                // caller owns the flag, so a stale cancelled job must not clobber the newer state.
+                if (coroutineContext[Job]?.isCancelled != true) {
+                    _isAdvertising.value = false
+                }
             }
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/pairing/PairingViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.data.local.PumpCredentialStore
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.DiscoveredPump
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingProfile
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
 import com.glycemicgpt.mobile.domain.pump.PumpScanner
 import com.glycemicgpt.mobile.service.PumpConnectionService
@@ -39,12 +41,40 @@ class PairingViewModel @Inject constructor(
     private val _selectedPump = MutableStateFlow<DiscoveredPump?>(null)
     val selectedPump: StateFlow<DiscoveredPump?> = _selectedPump.asStateFlow()
 
+    /** True while the phone is advertising and waiting for an advertise-and-wait pump to connect. */
+    private val _isAdvertising = MutableStateFlow(false)
+    val isAdvertising: StateFlow<Boolean> = _isAdvertising.asStateFlow()
+
     val connectionState: StateFlow<ConnectionState> = connectionManager.connectionState
+
+    /** How the active pump pairs -- the screen renders the central-scan or advertise-and-wait flow off this. */
+    val pairingProfile: StateFlow<PairingProfile> = connectionManager.pairingProfile
+
+    /** Why an advertise-and-wait pairing is stalled/failed, or null. */
+    val pairingFault: StateFlow<PairingFault?> = connectionManager.pairingFault
 
     val isPaired: Boolean get() = credentialStore.isPaired()
     val pairedAddress: String? get() = credentialStore.getPairedAddress()
 
     private var scanJob: Job? = null
+    private var advertiseJob: Job? = null
+
+    init {
+        // Tie the polling/connection foreground service to an actual session, not to the user tapping
+        // "Start Pairing". Starting it up front and then stopping it when advertising can't even begin
+        // (e.g. a phone that can't act as a BLE peripheral, where scan() closes immediately) crashes the
+        // app with ForegroundServiceDidNotStartInTime -- the service is torn down before it can promote
+        // itself. Instead, start it only once a pump is actually connecting/connected, so polling is
+        // ready and survives navigation away; it is stopped on unpair like the central-scan flow. Safe
+        // and idempotent for Tandem, whose pair() already starts it at its own connection point.
+        viewModelScope.launch {
+            connectionState.collect { state ->
+                if (state in SESSION_LIVE_OR_FORMING) {
+                    PumpConnectionService.start(appContext)
+                }
+            }
+        }
+    }
 
     fun startScan() {
         stopScan()
@@ -69,6 +99,39 @@ class PairingViewModel @Inject constructor(
         scanJob?.cancel()
         scanJob = null
         _isScanning.value = false
+    }
+
+    /**
+     * Advertise-and-wait pairing (phone-as-peripheral). Begins advertising and waits for the pump to
+     * connect; the connection manager drives [connectionState] all the way to CONNECTED (SAKE has no
+     * pairing code, so there is no [pair] step). The foreground service is started by the
+     * [connectionState] observer once a session forms, not here -- see the init block. On a device that
+     * cannot advertise, the flow completes immediately and [pairingFault] reports PERIPHERAL_UNSUPPORTED.
+     */
+    fun startAdvertising() {
+        cancelAdvertiseJob()
+        _isAdvertising.value = true
+        advertiseJob = viewModelScope.launch {
+            try {
+                // Collecting keeps advertising alive; emissions signal the pump connected, after which
+                // the manager owns the lifecycle. We only need to hold the flow open here.
+                pumpScanner.scan().collect { }
+            } finally {
+                _isAdvertising.value = false
+            }
+        }
+    }
+
+    /** Cancel advertise-and-wait before a session forms. The foreground service is only ever started
+     * once a session forms (see init), so there is nothing to stop here. */
+    fun stopAdvertising() {
+        cancelAdvertiseJob()
+        _isAdvertising.value = false
+    }
+
+    private fun cancelAdvertiseJob() {
+        advertiseJob?.cancel()
+        advertiseJob = null
     }
 
     fun selectPump(pump: DiscoveredPump) {
@@ -106,5 +169,15 @@ class PairingViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         stopScan()
+        cancelAdvertiseJob()
+    }
+
+    private companion object {
+        /** Connection states where a session is live or actively forming -- the service must keep running. */
+        val SESSION_LIVE_OR_FORMING = setOf(
+            ConnectionState.CONNECTING,
+            ConnectionState.AUTHENTICATING,
+            ConnectionState.CONNECTED,
+        )
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/PluginRegistryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/PluginRegistryTest.kt
@@ -64,7 +64,10 @@ class PluginRegistryTest {
         }
     }
 
-    private fun createRegistry(factories: Set<PluginFactory>): PluginRegistry =
+    private fun createRegistry(
+        factories: Set<PluginFactory>,
+        featureGate: PluginFeatureGate = PluginFeatureGate { true },
+    ): PluginRegistry =
         PluginRegistry(
             factories = factories,
             preferences = preferences,
@@ -73,6 +76,7 @@ class PluginRegistryTest {
             credentialProvider = credentialProvider,
             debugLogger = debugLogger,
             safetyLimitsStore = safetyLimitsStore,
+            featureGate = featureGate,
         )
 
     @Before
@@ -98,6 +102,26 @@ class PluginRegistryTest {
         verify { plugin.initialize(any()) }
         assertEquals(1, registry.availablePlugins.value.size)
         assertEquals("test.plugin.1", registry.availablePlugins.value[0].id)
+    }
+
+    @Test
+    fun `feature gate disabled plugin is never created and stays invisible`() {
+        val enabled = createFactory(createPlugin("test.enabled"))
+        val disabled = createFactory(createPlugin("test.disabled"))
+        val registry = createRegistry(
+            factories = setOf(enabled, disabled),
+            featureGate = PluginFeatureGate { it != "test.disabled" },
+        )
+
+        registry.initialize()
+
+        // The disabled plugin is never instantiated...
+        verify(exactly = 1) { enabled.create(any()) }
+        verify(exactly = 0) { disabled.create(any()) }
+        // ...and is absent from Available Plugins, so it cannot be selected or activated.
+        val ids = registry.availablePlugins.value.map { it.id }
+        assertEquals(listOf("test.enabled"), ids)
+        assertTrue(registry.activatePlugin("test.disabled").isFailure)
     }
 
     @Test
@@ -305,6 +329,7 @@ class PluginRegistryTest {
             credentialProvider = credentialProvider,
             debugLogger = debugLogger,
             safetyLimitsStore = localStore,
+            featureGate = PluginFeatureGate { true },
         )
         registry.initialize()
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/adapter/PumpConnectionAdapterTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/adapter/PumpConnectionAdapterTest.kt
@@ -3,6 +3,9 @@ package com.glycemicgpt.mobile.plugin.adapter
 import app.cash.turbine.test
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.plugin.DevicePlugin
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingProfile
+import com.glycemicgpt.mobile.domain.plugin.PairingStyle
 import com.glycemicgpt.mobile.plugin.PluginRegistry
 import io.mockk.every
 import io.mockk.mockk
@@ -10,6 +13,7 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -53,6 +57,48 @@ class PumpConnectionAdapterTest {
 
             connectionFlow.value = ConnectionState.CONNECTED
             assertEquals(ConnectionState.CONNECTED, awaitItem())
+        }
+    }
+
+    @Test
+    fun `pairingProfile follows active plugin`() = runTest {
+        val plugin: DevicePlugin = mockk(relaxed = true) {
+            every { pairingProfile } returns PairingProfile(
+                style = PairingStyle.ADVERTISE_AND_WAIT,
+                advertisedName = "Mobile 000001",
+            )
+            every { observePairingFault() } returns flowOf(null)
+        }
+
+        val adapter = PumpConnectionAdapter(registry)
+
+        adapter.pairingProfile.test {
+            // No active plugin yet -> the central-scan default.
+            assertEquals(PairingProfile(), awaitItem())
+
+            pluginFlow.value = plugin
+            assertEquals(
+                PairingProfile(PairingStyle.ADVERTISE_AND_WAIT, "Mobile 000001"),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `pairingFault follows active plugin`() = runTest {
+        val faultFlow = MutableStateFlow<PairingFault?>(null)
+        val plugin: DevicePlugin = mockk(relaxed = true) {
+            every { observePairingFault() } returns faultFlow
+        }
+        pluginFlow.value = plugin
+
+        val adapter = PumpConnectionAdapter(registry)
+
+        adapter.pairingFault.test {
+            assertEquals(null, awaitItem())
+
+            faultFlow.value = PairingFault.PERIPHERAL_UNSUPPORTED
+            assertEquals(PairingFault.PERIPHERAL_UNSUPPORTED, awaitItem())
         }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/pairing/PairingViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/pairing/PairingViewModelTest.kt
@@ -1,0 +1,149 @@
+package com.glycemicgpt.mobile.presentation.pairing
+
+import android.content.Context
+import com.glycemicgpt.mobile.data.local.PumpCredentialStore
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.DiscoveredPump
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingProfile
+import com.glycemicgpt.mobile.domain.plugin.PairingStyle
+import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
+import com.glycemicgpt.mobile.domain.pump.PumpScanner
+import com.glycemicgpt.mobile.service.PumpConnectionService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PairingViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val connectionStateFlow = MutableStateFlow(ConnectionState.DISCONNECTED)
+    private val pairingProfileFlow = MutableStateFlow(PairingProfile())
+    private val pairingFaultFlow = MutableStateFlow<PairingFault?>(null)
+
+    private val scanner: PumpScanner = mockk(relaxed = true)
+    private val connectionManager: PumpConnectionManager = mockk(relaxed = true) {
+        every { connectionState } returns connectionStateFlow
+        every { pairingProfile } returns pairingProfileFlow
+        every { pairingFault } returns pairingFaultFlow
+    }
+    private val credentialStore: PumpCredentialStore = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
+
+    private fun viewModel() =
+        PairingViewModel(scanner, connectionManager, credentialStore, context)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        // PumpConnectionService.start/stop construct Android Intents; stub them out.
+        mockkObject(PumpConnectionService.Companion)
+        every { PumpConnectionService.start(any()) } returns Unit
+        every { PumpConnectionService.stop(any()) } returns Unit
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `exposes the active plugin pairing profile`() {
+        pairingProfileFlow.value =
+            PairingProfile(PairingStyle.ADVERTISE_AND_WAIT, "Mobile 000001")
+
+        val vm = viewModel()
+
+        assertEquals(PairingStyle.ADVERTISE_AND_WAIT, vm.pairingProfile.value.style)
+        assertEquals("Mobile 000001", vm.pairingProfile.value.advertisedName)
+    }
+
+    @Test
+    fun `exposes the active plugin pairing fault`() {
+        val vm = viewModel()
+        assertEquals(null, vm.pairingFault.value)
+
+        pairingFaultFlow.value = PairingFault.PERIPHERAL_UNSUPPORTED
+
+        assertEquals(PairingFault.PERIPHERAL_UNSUPPORTED, vm.pairingFault.value)
+    }
+
+    @Test
+    fun `startAdvertising advertises without starting the foreground service`() {
+        // A flow that never completes keeps advertising "live" so isAdvertising stays true. The service
+        // must NOT start on the tap -- only once a session forms (a start-then-stop on instant-fail
+        // crashes with ForegroundServiceDidNotStartInTime).
+        every { scanner.scan() } returns MutableSharedFlow<DiscoveredPump>()
+
+        val vm = viewModel()
+        vm.startAdvertising()
+
+        assertTrue(vm.isAdvertising.value)
+        verify { scanner.scan() }
+        verify(exactly = 0) { PumpConnectionService.start(any()) }
+    }
+
+    @Test
+    fun `advertising that ends without a session never touches the service`() {
+        // A device that can't advertise closes the scan flow immediately (PERIPHERAL_UNSUPPORTED).
+        // Because the service was never started, there is nothing to stop -- and crucially no
+        // start-then-stop race.
+        every { scanner.scan() } returns emptyFlow()
+        connectionStateFlow.value = ConnectionState.DISCONNECTED
+
+        val vm = viewModel()
+        vm.startAdvertising()
+
+        assertFalse(vm.isAdvertising.value)
+        verify(exactly = 0) { PumpConnectionService.start(any()) }
+        verify(exactly = 0) { PumpConnectionService.stop(any()) }
+    }
+
+    @Test
+    fun `service starts once a pump session forms`() {
+        every { scanner.scan() } returns MutableSharedFlow<DiscoveredPump>()
+
+        val vm = viewModel()
+        vm.startAdvertising()
+        verify(exactly = 0) { PumpConnectionService.start(any()) }
+
+        // The pump connected and the handshake is running -- polling must be ready and survive
+        // navigation, so the service starts now.
+        connectionStateFlow.value = ConnectionState.AUTHENTICATING
+
+        verify { PumpConnectionService.start(any()) }
+    }
+
+    @Test
+    fun `stopAdvertising cancels advertising without touching the service`() {
+        every { scanner.scan() } returns MutableSharedFlow<DiscoveredPump>()
+        connectionStateFlow.value = ConnectionState.DISCONNECTED
+
+        val vm = viewModel()
+        vm.startAdvertising()
+        vm.stopAdvertising()
+
+        assertFalse(vm.isAdvertising.value)
+        verify(exactly = 0) { PumpConnectionService.stop(any()) }
+    }
+}

--- a/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/DevicePlugin.kt
+++ b/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/DevicePlugin.kt
@@ -4,6 +4,7 @@ import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.DiscoveredDevice
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * Extension of [Plugin] for plugins that connect to hardware devices via BLE
@@ -12,6 +13,19 @@ import kotlinx.coroutines.flow.StateFlow
 interface DevicePlugin : Plugin {
     /** Observable connection state for this device plugin. */
     fun observeConnectionState(): StateFlow<ConnectionState>
+
+    /**
+     * How this plugin pairs (central-scan vs advertise-and-wait). The pairing screen renders off this
+     * so each plugin drives its own flow. Defaults to [PairingStyle.CENTRAL_SCAN]; peripheral-mode
+     * plugins (phone advertises, device connects) override it with [PairingStyle.ADVERTISE_AND_WAIT].
+     */
+    val pairingProfile: PairingProfile get() = PairingProfile()
+
+    /**
+     * Why an advertise-and-wait pairing is stalled or failed, or `null` when there is nothing to
+     * report. Central-scan plugins keep the default (always `null`) and rely on connection state.
+     */
+    fun observePairingFault(): Flow<PairingFault?> = flowOf(null)
 
     /**
      * Connect to a device at the given address. Optional config for pairing codes, etc.

--- a/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/PairingFault.kt
+++ b/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/PairingFault.kt
@@ -1,0 +1,28 @@
+package com.glycemicgpt.mobile.domain.plugin
+
+/**
+ * Why an [PairingStyle.ADVERTISE_AND_WAIT] pairing attempt is stalled or has failed, surfaced in the
+ * pairing UI alongside [com.glycemicgpt.mobile.domain.model.ConnectionState].
+ *
+ * Central-scan plugins drive their UI from connection state alone and never emit a fault. Advertise-
+ * and-wait plugins need this because some failures (this device can't advertise, or the device is
+ * still bound to another phone) never produce a connection-state transition -- there is nothing to
+ * show without an explicit reason.
+ */
+enum class PairingFault {
+    /** This phone cannot advertise as a BLE peripheral, so it can never pair this device. */
+    PERIPHERAL_UNSUPPORTED,
+
+    /** The BLE advertiser was rejected by the OS (e.g. too many advertisers already active). */
+    ADVERTISE_FAILED,
+
+    /** The device connected but the secure handshake did not complete in time. */
+    HANDSHAKE_TIMEOUT,
+
+    /** The secure handshake ran but authentication was rejected. */
+    AUTH_FAILED,
+
+    /** Advertising has been running with nothing connecting -- the device is likely still paired to
+     * another phone (e.g. the manufacturer's official app) and must be removed from it first. */
+    BOUND_ELSEWHERE,
+}

--- a/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/PairingProfile.kt
+++ b/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/plugin/PairingProfile.kt
@@ -1,0 +1,30 @@
+package com.glycemicgpt.mobile.domain.plugin
+
+/**
+ * How the user pairs a [DevicePlugin]'s hardware, reflecting the BLE topology the plugin uses.
+ *
+ * The two styles drive fundamentally different pairing UI:
+ *  - [CENTRAL_SCAN]: the phone is the BLE central. It scans, shows a list of nearby devices, and the
+ *    user taps one (e.g. Tandem). There is a device list to populate.
+ *  - [ADVERTISE_AND_WAIT]: the phone is the BLE peripheral. It advertises and the device connects to
+ *    it as central (e.g. Medtronic MiniMed 700-series). There is no scan and no device list -- the
+ *    user triggers pairing from the device's own menu and selects the phone.
+ */
+enum class PairingStyle {
+    CENTRAL_SCAN,
+    ADVERTISE_AND_WAIT,
+}
+
+/**
+ * Static description of how a [DevicePlugin] pairs, used to drive the pairing screen off the active
+ * plugin rather than hard-coding a single vendor's flow.
+ *
+ * @param style the BLE pairing topology -- see [PairingStyle].
+ * @param advertisedName for [PairingStyle.ADVERTISE_AND_WAIT], the BLE name the phone advertises so
+ *   the user can recognise and select it from the device's pairing menu; `null` for central-scan
+ *   plugins, which have no advertised identity of their own.
+ */
+data class PairingProfile(
+    val style: PairingStyle = PairingStyle.CENTRAL_SCAN,
+    val advertisedName: String? = null,
+)

--- a/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/pump/PumpConnectionManager.kt
+++ b/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/pump/PumpConnectionManager.kt
@@ -1,6 +1,8 @@
 package com.glycemicgpt.mobile.domain.pump
 
 import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingProfile
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -22,6 +24,12 @@ interface PumpConnectionManager {
 
     /** Observable connection state. */
     val connectionState: StateFlow<ConnectionState>
+
+    /** How the active pump pairs (central-scan vs advertise-and-wait), reflecting the BLE topology. */
+    val pairingProfile: StateFlow<PairingProfile>
+
+    /** Why an advertise-and-wait pairing is stalled/failed, or `null`. Central-scan pumps stay `null`. */
+    val pairingFault: StateFlow<PairingFault?>
 
     /**
      * Connect to a pump at the given address.

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/MedtronicBleConnectionManager.kt
@@ -224,7 +224,10 @@ class MedtronicBleConnectionManager(
      */
     fun scan(): Flow<DiscoveredDevice> = callbackFlow {
         if (!peripheral.isSupported()) {
-            Timber.e("BLE peripheral advertising not supported; cannot scan")
+            // Handled, expected condition (some phones can't advertise as a peripheral) -- surfaced to
+            // the user via the PERIPHERAL_UNSUPPORTED fault, so log at WARN (a breadcrumb, not a
+            // Sentry-eligible error event).
+            Timber.w("BLE peripheral advertising not supported; cannot scan")
             worker.post { _fault.value = MedtronicConnectionFault.PERIPHERAL_UNSUPPORTED }
             close()
             return@callbackFlow
@@ -418,7 +421,9 @@ class MedtronicBleConnectionManager(
 
     private fun ensureSupported(): Boolean {
         if (peripheral.isSupported()) return true
-        Timber.e("BLE peripheral advertising not supported on this device")
+        // Handled, expected condition surfaced via the PERIPHERAL_UNSUPPORTED fault -- WARN (breadcrumb),
+        // not a Sentry-eligible error event.
+        Timber.w("BLE peripheral advertising not supported on this device")
         _fault.value = MedtronicConnectionFault.PERIPHERAL_UNSUPPORTED
         _connectionState.value = ConnectionState.DISCONNECTED
         return false

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePlugin.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePlugin.kt
@@ -9,11 +9,15 @@
 package com.glycemicgpt.mobile.plugin
 
 import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
+import com.glycemicgpt.mobile.ble.connection.MedtronicConnectionFault
 import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.DiscoveredDevice
 import com.glycemicgpt.mobile.domain.plugin.DevicePlugin
 import com.glycemicgpt.mobile.domain.plugin.PLUGIN_API_VERSION
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingProfile
+import com.glycemicgpt.mobile.domain.plugin.PairingStyle
 import com.glycemicgpt.mobile.domain.plugin.PluginCapability
 import com.glycemicgpt.mobile.domain.plugin.PluginCapabilityInterface
 import com.glycemicgpt.mobile.domain.plugin.PluginContext
@@ -28,6 +32,7 @@ import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlin.reflect.KClass
 
 class MedtronicDevicePlugin(
@@ -81,6 +86,26 @@ class MedtronicDevicePlugin(
 
     override fun observeConnectionState(): StateFlow<ConnectionState> =
         connectionManager.connectionState
+
+    /**
+     * Advertise-and-wait: the phone advertises as "Mobile …" and the pump (the BLE central) connects
+     * to it -- there is no central scan and no device list. The pairing screen renders this flow off
+     * [pairingProfile] instead of the central-scan flow used by client-mode pumps. [advertisedName]
+     * is the exact BLE name the user picks on the pump's pairing menu.
+     */
+    override val pairingProfile: PairingProfile = PairingProfile(
+        style = PairingStyle.ADVERTISE_AND_WAIT,
+        advertisedName = MedtronicBleConnectionManager.DEFAULT_LOCAL_NAME,
+    )
+
+    /**
+     * Surfaces the connection manager's [MedtronicConnectionFault] to the pairing UI as a transport-
+     * neutral [PairingFault]. Needed because several faults (this phone can't advertise; the pump is
+     * still bound to another phone) produce no [ConnectionState] transition, so the UI would otherwise
+     * have nothing to show after the user starts pairing.
+     */
+    override fun observePairingFault(): Flow<PairingFault?> =
+        connectionManager.fault.map { it?.toPairingFault() }
 
     /**
      * Begin a connection. In the inverted (phone-as-peripheral) topology there is no pump address to
@@ -145,4 +170,13 @@ class MedtronicDevicePlugin(
             protocolName = "Medtronic",
         )
     }
+}
+
+/** Maps the driver-internal connection fault onto the transport-neutral pairing fault the UI shows. */
+private fun MedtronicConnectionFault.toPairingFault(): PairingFault = when (this) {
+    MedtronicConnectionFault.PERIPHERAL_UNSUPPORTED -> PairingFault.PERIPHERAL_UNSUPPORTED
+    MedtronicConnectionFault.ADVERTISE_FAILED -> PairingFault.ADVERTISE_FAILED
+    MedtronicConnectionFault.HANDSHAKE_TIMEOUT -> PairingFault.HANDSHAKE_TIMEOUT
+    MedtronicConnectionFault.AUTH_FAILED -> PairingFault.AUTH_FAILED
+    MedtronicConnectionFault.BOUND_ELSEWHERE_SUSPECTED -> PairingFault.BOUND_ELSEWHERE
 }

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePluginTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicDevicePluginTest.kt
@@ -6,10 +6,13 @@
 package com.glycemicgpt.mobile.plugin
 
 import com.glycemicgpt.mobile.ble.connection.MedtronicBleConnectionManager
+import com.glycemicgpt.mobile.ble.connection.MedtronicConnectionFault
 import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.DiscoveredDevice
 import com.glycemicgpt.mobile.domain.plugin.PLUGIN_API_VERSION
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingStyle
 import com.glycemicgpt.mobile.domain.plugin.PluginCapability
 import com.glycemicgpt.mobile.domain.plugin.capabilities.BgmSource
 import com.glycemicgpt.mobile.domain.plugin.capabilities.GlucoseSource
@@ -131,6 +134,29 @@ class MedtronicDevicePluginTest {
         val device = DiscoveredDevice(name = "Mobile 000001", address = "AA:BB", pluginId = "com.glycemicgpt.medtronic")
         every { connectionManager.scan() } returns flowOf(device)
         assertEquals(device, plugin.scan().first())
+    }
+
+    @Test
+    fun `pairing profile is advertise-and-wait with the advertised name`() {
+        assertEquals(PairingStyle.ADVERTISE_AND_WAIT, plugin.pairingProfile.style)
+        assertEquals(
+            MedtronicBleConnectionManager.DEFAULT_LOCAL_NAME,
+            plugin.pairingProfile.advertisedName,
+        )
+    }
+
+    @Test
+    fun `observePairingFault maps the manager fault to a transport-neutral fault`() = runTest {
+        val faults = MutableStateFlow<MedtronicConnectionFault?>(null)
+        every { connectionManager.fault } returns faults
+
+        assertNull(plugin.observePairingFault().first())
+
+        faults.value = MedtronicConnectionFault.BOUND_ELSEWHERE_SUSPECTED
+        assertEquals(PairingFault.BOUND_ELSEWHERE, plugin.observePairingFault().first())
+
+        faults.value = MedtronicConnectionFault.PERIPHERAL_UNSUPPORTED
+        assertEquals(PairingFault.PERIPHERAL_UNSUPPORTED, plugin.observePairingFault().first())
     }
 
     @Test

--- a/plugins/shipped/tandem/src/main/java/com/glycemicgpt/mobile/ble/connection/BleConnectionManager.kt
+++ b/plugins/shipped/tandem/src/main/java/com/glycemicgpt/mobile/ble/connection/BleConnectionManager.kt
@@ -19,6 +19,8 @@ import com.glycemicgpt.mobile.domain.pump.DebugLogger
 import com.glycemicgpt.mobile.domain.pump.PumpCredentialProvider
 import com.glycemicgpt.mobile.domain.pump.toSpacedHex
 import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.plugin.PairingFault
+import com.glycemicgpt.mobile.domain.plugin.PairingProfile
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CompletableDeferred
@@ -67,6 +69,11 @@ class BleConnectionManager @Inject constructor(
 
     private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
     override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+    // Tandem is the BLE central: the phone scans and the user taps a pump from the list. There is no
+    // advertise-and-wait fault to surface, so the pairing screen drives Tandem off connection state.
+    override val pairingProfile: StateFlow<PairingProfile> = MutableStateFlow(PairingProfile())
+    override val pairingFault: StateFlow<PairingFault?> = MutableStateFlow(null)
 
     private var gatt: BluetoothGatt? = null
     private val gattLock = Any()


### PR DESCRIPTION
## Summary

Generalizes the Pump Pairing screen off the hardcoded Tandem central-scan flow onto the **active plugin's pairing model**, so each pump drives its own pairing UX through one screen, and adds a default-on kill-switch for the Medtronic read-only BLE driver.

Until now the pairing screen was hardcoded to Tandem's central-scan flow ("Scan for nearby Tandem pumps"), so a Medtronic 700-series pump could not actually be paired. Medtronic uses the inverted BLE topology — the phone advertises as a peripheral named "Mobile" and the pump connects to it (**advertise-and-wait**) — which has no scan and no device list.

## What changed

- **Generic pairing seams (`pump-driver-api`):** `PairingStyle` (`CENTRAL_SCAN` / `ADVERTISE_AND_WAIT`), `PairingProfile(style, advertisedName)`, and a transport-neutral `PairingFault`. `DevicePlugin` gains `pairingProfile` + `observePairingFault()` with defaults that leave every existing plugin unchanged.
- **Pairing screen** now branches on the active plugin's pairing style. The Tandem central-scan flow is unchanged (lifted into `CentralScanContent`); a new advertise-and-wait flow renders the single-peer instruction, a Start Pairing action, and the waiting / connecting / failed states driven off the connection manager's `connectionState` and fault flows.
- **Kill-switch:** `BuildConfig.MEDTRONIC_DRIVER_ENABLED` (default-on; build with `MEDTRONIC_DRIVER_ENABLED=false` to disable) is gated in `PluginRegistry` so a disabled driver is never created — invisible in Available Plugins, no pairing entry, never polled. Mirrors the existing backend per-integration kill-switch pattern.
- **Medtronic** overrides the advertise-and-wait profile and maps its connection fault to the neutral `PairingFault`. The driver remains strictly **read-only** (`connect()` only advertises).
- **Foreground service lifecycle:** the polling service is started once a pump session forms (connecting onward), not on the Start Pairing tap, so an instant advertise failure can no longer start-then-stop it.

## Testing

- Unit tests: advertise-and-wait ViewModel behavior, feature-gate gating, adapter + plugin pairing flows. All module + app tests, lint, and assemble are green (default build and kill-switch-off build).
- Emulator (states only): advertise-and-wait idle (single-peer + Start Pairing), terminal fault, Tandem central-scan unregressed, single-instance switch, and flag on/off visibility.
- Runtime validation surfaced and fixed a foreground-service start/stop crash on the advertise-failure path, and downgraded a handled device-capability condition from an error log to a breadcrumb; both verified resolved.

Live advertise-to-pump + handshake states require a physical 700-series pump and are a tracked follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added an advertise-and-wait pairing mode alongside central-scan.
  - Pairing UI now chooses flow by device profile, shows pairing code entry, waiting/advertising state, and contextual actions.
  - New user-facing pairing fault messages discriminate reasons like unsupported peripheral, advertise failure, handshake timeout, auth failure, or bound-elsewhere.

* **Bug Fixes**
  - Reduced noise for unsupported-advertising cases by lowering diagnostic severity and clarifying messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->