### PR TITLE
docs(medtronic): OpenMinimed attribution, GPL-3.0 licensing, and BLE pairing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,16 @@ GlycemicGPT is a monitoring and analysis platform. The plugin SDK exists for one
 2. Open an issue describing the device, the protocol you intend to use, and the data you'll surface
 3. Submit a PR with a new Gradle module under `plugins/shipped/<device-name>/` (these modules are compiled into official builds), declaring only capabilities from the official read-only enum. For device data drivers the relevant capabilities are typically `GLUCOSE_SOURCE`, `INSULIN_SOURCE`, `PUMP_STATUS`, `BGM_SOURCE`, `CALIBRATION_TARGET`, and/or `BOLUS_CATEGORY_PROVIDER`. The `DATA_SYNC` capability is reserved for future external-sync integrations (Nightscout, Tidepool); its interface is not yet defined and it is not currently implementable
 4. Include unit tests, especially for parsing and `SafetyLimits` validation of incoming values
-5. Existing plugins (`:tandem-pump-driver`, under `plugins/shipped/tandem/`) serve as the reference implementation. Runtime-loaded plugins (under `plugins/example/`) are a separate, advanced contribution path -- they are not compiled into official builds and run with `RestrictedPluginContext`
+5. Existing plugins serve as reference implementations. Runtime-loaded plugins (under `plugins/example/`) are a separate, advanced contribution path -- they are not compiled into official builds and run with `RestrictedPluginContext`
+
+**Shipped device data drivers:**
+
+| Driver | Module | Transport | Reads | Status |
+|---|---|---|---|---|
+| Tandem (t:slim X2 / Mobi) | `:tandem-pump-driver` (`plugins/shipped/tandem/`) | BLE (central) | Glucose, IoB, basal, bolus history, pump status | Stable — reference implementation |
+| Medtronic MiniMed (680G / 770G / 780G) | `:medtronic-pump-driver` (`plugins/shipped/medtronic/`) | BLE (peripheral, advertise-and-wait) | Sensor glucose, IoB, basal, bolus history, reservoir, battery | **Beta**, read-only |
+
+Both drivers are **read-only** — they read data from the pump and never issue therapeutic writes. The Medtronic driver is gated behind the `MEDTRONIC_DRIVER_ENABLED` build flag (default on); a build with the flag off omits the plugin entirely.
 
 ---
 
@@ -672,7 +681,8 @@ GlycemicGPT/
 ├── plugins/            # Plugin ecosystem
 │   ├── pump-driver-api/       # Plugin SDK (interfaces & domain models)
 │   ├── shipped/               # Built-in plugins (compiled into APK)
-│   │   └── tandem/            # Tandem plugin (t:slim X2 + Mobi)
+│   │   ├── tandem/            # Tandem plugin (t:slim X2 + Mobi)
+│   │   └── medtronic/         # Medtronic MiniMed plugin (680G/770G/780G, BLE, read-only, beta)
 │   └── example/               # Example runtime plugins (NOT compiled into APK)
 ├── sidecar/            # AI provider proxy (TypeScript/Express)
 │   ├── src/            # Source code

