### PR TITLE
fix(api): bump pyjwt to 2.13.0 to clear PYSEC-2026 advisories

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -57,6 +57,14 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
 
+[tool.uv]
+# Force the transitive pyjwt (pulled in by tconnectsync) to a patched release.
+# pyjwt 2.12.1 is flagged by PYSEC-2026-175/177/178/179 (fixed in 2.13.0); tconnectsync
+# requires pyjwt with no upper bound, so this constraint just lifts the resolved version
+# without changing our direct dependencies. We do not import pyjwt directly -- our own JWTs
+# use python-jose[cryptography] with HS256.
+constraint-dependencies = ["pyjwt>=2.13.0"]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[manifest]
+constraints = [{ name = "pyjwt", specifier = ">=2.13.0" }]
+
 [[package]]
 name = "alembic"
 version = "1.18.4"
@@ -1858,11 +1861,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the transitive `pyjwt` dependency from 2.12.1 to 2.13.0 to clear the freshly-disclosed PYSEC-2026-175 / 177 / 178 / 179 advisories, which are failing the dependency vulnerability scan repo-wide (including on `develop`).

`pyjwt` is pulled in transitively by `tconnectsync`, which requires it with no upper bound, so a `[tool.uv]` `constraint-dependencies` entry lifts the resolved version without changing our direct dependencies. We do not import `pyjwt` directly — the API's own JWT handling uses `python-jose[cryptography]` with HS256.

## Changes

- `apps/api/pyproject.toml`: add `[tool.uv] constraint-dependencies = ["pyjwt>=2.13.0"]` with a comment explaining why.
- `apps/api/uv.lock`: regenerated — the only package change is `pyjwt 2.12.1 -> 2.13.0`.

## Verification

- `uv lock` updates only `pyjwt` (2.12.1 → 2.13.0).
- `pyjwt` and its consumer `tconnectsync` import cleanly at 2.13.0.
- Backend lint passes: `ruff check src/ tests/` and `ruff format --check src/ tests/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to ensure application stability and compatibility requirements are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->