### PR TITLE
feat(mobile): Nightscout cloud-source plugin

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -152,6 +152,10 @@ android {
             it.maxHeapSize = "2g"
         }
     }
+
+    // Expose the exported Room schemas to instrumented tests so MigrationTestHelper
+    // can build historical schema versions for migration tests.
+    sourceSets.getByName("androidTest").assets.srcDirs(files("$projectDir/schemas"))
 }
 
 ksp {
@@ -249,4 +253,5 @@ dependencies {
     androidTestImplementation(libs.espresso)
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test)
+    androidTestImplementation(libs.room.testing)
 }

--- a/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/12.json
+++ b/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/12.json
@@ -1,0 +1,613 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "e726c682e5b98d81501ff9e453ab660d",
+    "entities": [
+      {
+        "tableName": "iob_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `iob` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iob",
+            "columnName": "iob",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_iob_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_iob_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "basal_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `rate` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `activityMode` TEXT NOT NULL, `source` TEXT NOT NULL DEFAULT '', `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityMode",
+            "columnName": "activityMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_basal_readings_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_basal_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "bolus_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `units` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `isCorrection` INTEGER NOT NULL, `correctionUnits` REAL NOT NULL DEFAULT 0.0, `mealUnits` REAL NOT NULL DEFAULT 0.0, `source` TEXT NOT NULL DEFAULT '', `category` TEXT NOT NULL DEFAULT '', `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "units",
+            "columnName": "units",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCorrection",
+            "columnName": "isCorrection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctionUnits",
+            "columnName": "correctionUnits",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "mealUnits",
+            "columnName": "mealUnits",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bolus_events_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bolus_events_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          },
+          {
+            "name": "index_bolus_events_units_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "units",
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bolus_events_units_timestampMs` ON `${TABLE_NAME}` (`units`, `timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "battery_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `percentage` INTEGER NOT NULL, `isCharging` INTEGER NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentage",
+            "columnName": "percentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCharging",
+            "columnName": "isCharging",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_battery_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reservoir_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `unitsRemaining` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitsRemaining",
+            "columnName": "unitsRemaining",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reservoir_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reservoir_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sync_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eventType` TEXT NOT NULL, `eventTimestampMs` INTEGER NOT NULL, `payload` TEXT NOT NULL, `status` TEXT NOT NULL, `retryCount` INTEGER NOT NULL, `createdAtMs` INTEGER NOT NULL, `lastAttemptMs` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTimestampMs",
+            "columnName": "eventTimestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptMs",
+            "columnName": "lastAttemptMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_queue_status_createdAtMs",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "createdAtMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_queue_status_createdAtMs` ON `${TABLE_NAME}` (`status`, `createdAtMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "raw_history_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sequenceNumber` INTEGER NOT NULL, `rawBytesB64` TEXT NOT NULL, `eventTypeId` INTEGER NOT NULL, `pumpTimeSeconds` INTEGER NOT NULL, `sentToBackend` INTEGER NOT NULL, `createdAtMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceNumber",
+            "columnName": "sequenceNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawBytesB64",
+            "columnName": "rawBytesB64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTypeId",
+            "columnName": "eventTypeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pumpTimeSeconds",
+            "columnName": "pumpTimeSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentToBackend",
+            "columnName": "sentToBackend",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_raw_history_logs_sequenceNumber",
+            "unique": true,
+            "columnNames": [
+              "sequenceNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_raw_history_logs_sequenceNumber` ON `${TABLE_NAME}` (`sequenceNumber`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cgm_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `glucoseMgDl` INTEGER NOT NULL, `trendArrow` TEXT NOT NULL, `source` TEXT NOT NULL DEFAULT '', `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "glucoseMgDl",
+            "columnName": "glucoseMgDl",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trendArrow",
+            "columnName": "trendArrow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cgm_readings_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cgm_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `server_id` TEXT NOT NULL, `alert_type` TEXT NOT NULL, `severity` TEXT NOT NULL, `message` TEXT NOT NULL, `current_value` REAL NOT NULL, `predicted_value` REAL, `iob_value` REAL, `trend_rate` REAL, `patient_name` TEXT, `acknowledged` INTEGER NOT NULL, `timestamp_ms` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertType",
+            "columnName": "alert_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentValue",
+            "columnName": "current_value",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "predictedValue",
+            "columnName": "predicted_value",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iobValue",
+            "columnName": "iob_value",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "trendRate",
+            "columnName": "trend_rate",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "patientName",
+            "columnName": "patient_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "acknowledged",
+            "columnName": "acknowledged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestamp_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_alerts_timestamp_ms",
+            "unique": false,
+            "columnNames": [
+              "timestamp_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_alerts_timestamp_ms` ON `${TABLE_NAME}` (`timestamp_ms`)"
+          },
+          {
+            "name": "index_alerts_acknowledged",
+            "unique": false,
+            "columnNames": [
+              "acknowledged"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_alerts_acknowledged` ON `${TABLE_NAME}` (`acknowledged`)"
+          },
+          {
+            "name": "index_alerts_server_id",
+            "unique": true,
+            "columnNames": [
+              "server_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_alerts_server_id` ON `${TABLE_NAME}` (`server_id`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e726c682e5b98d81501ff9e453ab660d')"
+    ]
+  }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/Migration11To12Test.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/Migration11To12Test.kt
@@ -1,0 +1,65 @@
+package com.glycemicgpt.mobile.data.local
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.glycemicgpt.mobile.di.DatabaseModule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the Room 11 -> 12 migration (Story 43.8) that adds a `source` column to
+ * `cgm_readings` and `basal_readings`. Guards two things at once:
+ *
+ *  1. `runMigrationsAndValidate` re-creates the v11 schema from the exported `11.json`, applies the
+ *     real [DatabaseModule.ALL_MIGRATIONS], and asserts the result matches the exported `12.json` --
+ *     so a wrong `ALTER TABLE` would fail here, not silently ship.
+ *  2. Existing rows written at v11 survive the upgrade and the new column defaults to "" -- the
+ *     contract the BLE writers rely on (they leave `source` empty).
+ *
+ * Instrumented (needs real SQLite): run with `./gradlew :app:connectedDebugAndroidTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class Migration11To12Test {
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java,
+    )
+
+    @Test
+    fun migrate11To12_addsSourceColumn_andPreservesExistingRows() {
+        // v11: cgm_readings and basal_readings have no `source` column yet.
+        helper.createDatabase(TEST_DB, 11).use { db ->
+            db.execSQL(
+                "INSERT INTO cgm_readings (glucoseMgDl, trendArrow, timestampMs) " +
+                    "VALUES (120, 'FLAT', 1000)",
+            )
+            db.execSQL(
+                "INSERT INTO basal_readings (rate, isAutomated, activityMode, timestampMs) " +
+                    "VALUES (0.75, 1, 'NONE', 2000)",
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 12, true, *DatabaseModule.ALL_MIGRATIONS)
+
+        db.query("SELECT glucoseMgDl, source FROM cgm_readings").use { cursor ->
+            assertTrue("cgm row should survive the migration", cursor.moveToFirst())
+            assertEquals(120, cursor.getInt(0))
+            assertEquals("", cursor.getString(1))
+        }
+        db.query("SELECT rate, source FROM basal_readings").use { cursor ->
+            assertTrue("basal row should survive the migration", cursor.moveToFirst())
+            assertEquals(0.75f, cursor.getFloat(0), 0.0001f)
+            assertEquals("", cursor.getString(1))
+        }
+    }
+
+    private companion object {
+        const val TEST_DB = "migration-11-12-test"
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
@@ -28,7 +28,7 @@ import com.glycemicgpt.mobile.data.local.entity.SyncQueueEntity
         CgmReadingEntity::class,
         AlertEntity::class,
     ],
-    version = 11,
+    version = 12,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/PumpEntities.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/PumpEntities.kt
@@ -24,6 +24,7 @@ data class BasalReadingEntity(
     val rate: Float,
     val isAutomated: Boolean,
     val activityMode: String,
+    @ColumnInfo(defaultValue = "") val source: String = "",
     val timestampMs: Long,
 )
 
@@ -75,5 +76,6 @@ data class CgmReadingEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val glucoseMgDl: Int,
     val trendArrow: String,
+    @ColumnInfo(defaultValue = "") val source: String = "",
     val timestampMs: Long,
 )

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -16,6 +16,8 @@ import com.glycemicgpt.mobile.data.remote.dto.HealthResponse
 import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
 import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
 import com.glycemicgpt.mobile.data.remote.dto.PumpPushRequest
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
 import com.glycemicgpt.mobile.data.remote.dto.PumpPushResponse
 import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
 import retrofit2.Response
@@ -23,6 +25,7 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 import retrofit2.http.PUT
 import retrofit2.http.Path
 
@@ -85,4 +88,17 @@ interface GlycemicGptApi {
 
     @DELETE("/api/settings/plugin-declarations")
     suspend fun deletePluginDeclarations(): Response<Unit>
+
+    // Nightscout cloud-source plugin (Story 43.8): the mobile plugin pulls the
+    // user's Nightscout-sourced data from the backend (the only Nightscout
+    // client lives in the Python backend) and writes it into Room.
+    @GET("/api/integrations/nightscout")
+    suspend fun listNightscoutConnections(): Response<List<NightscoutConnectionDto>>
+
+    @GET("/api/integrations/nightscout/{connectionId}/data")
+    suspend fun getNightscoutData(
+        @Path("connectionId") connectionId: String,
+        @Query("since") since: String? = null,
+        @Query("limit") limit: Int = 500,
+    ): Response<NightscoutDataDto>
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -16,7 +16,7 @@ import com.glycemicgpt.mobile.data.remote.dto.HealthResponse
 import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
 import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
 import com.glycemicgpt.mobile.data.remote.dto.PumpPushRequest
-import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionListDto
 import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
 import com.glycemicgpt.mobile.data.remote.dto.PumpPushResponse
 import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
@@ -93,7 +93,7 @@ interface GlycemicGptApi {
     // user's Nightscout-sourced data from the backend (the only Nightscout
     // client lives in the Python backend) and writes it into Room.
     @GET("/api/integrations/nightscout")
-    suspend fun listNightscoutConnections(): Response<List<NightscoutConnectionDto>>
+    suspend fun listNightscoutConnections(): Response<NightscoutConnectionListDto>
 
     @GET("/api/integrations/nightscout/{connectionId}/data")
     suspend fun getNightscoutData(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -98,7 +98,7 @@ interface GlycemicGptApi {
     @GET("/api/integrations/nightscout/{connectionId}/data")
     suspend fun getNightscoutData(
         @Path("connectionId") connectionId: String,
-        @Query("since") since: String? = null,
-        @Query("limit") limit: Int = 500,
+        @Query("since") since: String?,
+        @Query("limit") limit: Int,
     ): Response<NightscoutDataDto>
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/NightscoutDtos.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/NightscoutDtos.kt
@@ -1,0 +1,50 @@
+package com.glycemicgpt.mobile.data.remote.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.time.Instant
+
+/**
+ * DTOs for the cloud-source mobile plugin (Story 43.8). These mirror the
+ * backend's `NightscoutDataResponse` family (apps/api/src/schemas/nightscout.py).
+ * The plugin pulls these and writes the rows into the same Room tables the BLE
+ * plugins use, so the mobile dashboard populates without a second Nightscout
+ * client on Android.
+ */
+
+@JsonClass(generateAdapter = true)
+data class NightscoutConnectionDto(
+    val id: String,
+    val name: String,
+    @Json(name = "is_active") val isActive: Boolean = true,
+)
+
+@JsonClass(generateAdapter = true)
+data class NightscoutGlucoseReadingDto(
+    @Json(name = "ns_id") val nsId: String? = null,
+    @Json(name = "reading_timestamp") val readingTimestamp: Instant,
+    val value: Int,
+    val trend: String,
+    @Json(name = "trend_rate") val trendRate: Float? = null,
+    val source: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class NightscoutPumpEventDto(
+    @Json(name = "ns_id") val nsId: String? = null,
+    @Json(name = "event_timestamp") val eventTimestamp: Instant,
+    @Json(name = "event_type") val eventType: String,
+    val units: Float? = null,
+    @Json(name = "duration_minutes") val durationMinutes: Int? = null,
+    @Json(name = "is_automated") val isAutomated: Boolean = false,
+    val source: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class NightscoutDataDto(
+    @Json(name = "connection_id") val connectionId: String,
+    @Json(name = "fetched_at") val fetchedAt: Instant,
+    @Json(name = "effective_limit_per_array") val effectiveLimitPerArray: Int,
+    @Json(name = "glucose_readings") val glucoseReadings: List<NightscoutGlucoseReadingDto>,
+    @Json(name = "pump_events") val pumpEvents: List<NightscoutPumpEventDto>,
+)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/NightscoutDtos.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/NightscoutDtos.kt
@@ -17,8 +17,6 @@ data class NightscoutConnectionDto(
     val id: String,
     val name: String,
     @Json(name = "is_active") val isActive: Boolean = true,
-    /** The user's chosen Nightscout sync interval (minutes). Informs the worker's cadence (AC3). */
-    @Json(name = "sync_interval_minutes") val syncIntervalMinutes: Int = 0,
 )
 
 /**

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/NightscoutDtos.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/NightscoutDtos.kt
@@ -17,6 +17,18 @@ data class NightscoutConnectionDto(
     val id: String,
     val name: String,
     @Json(name = "is_active") val isActive: Boolean = true,
+    /** The user's chosen Nightscout sync interval (minutes). Informs the worker's cadence (AC3). */
+    @Json(name = "sync_interval_minutes") val syncIntervalMinutes: Int = 0,
+)
+
+/**
+ * Wrapper for `GET /api/integrations/nightscout` -- the backend returns
+ * `{"connections": [...]}`, not a bare array (see
+ * apps/api/src/schemas/nightscout.py `NightscoutConnectionListResponse`).
+ */
+@JsonClass(generateAdapter = true)
+data class NightscoutConnectionListDto(
+    val connections: List<NightscoutConnectionDto>,
 )
 
 @JsonClass(generateAdapter = true)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
@@ -84,6 +84,18 @@ object DatabaseModule {
     }
 
     /**
+     * Migration 11->12: add a `source` column to cgm_readings and basal_readings so
+     * cloud-sourced rows (the Nightscout-source plugin, Story 43.8) carry the same
+     * per-row attribution that bolus_events already has. BLE writers leave it "".
+     */
+    private val MIGRATION_11_12 = object : Migration(11, 12) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE cgm_readings ADD COLUMN source TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE basal_readings ADD COLUMN source TEXT NOT NULL DEFAULT ''")
+        }
+    }
+
+    /**
      * Retrieve or generate the database passphrase from EncryptedSharedPreferences.
      *
      * The passphrase is generated once using SecureRandom and stored encrypted
@@ -151,7 +163,10 @@ object DatabaseModule {
 
         return Room.databaseBuilder(context, AppDatabase::class.java, "glycemicgpt_encrypted.db")
             .openHelperFactory(factory)
-            .addMigrations(MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
+            .addMigrations(
+                MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11,
+                MIGRATION_11_12,
+            )
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
@@ -95,6 +95,13 @@ object DatabaseModule {
         }
     }
 
+    /** All schema migrations, in order. Single source of truth shared by the database builder
+     *  and the instrumented migration tests. */
+    internal val ALL_MIGRATIONS: Array<Migration> = arrayOf(
+        MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11,
+        MIGRATION_11_12,
+    )
+
     /**
      * Retrieve or generate the database passphrase from EncryptedSharedPreferences.
      *
@@ -163,10 +170,7 @@ object DatabaseModule {
 
         return Room.databaseBuilder(context, AppDatabase::class.java, "glycemicgpt_encrypted.db")
             .openHelperFactory(factory)
-            .addMigrations(
-                MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11,
-                MIGRATION_11_12,
-            )
+            .addMigrations(*ALL_MIGRATIONS)
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/NightscoutSourceModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/NightscoutSourceModule.kt
@@ -1,0 +1,40 @@
+package com.glycemicgpt.mobile.di
+
+import android.content.Context
+import com.glycemicgpt.mobile.domain.plugin.PluginFactory
+import com.glycemicgpt.mobile.plugin.PluginSettingsStoreImpl
+import com.glycemicgpt.mobile.plugin.nightscout.NightscoutSourceFactory
+import com.glycemicgpt.mobile.plugin.nightscout.NightscoutSourcePlugin
+import com.glycemicgpt.mobile.plugin.nightscout.NightscoutSyncStore
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import javax.inject.Singleton
+
+/**
+ * Hilt wiring for the built-in Nightscout-source plugin (Story 43.8). Binds the factory into the
+ * platform's `Set<PluginFactory>` multibinding (compile-time discovery, AC1) and provides the
+ * shared [NightscoutSyncStore] backed by the plugin's per-plugin SharedPreferences file. Using the
+ * canonical plugin id keys the store to the same file the platform's [PluginSettingsStoreImpl]
+ * (and the detail-screen connection picker) write through, so the worker reads the user's selection.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class NightscoutSourceModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindNightscoutFactory(impl: NightscoutSourceFactory): PluginFactory
+
+    companion object {
+
+        @Provides
+        @Singleton
+        fun provideNightscoutSyncStore(@ApplicationContext context: Context): NightscoutSyncStore =
+            NightscoutSyncStore(PluginSettingsStoreImpl(context, NightscoutSourcePlugin.PLUGIN_ID))
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
@@ -6,26 +6,30 @@ import com.glycemicgpt.mobile.data.local.entity.CgmReadingEntity
 import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
 import com.glycemicgpt.mobile.domain.model.BolusEvent
 import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.pump.SafetyLimits
 
 /**
- * Maps the backend's Nightscout data slice (Story 43.8) into the Room entities
- * the BLE plugins also write, so the dashboard is source-agnostic. Pure and
- * synchronous so it's unit-testable without Android.
+ * Maps the backend's Nightscout data slice into the Room entities the BLE plugins
+ * also write, so the dashboard is source-agnostic. Pure and synchronous so it's
+ * unit-testable without Android.
  *
- * Source attribution (AC4): every row carries `source = "nightscout-source"`
- * (cgm_readings, basal_readings, and bolus_events all have a `source` column).
- * Cross-source coexistence (AC5) is last-writer-wins by timestamp: the unique
- * `timestampMs` (cgm/basal) and `(units, timestampMs)` (bolus) indexes mean a
- * Nightscout row and a BLE row at the same timestamp collapse to one row (the
- * later write wins and its `source` is what's kept) -- they do not both persist.
+ * Source attribution: every row carries `source = "nightscout-source"` (cgm_readings,
+ * basal_readings, and bolus_events all have a `source` column).
+ *
+ * Cross-source coexistence: a Nightscout row and a BLE row at the same timestamp
+ * collapse to a single row via the unique `timestampMs` (cgm/basal) and
+ * `(units, timestampMs)` (bolus) indexes -- they never both persist. The kept row
+ * depends on the DAO's conflict strategy: cgm_readings/basal_readings batch inserts
+ * use `IGNORE` (the existing row wins -- first writer), while bolus_events uses
+ * `REPLACE` (the new row wins -- last writer). Either way there is no double-counting.
  *
  * Validation: out-of-range values from the backend are dropped at this ingestion
  * boundary (rather than throwing, which would abort a whole page) so the local DB
- * never stores physiologically impossible readings. The bounds mirror the domain
- * models' own invariants ([CgmReading] requires 20..500 mg/dL; [BolusEvent] caps
- * units at [BolusEvent.MAX_BOLUS_UNITS]); without this, such rows would be written
- * and then silently discarded again when the entity is mapped back to its domain
- * model on read.
+ * never stores physiologically impossible readings. The bounds mirror the platform's
+ * own invariants ([CgmReading] requires 20..500 mg/dL; [BolusEvent] caps units at
+ * [BolusEvent.MAX_BOLUS_UNITS]; basal rate is capped at the [SafetyLimits] absolute
+ * ceiling); without this, such rows would be written and then silently discarded
+ * again when the entity is mapped back to its domain model on read.
  */
 object NightscoutDataMapper {
 
@@ -33,6 +37,9 @@ object NightscoutDataMapper {
 
     /** Physiologically valid CGM range, matching [CgmReading]'s own invariant. */
     private val GLUCOSE_RANGE = CgmReading.MIN_MG_DL..CgmReading.MAX_MG_DL
+
+    /** Hard upper bound for a basal rate (U/hr), reusing the platform safety ceiling. */
+    private const val MAX_BASAL_RATE_U_HR = SafetyLimits.ABSOLUTE_MAX_BASAL_MILLIUNITS / 1000f
 
     /**
      * event_type values that map to a discrete insulin bolus. `combo_bolus` is
@@ -74,7 +81,8 @@ object NightscoutDataMapper {
 
     fun toBasalEntities(data: NightscoutDataDto): List<BasalReadingEntity> =
         data.pumpEvents
-            .filter { it.eventType == "basal" && it.units != null && it.units >= 0f && it.units.isFinite() }
+            // `in 0f..MAX` also rejects NaN/Infinity (out-of-range comparisons are false).
+            .filter { it.eventType == "basal" && it.units != null && it.units in 0f..MAX_BASAL_RATE_U_HR }
             .map { e ->
                 BasalReadingEntity(
                     rate = e.units!!,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
@@ -12,16 +12,23 @@ import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
  *
  * Source attribution (AC4): every row carries `source = "nightscout-source"`
  * (cgm_readings, basal_readings, and bolus_events all have a `source` column).
- * Cross-source dedupe still works via the unique `timestampMs` (cgm/basal) and
- * `(units, timestampMs)` (bolus) indexes when a BLE plugin writes the same
- * reading.
+ * Cross-source coexistence (AC5) is last-writer-wins by timestamp: the unique
+ * `timestampMs` (cgm/basal) and `(units, timestampMs)` (bolus) indexes mean a
+ * Nightscout row and a BLE row at the same timestamp collapse to one row (the
+ * later write wins and its `source` is what's kept) -- they do not both persist.
  */
 object NightscoutDataMapper {
 
     const val SOURCE = "nightscout-source"
 
-    /** event_type values that map to a discrete insulin bolus. */
-    private val BOLUS_TYPES = setOf("bolus", "correction", "combo_bolus")
+    /**
+     * event_type values that map to a discrete insulin bolus. `combo_bolus` is
+     * deliberately excluded: the backend taxonomy uses it for either a real combo
+     * bolus or an AAPS extendedEmulated temp-basal-rate, whose `units` is the
+     * extended portion rather than a point-in-time dose -- counting it here would
+     * inflate bolus totals / IoB. It is left out until its semantics are validated.
+     */
+    private val BOLUS_TYPES = setOf("bolus", "correction")
 
     fun toCgmEntities(data: NightscoutDataDto): List<CgmReadingEntity> =
         data.glucoseReadings.map { r ->
@@ -37,10 +44,14 @@ object NightscoutDataMapper {
         data.pumpEvents
             .filter { it.eventType in BOLUS_TYPES && it.units != null }
             .map { e ->
+                val isCorrection = e.eventType == "correction"
                 BolusEventEntity(
                     units = e.units!!,
-                    isAutomated = e.isAutomated,
-                    isCorrection = e.eventType == "correction",
+                    // A `correction` is by definition an automated (Control-IQ-style) correction in
+                    // the platform taxonomy, so it is automated regardless of the upload's flag;
+                    // user-initiated doses arrive as `bolus`.
+                    isAutomated = e.isAutomated || isCorrection,
+                    isCorrection = isCorrection,
                     source = SOURCE,
                     timestampMs = e.eventTimestamp.toEpochMilli(),
                 )
@@ -53,6 +64,8 @@ object NightscoutDataMapper {
                 BasalReadingEntity(
                     rate = e.units!!,
                     isAutomated = e.isAutomated,
+                    // Nightscout basal events carry no pump activity mode (sleep/exercise); leave it
+                    // blank, matching how BLE writers leave fields they don't observe.
                     activityMode = "",
                     source = SOURCE,
                     timestampMs = e.eventTimestamp.toEpochMilli(),

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
@@ -4,6 +4,8 @@ import com.glycemicgpt.mobile.data.local.entity.BasalReadingEntity
 import com.glycemicgpt.mobile.data.local.entity.BolusEventEntity
 import com.glycemicgpt.mobile.data.local.entity.CgmReadingEntity
 import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
+import com.glycemicgpt.mobile.domain.model.BolusEvent
+import com.glycemicgpt.mobile.domain.model.CgmReading
 
 /**
  * Maps the backend's Nightscout data slice (Story 43.8) into the Room entities
@@ -16,10 +18,21 @@ import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
  * `timestampMs` (cgm/basal) and `(units, timestampMs)` (bolus) indexes mean a
  * Nightscout row and a BLE row at the same timestamp collapse to one row (the
  * later write wins and its `source` is what's kept) -- they do not both persist.
+ *
+ * Validation: out-of-range values from the backend are dropped at this ingestion
+ * boundary (rather than throwing, which would abort a whole page) so the local DB
+ * never stores physiologically impossible readings. The bounds mirror the domain
+ * models' own invariants ([CgmReading] requires 20..500 mg/dL; [BolusEvent] caps
+ * units at [BolusEvent.MAX_BOLUS_UNITS]); without this, such rows would be written
+ * and then silently discarded again when the entity is mapped back to its domain
+ * model on read.
  */
 object NightscoutDataMapper {
 
     const val SOURCE = "nightscout-source"
+
+    /** Physiologically valid CGM range, matching [CgmReading]'s own invariant. */
+    private val GLUCOSE_RANGE = CgmReading.MIN_MG_DL..CgmReading.MAX_MG_DL
 
     /**
      * event_type values that map to a discrete insulin bolus. `combo_bolus` is
@@ -31,18 +44,20 @@ object NightscoutDataMapper {
     private val BOLUS_TYPES = setOf("bolus", "correction")
 
     fun toCgmEntities(data: NightscoutDataDto): List<CgmReadingEntity> =
-        data.glucoseReadings.map { r ->
-            CgmReadingEntity(
-                glucoseMgDl = r.value,
-                trendArrow = r.trend,
-                source = SOURCE,
-                timestampMs = r.readingTimestamp.toEpochMilli(),
-            )
-        }
+        data.glucoseReadings
+            .filter { it.value in GLUCOSE_RANGE }
+            .map { r ->
+                CgmReadingEntity(
+                    glucoseMgDl = r.value,
+                    trendArrow = r.trend,
+                    source = SOURCE,
+                    timestampMs = r.readingTimestamp.toEpochMilli(),
+                )
+            }
 
     fun toBolusEntities(data: NightscoutDataDto): List<BolusEventEntity> =
         data.pumpEvents
-            .filter { it.eventType in BOLUS_TYPES && it.units != null }
+            .filter { it.eventType in BOLUS_TYPES && it.units != null && it.units in BOLUS_RANGE }
             .map { e ->
                 val isCorrection = e.eventType == "correction"
                 BolusEventEntity(
@@ -59,7 +74,7 @@ object NightscoutDataMapper {
 
     fun toBasalEntities(data: NightscoutDataDto): List<BasalReadingEntity> =
         data.pumpEvents
-            .filter { it.eventType == "basal" && it.units != null }
+            .filter { it.eventType == "basal" && it.units != null && it.units >= 0f && it.units.isFinite() }
             .map { e ->
                 BasalReadingEntity(
                     rate = e.units!!,
@@ -71,4 +86,7 @@ object NightscoutDataMapper {
                     timestampMs = e.eventTimestamp.toEpochMilli(),
                 )
             }
+
+    /** Discrete-bolus dose bounds, mirroring [BolusEvent]'s hard cap. */
+    private val BOLUS_RANGE = 0f..BolusEvent.MAX_BOLUS_UNITS
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
@@ -1,0 +1,59 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.data.local.entity.BasalReadingEntity
+import com.glycemicgpt.mobile.data.local.entity.BolusEventEntity
+import com.glycemicgpt.mobile.data.local.entity.CgmReadingEntity
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
+
+/**
+ * Maps the backend's Nightscout data slice (Story 43.8) into the Room entities
+ * the BLE plugins also write, so the dashboard is source-agnostic. Pure and
+ * synchronous so it's unit-testable without Android.
+ *
+ * Source attribution (AC4): bolus rows carry `source = "nightscout-source"`
+ * (the `bolus_events` table already has a `source` column). CGM/basal rows are
+ * written without source until those entities gain a `source` column (tracked
+ * in the story plan); their cross-source dedupe still works via the unique
+ * `timestampMs` indexes.
+ */
+object NightscoutDataMapper {
+
+    const val SOURCE = "nightscout-source"
+
+    /** event_type values that map to a discrete insulin bolus. */
+    private val BOLUS_TYPES = setOf("bolus", "correction", "combo_bolus")
+
+    fun toCgmEntities(data: NightscoutDataDto): List<CgmReadingEntity> =
+        data.glucoseReadings.map { r ->
+            CgmReadingEntity(
+                glucoseMgDl = r.value,
+                trendArrow = r.trend,
+                timestampMs = r.readingTimestamp.toEpochMilli(),
+            )
+        }
+
+    fun toBolusEntities(data: NightscoutDataDto): List<BolusEventEntity> =
+        data.pumpEvents
+            .filter { it.eventType in BOLUS_TYPES && it.units != null }
+            .map { e ->
+                BolusEventEntity(
+                    units = e.units!!,
+                    isAutomated = e.isAutomated,
+                    isCorrection = e.eventType == "correction",
+                    source = SOURCE,
+                    timestampMs = e.eventTimestamp.toEpochMilli(),
+                )
+            }
+
+    fun toBasalEntities(data: NightscoutDataDto): List<BasalReadingEntity> =
+        data.pumpEvents
+            .filter { it.eventType == "basal" && it.units != null }
+            .map { e ->
+                BasalReadingEntity(
+                    rate = e.units!!,
+                    isAutomated = e.isAutomated,
+                    activityMode = "",
+                    timestampMs = e.eventTimestamp.toEpochMilli(),
+                )
+            }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapper.kt
@@ -10,11 +10,11 @@ import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
  * the BLE plugins also write, so the dashboard is source-agnostic. Pure and
  * synchronous so it's unit-testable without Android.
  *
- * Source attribution (AC4): bolus rows carry `source = "nightscout-source"`
- * (the `bolus_events` table already has a `source` column). CGM/basal rows are
- * written without source until those entities gain a `source` column (tracked
- * in the story plan); their cross-source dedupe still works via the unique
- * `timestampMs` indexes.
+ * Source attribution (AC4): every row carries `source = "nightscout-source"`
+ * (cgm_readings, basal_readings, and bolus_events all have a `source` column).
+ * Cross-source dedupe still works via the unique `timestampMs` (cgm/basal) and
+ * `(units, timestampMs)` (bolus) indexes when a BLE plugin writes the same
+ * reading.
  */
 object NightscoutDataMapper {
 
@@ -28,6 +28,7 @@ object NightscoutDataMapper {
             CgmReadingEntity(
                 glucoseMgDl = r.value,
                 trendArrow = r.trend,
+                source = SOURCE,
                 timestampMs = r.readingTimestamp.toEpochMilli(),
             )
         }
@@ -53,6 +54,7 @@ object NightscoutDataMapper {
                     rate = e.units!!,
                     isAutomated = e.isAutomated,
                     activityMode = "",
+                    source = SOURCE,
                     timestampMs = e.eventTimestamp.toEpochMilli(),
                 )
             }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourceFactory.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourceFactory.kt
@@ -1,0 +1,41 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
+import com.glycemicgpt.mobile.domain.plugin.Plugin
+import com.glycemicgpt.mobile.domain.plugin.PluginContext
+import com.glycemicgpt.mobile.domain.plugin.PluginFactory
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Factory for the Nightscout-source plugin (Story 43.8), bound into the platform's
+ * `Set<PluginFactory>` multibinding by [com.glycemicgpt.mobile.di.NightscoutSourceModule].
+ * Dependencies come from `:app` (the api + Room + WorkManager wiring) -- which is why this
+ * plugin lives in `:app` rather than a standalone module that can't depend on `:app`.
+ */
+@Singleton
+class NightscoutSourceFactory @Inject constructor(
+    private val syncManager: NightscoutSyncManager,
+    private val store: NightscoutSyncStore,
+    private val api: GlycemicGptApi,
+) : PluginFactory {
+
+    override val metadata = NightscoutSourcePlugin.METADATA
+
+    override fun create(context: PluginContext): Plugin =
+        NightscoutSourcePlugin(
+            syncManager = syncManager,
+            store = store,
+            connectionsProvider = ::fetchConnections,
+        )
+
+    private suspend fun fetchConnections(): List<NightscoutConnectionDto> {
+        val response = api.listNightscoutConnections()
+        return if (response.isSuccessful) {
+            response.body()?.connections ?: emptyList()
+        } else {
+            emptyList()
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePlugin.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePlugin.kt
@@ -18,6 +18,7 @@ import com.glycemicgpt.mobile.domain.plugin.ui.PluginIcon
 import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsDescriptor
 import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsSection
 import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
+import com.glycemicgpt.mobile.domain.plugin.ui.UiColor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -53,7 +54,11 @@ class NightscoutSourcePlugin(
     override val capabilities: Set<PluginCapability> = setOf(PluginCapability.DATA_SYNC)
 
     override fun initialize(context: PluginContext) {
-        // No resources to set up: the sync manager + store are injected ready-to-use.
+        // Intentionally does not use context.settingsStore. The sync worker is constructed by
+        // WorkManager's HiltWorkerFactory outside this plugin's lifecycle, so it can't receive the
+        // PluginContext; instead the worker, this plugin, and the manager all share one Hilt-injected
+        // NightscoutSyncStore. It is backed by the same PluginSettingsStoreImpl(pluginId) file the
+        // platform hands out here, so the detail-screen connection picker and the worker stay in sync.
     }
 
     override fun shutdown() {
@@ -70,7 +75,6 @@ class NightscoutSourcePlugin(
         syncManager.disable()
     }
 
-    @Suppress("UNCHECKED_CAST")
     override fun <T : PluginCapabilityInterface> getCapability(type: KClass<T>): T? = null
 
     override fun settingsDescriptor(): PluginSettingsDescriptor = PluginSettingsDescriptor(
@@ -90,7 +94,7 @@ class NightscoutSourcePlugin(
     )
 
     override fun observeDashboardCards(): Flow<List<DashboardCardDescriptor>> =
-        store.lastSyncAtMs.map { listOf(buildCard(it)) }
+        store.state.map { listOf(buildCard(it)) }
 
     override fun observeDetailScreen(cardId: String): Flow<DetailScreenDescriptor>? {
         if (cardId != CARD_ID) return null
@@ -103,21 +107,16 @@ class NightscoutSourcePlugin(
         }
     }
 
-    private fun buildCard(lastSyncAtMs: Long?): DashboardCardDescriptor = DashboardCardDescriptor(
+    private fun buildCard(state: NightscoutSyncState): DashboardCardDescriptor = DashboardCardDescriptor(
         id = CARD_ID,
         title = "Nightscout",
         priority = CARD_PRIORITY,
         hasDetail = true,
-        elements = listOf(
-            CardElement.IconValue(
-                icon = PluginIcon.SYNC,
-                value = "Cloud source",
-            ),
-            CardElement.Label(
-                text = formatLastSync(lastSyncAtMs),
-                style = LabelStyle.CAPTION,
-            ),
-        ),
+        elements = buildList {
+            add(CardElement.IconValue(icon = PluginIcon.SYNC, value = "Cloud source"))
+            add(CardElement.Label(formatLastSync(state.lastSuccessAtMs), LabelStyle.CAPTION))
+            statusBadge(state.status)?.let { add(it) }
+        },
     )
 
     private suspend fun buildDetailScreen(): DetailScreenDescriptor {
@@ -128,14 +127,16 @@ class NightscoutSourcePlugin(
             emptyList()
         }
         val activeConnections = connections.filter { it.isActive }
+        val state = store.state.value
 
         val elements = buildList {
             add(DetailElement.SectionHeader("Nightscout sync"))
             add(
                 DetailElement.Display(
-                    CardElement.Label(formatLastSync(store.lastSyncAtMs.value), LabelStyle.BODY),
+                    CardElement.Label(formatLastSync(state.lastSuccessAtMs), LabelStyle.BODY),
                 ),
             )
+            statusBadge(state.status)?.let { add(DetailElement.Display(it)) }
             // Only offer a picker when there is an actual choice to make.
             if (activeConnections.size > 1) {
                 add(
@@ -187,5 +188,16 @@ class NightscoutSourcePlugin(
             } else {
                 "Last sync: ${LAST_SYNC_FORMAT.format(Instant.ofEpochMilli(lastSyncAtMs))}"
             }
+
+        /** A user-facing badge for the latest sync outcome, or null when nothing is worth flagging. */
+        internal fun statusBadge(status: NightscoutSyncStatus): CardElement.StatusBadge? = when (status) {
+            NightscoutSyncStatus.OK, NightscoutSyncStatus.NEVER -> null
+            NightscoutSyncStatus.NO_CONNECTION ->
+                CardElement.StatusBadge("No active Nightscout connection", UiColor.WARNING)
+            NightscoutSyncStatus.AUTH_ERROR ->
+                CardElement.StatusBadge("Reconnect needed", UiColor.ERROR)
+            NightscoutSyncStatus.ERROR ->
+                CardElement.StatusBadge("Sync error — will retry", UiColor.WARNING)
+        }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePlugin.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePlugin.kt
@@ -1,0 +1,191 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
+import com.glycemicgpt.mobile.domain.plugin.PLUGIN_API_VERSION
+import com.glycemicgpt.mobile.domain.plugin.Plugin
+import com.glycemicgpt.mobile.domain.plugin.PluginCapability
+import com.glycemicgpt.mobile.domain.plugin.PluginCapabilityInterface
+import com.glycemicgpt.mobile.domain.plugin.PluginContext
+import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
+import com.glycemicgpt.mobile.domain.plugin.ui.ButtonStyle
+import com.glycemicgpt.mobile.domain.plugin.ui.CardElement
+import com.glycemicgpt.mobile.domain.plugin.ui.DashboardCardDescriptor
+import com.glycemicgpt.mobile.domain.plugin.ui.DetailElement
+import com.glycemicgpt.mobile.domain.plugin.ui.DetailScreenDescriptor
+import com.glycemicgpt.mobile.domain.plugin.ui.DropdownOption
+import com.glycemicgpt.mobile.domain.plugin.ui.LabelStyle
+import com.glycemicgpt.mobile.domain.plugin.ui.PluginIcon
+import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsDescriptor
+import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsSection
+import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import timber.log.Timber
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.reflect.KClass
+
+/**
+ * Cloud-mediated data-source plugin (Story 43.8). Unlike the BLE drivers, it talks to no
+ * device: when enabled it pulls the user's Nightscout-sourced data from the backend read API
+ * (the only Nightscout client lives in the Python backend) into the same Room tables the BLE
+ * plugins write, so the mobile dashboard populates without a second Nightscout client on Android.
+ *
+ * It declares only [PluginCapability.DATA_SYNC] (MULTI_INSTANCE) so it coexists with any active
+ * BLE plugin -- enabling it never evicts a pump's glucose/insulin slots (AC5). The sync itself is
+ * driven by a WorkManager schedule via [NightscoutSyncManager], not by a polled capability source.
+ *
+ * The plugin's activate/deactivate toggle in Settings -> Plugins is the on/off control (AC1, off by
+ * default); activating triggers the initial + periodic sync, deactivating stops the schedule but
+ * keeps cached data (AC8). The dashboard card opens a detail screen with a connection picker (when
+ * more than one connection exists) and a "Sync now" action.
+ */
+class NightscoutSourcePlugin(
+    private val syncManager: NightscoutSyncManager,
+    private val store: NightscoutSyncStore,
+    private val connectionsProvider: suspend () -> List<NightscoutConnectionDto>,
+) : Plugin {
+
+    override val metadata: PluginMetadata = METADATA
+
+    override val capabilities: Set<PluginCapability> = setOf(PluginCapability.DATA_SYNC)
+
+    override fun initialize(context: PluginContext) {
+        // No resources to set up: the sync manager + store are injected ready-to-use.
+    }
+
+    override fun shutdown() {
+        // Lifecycle is governed by onActivated/onDeactivated; there are no held resources to
+        // release here (WorkManager state is external and keyed). shutdown() is reserved for
+        // runtime-plugin removal, which does not apply to this built-in plugin.
+    }
+
+    override fun onActivated() {
+        syncManager.enable()
+    }
+
+    override fun onDeactivated() {
+        syncManager.disable()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : PluginCapabilityInterface> getCapability(type: KClass<T>): T? = null
+
+    override fun settingsDescriptor(): PluginSettingsDescriptor = PluginSettingsDescriptor(
+        sections = listOf(
+            PluginSettingsSection(
+                title = "Nightscout",
+                items = listOf(
+                    SettingDescriptor.InfoText(
+                        key = "cloud_mediated_note",
+                        text = "Cloud-mediated: when enabled, your Nightscout data is pulled from " +
+                            "your GlycemicGPT account on this device. Requires a Nightscout " +
+                            "connection set up on your account.",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    override fun observeDashboardCards(): Flow<List<DashboardCardDescriptor>> =
+        store.lastSyncAtMs.map { listOf(buildCard(it)) }
+
+    override fun observeDetailScreen(cardId: String): Flow<DetailScreenDescriptor>? {
+        if (cardId != CARD_ID) return null
+        return flow { emit(buildDetailScreen()) }
+    }
+
+    override fun onDetailAction(cardId: String, actionKey: String) {
+        if (cardId == CARD_ID && actionKey == ACTION_SYNC_NOW) {
+            syncManager.syncNow()
+        }
+    }
+
+    private fun buildCard(lastSyncAtMs: Long?): DashboardCardDescriptor = DashboardCardDescriptor(
+        id = CARD_ID,
+        title = "Nightscout",
+        priority = CARD_PRIORITY,
+        hasDetail = true,
+        elements = listOf(
+            CardElement.IconValue(
+                icon = PluginIcon.SYNC,
+                value = "Cloud source",
+            ),
+            CardElement.Label(
+                text = formatLastSync(lastSyncAtMs),
+                style = LabelStyle.CAPTION,
+            ),
+        ),
+    )
+
+    private suspend fun buildDetailScreen(): DetailScreenDescriptor {
+        val connections = try {
+            connectionsProvider()
+        } catch (e: Exception) {
+            Timber.w(e, "Nightscout detail: failed to load connections")
+            emptyList()
+        }
+        val activeConnections = connections.filter { it.isActive }
+
+        val elements = buildList {
+            add(DetailElement.SectionHeader("Nightscout sync"))
+            add(
+                DetailElement.Display(
+                    CardElement.Label(formatLastSync(store.lastSyncAtMs.value), LabelStyle.BODY),
+                ),
+            )
+            // Only offer a picker when there is an actual choice to make.
+            if (activeConnections.size > 1) {
+                add(
+                    DetailElement.Interactive(
+                        SettingDescriptor.Dropdown(
+                            key = NightscoutSyncStore.KEY_SELECTED_CONNECTION,
+                            label = "Connection",
+                            options = activeConnections.map { DropdownOption(it.id, it.name) },
+                        ),
+                    ),
+                )
+            }
+            add(
+                DetailElement.Interactive(
+                    SettingDescriptor.ActionButton(
+                        key = ACTION_SYNC_NOW,
+                        label = "Sync now",
+                        style = ButtonStyle.PRIMARY,
+                    ),
+                ),
+            )
+        }
+        return DetailScreenDescriptor(title = "Nightscout", elements = elements)
+    }
+
+    companion object {
+        const val PLUGIN_ID = "com.glycemicgpt.nightscout-source"
+        const val CARD_ID = "nightscout_sync"
+        const val ACTION_SYNC_NOW = "sync_now"
+        private const val CARD_PRIORITY = 200
+
+        private val LAST_SYNC_FORMAT: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("MMM d, HH:mm").withZone(ZoneId.systemDefault())
+
+        /** Shared metadata -- used by both [NightscoutSourcePlugin] and [NightscoutSourceFactory]. */
+        val METADATA = PluginMetadata(
+            id = PLUGIN_ID,
+            name = "Nightscout Data Source",
+            version = "1.0.0",
+            apiVersion = PLUGIN_API_VERSION,
+            description = "Cloud-mediated: pulls glucose & insulin from your Nightscout connection.",
+            author = "GlycemicGPT",
+            protocolName = "Nightscout",
+        )
+
+        internal fun formatLastSync(lastSyncAtMs: Long?): String =
+            if (lastSyncAtMs == null) {
+                "Not synced yet"
+            } else {
+                "Last sync: ${LAST_SYNC_FORMAT.format(Instant.ofEpochMilli(lastSyncAtMs))}"
+            }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePlugin.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePlugin.kt
@@ -20,6 +20,7 @@ import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsSection
 import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
 import com.glycemicgpt.mobile.domain.plugin.ui.UiColor
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
@@ -98,7 +99,13 @@ class NightscoutSourcePlugin(
 
     override fun observeDetailScreen(cardId: String): Flow<DetailScreenDescriptor>? {
         if (cardId != CARD_ID) return null
-        return flow { emit(buildDetailScreen()) }
+        // Load the connection list once when the screen opens, then re-render reactively on every
+        // sync-state change (last-sync time, status badge) so the detail UI never goes stale -- e.g.
+        // after a "Sync now" tap updates the status.
+        return flow {
+            val activeConnections = loadActiveConnections()
+            emitAll(store.state.map { state -> buildDetailScreen(activeConnections, state) })
+        }
     }
 
     override fun onDetailAction(cardId: String, actionKey: String) {
@@ -119,16 +126,18 @@ class NightscoutSourcePlugin(
         },
     )
 
-    private suspend fun buildDetailScreen(): DetailScreenDescriptor {
-        val connections = try {
-            connectionsProvider()
+    private suspend fun loadActiveConnections(): List<NightscoutConnectionDto> =
+        try {
+            connectionsProvider().filter { it.isActive }
         } catch (e: Exception) {
             Timber.w(e, "Nightscout detail: failed to load connections")
             emptyList()
         }
-        val activeConnections = connections.filter { it.isActive }
-        val state = store.state.value
 
+    private fun buildDetailScreen(
+        activeConnections: List<NightscoutConnectionDto>,
+        state: NightscoutSyncState,
+    ): DetailScreenDescriptor {
         val elements = buildList {
             add(DetailElement.SectionHeader("Nightscout sync"))
             add(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngine.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngine.kt
@@ -1,0 +1,153 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.data.local.dao.PumpDao
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
+import retrofit2.Response
+import timber.log.Timber
+import java.io.IOException
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** The outcome of one sync pass. The worker maps these onto a WorkManager Result. */
+sealed interface SyncOutcome {
+    /** The plugin is disabled -- nothing to do. */
+    data object Disabled : SyncOutcome
+
+    /** No active Nightscout connection is available on this account. */
+    data object NoConnection : SyncOutcome
+
+    /** A successful pull; counts are row counts written (post-mapping, pre-dedupe). */
+    data class Success(val pages: Int, val cgm: Int, val bolus: Int, val basal: Int) : SyncOutcome
+
+    /** Auth/not-found (401/403/404): give up this run without retrying. */
+    data object AuthError : SyncOutcome
+
+    /** A transient error (network, 5xx): the run should be retried with backoff. */
+    data object Transient : SyncOutcome
+}
+
+/**
+ * The pure sync logic for the Nightscout-source plugin (Story 43.8), extracted from
+ * the WorkManager worker so it is unit-testable without an Android/WorkManager harness.
+ *
+ * It pulls the user's Nightscout-sourced data from the backend's unified read endpoint
+ * (`GET /api/integrations/nightscout/{id}/data?since=...`) and writes it into the same
+ * Room tables the BLE plugins use (AC2/AC4). The `since` cursor is **inclusive**, so the
+ * idempotent DAO inserts (unique `timestampMs` / `(units, timestampMs)` indexes) absorb the
+ * boundary-row duplicates the backend warns about -- there is no separate ns_id dedupe pass.
+ *
+ * Logging is counts + connection id only -- never glucose/insulin values (PHI).
+ */
+@Singleton
+class NightscoutSyncEngine @Inject constructor(
+    private val api: GlycemicGptApi,
+    private val pumpDao: PumpDao,
+    private val store: NightscoutSyncStore,
+) {
+
+    suspend fun syncOnce(nowMs: Long = System.currentTimeMillis()): SyncOutcome {
+        if (!store.enabled) return SyncOutcome.Disabled
+        return try {
+            val connections = api.listNightscoutConnections().bodyOrThrow().connections
+            val connection = resolveConnection(connections) ?: return SyncOutcome.NoConnection
+            runSync(connection, nowMs)
+        } catch (e: SyncAuthError) {
+            Timber.w("Nightscout sync gave up (http %d)", e.code)
+            SyncOutcome.AuthError
+        } catch (e: SyncTransientError) {
+            Timber.w("Nightscout sync transient error: %s", e.message)
+            SyncOutcome.Transient
+        } catch (e: IOException) {
+            Timber.w(e, "Nightscout sync network error")
+            SyncOutcome.Transient
+        }
+    }
+
+    /**
+     * Pick the connection to sync: the user-selected one if it is still present and active,
+     * otherwise the first active connection.
+     */
+    private fun resolveConnection(connections: List<NightscoutConnectionDto>): NightscoutConnectionDto? {
+        val active = connections.filter { it.isActive }
+        val selectedId = store.selectedConnectionId
+        return active.firstOrNull { selectedId.isNotEmpty() && it.id == selectedId }
+            ?: active.firstOrNull()
+    }
+
+    private suspend fun runSync(connection: NightscoutConnectionDto, nowMs: Long): SyncOutcome {
+        var cursorMs = store.lastSyncCursorMs
+        var pages = 0
+        var cgmTotal = 0
+        var bolusTotal = 0
+        var basalTotal = 0
+
+        while (true) {
+            val sinceIso = if (cursorMs > 0) Instant.ofEpochMilli(cursorMs).toString() else null
+            val data = api.getNightscoutData(connection.id, sinceIso, PAGE_LIMIT).bodyOrThrow()
+            pages++
+
+            if (data.glucoseReadings.isEmpty() && data.pumpEvents.isEmpty()) break
+
+            val cgm = NightscoutDataMapper.toCgmEntities(data)
+            val bolus = NightscoutDataMapper.toBolusEntities(data)
+            val basal = NightscoutDataMapper.toBasalEntities(data)
+            if (cgm.isNotEmpty()) pumpDao.insertCgmBatch(cgm)
+            if (bolus.isNotEmpty()) pumpDao.insertBoluses(bolus)
+            if (basal.isNotEmpty()) pumpDao.insertBasalBatch(basal)
+            cgmTotal += cgm.size
+            bolusTotal += bolus.size
+            basalTotal += basal.size
+
+            val effLimit = data.effectiveLimitPerArray.coerceAtLeast(1)
+            val glucoseFull = data.glucoseReadings.size >= effLimit
+            val eventsFull = data.pumpEvents.size >= effLimit
+            val glucoseMax = data.glucoseReadings.maxOfOrNull { it.readingTimestamp.toEpochMilli() }
+            val eventsMax = data.pumpEvents.maxOfOrNull { it.eventTimestamp.toEpochMilli() }
+            val overallMax = maxOf(cursorMs, glucoseMax ?: cursorMs, eventsMax ?: cursorMs)
+
+            if (!glucoseFull && !eventsFull) {
+                // Both streams fully drained: advance past everything we pulled and stop.
+                cursorMs = overallMax
+                break
+            }
+            // At least one stream is truncated; advance only as far as the lagging full stream so
+            // its un-fetched tail is never skipped. The other stream's re-fetched boundary rows are
+            // harmless (idempotent inserts). A cursor that can't move forward (all rows share the
+            // boundary timestamp) stops the loop.
+            val next = listOfNotNull(
+                glucoseMax.takeIf { glucoseFull },
+                eventsMax.takeIf { eventsFull },
+            ).minOrNull() ?: overallMax
+            if (next <= cursorMs) break
+            cursorMs = next
+        }
+
+        store.lastSyncCursorMs = cursorMs
+        store.recordSyncCompleted(nowMs)
+        Timber.i(
+            "Nightscout sync ok: pages=%d cgm=%d bolus=%d basal=%d",
+            pages, cgmTotal, bolusTotal, basalTotal,
+        )
+        return SyncOutcome.Success(pages, cgmTotal, bolusTotal, basalTotal)
+    }
+
+    private fun <T> Response<T>.bodyOrThrow(): T {
+        if (isSuccessful) {
+            return body() ?: throw SyncTransientError("empty body")
+        }
+        when (code()) {
+            401, 403, 404 -> throw SyncAuthError(code())
+            else -> throw SyncTransientError("http ${code()}")
+        }
+    }
+
+    private class SyncAuthError(val code: Int) : Exception("http $code")
+    private class SyncTransientError(message: String) : Exception(message)
+
+    private companion object {
+        /** Per-array page size; matches the backend's default `limit`. */
+        const val PAGE_LIMIT = 500
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngine.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngine.kt
@@ -129,13 +129,20 @@ class NightscoutSyncEngine @Inject constructor(
             // `ts >= since ORDER BY ts ASC LIMIT n`, so a *short* array is fully drained for this
             // `since` -- only a *full* array may have more rows. Advance only as far as the lagging
             // full stream so its un-fetched tail is never skipped; the other stream's re-fetched
-            // boundary rows are harmless (idempotent inserts). A cursor that can't move forward (all
-            // rows share the boundary timestamp) stops the loop.
+            // boundary rows are harmless (idempotent inserts).
             val next = listOfNotNull(
                 glucoseMax.takeIf { glucoseFull },
                 eventsMax.takeIf { eventsFull },
             ).minOrNull() ?: overallMax
-            if (next <= cursorMs) break
+            if (next <= cursorMs) {
+                // Cursor stall: a full page whose rows all sit on the boundary timestamp, so an
+                // inclusive `since` cursor cannot advance without re-fetching the same page. Persist
+                // the progress made, then surface a retryable error instead of a false success that
+                // would silently drop the un-fetched tail. (Unreachable with real CGM data -- it would
+                // need more than PAGE_LIMIT rows sharing a single millisecond.)
+                store.setCursor(connection.id, cursorMs)
+                throw SyncTransientError("cursor stalled at $cursorMs on a saturated boundary page")
+            }
             cursorMs = next
         }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngine.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngine.kt
@@ -38,7 +38,8 @@ sealed interface SyncOutcome {
  * idempotent DAO inserts (unique `timestampMs` / `(units, timestampMs)` indexes) absorb the
  * boundary-row duplicates the backend warns about -- there is no separate ns_id dedupe pass.
  *
- * Logging is counts + connection id only -- never glucose/insulin values (PHI).
+ * Logging is row counts + HTTP status only -- never glucose/insulin values or connection
+ * credentials (PHI).
  */
 @Singleton
 class NightscoutSyncEngine @Inject constructor(
@@ -51,33 +52,45 @@ class NightscoutSyncEngine @Inject constructor(
         if (!store.enabled) return SyncOutcome.Disabled
         return try {
             val connections = api.listNightscoutConnections().bodyOrThrow().connections
-            val connection = resolveConnection(connections) ?: return SyncOutcome.NoConnection
-            runSync(connection, nowMs)
+            val connection = resolveConnection(connections)
+            if (connection == null) {
+                store.recordStatus(NightscoutSyncStatus.NO_CONNECTION)
+                return SyncOutcome.NoConnection
+            }
+            runSync(connection, nowMs) // records success internally
         } catch (e: SyncAuthError) {
             Timber.w("Nightscout sync gave up (http %d)", e.code)
+            store.recordStatus(NightscoutSyncStatus.AUTH_ERROR)
             SyncOutcome.AuthError
         } catch (e: SyncTransientError) {
             Timber.w("Nightscout sync transient error: %s", e.message)
+            store.recordStatus(NightscoutSyncStatus.ERROR)
             SyncOutcome.Transient
         } catch (e: IOException) {
             Timber.w(e, "Nightscout sync network error")
+            store.recordStatus(NightscoutSyncStatus.ERROR)
             SyncOutcome.Transient
         }
     }
 
     /**
-     * Pick the connection to sync: the user-selected one if it is still present and active,
-     * otherwise the first active connection.
+     * Pick the connection to sync. An explicit user selection is honored only while it is still
+     * active -- if the selected connection was deleted/deactivated we return null (surfaced as
+     * NO_CONNECTION) rather than silently syncing a *different* connection into the same tables.
+     * With no selection, fall back to the first active connection.
      */
     private fun resolveConnection(connections: List<NightscoutConnectionDto>): NightscoutConnectionDto? {
         val active = connections.filter { it.isActive }
         val selectedId = store.selectedConnectionId
-        return active.firstOrNull { selectedId.isNotEmpty() && it.id == selectedId }
-            ?: active.firstOrNull()
+        return if (selectedId.isNotEmpty()) {
+            active.firstOrNull { it.id == selectedId }
+        } else {
+            active.firstOrNull()
+        }
     }
 
     private suspend fun runSync(connection: NightscoutConnectionDto, nowMs: Long): SyncOutcome {
-        var cursorMs = store.lastSyncCursorMs
+        var cursorMs = store.getCursor(connection.id)
         var pages = 0
         var cgmTotal = 0
         var bolusTotal = 0
@@ -112,10 +125,12 @@ class NightscoutSyncEngine @Inject constructor(
                 cursorMs = overallMax
                 break
             }
-            // At least one stream is truncated; advance only as far as the lagging full stream so
-            // its un-fetched tail is never skipped. The other stream's re-fetched boundary rows are
-            // harmless (idempotent inserts). A cursor that can't move forward (all rows share the
-            // boundary timestamp) stops the loop.
+            // At least one stream is truncated. The backend pages each array independently as
+            // `ts >= since ORDER BY ts ASC LIMIT n`, so a *short* array is fully drained for this
+            // `since` -- only a *full* array may have more rows. Advance only as far as the lagging
+            // full stream so its un-fetched tail is never skipped; the other stream's re-fetched
+            // boundary rows are harmless (idempotent inserts). A cursor that can't move forward (all
+            // rows share the boundary timestamp) stops the loop.
             val next = listOfNotNull(
                 glucoseMax.takeIf { glucoseFull },
                 eventsMax.takeIf { eventsFull },
@@ -124,8 +139,8 @@ class NightscoutSyncEngine @Inject constructor(
             cursorMs = next
         }
 
-        store.lastSyncCursorMs = cursorMs
-        store.recordSyncCompleted(nowMs)
+        store.setCursor(connection.id, cursorMs)
+        store.recordSuccess(nowMs)
         Timber.i(
             "Nightscout sync ok: pages=%d cgm=%d bolus=%d basal=%d",
             pages, cgmTotal, bolusTotal, basalTotal,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncManager.kt
@@ -1,0 +1,87 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Owns the WorkManager schedule for the Nightscout-source plugin (Story 43.8).
+ *
+ * Enabling (the plugin's activate toggle, AC1/AC8) flips the persisted flag, schedules
+ * the periodic sync, and kicks off an immediate one-shot sync. Disabling cancels the
+ * schedule but **retains** the cached Room data (AC8). Both the periodic and one-shot
+ * requests require connectivity (AC6); offline simply leaves the last-cached data in place.
+ */
+@Singleton
+class NightscoutSyncManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val store: NightscoutSyncStore,
+) {
+
+    /** Enable syncing: persist the flag, schedule periodic work, and run an initial sync. */
+    fun enable() {
+        store.enabled = true
+        enqueuePeriodic()
+        syncNow()
+        Timber.i("Nightscout-source sync enabled")
+    }
+
+    /** Disable syncing: clear the flag and cancel the schedule. Cached Room data is kept. */
+    fun disable() {
+        store.enabled = false
+        WorkManager.getInstance(context).cancelUniqueWork(PERIODIC_WORK)
+        Timber.i("Nightscout-source sync disabled (cached data retained)")
+    }
+
+    /** Trigger an immediate one-shot sync (the detail screen's "Sync now" action, AC8). */
+    fun syncNow() {
+        val request = OneTimeWorkRequestBuilder<NightscoutSyncWorker>()
+            .setConstraints(networkConstraint())
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            ONESHOT_WORK,
+            ExistingWorkPolicy.REPLACE,
+            request,
+        )
+    }
+
+    private fun enqueuePeriodic() {
+        val request = PeriodicWorkRequestBuilder<NightscoutSyncWorker>(
+            SYNC_INTERVAL_MINUTES, TimeUnit.MINUTES,
+        )
+            .setConstraints(networkConstraint())
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            PERIODIC_WORK,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request,
+        )
+    }
+
+    private fun networkConstraint(): Constraints =
+        Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+    companion object {
+        const val PERIODIC_WORK = "nightscout_source_periodic_sync"
+        const val ONESHOT_WORK = "nightscout_source_oneshot_sync"
+
+        /**
+         * Periodic cadence. WorkManager's periodic floor is 15 minutes; each run fully
+         * backfills everything since the cursor, so a faster Nightscout interval never
+         * loses data -- it only changes freshness (AC3).
+         */
+        const val SYNC_INTERVAL_MINUTES = 15L
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncStore.kt
@@ -5,6 +5,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+/** Outcome class of the most recent sync attempt, surfaced on the dashboard card. */
+enum class NightscoutSyncStatus { NEVER, OK, NO_CONNECTION, AUTH_ERROR, ERROR }
+
+/** The most recent sync state: its [status] plus the wall-clock of the last *successful* sync. */
+data class NightscoutSyncState(
+    val status: NightscoutSyncStatus,
+    val lastSuccessAtMs: Long?,
+)
+
 /**
  * Typed persistence for the Nightscout-source plugin (Story 43.8), backed by the
  * plugin's [PluginSettingsStore] (a per-plugin SharedPreferences file). It holds:
@@ -12,9 +21,9 @@ import kotlinx.coroutines.flow.asStateFlow
  *  - the enabled flag (AC1/AC8 -- the plugin's activate/deactivate toggle),
  *  - the user-selected connection id (written by the detail-screen connection
  *    picker via the same SharedPreferences file),
- *  - the incremental sync cursor (max data timestamp pulled so far, AC2),
- *  - the wall-clock of the last successful sync, surfaced reactively on the
- *    dashboard card via [lastSyncAtMs].
+ *  - a per-connection incremental sync cursor (max data timestamp pulled, AC2),
+ *  - the most recent [NightscoutSyncState], surfaced reactively on the dashboard
+ *    card via [state] so auth/connection errors are visible (AC8).
  *
  * The same singleton instance is shared by the plugin, the sync manager, and the
  * worker (all Hilt-injected), so the worker's writes are visible to the card.
@@ -36,28 +45,45 @@ class NightscoutSyncStore(
     val selectedConnectionId: String
         get() = store.getString(KEY_SELECTED_CONNECTION, "")
 
-    /** Max data timestamp (epoch ms) pulled so far; 0 means "no sync yet" (full backfill). */
-    var lastSyncCursorMs: Long
-        get() = store.getString(KEY_CURSOR, "0").toLongOrNull() ?: 0L
-        set(value) = store.putString(KEY_CURSOR, value.toString())
+    /** Max data timestamp (epoch ms) pulled so far for [connectionId]; 0 means full backfill. */
+    fun getCursor(connectionId: String): Long =
+        store.getString(cursorKey(connectionId), "0").toLongOrNull() ?: 0L
 
-    private val _lastSyncAtMs = MutableStateFlow(readLastSyncAtMs())
-    /** Wall-clock epoch ms of the last successful sync, or null if never synced. */
-    val lastSyncAtMs: StateFlow<Long?> = _lastSyncAtMs.asStateFlow()
-
-    /** Record a successful sync at [nowMs]; updates the persisted value and the card flow. */
-    fun recordSyncCompleted(nowMs: Long) {
-        store.putString(KEY_LAST_SYNC_AT, nowMs.toString())
-        _lastSyncAtMs.value = nowMs
+    fun setCursor(connectionId: String, value: Long) {
+        store.putString(cursorKey(connectionId), value.toString())
     }
 
-    private fun readLastSyncAtMs(): Long? =
-        store.getString(KEY_LAST_SYNC_AT, "").toLongOrNull()
+    private val _state = MutableStateFlow(readState())
+    /** Latest sync state; drives the dashboard card's last-sync line and error badge. */
+    val state: StateFlow<NightscoutSyncState> = _state.asStateFlow()
+
+    /** Record a successful sync at [nowMs]: status OK and a fresh last-success timestamp. */
+    fun recordSuccess(nowMs: Long) {
+        store.putString(KEY_STATUS, NightscoutSyncStatus.OK.name)
+        store.putString(KEY_LAST_SYNC_AT, nowMs.toString())
+        _state.value = NightscoutSyncState(NightscoutSyncStatus.OK, nowMs)
+    }
+
+    /** Record a non-success outcome, preserving the last *successful* sync timestamp. */
+    fun recordStatus(status: NightscoutSyncStatus) {
+        store.putString(KEY_STATUS, status.name)
+        _state.value = _state.value.copy(status = status)
+    }
+
+    private fun readState(): NightscoutSyncState {
+        val status = runCatching { NightscoutSyncStatus.valueOf(store.getString(KEY_STATUS, "")) }
+            .getOrDefault(NightscoutSyncStatus.NEVER)
+        val lastSuccess = store.getString(KEY_LAST_SYNC_AT, "").toLongOrNull()
+        return NightscoutSyncState(status, lastSuccess)
+    }
+
+    private fun cursorKey(connectionId: String) = "$KEY_CURSOR_PREFIX$connectionId"
 
     companion object {
         const val KEY_ENABLED = "enabled"
         const val KEY_SELECTED_CONNECTION = "selected_connection_id"
-        const val KEY_CURSOR = "last_sync_cursor_ms"
+        const val KEY_CURSOR_PREFIX = "last_sync_cursor_ms."
         const val KEY_LAST_SYNC_AT = "last_sync_at_ms"
+        const val KEY_STATUS = "last_sync_status"
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncStore.kt
@@ -1,0 +1,63 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.domain.plugin.PluginSettingsStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Typed persistence for the Nightscout-source plugin (Story 43.8), backed by the
+ * plugin's [PluginSettingsStore] (a per-plugin SharedPreferences file). It holds:
+ *
+ *  - the enabled flag (AC1/AC8 -- the plugin's activate/deactivate toggle),
+ *  - the user-selected connection id (written by the detail-screen connection
+ *    picker via the same SharedPreferences file),
+ *  - the incremental sync cursor (max data timestamp pulled so far, AC2),
+ *  - the wall-clock of the last successful sync, surfaced reactively on the
+ *    dashboard card via [lastSyncAtMs].
+ *
+ * The same singleton instance is shared by the plugin, the sync manager, and the
+ * worker (all Hilt-injected), so the worker's writes are visible to the card.
+ * Longs are stored as strings because [PluginSettingsStore] has no long accessor.
+ */
+class NightscoutSyncStore(
+    private val store: PluginSettingsStore,
+) {
+
+    var enabled: Boolean
+        get() = store.getBoolean(KEY_ENABLED, false)
+        set(value) = store.putBoolean(KEY_ENABLED, value)
+
+    /**
+     * The connection the user picked in the detail-screen dropdown, or "" when none
+     * is chosen (the worker then falls back to the first active connection). The
+     * dropdown persists this under [KEY_SELECTED_CONNECTION] through the same store.
+     */
+    val selectedConnectionId: String
+        get() = store.getString(KEY_SELECTED_CONNECTION, "")
+
+    /** Max data timestamp (epoch ms) pulled so far; 0 means "no sync yet" (full backfill). */
+    var lastSyncCursorMs: Long
+        get() = store.getString(KEY_CURSOR, "0").toLongOrNull() ?: 0L
+        set(value) = store.putString(KEY_CURSOR, value.toString())
+
+    private val _lastSyncAtMs = MutableStateFlow(readLastSyncAtMs())
+    /** Wall-clock epoch ms of the last successful sync, or null if never synced. */
+    val lastSyncAtMs: StateFlow<Long?> = _lastSyncAtMs.asStateFlow()
+
+    /** Record a successful sync at [nowMs]; updates the persisted value and the card flow. */
+    fun recordSyncCompleted(nowMs: Long) {
+        store.putString(KEY_LAST_SYNC_AT, nowMs.toString())
+        _lastSyncAtMs.value = nowMs
+    }
+
+    private fun readLastSyncAtMs(): Long? =
+        store.getString(KEY_LAST_SYNC_AT, "").toLongOrNull()
+
+    companion object {
+        const val KEY_ENABLED = "enabled"
+        const val KEY_SELECTED_CONNECTION = "selected_connection_id"
+        const val KEY_CURSOR = "last_sync_cursor_ms"
+        const val KEY_LAST_SYNC_AT = "last_sync_at_ms"
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncWorker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncWorker.kt
@@ -1,0 +1,32 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+
+/**
+ * Thin WorkManager shell for the Nightscout-source sync (Story 43.8). All logic lives in
+ * [NightscoutSyncEngine] (unit-tested without an Android harness); this just maps the
+ * outcome onto a WorkManager [Result] and never crashes the run.
+ */
+@HiltWorker
+class NightscoutSyncWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val engine: NightscoutSyncEngine,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val outcome = try {
+            engine.syncOnce()
+        } catch (e: Exception) {
+            Timber.e(e, "Nightscout sync worker crashed; will retry")
+            return Result.retry()
+        }
+        return if (outcome is SyncOutcome.Transient) Result.retry() else Result.success()
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncWorker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
 import timber.log.Timber
 
 /**
@@ -23,6 +24,10 @@ class NightscoutSyncWorker @AssistedInject constructor(
     override suspend fun doWork(): Result {
         val outcome = try {
             engine.syncOnce()
+        } catch (e: CancellationException) {
+            // Cooperative cancellation (e.g. WorkManager stopping the work) must propagate, not be
+            // swallowed into a retry.
+            throw e
         } catch (e: Exception) {
             Timber.e(e, "Nightscout sync worker crashed; will retry")
             return Result.retry()

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/FakePluginSettingsStore.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/FakePluginSettingsStore.kt
@@ -1,0 +1,23 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.domain.plugin.PluginSettingsStore
+
+/** Minimal in-memory [PluginSettingsStore] for exercising the Nightscout plugin without Android. */
+internal class FakePluginSettingsStore : PluginSettingsStore {
+    private val strings = mutableMapOf<String, String>()
+    private val booleans = mutableMapOf<String, Boolean>()
+    private val ints = mutableMapOf<String, Int>()
+    private val floats = mutableMapOf<String, Float>()
+
+    override fun getString(key: String, default: String) = strings[key] ?: default
+    override fun putString(key: String, value: String) { strings[key] = value }
+    override fun getBoolean(key: String, default: Boolean) = booleans[key] ?: default
+    override fun putBoolean(key: String, value: Boolean) { booleans[key] = value }
+    override fun getInt(key: String, default: Int) = ints[key] ?: default
+    override fun putInt(key: String, value: Int) { ints[key] = value }
+    override fun getFloat(key: String, default: Float) = floats[key] ?: default
+    override fun putFloat(key: String, value: Float) { floats[key] = value }
+    override fun remove(key: String) {
+        strings.remove(key); booleans.remove(key); ints.remove(key); floats.remove(key)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
@@ -106,6 +106,44 @@ class NightscoutDataMapperTest {
     }
 
     @Test
+    fun `out-of-range glucose readings are dropped`() {
+        val out = NightscoutDataMapper.toCgmEntities(
+            data(
+                glucose = listOf(
+                    glucose(10, "2026-03-01T12:00:00Z"),  // below 20
+                    glucose(95, "2026-03-01T12:05:00Z"),  // valid
+                    glucose(600, "2026-03-01T12:10:00Z"), // above 500
+                )
+            )
+        )
+        assertEquals(1, out.size)
+        assertEquals(95, out[0].glucoseMgDl)
+    }
+
+    @Test
+    fun `negative and over-cap boluses are dropped`() {
+        val out = NightscoutDataMapper.toBolusEntities(
+            data(
+                events = listOf(
+                    event("bolus", "2026-03-01T12:00:00Z", -1.0f),  // negative
+                    event("bolus", "2026-03-01T12:05:00Z", 4.0f),   // valid
+                    event("bolus", "2026-03-01T12:10:00Z", 99.0f),  // over the 25U hard cap
+                )
+            )
+        )
+        assertEquals(1, out.size)
+        assertEquals(4.0f, out[0].units)
+    }
+
+    @Test
+    fun `negative basal rates are dropped`() {
+        val out = NightscoutDataMapper.toBasalEntities(
+            data(events = listOf(event("basal", "2026-03-01T12:00:00Z", -0.5f)))
+        )
+        assertTrue(out.isEmpty())
+    }
+
+    @Test
     fun `basal events map to basal readings with rate`() {
         val out = NightscoutDataMapper.toBasalEntities(
             data(events = listOf(event("basal", "2026-03-01T12:00:00Z", 0.65f, automated = true)))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
@@ -50,6 +50,7 @@ class NightscoutDataMapperTest {
         assertEquals(1, out.size)
         assertEquals(142, out[0].glucoseMgDl)
         assertEquals("SingleUp", out[0].trendArrow)
+        assertEquals(NightscoutDataMapper.SOURCE, out[0].source)
         assertEquals(Instant.parse("2026-03-01T12:00:00Z").toEpochMilli(), out[0].timestampMs)
     }
 
@@ -92,5 +93,6 @@ class NightscoutDataMapperTest {
         assertEquals(1, out.size)
         assertEquals(0.65f, out[0].rate)
         assertEquals(true, out[0].isAutomated)
+        assertEquals(NightscoutDataMapper.SOURCE, out[0].source)
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
@@ -72,17 +72,37 @@ class NightscoutDataMapperTest {
     }
 
     @Test
-    fun `non-delivery and unit-less events are excluded from bolus and basal`() {
+    fun `non-delivery, unit-less, and combo_bolus events are excluded from bolus`() {
         val out = NightscoutDataMapper.toBolusEntities(
             data(
                 events = listOf(
                     event("note", "2026-03-01T12:00:00Z", null),
                     event("bg_reading", "2026-03-01T12:01:00Z", null),
                     event("bolus", "2026-03-01T12:02:00Z", null), // bolus but no units
+                    // combo_bolus is excluded: its units can be an AAPS extended-emulated TBR portion.
+                    event("combo_bolus", "2026-03-01T12:03:00Z", 1.5f),
                 )
             )
         )
         assertTrue(out.isEmpty())
+    }
+
+    @Test
+    fun `unit-less basal events are excluded from basal`() {
+        val out = NightscoutDataMapper.toBasalEntities(
+            data(events = listOf(event("basal", "2026-03-01T12:00:00Z", null)))
+        )
+        assertTrue(out.isEmpty())
+    }
+
+    @Test
+    fun `a correction is automated even when the upload omits the automated flag`() {
+        val out = NightscoutDataMapper.toBolusEntities(
+            data(events = listOf(event("correction", "2026-03-01T12:00:00Z", 0.5f, automated = false)))
+        )
+        assertEquals(1, out.size)
+        assertTrue(out[0].isCorrection)
+        assertTrue(out[0].isAutomated)
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
@@ -1,0 +1,96 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutGlucoseReadingDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutPumpEventDto
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NightscoutDataMapperTest {
+
+    private fun data(
+        glucose: List<NightscoutGlucoseReadingDto> = emptyList(),
+        events: List<NightscoutPumpEventDto> = emptyList(),
+    ) = NightscoutDataDto(
+        connectionId = "c1",
+        fetchedAt = Instant.parse("2026-03-01T12:00:00Z"),
+        effectiveLimitPerArray = 500,
+        glucoseReadings = glucose,
+        pumpEvents = events,
+    )
+
+    private fun glucose(value: Int, ts: String, trend: String = "Flat") =
+        NightscoutGlucoseReadingDto(
+            nsId = "g-$ts",
+            readingTimestamp = Instant.parse(ts),
+            value = value,
+            trend = trend,
+            trendRate = 0.0f,
+            source = "nightscout:c1",
+        )
+
+    private fun event(type: String, ts: String, units: Float?, automated: Boolean = false) =
+        NightscoutPumpEventDto(
+            nsId = "e-$type-$ts",
+            eventTimestamp = Instant.parse(ts),
+            eventType = type,
+            units = units,
+            durationMinutes = null,
+            isAutomated = automated,
+            source = "nightscout:c1",
+        )
+
+    @Test
+    fun `glucose maps to cgm entities with value and epoch ms`() {
+        val out = NightscoutDataMapper.toCgmEntities(
+            data(glucose = listOf(glucose(142, "2026-03-01T12:00:00Z", "SingleUp")))
+        )
+        assertEquals(1, out.size)
+        assertEquals(142, out[0].glucoseMgDl)
+        assertEquals("SingleUp", out[0].trendArrow)
+        assertEquals(Instant.parse("2026-03-01T12:00:00Z").toEpochMilli(), out[0].timestampMs)
+    }
+
+    @Test
+    fun `boluses carry the nightscout-source attribution and correction flag`() {
+        val out = NightscoutDataMapper.toBolusEntities(
+            data(
+                events = listOf(
+                    event("bolus", "2026-03-01T12:00:00Z", 2.5f),
+                    event("correction", "2026-03-01T12:05:00Z", 0.8f, automated = true),
+                )
+            )
+        )
+        assertEquals(2, out.size)
+        assertTrue(out.all { it.source == NightscoutDataMapper.SOURCE })
+        assertEquals(false, out[0].isCorrection)
+        assertEquals(true, out[1].isCorrection)
+        assertEquals(true, out[1].isAutomated)
+    }
+
+    @Test
+    fun `non-delivery and unit-less events are excluded from bolus and basal`() {
+        val out = NightscoutDataMapper.toBolusEntities(
+            data(
+                events = listOf(
+                    event("note", "2026-03-01T12:00:00Z", null),
+                    event("bg_reading", "2026-03-01T12:01:00Z", null),
+                    event("bolus", "2026-03-01T12:02:00Z", null), // bolus but no units
+                )
+            )
+        )
+        assertTrue(out.isEmpty())
+    }
+
+    @Test
+    fun `basal events map to basal readings with rate`() {
+        val out = NightscoutDataMapper.toBasalEntities(
+            data(events = listOf(event("basal", "2026-03-01T12:00:00Z", 0.65f, automated = true)))
+        )
+        assertEquals(1, out.size)
+        assertEquals(0.65f, out[0].rate)
+        assertEquals(true, out[0].isAutomated)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutDataMapperTest.kt
@@ -136,11 +136,18 @@ class NightscoutDataMapperTest {
     }
 
     @Test
-    fun `negative basal rates are dropped`() {
+    fun `negative and over-cap basal rates are dropped`() {
         val out = NightscoutDataMapper.toBasalEntities(
-            data(events = listOf(event("basal", "2026-03-01T12:00:00Z", -0.5f)))
+            data(
+                events = listOf(
+                    event("basal", "2026-03-01T12:00:00Z", -0.5f), // negative
+                    event("basal", "2026-03-01T12:05:00Z", 0.8f),  // valid
+                    event("basal", "2026-03-01T12:10:00Z", 999f),  // absurdly large
+                )
+            )
         )
-        assertTrue(out.isEmpty())
+        assertEquals(1, out.size)
+        assertEquals(0.8f, out[0].rate)
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePluginTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePluginTest.kt
@@ -1,0 +1,126 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
+import com.glycemicgpt.mobile.domain.plugin.PLUGIN_API_VERSION
+import com.glycemicgpt.mobile.domain.plugin.PluginCapability
+import com.glycemicgpt.mobile.domain.plugin.capabilities.GlucoseSource
+import com.glycemicgpt.mobile.domain.plugin.ui.DetailElement
+import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NightscoutSourcePluginTest {
+
+    private val syncManager: NightscoutSyncManager = mockk(relaxed = true)
+    private val store = NightscoutSyncStore(FakePluginSettingsStore())
+    private var connections: List<NightscoutConnectionDto> = emptyList()
+
+    private val plugin = NightscoutSourcePlugin(
+        syncManager = syncManager,
+        store = store,
+        connectionsProvider = { connections },
+    )
+
+    @Test
+    fun `metadata advertises the cloud-mediated Nightscout source`() {
+        val meta = plugin.metadata
+        assertEquals(NightscoutSourcePlugin.PLUGIN_ID, meta.id)
+        assertEquals(PLUGIN_API_VERSION, meta.apiVersion)
+        assertEquals("Nightscout", meta.protocolName)
+    }
+
+    @Test
+    fun `declares only DATA_SYNC so it coexists with BLE plugins`() {
+        assertEquals(setOf(PluginCapability.DATA_SYNC), plugin.capabilities)
+        assertFalse(plugin.capabilities.contains(PluginCapability.GLUCOSE_SOURCE))
+    }
+
+    @Test
+    fun `exposes no capability interfaces`() {
+        assertNull(plugin.getCapability(GlucoseSource::class))
+    }
+
+    @Test
+    fun `activate enables sync and deactivate disables it`() {
+        plugin.onActivated()
+        verify(exactly = 1) { syncManager.enable() }
+
+        plugin.onDeactivated()
+        verify(exactly = 1) { syncManager.disable() }
+    }
+
+    @Test
+    fun `sync-now detail action triggers an immediate sync`() {
+        plugin.onDetailAction(NightscoutSourcePlugin.CARD_ID, NightscoutSourcePlugin.ACTION_SYNC_NOW)
+        verify(exactly = 1) { syncManager.syncNow() }
+    }
+
+    @Test
+    fun `unknown detail action does not trigger a sync`() {
+        plugin.onDetailAction(NightscoutSourcePlugin.CARD_ID, "something_else")
+        plugin.onDetailAction("other_card", NightscoutSourcePlugin.ACTION_SYNC_NOW)
+        verify(exactly = 0) { syncManager.syncNow() }
+    }
+
+    @Test
+    fun `settings descriptor surfaces the cloud-mediated note`() {
+        val items = plugin.settingsDescriptor().sections.flatMap { it.items }
+        assertTrue(items.any { it is SettingDescriptor.InfoText })
+    }
+
+    @Test
+    fun `dashboard card is tappable and shows not-synced before any sync`() = runTest {
+        val cards = plugin.observeDashboardCards().first()
+        assertEquals(1, cards.size)
+        val card = cards.single()
+        assertEquals(NightscoutSourcePlugin.CARD_ID, card.id)
+        assertTrue(card.hasDetail)
+    }
+
+    @Test
+    fun `detail screen offers sync-now and omits the picker for a single connection`() = runTest {
+        connections = listOf(connection("conn-1"))
+        val screen = plugin.observeDetailScreen(NightscoutSourcePlugin.CARD_ID)!!.first()
+
+        val actionKeys = screen.elements
+            .filterIsInstance<DetailElement.Interactive>()
+            .map { it.setting.key }
+        assertTrue(actionKeys.contains(NightscoutSourcePlugin.ACTION_SYNC_NOW))
+        assertFalse(actionKeys.contains(NightscoutSyncStore.KEY_SELECTED_CONNECTION))
+    }
+
+    @Test
+    fun `detail screen shows a connection picker when more than one connection exists`() = runTest {
+        connections = listOf(connection("conn-1"), connection("conn-2"))
+        val screen = plugin.observeDetailScreen(NightscoutSourcePlugin.CARD_ID)!!.first()
+
+        val dropdown = screen.elements
+            .filterIsInstance<DetailElement.Interactive>()
+            .map { it.setting }
+            .filterIsInstance<SettingDescriptor.Dropdown>()
+            .singleOrNull()
+        assertTrue(dropdown != null)
+        assertEquals(NightscoutSyncStore.KEY_SELECTED_CONNECTION, dropdown!!.key)
+        assertEquals(2, dropdown.options.size)
+    }
+
+    @Test
+    fun `detail screen is null for an unrelated card`() {
+        assertNull(plugin.observeDetailScreen("unrelated"))
+    }
+
+    @Test
+    fun `formatLastSync renders a placeholder when never synced`() {
+        assertEquals("Not synced yet", NightscoutSourcePlugin.formatLastSync(null))
+    }
+
+    private fun connection(id: String) =
+        NightscoutConnectionDto(id = id, name = "NS $id", isActive = true)
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePluginTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSourcePluginTest.kt
@@ -1,9 +1,11 @@
 package com.glycemicgpt.mobile.plugin.nightscout
 
+import app.cash.turbine.test
 import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
 import com.glycemicgpt.mobile.domain.plugin.PLUGIN_API_VERSION
 import com.glycemicgpt.mobile.domain.plugin.PluginCapability
 import com.glycemicgpt.mobile.domain.plugin.capabilities.GlucoseSource
+import com.glycemicgpt.mobile.domain.plugin.ui.CardElement
 import com.glycemicgpt.mobile.domain.plugin.ui.DetailElement
 import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
 import io.mockk.mockk
@@ -114,6 +116,23 @@ class NightscoutSourcePluginTest {
     @Test
     fun `detail screen is null for an unrelated card`() {
         assertNull(plugin.observeDetailScreen("unrelated"))
+    }
+
+    @Test
+    fun `detail screen reacts to sync-state changes`() = runTest {
+        connections = listOf(connection("conn-1"))
+        plugin.observeDetailScreen(NightscoutSourcePlugin.CARD_ID)!!.test {
+            val initial = awaitItem()
+            assertFalse(initial.elements.any { it is DetailElement.Display && it.element is CardElement.StatusBadge })
+
+            store.recordStatus(NightscoutSyncStatus.AUTH_ERROR)
+
+            val updated = awaitItem()
+            assertTrue(
+                updated.elements.any { it is DetailElement.Display && it.element is CardElement.StatusBadge },
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngineTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngineTest.kt
@@ -45,6 +45,19 @@ class NightscoutSyncEngineTest {
         val outcome = engine.syncOnce(nowMs = 1000L)
 
         assertEquals(SyncOutcome.NoConnection, outcome)
+        assertEquals(NightscoutSyncStatus.NO_CONNECTION, store.state.value.status)
+        coVerify(exactly = 0) { api.getNightscoutData(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a selected-but-inactive connection is not silently swapped for another`() = runTest {
+        store.enabled = true
+        backing.putString(NightscoutSyncStore.KEY_SELECTED_CONNECTION, "conn-gone")
+        coEvery { api.listNightscoutConnections() } returns Response.success(
+            NightscoutConnectionListDto(listOf(connection("conn-1"))),
+        )
+
+        assertEquals(SyncOutcome.NoConnection, engine.syncOnce(nowMs = 1L))
         coVerify(exactly = 0) { api.getNightscoutData(any(), any(), any()) }
     }
 
@@ -74,8 +87,52 @@ class NightscoutSyncEngineTest {
         coVerify(exactly = 1) { dao.insertBasalBatch(any()) }
         // A short page is the end of data: it must not re-fetch the inclusive boundary forever.
         coVerify(exactly = 1) { api.getNightscoutData(connId, any(), any()) }
-        assertEquals(Instant.parse(T1).toEpochMilli(), store.lastSyncCursorMs)
-        assertEquals(9999L, store.lastSyncAtMs.value)
+        assertEquals(Instant.parse(T1).toEpochMilli(), store.getCursor(connId))
+        assertEquals(NightscoutSyncStatus.OK, store.state.value.status)
+        assertEquals(9999L, store.state.value.lastSuccessAtMs)
+    }
+
+    @Test
+    fun `a full events stream alongside a short glucose stream advances safely and terminates`() = runTest {
+        // Regression for the asymmetric-truncation path: the backend pages each array independently,
+        // so a short glucose array is fully drained even when events are still truncated. The cursor
+        // must follow the lagging full stream (events) without skipping or looping.
+        store.enabled = true
+        coEvery { api.listNightscoutConnections() } returns
+            Response.success(NightscoutConnectionListDto(listOf(connection(connId))))
+        coEvery { api.getNightscoutData(connId, null, 500) } returns Response.success(
+            data(
+                limit = 2,
+                glucose = listOf(glucose(120, T0)),
+                events = listOf(event("bolus", T0, 1.0f), event("bolus", T1, 2.0f)),
+            ),
+        )
+        coEvery { api.getNightscoutData(connId, Instant.parse(T1).toString(), 500) } returns
+            Response.success(data(limit = 2, events = listOf(event("bolus", T2, 3.0f))))
+
+        val outcome = engine.syncOnce(nowMs = 1L)
+
+        assertTrue(outcome is SyncOutcome.Success)
+        assertEquals(2, (outcome as SyncOutcome.Success).pages)
+        assertEquals(Instant.parse(T2).toEpochMilli(), store.getCursor(connId))
+    }
+
+    @Test
+    fun `cursors are tracked per connection`() = runTest {
+        // A cursor for one connection must not leak into a different connection's backfill.
+        store.enabled = true
+        store.setCursor("conn-1", Instant.parse(T2).toEpochMilli())
+        backing.putString(NightscoutSyncStore.KEY_SELECTED_CONNECTION, "conn-2")
+        coEvery { api.listNightscoutConnections() } returns Response.success(
+            NightscoutConnectionListDto(listOf(connection("conn-1"), connection("conn-2"))),
+        )
+        coEvery { api.getNightscoutData("conn-2", null, 500) } returns
+            Response.success(data(limit = 500))
+
+        engine.syncOnce(nowMs = 1L)
+
+        // conn-2 starts a fresh backfill (since=null), unaffected by conn-1's cursor.
+        coVerify(exactly = 1) { api.getNightscoutData("conn-2", null, 500) }
     }
 
     @Test
@@ -97,7 +154,7 @@ class NightscoutSyncEngineTest {
         assertEquals(2, (outcome as SyncOutcome.Success).pages)
         coVerify(exactly = 1) { api.getNightscoutData(connId, null, 500) }
         coVerify(exactly = 1) { api.getNightscoutData(connId, Instant.parse(T1).toString(), 500) }
-        assertEquals(Instant.parse(T2).toEpochMilli(), store.lastSyncCursorMs)
+        assertEquals(Instant.parse(T2).toEpochMilli(), store.getCursor(connId))
     }
 
     @Test
@@ -128,6 +185,7 @@ class NightscoutSyncEngineTest {
             Response.error(401, "unauthorized".toResponseBody(null))
 
         assertEquals(SyncOutcome.AuthError, engine.syncOnce(nowMs = 1L))
+        assertEquals(NightscoutSyncStatus.AUTH_ERROR, store.state.value.status)
     }
 
     @Test
@@ -137,6 +195,7 @@ class NightscoutSyncEngineTest {
             Response.error(503, "down".toResponseBody(null))
 
         assertEquals(SyncOutcome.Transient, engine.syncOnce(nowMs = 1L))
+        assertEquals(NightscoutSyncStatus.ERROR, store.state.value.status)
     }
 
     // -- Fixtures -------------------------------------------------------------

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngineTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngineTest.kt
@@ -1,0 +1,183 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.data.local.dao.PumpDao
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionListDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutGlucoseReadingDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutPumpEventDto
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+import java.time.Instant
+
+class NightscoutSyncEngineTest {
+
+    private val api: GlycemicGptApi = mockk()
+    private val dao: PumpDao = mockk(relaxed = true)
+    private val backing = FakePluginSettingsStore()
+    private val store = NightscoutSyncStore(backing)
+    private val engine = NightscoutSyncEngine(api, dao, store)
+
+    private val connId = "conn-1"
+
+    @Test
+    fun `disabled returns Disabled and makes no api calls`() = runTest {
+        store.enabled = false
+        val outcome = engine.syncOnce(nowMs = 1000L)
+        assertEquals(SyncOutcome.Disabled, outcome)
+        coVerify(exactly = 0) { api.listNightscoutConnections() }
+    }
+
+    @Test
+    fun `no active connection returns NoConnection`() = runTest {
+        store.enabled = true
+        coEvery { api.listNightscoutConnections() } returns
+            Response.success(NightscoutConnectionListDto(listOf(connection(connId, active = false))))
+
+        val outcome = engine.syncOnce(nowMs = 1000L)
+
+        assertEquals(SyncOutcome.NoConnection, outcome)
+        coVerify(exactly = 0) { api.getNightscoutData(any(), any(), any()) }
+    }
+
+    @Test
+    fun `single short page writes rows, advances cursor, and records completion`() = runTest {
+        store.enabled = true
+        coEvery { api.listNightscoutConnections() } returns
+            Response.success(NightscoutConnectionListDto(listOf(connection(connId))))
+        coEvery { api.getNightscoutData(connId, null, 500) } returns Response.success(
+            data(
+                limit = 500,
+                glucose = listOf(glucose(120, T0), glucose(130, T1)),
+                events = listOf(event("bolus", T1, 2.0f), event("basal", T0, 0.7f)),
+            ),
+        )
+
+        val outcome = engine.syncOnce(nowMs = 9999L)
+
+        assertTrue(outcome is SyncOutcome.Success)
+        outcome as SyncOutcome.Success
+        assertEquals(1, outcome.pages)
+        assertEquals(2, outcome.cgm)
+        assertEquals(1, outcome.bolus)
+        assertEquals(1, outcome.basal)
+        coVerify(exactly = 1) { dao.insertCgmBatch(any()) }
+        coVerify(exactly = 1) { dao.insertBoluses(any()) }
+        coVerify(exactly = 1) { dao.insertBasalBatch(any()) }
+        // A short page is the end of data: it must not re-fetch the inclusive boundary forever.
+        coVerify(exactly = 1) { api.getNightscoutData(connId, any(), any()) }
+        assertEquals(Instant.parse(T1).toEpochMilli(), store.lastSyncCursorMs)
+        assertEquals(9999L, store.lastSyncAtMs.value)
+    }
+
+    @Test
+    fun `pages until a short page using an inclusive since cursor`() = runTest {
+        store.enabled = true
+        coEvery { api.listNightscoutConnections() } returns
+            Response.success(NightscoutConnectionListDto(listOf(connection(connId))))
+        // First page fills the (tiny) glucose limit -> more to fetch; second page is short -> stop.
+        coEvery { api.getNightscoutData(connId, null, 500) } returns Response.success(
+            data(limit = 2, glucose = listOf(glucose(100, T0), glucose(110, T1))),
+        )
+        // Second page is fetched with the inclusive cursor set to the first page's max timestamp.
+        coEvery { api.getNightscoutData(connId, Instant.parse(T1).toString(), 500) } returns
+            Response.success(data(limit = 2, glucose = listOf(glucose(120, T2))))
+
+        val outcome = engine.syncOnce(nowMs = 1L)
+
+        assertTrue(outcome is SyncOutcome.Success)
+        assertEquals(2, (outcome as SyncOutcome.Success).pages)
+        coVerify(exactly = 1) { api.getNightscoutData(connId, null, 500) }
+        coVerify(exactly = 1) { api.getNightscoutData(connId, Instant.parse(T1).toString(), 500) }
+        assertEquals(Instant.parse(T2).toEpochMilli(), store.lastSyncCursorMs)
+    }
+
+    @Test
+    fun `resolves the user-selected connection over the first active one`() = runTest {
+        store.enabled = true
+        backing.putString(NightscoutSyncStore.KEY_SELECTED_CONNECTION, "conn-2")
+        coEvery { api.listNightscoutConnections() } returns Response.success(
+            NightscoutConnectionListDto(
+                listOf(connection("conn-1"), connection("conn-2")),
+            ),
+        )
+        coEvery { api.getNightscoutData("conn-2", null, 500) } returns
+            Response.success(data(limit = 500))
+
+        val outcome = engine.syncOnce(nowMs = 1L)
+
+        assertTrue(outcome is SyncOutcome.Success)
+        coVerify(exactly = 1) { api.getNightscoutData("conn-2", null, 500) }
+        coVerify(exactly = 0) { api.getNightscoutData("conn-1", any(), any()) }
+    }
+
+    @Test
+    fun `401 from the data endpoint returns AuthError without retrying`() = runTest {
+        store.enabled = true
+        coEvery { api.listNightscoutConnections() } returns
+            Response.success(NightscoutConnectionListDto(listOf(connection(connId))))
+        coEvery { api.getNightscoutData(connId, null, 500) } returns
+            Response.error(401, "unauthorized".toResponseBody(null))
+
+        assertEquals(SyncOutcome.AuthError, engine.syncOnce(nowMs = 1L))
+    }
+
+    @Test
+    fun `5xx returns Transient so the worker retries`() = runTest {
+        store.enabled = true
+        coEvery { api.listNightscoutConnections() } returns
+            Response.error(503, "down".toResponseBody(null))
+
+        assertEquals(SyncOutcome.Transient, engine.syncOnce(nowMs = 1L))
+    }
+
+    // -- Fixtures -------------------------------------------------------------
+
+    private fun connection(id: String, active: Boolean = true) =
+        NightscoutConnectionDto(id = id, name = "NS $id", isActive = active)
+
+    private fun data(
+        limit: Int,
+        glucose: List<NightscoutGlucoseReadingDto> = emptyList(),
+        events: List<NightscoutPumpEventDto> = emptyList(),
+    ) = NightscoutDataDto(
+        connectionId = connId,
+        fetchedAt = Instant.parse(T0),
+        effectiveLimitPerArray = limit,
+        glucoseReadings = glucose,
+        pumpEvents = events,
+    )
+
+    private fun glucose(value: Int, ts: String) = NightscoutGlucoseReadingDto(
+        nsId = "g-$ts",
+        readingTimestamp = Instant.parse(ts),
+        value = value,
+        trend = "Flat",
+        trendRate = 0f,
+        source = "nightscout:$connId",
+    )
+
+    private fun event(type: String, ts: String, units: Float?) = NightscoutPumpEventDto(
+        nsId = "e-$type-$ts",
+        eventTimestamp = Instant.parse(ts),
+        eventType = type,
+        units = units,
+        durationMinutes = null,
+        isAutomated = false,
+        source = "nightscout:$connId",
+    )
+
+    private companion object {
+        const val T0 = "2026-03-01T12:00:00Z"
+        const val T1 = "2026-03-01T12:05:00Z"
+        const val T2 = "2026-03-01T12:10:00Z"
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngineTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngineTest.kt
@@ -118,6 +118,26 @@ class NightscoutSyncEngineTest {
     }
 
     @Test
+    fun `a saturated boundary page is a retryable stall, not a false success`() = runTest {
+        // A full page whose only row sits exactly on the cursor cannot advance an inclusive cursor.
+        store.enabled = true
+        val boundary = Instant.parse(T1).toEpochMilli()
+        store.setCursor(connId, boundary)
+        coEvery { api.listNightscoutConnections() } returns
+            Response.success(NightscoutConnectionListDto(listOf(connection(connId))))
+        coEvery { api.getNightscoutData(connId, Instant.parse(T1).toString(), 500) } returns
+            Response.success(data(limit = 1, glucose = listOf(glucose(120, T1))))
+
+        val outcome = engine.syncOnce(nowMs = 1L)
+
+        assertEquals(SyncOutcome.Transient, outcome)
+        assertEquals(NightscoutSyncStatus.ERROR, store.state.value.status)
+        // Cursor is preserved (progress not lost), and no clean success was recorded.
+        assertEquals(boundary, store.getCursor(connId))
+        assertEquals(null, store.state.value.lastSuccessAtMs)
+    }
+
+    @Test
     fun `cursors are tracked per connection`() = runTest {
         // A cursor for one connection must not leak into a different connection's backfill.
         store.enabled = true

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -70,6 +70,7 @@ hilt-work-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 
 # DataStore (encrypted settings)
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }

--- a/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
+++ b/plugins/pump-driver-api/src/main/java/com/glycemicgpt/mobile/domain/model/PumpModels.kt
@@ -94,9 +94,15 @@ data class CgmReading(
     val timestamp: Instant,
 ) {
     init {
-        require(glucoseMgDl in 20..500) {
-            "glucoseMgDl must be in 20..500, was $glucoseMgDl"
+        require(glucoseMgDl in MIN_MG_DL..MAX_MG_DL) {
+            "glucoseMgDl must be in $MIN_MG_DL..$MAX_MG_DL, was $glucoseMgDl"
         }
+    }
+
+    companion object {
+        /** Physiologically valid CGM bounds (mg/dL); shared with ingestion-side validation. */
+        const val MIN_MG_DL = 20
+        const val MAX_MG_DL = 500
     }
 }
 


### PR DESCRIPTION
## Mobile Nightscout cloud-source plugin

A built-in, cloud-mediated mobile plugin. When enabled, it pulls the user's Nightscout data from the backend's unified read API into the same Room tables the BLE plugins write, so the mobile dashboard populates without shipping a second Nightscout client on Android. The mobile UI stays source-agnostic.

### Capability design — `DATA_SYNC` only
The plugin declares **only `DATA_SYNC`** (multi-instance), not `GLUCOSE_SOURCE`. A single-instance glucose capability would make `PluginRegistry.activatePlugin` evict an already-active BLE plugin (Tandem/Medtronic also declare `GLUCOSE_SOURCE`), fully deactivating it including its insulin/pump-status slots. `DATA_SYNC` is multi-instance, so the plugin coexists with any active BLE plugin. Data flows via a self-driven WorkManager job, so no capability slot is needed for it to function.

### How it works
- `NightscoutSyncEngine` — incremental paging over `GET /api/integrations/nightscout/{id}/data?since=<ISO>&limit=N`. The `since` cursor is inclusive; idempotent Room writes absorb boundary-row duplicates. Per-array truncation advances only the lagging full stream (a short array means that stream is drained, per the backend's per-array `LIMIT`), so no rows are skipped. A saturated-boundary stall is surfaced as a retryable error rather than a false success. Cursor is tracked per connection.
- `NightscoutSyncManager` / `NightscoutSyncWorker` — WorkManager unique periodic + one-shot sync with a `NetworkType.CONNECTED` constraint. Enabling schedules + kicks an initial sync; disabling cancels the schedule but retains cached data. The worker re-throws `CancellationException` (cooperative cancellation) and retries only on real errors.
- `NightscoutSourcePlugin` — activate/deactivate is the on/off toggle (off by default). Contributes a dashboard card → detail screen (connection picker when more than one, "Sync now" action); both the card and detail screen react live to sync status (no-connection / reconnect-needed / error).
- `NightscoutDataMapper` — DTO → Room entities, `source = "nightscout-source"` per row. Validates at the ingestion boundary: glucose within `CgmReading`'s 20..500, boluses within `BolusEvent.MAX_BOLUS_UNITS`, basal within the `SafetyLimits` ceiling; `combo_bolus` is excluded (ambiguous AAPS extended-emulated temp-basal-rate).
- Room: added a `source` column to `cgm_readings` and `basal_readings` (migration 11→12) so cloud rows carry the same attribution `bolus_events` already had.

### Behavior
- Built-in, listed in Settings → Plugins, off by default.
- When enabled, pulls the unified read endpoint on a periodic WorkManager schedule plus a manual "Sync now".
- Writes to the same Room tables as the BLE plugins, with per-row source attribution; same-timestamp collisions collapse via the existing unique indexes (cgm/basal keep the existing row via `IGNORE`, bolus replaces via `REPLACE`) — no double-counting.
- Coexists with an active BLE plugin.
- Offline shows the last-cached Room data; sync requires connectivity. AI chat is unchanged (it already reads the backend's merged data).
- Enable → initial + periodic sync; disable stops syncing but retains cached data.

### Verification
- Full `:app` unit suite green, including mapper validation, engine paging/cursor/stall/status, and plugin lifecycle + detail-screen reactivity.
- On-device E2E on the emulator: seeded a backend connection + readings, enabled the plugin → dashboard populated within one sync cycle (hero BG, glucose-trend chart with a bolus marker, basal, time-in-range). Confirmed it coexists with an active BLE plugin and that disabling retains the cached data.
- Exercised the sync path on a runtime-instrumented build; no new runtime issues attributable to the change; logs carry only row counts and HTTP status — never glucose/insulin values or credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightscout cloud data source with background and on-demand sync
  * Dashboard card showing Nightscout sync status and last successful sync
  * Support for multiple Nightscout connections and connection selection

* **Chores**
  * Database schema bumped to v12 to support cloud-source attribution

* **Tests**
  * Added unit and migration tests covering Nightscout sync and data mapping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->