--- a/apps/mobile/THIRD_PARTY_LICENSES.md
+++ b/apps/mobile/THIRD_PARTY_LICENSES.md
@@ -47,3 +47,66 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+## Medtronic MiniMed BLE Protocol Implementation (OpenMinimed)
+
+Unlike the Tandem implementation above (an independent reimplementation that
+imports no upstream code), the Medtronic MiniMed 700-series read-only driver is
+a **direct vendor / port** of the OpenMinimed project. OpenMinimed's SAKE
+handshake is vendored as a **runtime dependency** (compiled into the app), and
+its read-only readers are ported line-for-line into Kotlin — not merely studied
+as a reference. This is possible because OpenMinimed is GPL-3.0 and GlycemicGPT
+is itself GPL-3.0, so the licenses are compatible and copyleft propagation is a
+non-issue.
+
+The driver is used **with the explicit permission of the OpenMinimed author**
+(palmarci / Pál Marci), who relicensed the work to **GPL-3.0** for this purpose.
+Upstream copyright notices and GPL-3.0 headers are retained verbatim in every
+vendored and ported file; in-source headers in
+`plugins/shipped/medtronic/` cite the specific upstream source file each port is
+derived from.
+
+### OpenMinimed
+
+- Organization: https://github.com/OpenMinimed
+- License: GPL-3.0
+- Copyright: palmarci (Pál Marci) and contributors — drfubar, Morten Fyhn
+  Amundsen, Stenium. Original `medtronic-bt-decrypt` proof-of-concept by
+  @planiitis.
+
+The four repositories this driver is built from:
+
+| Repository | Role in this app |
+|---|---|
+| [PythonSake](https://github.com/OpenMinimed/PythonSake) | Reference implementation of the 6-stage SAKE symmetric authenticated key exchange. |
+| [PythonPumpConnector](https://github.com/OpenMinimed/PythonPumpConnector) | Authoritative read-only reader logic (Linux/Python). The CGM, IDD status, history, device-info, and battery readers are **ported to Kotlin** from this project. |
+| [JavaSake](https://github.com/OpenMinimed/JavaSake) | Production-grade SAKE handshake for the JVM/Android. **Vendored verbatim** as a runtime dependency (package `org.openminimed.sake`) and driven through `MedtronicSakeSession`. |
+| [JavaPumpConnector](https://github.com/OpenMinimed/JavaPumpConnector) | Android BLE peripheral scaffolding (permissions, advertising). Informed the connection-manager structure; no data readers exist upstream. |
+
+The Android/JVM ports of JavaSake and JavaPumpConnector are maintained under
+[jlengelbrecht](https://github.com/jlengelbrecht) (the GlycemicGPT project lead).
+
+The firmware-derived SAKE key material that the handshake depends on is published
+upstream by OpenMinimed under the same GPL-3.0 license; it is vendored as-is and
+introduces no new secret.
+
+---
+
+GPL-3.0 License
+
+The OpenMinimed-derived code above, like GlycemicGPT as a whole, is licensed
+under the GNU General Public License, version 3. The full license text ships at
+the repository root in [`LICENSE`](../../LICENSE). In short, you may use, study,
+share, and modify this software, provided that derivative works are distributed
+under the same license and that copyright and license notices are preserved.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.

--- a/docs/concepts/acknowledgments.md
+++ b/docs/concepts/acknowledgments.md
@@ -38,6 +38,20 @@ MIT-licensed by Gage Benne. Credit lives in [`apps/api/THIRD_PARTY_LICENSES.md`]
 
 xDrip+ is **GPL-3.0**-licensed; GlycemicGPT is also GPL-3.0, so the two are license-compatible and this project remains GPL-3.0 accordingly. API-side credit lives in [`apps/api/THIRD_PARTY_LICENSES.md`](https://github.com/GlycemicGPT/GlycemicGPT/blob/main/apps/api/THIRD_PARTY_LICENSES.md), and the `connect_mapper.py` and `connect_client.py` source files reference it in their module docstrings. (xDrip+ also appears below under the diabetes-OSS movement for its broader influence on the category.)
 
+### palmarci ([@palmarci](https://github.com/palmarci)) and the OpenMinimed project
+
+The Medtronic MiniMed **on-device Bluetooth** driver (which talks to a 680G / 770G / 780G pump directly, no cloud) exists because of [OpenMinimed](https://github.com/OpenMinimed) -- a community project that reverse-engineered the MiniMed 700-series BLE protocol, including the SAKE authenticated key exchange and the read-only data surface (sensor glucose, insulin-on-board, basal, bolus history, reservoir, battery).
+
+This is the **one place GlycemicGPT differs from its Tandem posture.** Where the Tandem driver is an independent reimplementation that imports no upstream code, the Medtronic BLE driver is a **direct vendor / port** of OpenMinimed:
+
+- **[JavaSake](https://github.com/OpenMinimed/JavaSake)** -- ***runtime dependency.*** OpenMinimed's production-grade SAKE handshake is vendored verbatim (package `org.openminimed.sake`) and compiled into the app, driven through `MedtronicSakeSession`.
+- **[PythonPumpConnector](https://github.com/OpenMinimed/PythonPumpConnector)** -- ***ported, not merely referenced.*** The CGM, IDD-status, history, device-info, and battery readers are ported line-for-line into Kotlin from this project.
+- **[PythonSake](https://github.com/OpenMinimed/PythonSake)** and **[JavaPumpConnector](https://github.com/OpenMinimed/JavaPumpConnector)** -- the SAKE reference and the Android BLE peripheral scaffolding that informed the connection manager.
+
+This is possible because **OpenMinimed is GPL-3.0 and GlycemicGPT is itself GPL-3.0**, so the licenses are compatible and copyleft propagation is a non-issue. The work is used **with the explicit permission of the author, palmarci (Pál Marci)**, who relicensed OpenMinimed to GPL-3.0 for this purpose. Upstream copyright and GPL-3.0 notices are retained verbatim in every vendored and ported file, and in-source headers cite the specific upstream source file each port derives from. The project credits **palmarci** as primary author and reverse-engineer, contributors **drfubar**, **Morten Fyhn Amundsen**, and **Stenium**, and the original `medtronic-bt-decrypt` proof-of-concept by **[@planiitis](https://github.com/planiitis)**. The Android/JVM ports of JavaSake and JavaPumpConnector are maintained by the GlycemicGPT project lead under [jlengelbrecht](https://github.com/jlengelbrecht).
+
+Without OpenMinimed's published reverse-engineering, the Medtronic on-device driver would not exist. Mobile-side per-package credit lives in [`apps/mobile/THIRD_PARTY_LICENSES.md`](https://github.com/GlycemicGPT/GlycemicGPT/blob/main/apps/mobile/THIRD_PARTY_LICENSES.md). (This BLE driver is separate from the Medtronic **CareLink / CarePartner cloud** sync credited above under xDrip+; the two are different data paths.)
+
 ## The diabetes-OSS movement
 
 GlycemicGPT is part of a much larger #WeAreNotWaiting tradition that has been building open-source diabetes tools collaboratively since around 2013. The projects below predate this one by years; in many cases by a decade. We're listed alongside them, not above them.

--- a/docs/daily-use/_meta.json
+++ b/docs/daily-use/_meta.json
@@ -6,6 +6,7 @@
     "connecting-dexcom",
     "connecting-tandem-cloud",
     "connecting-medtronic",
+    "connecting-medtronic-pump",
     "ai-chat",
     "briefs",
     "alerts",

--- a/docs/daily-use/connecting-medtronic-pump.md
+++ b/docs/daily-use/connecting-medtronic-pump.md
@@ -1,0 +1,75 @@
+---
+title: Pairing Your Medtronic Pump over Bluetooth (Beta)
+description: Pair a Medtronic MiniMed 700-series pump (680G / 770G / 780G) directly to the GlycemicGPT mobile app over Bluetooth — no cloud account, read-only.
+---
+
+The GlycemicGPT mobile app can connect to a **Medtronic MiniMed 700-series pump directly over Bluetooth** — no Medtronic account, no cloud, no browser step. Your phone pairs with the pump the same way a CGM display or accessory would, and reads sensor glucose, insulin-on-board, basal, bolus history, reservoir, and battery straight off the pump.
+
+This is **read-only.** GlycemicGPT never sends anything to the pump — no boluses, no basal changes, no setting changes. It only reads.
+
+> **Beta.** On-device Bluetooth pairing is new and still being validated against live pumps. Treat the data as beta and sanity-check important values against the pump itself. If something looks wrong, [open an issue](https://github.com/GlycemicGPT/GlycemicGPT/issues/new/choose).
+
+## Bluetooth (this page) vs CareLink cloud sync — which do I want?
+
+There are **two unrelated ways** to get Medtronic data into GlycemicGPT. They don't depend on each other; pick whichever fits.
+
+| | **Pair over Bluetooth** (this page) | **[CareLink cloud sync](./connecting-medtronic.md)** |
+|---|---|---|
+| How | Phone talks to the pump directly over BLE | GlycemicGPT pulls from Medtronic's cloud |
+| Needs | The pump in Bluetooth range of your phone | A CareLink account + browser sign-in |
+| App | GlycemicGPT **mobile app** | Works with the web dashboard |
+| Account | None | CareLink login (captcha in your browser) |
+| Freshness | As fast as the pump reports | Whatever the cloud has (delayed) |
+
+Use **Bluetooth** if you want the freshest data and your phone is usually near the pump. Use **CareLink cloud sync** if you'd rather not pair the pump to your phone, or you also want history that's already in Medtronic's cloud. You *can* run both, but most people pick one.
+
+## Before you start
+
+- A Medtronic **MiniMed 680G, 770G, or 780G** pump (the 700-series). Older MiniMed pumps are not supported.
+- The **GlycemicGPT mobile app** installed and signed in.
+- Bluetooth turned on, and the pump within a few feet of the phone.
+
+> **Remove the pump from the official Medtronic app first.** A MiniMed pump pairs with **only one phone at a time.** If the pump is currently paired to Medtronic's own app (MiniMed Mobile) — or any other phone — it won't pair with GlycemicGPT until you remove it there. The app shows this same reminder on the pairing screen.
+
+## How pairing works
+
+Unlike a Tandem pump (where your phone scans for the pump), a MiniMed pump is the one that goes looking. So pairing is **advertise-and-wait**: GlycemicGPT makes your phone discoverable as a Bluetooth accessory named **"Mobile 000001"**, and then you tell the pump to connect to it from the pump's own menu. Your phone waits; the pump initiates.
+
+## Pairing steps
+
+1. In the GlycemicGPT mobile app, go to the pump settings and choose **Medtronic** as your pump.
+2. Open **Pump Pairing**. You'll see a **"Before you start"** note about removing the pump from the manufacturer's app first.
+3. Tap **Start Pairing**. Your phone becomes discoverable as **"Mobile 000001"** and shows **"Waiting for your pump."**
+4. On the **pump**, open the Bluetooth pairing menu (**Add / Pair new device**) and select **"Mobile 000001."**
+5. Confirm the pairing on the pump if it prompts you. The app moves from *waiting* → *connecting* → connected, and your data begins to appear on the dashboard.
+
+Once paired, the pump is remembered — GlycemicGPT reconnects on its own when the pump is back in range; you don't repeat this flow.
+
+## What it reads
+
+- **Sensor glucose** (your CGM trace) — drives the dashboard, time-in-range, and alerts
+- **Insulin-on-board (IoB)**
+- **Basal rate** (the active rate)
+- **Bolus history**
+- **Reservoir** level and **pump battery**
+
+> Basal is shown as the active rate the pump reports; SmartGuard auto-basal micro-boluses are not yet fully attributed, and IoB is read straight off the pump as it exposes it. These are documented limitations of the on-device read path while the data mapping is validated against live pumps.
+
+## If pairing doesn't complete
+
+The pairing screen tells you what happened and offers **Try Again**:
+
+- **"No pump has connected yet."** Nothing selected your phone. Make sure the pump isn't still paired to the manufacturer's app, that Bluetooth is on, and that you picked **"Mobile 000001"** in the pump's pairing menu.
+- **"This phone can't act as a Bluetooth accessory."** Some phones can't advertise as a BLE peripheral, which this pairing needs. Try a different phone.
+- **"Couldn't start Bluetooth advertising."** Close other Bluetooth apps and try again.
+- **"The secure handshake timed out"** / **"the pump rejected the secure handshake."** The pump connected but the encrypted session didn't establish. Try again; keep the pump close.
+
+## Privacy
+
+- Pairing is **direct, phone-to-pump.** No Medtronic account is involved and nothing leaves your phone to a third party as part of pairing.
+- The connection is **read-only** — data flows from the pump into GlycemicGPT only.
+- See [Privacy](../concepts/privacy.md) for the full picture.
+
+## Still stuck?
+
+If the pump shows as connected but data isn't appearing, see [BG isn't updating](../troubleshooting/bg-not-updating.md), or ask on [Discord](https://discord.gg/QbyhCQKDBs) with your phone model and pump model.

--- a/docs/daily-use/connecting-medtronic.md
+++ b/docs/daily-use/connecting-medtronic.md
@@ -5,6 +5,8 @@ description: How GlycemicGPT pulls Medtronic pump and CGM data from CareLink —
 
 GlycemicGPT can bring your Medtronic pump and sensor data in from **Medtronic CareLink** without linking your pump to a phone over Bluetooth. This is an onramp for Medtronic users: your CGM readings, boluses, carbs, and fingersticks flow into GlycemicGPT so the dashboard and AI analysis have the same data CareLink shows.
 
+> **Prefer to skip the cloud?** If you use the GlycemicGPT mobile app and have a MiniMed 680G / 770G / 780G, you can [pair the pump directly over Bluetooth](./connecting-medtronic-pump.md) (beta) — no CareLink account needed. This page covers the **CareLink cloud** path; the two are independent.
+
 There are **two ways** to bring Medtronic data in, and you can use either or both.
 
 > **Continuous vs one-time, what's the difference?**

--- a/docs/daily-use/integrations.md
+++ b/docs/daily-use/integrations.md
@@ -16,10 +16,11 @@ This page is the index. Each integration with a longer setup flow has its own pa
 | [Dexcom](./connecting-dexcom.md) | Real-time glucose | Have a Dexcom G6 / G7 / ONE+ | Dexcom email + password |
 | [Tandem Cloud](./connecting-tandem-cloud.md) | Pump history, boluses, basal, IoB | Have a t:slim X2 or Mobi | Tandem email + password |
 | [Medtronic CareLink](./connecting-medtronic.md) | CGM, boluses, carbs, fingersticks | Have a Medtronic pump + CGM on CareLink | CareLink login (signed in via your browser) |
+| [Medtronic over Bluetooth](./connecting-medtronic-pump.md) *(beta)* | Glucose, IoB, basal, bolus history, reservoir, battery | Have a MiniMed 680G / 770G / 780G and use the mobile app | None — pair in the mobile app (one phone at a time; remove it from the Medtronic app first) |
 | [Omnipod (via Glooko)](./connecting-omnipod.md) | Basal, boluses, pod changes, CGM when available | Have an Omnipod 5 uploading to Glooko | Glooko email + password |
 | [Nightscout](#nightscout) | CGM entries, treatments, devicestatus, profile | Already run a Nightscout site -- often with a CGM we don't speak directly to (Libre, Eversense, etc.) | Nightscout URL + API_SECRET |
 
-Everything lives at **Settings → Integrations** on the dashboard.
+Most of these live at **Settings → Integrations** on the dashboard. The one exception is **[Medtronic over Bluetooth](./connecting-medtronic-pump.md)**, which is an on-device pairing done in the **mobile app's** pump settings rather than on the dashboard.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the mandatory GPL-3.0 attribution/licensing and the user-facing documentation for the Medtronic MiniMed 700-series read-only Bluetooth driver. Docs only — no code changes.

The Medtronic BLE driver is the one place this project departs from its Tandem posture. The Tandem driver is an independent reimplementation that imports no upstream code (pumpX2, MIT, credited as an architectural reference). The Medtronic driver instead **vendors and ports the OpenMinimed project directly**: OpenMinimed's `JavaSake` handshake is a runtime dependency (`org.openminimed.sake`) and its `PythonPumpConnector` readers are ported line-for-line into Kotlin. This is sound because both OpenMinimed and GlycemicGPT are GPL-3.0, so the licenses are compatible and copyleft propagation is a non-issue.

## Provenance (permission grant + relicense)

The OpenMinimed work is used **with the explicit permission of its author, palmarci (Pál Marci)**, who relicensed the project to **GPL-3.0** for this purpose. This PR records that grant in `docs/concepts/acknowledgments.md` and `apps/mobile/THIRD_PARTY_LICENSES.md` so the provenance is auditable. Upstream copyright and GPL-3.0 notices are retained verbatim in every vendored/ported file, and in-source headers cite the specific upstream source each port derives from. Credit: palmarci (primary author / reverse-engineer), contributors drfubar / Morten Fyhn Amundsen / Stenium, and the original `medtronic-bt-decrypt` proof-of-concept by @planiitis. The Android/JVM ports are maintained under jlengelbrecht.

## Changes

- **`apps/mobile/THIRD_PARTY_LICENSES.md`** — new OpenMinimed section: all four repos (PythonSake, PythonPumpConnector, JavaSake, JavaPumpConnector), GPL-3.0, per-repo role (runtime dependency vs direct port), copyright + contributors, Android ports credited, GPL-3.0 license pointer.
- **`docs/concepts/acknowledgments.md`** — narrative credit mirroring the existing pumpX2/Woglom entry, plus the permission-grant/relicense provenance. Explicitly notes the on-device BLE driver is separate from the Medtronic CareLink cloud sync.
- **`CONTRIBUTING.md`** — Medtronic added to the shipped device-data-driver list (read-only, BLE, beta) and to the project-structure tree.
- **`docs/daily-use/connecting-medtronic-pump.md`** (new) — user guide for pairing a MiniMed 680G / 770G / 780G over Bluetooth (advertise-and-wait: the phone advertises as "Mobile 000001" and the pump connects from its own pairing menu). Covers the single-peer limitation (remove the official Medtronic app first), supported models, read-only scope, and beta status. A "Bluetooth vs CareLink cloud" comparison table and bidirectional cross-links keep it clearly distinct from the existing cloud-sync doc.
- **`docs/daily-use/connecting-medtronic.md`**, **`integrations.md`**, **`_meta.json`** — cross-link and index the new doc; clarify that on-device pairing happens in the mobile app rather than the dashboard.

In-source GPL-3.0 + OpenMinimed attribution headers were audited and confirmed complete across the vendored/ported protocol/crypto/reader/parser files — no header changes were required.

## Scope

Read-only and docs-only. Per-model verification and live end-to-end validation against a physical pump are tracked as a separate, hardware-gated follow-up.

## Testing

Documentation change — markdown links and cross-references verified to resolve; `_meta.json` validated; no application code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct Bluetooth pairing for Medtronic MiniMed 700-series pumps now available (beta).

* **Documentation**
  * Added comprehensive guide for Medtronic pump Bluetooth pairing setup and troubleshooting.
  * Updated integrations documentation with Medtronic Bluetooth option.
  * Added attribution and licensing documentation for third-party components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->