### PR TITLE
fix(sidecar): require SIDECAR_API_KEY at startup, fail closed on missing auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ SECRET_KEY=change-me-in-production-use-openssl-rand-hex-32
 # Optional: separate key for credential encryption (falls back to SECRET_KEY)
 # ENCRYPTION_KEY=
 
+# AI sidecar auth -- shared bearer key between the API and the sidecar.
+# Empty is tolerated ONLY by the local dev stack (docker-compose.yml sets
+# SIDECAR_ALLOW_UNAUTHENTICATED=true; the sidecar is not published to the
+# host there). Production templates require a value. Generate with:
+# openssl rand -hex 32
+SIDECAR_API_KEY=
+
 # Logging (json or text)
 LOG_FORMAT=json
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ docker compose up --build -d
 
 # Verify services
 curl localhost:8000/health   # API
-curl localhost:3456/health   # AI sidecar
+docker compose exec api curl -s http://ai-sidecar:3456/health   # AI sidecar (not published to the host)
 # Web UI at http://localhost:3000
 ```
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -64,7 +64,7 @@ Each example includes a `docker-compose.yml` and `.env.example`. See [`examples/
 | `REDIS_URL` | No | `redis://redis:6379/0` | Full Redis URL (overrides bundled Redis) |
 | `IMAGE_TAG` | No | `latest` | Container image version |
 | `CORS_ORIGINS` | No | `[]` | JSON array of allowed CORS origins |
-| `SIDECAR_API_KEY` | No | (none) | Shared key between API and AI sidecar |
+| `SIDECAR_API_KEY` | Yes | (none) | Shared key between API and AI sidecar; the sidecar refuses to start without it. Generate with `openssl rand -hex 32` |
 | `ALLOW_PRIVATE_AI_URLS` | No | `true` | Set `false` for cloud deployments to block private-network AI URLs |
 | `LOG_FORMAT` | No | `json` | `json` or `text` |
 

--- a/deploy/examples/README.md
+++ b/deploy/examples/README.md
@@ -24,6 +24,7 @@ cp .env.example .env
 echo "SECRET_KEY:          $(openssl rand -hex 32)"
 echo "POSTGRES_PASSWORD:   $(openssl rand -hex 32)"
 echo "REDIS_PASSWORD:      $(openssl rand -hex 32)"
+echo "SIDECAR_API_KEY:     $(openssl rand -hex 32)"
 
 # Edit .env with the generated values above,
 # update your domain in CORS_ORIGINS and Caddyfile, then:
@@ -42,6 +43,7 @@ You need separate values for:
 - `SECRET_KEY` -- API session signing
 - `POSTGRES_PASSWORD` -- database access
 - `REDIS_PASSWORD` -- Redis authentication (prod examples)
+- `SIDECAR_API_KEY` -- API-to-sidecar auth; the sidecar refuses to start without it
 
 ## External Redis / Valkey
 

--- a/deploy/examples/cloudflare-tunnel/.env.example
+++ b/deploy/examples/cloudflare-tunnel/.env.example
@@ -22,7 +22,8 @@ REDIS_PASSWORD=
 # API secret key (REQUIRED -- generate: openssl rand -hex 32)
 SECRET_KEY=
 
-# AI Sidecar
+# AI Sidecar -- REQUIRED: the sidecar refuses to start without a key.
+# Generate with: openssl rand -hex 32
 SIDECAR_API_KEY=
 
 # CORS -- required for mobile app access. Replace with your domain:

--- a/deploy/examples/cloudflare-tunnel/README.md
+++ b/deploy/examples/cloudflare-tunnel/README.md
@@ -20,7 +20,7 @@ That guide is written for non-technical users with no prior Cloudflare experienc
 ```bash
 cp .env.example .env
 # Edit .env: paste CLOUDFLARE_TUNNEL_TOKEN, generate POSTGRES_PASSWORD,
-# REDIS_PASSWORD, and SECRET_KEY with: openssl rand -hex 32
+# REDIS_PASSWORD, SECRET_KEY, and SIDECAR_API_KEY with: openssl rand -hex 32
 docker compose up -d
 ```
 

--- a/deploy/examples/cloudflare-tunnel/docker-compose.yml
+++ b/deploy/examples/cloudflare-tunnel/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - sidecar_codex:/home/sidecar/.codex
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
       interval: 15s
@@ -74,7 +74,7 @@ services:
       LOG_FORMAT: ${LOG_FORMAT:-json}
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
       AI_SIDECAR_URL: http://ai-sidecar:3456
-      AI_SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      AI_SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
       CORS_ORIGINS: ${CORS_ORIGINS:-[]}
       ALLOW_PRIVATE_AI_URLS: "false"
     depends_on:

--- a/deploy/examples/external-redis/.env.example
+++ b/deploy/examples/external-redis/.env.example
@@ -19,7 +19,8 @@ POSTGRES_DB=glycemicgpt
 # API secret key (REQUIRED -- generate: openssl rand -hex 32)
 SECRET_KEY=
 
-# AI Sidecar
+# AI Sidecar -- REQUIRED: the sidecar refuses to start without a key.
+# Generate with: openssl rand -hex 32
 SIDECAR_API_KEY=
 
 # Port configuration (if not behind a reverse proxy)

--- a/deploy/examples/external-redis/README.md
+++ b/deploy/examples/external-redis/README.md
@@ -27,6 +27,7 @@ Set:
 | `REDIS_URL` | A full URL pointing at your Redis or Valkey instance, with auth if required. Examples: `redis://:yourpassword@valkey.example.com:6379/0` (single-instance with password) or `redis://valkey.cache.svc.cluster.local:6379/2` (in-cluster Valkey on a specific database number) |
 | `POSTGRES_PASSWORD` | A strong password (run `openssl rand -hex 32`) |
 | `SECRET_KEY` | Generate with `openssl rand -hex 32` |
+| `SIDECAR_API_KEY` | Generate with `openssl rand -hex 32` -- the AI sidecar refuses to start without it |
 
 ### 2. Start the stack
 

--- a/deploy/examples/external-redis/docker-compose.yml
+++ b/deploy/examples/external-redis/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - sidecar_codex:/home/sidecar/.codex
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
       interval: 15s
@@ -55,7 +55,7 @@ services:
       LOG_FORMAT: ${LOG_FORMAT:-json}
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
       AI_SIDECAR_URL: http://ai-sidecar:3456
-      AI_SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      AI_SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
       CORS_ORIGINS: ${CORS_ORIGINS:-[]}
       ALLOW_PRIVATE_AI_URLS: "false"
     depends_on:

--- a/deploy/examples/prod-caddy/.env.example
+++ b/deploy/examples/prod-caddy/.env.example
@@ -17,7 +17,8 @@ REDIS_PASSWORD=
 # API secret key (REQUIRED -- generate: openssl rand -hex 32)
 SECRET_KEY=
 
-# AI Sidecar
+# AI Sidecar -- REQUIRED: the sidecar refuses to start without a key.
+# Generate with: openssl rand -hex 32
 SIDECAR_API_KEY=
 
 # CORS -- required for mobile app access. Replace with your domain:

--- a/deploy/examples/prod-caddy/docker-compose.yml
+++ b/deploy/examples/prod-caddy/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - sidecar_codex:/home/sidecar/.codex
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
       interval: 15s
@@ -79,7 +79,7 @@ services:
       LOG_FORMAT: ${LOG_FORMAT:-json}
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
       AI_SIDECAR_URL: http://ai-sidecar:3456
-      AI_SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      AI_SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
       CORS_ORIGINS: ${CORS_ORIGINS:-[]}
       ALLOW_PRIVATE_AI_URLS: "false"
     depends_on:

--- a/deploy/examples/public-cloud/.env.example
+++ b/deploy/examples/public-cloud/.env.example
@@ -49,6 +49,7 @@ SECRET_KEY=
 # internal API->sidecar requests. It does NOT grant access to any external AI
 # provider; the actual AI provider credentials (your Claude / ChatGPT / OpenAI
 # / Ollama config) are entered by each user in the dashboard.
+# REQUIRED: the sidecar refuses to start without a key.
 # Generate a value with: openssl rand -hex 32
 SIDECAR_API_KEY=
 

--- a/deploy/examples/public-cloud/README.md
+++ b/deploy/examples/public-cloud/README.md
@@ -21,7 +21,7 @@ That guide also covers Docker installation, `.env` hardening for any non-laptop 
 ```bash
 cp .env.example .env
 # Edit .env: set DOMAIN, ACME_EMAIL, and generate POSTGRES_PASSWORD,
-# REDIS_PASSWORD, and SECRET_KEY with: openssl rand -hex 32
+# REDIS_PASSWORD, SECRET_KEY, and SIDECAR_API_KEY with: openssl rand -hex 32
 docker compose up -d
 ```
 

--- a/deploy/examples/public-cloud/docker-compose.yml
+++ b/deploy/examples/public-cloud/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - sidecar_codex:/home/sidecar/.codex
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3456/health"]
       interval: 15s
@@ -90,7 +90,7 @@ services:
       LOG_FORMAT: ${LOG_FORMAT:-json}
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required (generate with: openssl rand -hex 32)}
       AI_SIDECAR_URL: http://ai-sidecar:3456
-      AI_SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      AI_SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
       CORS_ORIGINS: '["https://${DOMAIN}"]'
       COOKIE_SECURE: "true"
       ALLOW_PRIVATE_AI_URLS: "false"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,7 +48,9 @@ services:
       - sidecar_codex:/home/sidecar/.codex
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      # Required: the sidecar refuses to start without a key. Generate with:
+      # openssl rand -hex 32
+      SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
       # Sentry error monitoring (own project) -- empty default = disabled.
       # Runtime-only; never baked into the image (see PRIVACY.md).
       GLYCEMICGPT_SIDECAR_SENTRY_DSN: ${GLYCEMICGPT_SIDECAR_SENTRY_DSN:-}
@@ -73,7 +75,7 @@ services:
       LOG_FORMAT: ${LOG_FORMAT:-json}
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
       AI_SIDECAR_URL: http://ai-sidecar:3456
-      AI_SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      AI_SIDECAR_API_KEY: "${SIDECAR_API_KEY:?SIDECAR_API_KEY is required -- generate with openssl rand -hex 32}"
       # Sentry error monitoring (Sentry for Good) -- empty default = disabled.
       # Set only in the project's own dev/CI/staging; never in a distributed build.
       GLYCEMICGPT_SENTRY_DSN: ${GLYCEMICGPT_SENTRY_DSN:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,10 @@ services:
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-info}
       SIDECAR_API_KEY: ${SIDECAR_API_KEY:-}
+      # Dev-only escape hatch: lets the sidecar start with an empty key since
+      # it is not published to the host here. Production templates require a
+      # key; setting SIDECAR_API_KEY above enforces auth regardless of this.
+      SIDECAR_ALLOW_UNAUTHENTICATED: ${SIDECAR_ALLOW_UNAUTHENTICATED:-true}
       # Sentry error monitoring (own project) -- empty default = disabled.
       # Runtime-only; never baked into the image (see PRIVACY.md).
       GLYCEMICGPT_SIDECAR_SENTRY_DSN: ${GLYCEMICGPT_SIDECAR_SENTRY_DSN:-}

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -97,6 +97,7 @@ Most of GlycemicGPT's behavior is controlled by environment variables in the `.e
 - **`SECRET_KEY`** -- Used to sign authentication tokens. Generate a new value with `openssl rand -hex 32`.
 - **`POSTGRES_PASSWORD`** -- Database password. Generate a new value with `openssl rand -hex 32`.
 - **`REDIS_PASSWORD`** -- Redis password (the public-cloud example requires one). Generate with `openssl rand -hex 32`.
+- **`SIDECAR_API_KEY`** -- Shared key authenticating the API to the AI sidecar. The production templates require it and the sidecar refuses to start without one. Generate with `openssl rand -hex 32`.
 - **`COOKIE_SECURE`** -- Set to `true` when your platform is served over HTTPS. **Set to `false` if you are serving over plain `http://` from a non-localhost address (e.g. a LAN IP)** — otherwise browsers silently drop the session cookie and login appears to succeed but the dashboard bounces back to `/login`. See [Troubleshooting](#troubleshooting) below.
 - **`CORS_ORIGINS`** -- A list of URLs where your dashboard will be served from. The public-cloud example sets this automatically from your `DOMAIN`.
 
@@ -331,6 +332,7 @@ Open `.env` in your editor and fill in:
 | `POSTGRES_PASSWORD` | Run `openssl rand -hex 32` in a terminal, paste output |
 | `REDIS_PASSWORD` | Run `openssl rand -hex 32`, paste output |
 | `SECRET_KEY` | Run `openssl rand -hex 32`, paste output |
+| `SIDECAR_API_KEY` | Run `openssl rand -hex 32`, paste output -- the AI sidecar refuses to start without it |
 | `CORS_ORIGINS` | `["https://glycemicgpt.yourdomain.com"]` (the public hostname you set in step 4) |
 
 ### 6. Start everything
@@ -450,6 +452,7 @@ Edit `.env` and set:
 | `POSTGRES_PASSWORD` | Run `openssl rand -hex 32`, paste output |
 | `REDIS_PASSWORD` | Run `openssl rand -hex 32`, paste output |
 | `SECRET_KEY` | Run `openssl rand -hex 32`, paste output |
+| `SIDECAR_API_KEY` | Run `openssl rand -hex 32`, paste output -- the AI sidecar refuses to start without it |
 
 Leave the other variables at their defaults.
 

--- a/k8s/base/secret.yaml
+++ b/k8s/base/secret.yaml
@@ -30,8 +30,10 @@ stringData:
 
   # AI Sidecar API key - shared between API and sidecar for internal auth.
   # Inject at deploy time (via overlay patch, secret manager, External Secrets,
-  # SealedSecrets, or `kubectl create secret`); do NOT rely on the empty default
-  # below. Generate the value with: openssl rand -hex 32
+  # SealedSecrets, or `kubectl create secret`). The sidecar REFUSES TO START
+  # with an empty key (it will crash-loop until one is provided), so the empty
+  # default below is a placeholder, not a working configuration.
+  # Generate the value with: openssl rand -hex 32
   SIDECAR_API_KEY: ""
 
   # Sentry DSNs -- OPTIONAL, OFF when empty. One per service (each its own Sentry

--- a/sidecar/src/server.ts
+++ b/sidecar/src/server.ts
@@ -13,6 +13,10 @@
  *   POST /auth/start          - return auth method info for a provider
  *   POST /auth/token          - accept token submission
  *   POST /auth/revoke         - revoke stored auth
+ *
+ * Every endpoint except /health requires `Authorization: Bearer $SIDECAR_API_KEY`.
+ * The server refuses to start without a key unless SIDECAR_ALLOW_UNAUTHENTICATED=true
+ * is set explicitly (isolated local development only).
  */
 
 // Sentry must be imported before express/http so it can instrument them; no-op
@@ -22,7 +26,9 @@ import * as Sentry from "@sentry/node";
 import { isSentryEnabled } from "./observability.js";
 
 import express from "express";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import { healthHandler } from "./health.js";
 import { authRouter } from "./auth/oauth-server.js";
 import { claude, codex } from "./providers/index.js";
@@ -32,6 +38,10 @@ const app = express();
 const PORT = parseInt(process.env.SIDECAR_PORT || "3456", 10);
 const BIND_HOST = process.env.SIDECAR_BIND_HOST || "0.0.0.0";
 const SIDECAR_API_KEY = process.env.SIDECAR_API_KEY || "";
+// Explicit opt-out for isolated local development only. Without a key the
+// AI proxy and token-store write/revoke endpoints accept any caller, so an
+// empty key must never be a silent default -- startup fails without this flag.
+const ALLOW_UNAUTHENTICATED = process.env.SIDECAR_ALLOW_UNAUTHENTICATED === "true";
 const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS || "http://localhost:3000")
   .split(",")
   .map((o) => o.trim())
@@ -85,13 +95,20 @@ app.use((req, _res, next) => {
   next();
 });
 
+/** Constant-time string comparison; hashing both sides equalizes lengths. */
+function safeEqual(a: string, b: string): boolean {
+  const digestA = createHash("sha256").update(a).digest();
+  const digestB = createHash("sha256").update(b).digest();
+  return timingSafeEqual(digestA, digestB);
+}
+
 // Bearer token authentication (skip /health for Docker healthchecks)
 app.use((req, res, next) => {
   if (req.path === "/health") return next();
 
   if (SIDECAR_API_KEY) {
     const auth = req.headers.authorization;
-    if (!auth || auth !== `Bearer ${SIDECAR_API_KEY}`) {
+    if (!auth || !safeEqual(auth, `Bearer ${SIDECAR_API_KEY}`)) {
       res.status(401).json({
         error: { message: "Unauthorized", type: "authentication_error" },
       });
@@ -301,11 +318,39 @@ if (isSentryEnabled()) {
 
 // --- Start ---
 
-app.listen(PORT, BIND_HOST, () => {
-  console.log(`AI Sidecar listening on ${BIND_HOST}:${PORT}`);
-  if (!SIDECAR_API_KEY) {
-    console.warn("WARNING: SIDECAR_API_KEY not set. Endpoints are unauthenticated.");
+// Only start listening when executed directly (node dist/server.js); tests
+// import { app } and must not bind a socket or trip the startup guard.
+// realpath both sides: Node resolves symlinks in import.meta.url for the ESM
+// entry but leaves process.argv[1] as given.
+const isMainModule = (() => {
+  if (process.argv[1] === undefined) return false;
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
   }
-});
+})();
+
+if (isMainModule) {
+  if (!SIDECAR_API_KEY && !ALLOW_UNAUTHENTICATED) {
+    console.error(
+      "FATAL: SIDECAR_API_KEY is not set. Generate one with `openssl rand -hex 32` " +
+        "and set it for both the sidecar (SIDECAR_API_KEY) and the API (AI_SIDECAR_API_KEY). " +
+        "For isolated local development only, set SIDECAR_ALLOW_UNAUTHENTICATED=true to " +
+        "run without authentication.",
+    );
+    process.exit(1);
+  }
+
+  app.listen(PORT, BIND_HOST, () => {
+    console.log(`AI Sidecar listening on ${BIND_HOST}:${PORT}`);
+    if (!SIDECAR_API_KEY) {
+      console.warn(
+        "WARNING: running unauthenticated (SIDECAR_ALLOW_UNAUTHENTICATED=true). " +
+          "All endpoints accept any caller.",
+      );
+    }
+  });
+}
 
 export { app };

--- a/sidecar/tests/server.test.ts
+++ b/sidecar/tests/server.test.ts
@@ -4,8 +4,12 @@
  * Uses direct function calls against the app (no HTTP server needed).
  */
 
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import express from "express";
+
+// The unauthenticated suite below requires no key in the environment; a
+// developer's exported SIDECAR_API_KEY would otherwise 401 every request.
+delete process.env.SIDECAR_API_KEY;
 
 // Mock singleton providers
 const mockClaudeComplete = vi.fn().mockResolvedValue({
@@ -65,6 +69,7 @@ async function injectRequest(
   method: "get" | "post",
   path: string,
   body?: unknown,
+  extraHeaders?: Record<string, string>,
 ): Promise<{ status: number; body: unknown; headers: Record<string, string> }> {
   return new Promise((resolve) => {
     const req = {
@@ -72,7 +77,11 @@ async function injectRequest(
       url: path,
       path,
       ip: "127.0.0.1",
-      headers: { "content-type": "application/json", host: "localhost:3456" },
+      headers: {
+        "content-type": "application/json",
+        host: "localhost:3456",
+        ...extraHeaders,
+      },
       params: {},
       body,
       get: () => undefined,
@@ -326,5 +335,61 @@ describe("Server endpoints", () => {
       expect(result.headers["x-content-type-options"]).toBe("nosniff");
       expect(result.headers["x-frame-options"]).toBe("DENY");
     });
+  });
+});
+
+describe("Bearer authentication (SIDECAR_API_KEY set)", () => {
+  let authedApp: express.Express;
+  const TEST_KEY = "test-sidecar-key";
+
+  beforeAll(async () => {
+    vi.resetModules();
+    vi.stubEnv("SIDECAR_API_KEY", TEST_KEY);
+    const mod = await import("../src/server.js");
+    authedApp = mod.app;
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects requests without an Authorization header", async () => {
+    const result = await injectRequest(authedApp, "get", "/v1/models");
+    expect(result.status).toBe(401);
+    const body = result.body as { error: { type: string } };
+    expect(body.error.type).toBe("authentication_error");
+  });
+
+  it("rejects requests with a wrong bearer token", async () => {
+    const result = await injectRequest(authedApp, "get", "/v1/models", undefined, {
+      authorization: "Bearer wrong-key",
+    });
+    expect(result.status).toBe(401);
+  });
+
+  it("rejects a token of different length without throwing", async () => {
+    const result = await injectRequest(authedApp, "get", "/v1/models", undefined, {
+      authorization: `Bearer ${TEST_KEY}-and-more`,
+    });
+    expect(result.status).toBe(401);
+  });
+
+  it("accepts requests with the correct bearer token", async () => {
+    const result = await injectRequest(authedApp, "get", "/v1/models", undefined, {
+      authorization: `Bearer ${TEST_KEY}`,
+    });
+    expect(result.status).toBe(200);
+  });
+
+  it("rejects auth-route requests without a token", async () => {
+    const result = await injectRequest(authedApp, "post", "/auth/revoke", {
+      provider: "claude",
+    });
+    expect(result.status).toBe(401);
+  });
+
+  it("leaves /health reachable without a token (Docker healthcheck)", async () => {
+    const result = await injectRequest(authedApp, "get", "/health");
+    expect(result.status).toBe(200);
   });
 });

--- a/sidecar/tests/startup.test.ts
+++ b/sidecar/tests/startup.test.ts
@@ -7,11 +7,14 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const sidecarRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const tsxCli = path.join(sidecarRoot, "node_modules", "tsx", "dist", "cli.mjs");
+// Resolve through the package exports map so hoisted/workspace installs work;
+// "tsx/dist/cli.mjs" is not an exported subpath.
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
 
 const children: ChildProcess[] = [];
 

--- a/sidecar/tests/startup.test.ts
+++ b/sidecar/tests/startup.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Startup-guard tests: run the real entrypoint as a child process and verify
+ * the SIDECAR_API_KEY enforcement that import-based tests cannot reach (the
+ * guard only runs when the server is executed directly).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const sidecarRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const tsxCli = path.join(sidecarRoot, "node_modules", "tsx", "dist", "cli.mjs");
+
+const children: ChildProcess[] = [];
+
+function startServer(env: Record<string, string>): {
+  child: ChildProcess;
+  output: () => { stdout: string; stderr: string };
+  exited: Promise<number | null>;
+} {
+  const child = spawn(process.execPath, [tsxCli, "src/server.ts"], {
+    cwd: sidecarRoot,
+    env: {
+      ...process.env,
+      SIDECAR_API_KEY: "",
+      SIDECAR_ALLOW_UNAUTHENTICATED: "",
+      SIDECAR_PORT: "0",
+      // Keep transient test listeners off non-loopback interfaces.
+      SIDECAR_BIND_HOST: "127.0.0.1",
+      ...env,
+    },
+  });
+  children.push(child);
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (d: Buffer) => (stdout += d.toString()));
+  child.stderr?.on("data", (d: Buffer) => (stderr += d.toString()));
+  const exited = new Promise<number | null>((resolve) => child.on("exit", resolve));
+  return { child, output: () => ({ stdout, stderr }), exited };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number, describeWait: () => string) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for: ${describeWait()}`);
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+afterEach(() => {
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null) child.kill("SIGKILL");
+  }
+});
+
+describe("startup guard (child process)", () => {
+  it("tsx CLI is present for spawning", () => {
+    expect(existsSync(tsxCli)).toBe(true);
+  });
+
+  it("refuses to start when SIDECAR_API_KEY is empty", async () => {
+    const { output, exited } = startServer({});
+    const code = await exited;
+    expect(code).toBe(1);
+    expect(output().stderr).toContain("FATAL: SIDECAR_API_KEY is not set");
+    expect(output().stdout).not.toContain("AI Sidecar listening");
+  }, 15000);
+
+  it("starts unauthenticated only with the explicit override, and says so", async () => {
+    const { output } = startServer({ SIDECAR_ALLOW_UNAUTHENTICATED: "true" });
+    await waitFor(
+      () =>
+        output().stdout.includes("AI Sidecar listening") &&
+        output().stderr.includes("running unauthenticated"),
+      10000,
+      () => JSON.stringify(output()),
+    );
+  }, 15000);
+
+  it("starts silently authenticated when a key is provided", async () => {
+    const { output } = startServer({ SIDECAR_API_KEY: "startup-test-key" });
+    await waitFor(
+      () => output().stdout.includes("AI Sidecar listening"),
+      10000,
+      () => JSON.stringify(output()),
+    );
+    // Give stderr a beat to flush before asserting the warning is absent.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(output().stderr).not.toContain("running unauthenticated");
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

The AI sidecar previously skipped bearer authentication entirely when `SIDECAR_API_KEY` was empty, and every deployment template defaulted the key to empty. The AI proxy and the token-store write/revoke endpoints (`/auth/token`, `/auth/revoke`) therefore shipped unauthenticated by default, reachable by anything on the docker network or k8s cluster.

## Changes

**Sidecar (`sidecar/src/server.ts`)**
- Refuses to start with an empty `SIDECAR_API_KEY` unless `SIDECAR_ALLOW_UNAUTHENTICATED=true` is set explicitly (dev-only escape hatch). Exits 1 with an actionable message naming both env vars.
- Bearer tokens are now compared in constant time (sha256 + `timingSafeEqual`), fixing a timing side channel and a potential throw on length mismatch.
- `listen()` only runs when executed as the main module (symlink-safe via `realpathSync`), so tests import the app without binding sockets or tripping the startup guard.

**Deployment templates**
- `docker-compose.prod.yml` and all four `deploy/examples` templates now require `SIDECAR_API_KEY` via `${VAR:?}` on both the sidecar and the API side -- `docker compose up` fails fast with generation instructions instead of silently deploying unauthenticated.
- Dev `docker-compose.yml` keeps zero-config `docker compose up` working by setting `SIDECAR_ALLOW_UNAUTHENTICATED` (default `true`); the sidecar is not published to the host there, and setting a key still enforces auth regardless of the flag.
- k8s secret template comment now states the crash-loop behavior on an empty key.

**Docs** -- root `.env.example`, install walkthroughs (`docs/install/docker.md`), all deploy example READMEs, and `deploy/README.md` updated to list the key as required with `openssl rand -hex 32` generation. Root README sidecar health-check command fixed (port 3456 was never published to the host).

**Tests** -- new child-process startup-guard suite (refuses without key / starts with override / starts with key) and bearer-auth middleware tests (401 without/with wrong/wrong-length key, 200 with key, `/health` exemption). 62/62 pass.

## Breaking change / upgrade notes

The refusal-to-start ships in the sidecar image and applies to deployments on old compose files or k8s manifests after their next image pull:

- **docker compose (prod)**: add `SIDECAR_API_KEY=$(openssl rand -hex 32)` to `.env`. Note `${VAR:?}` makes all compose subcommands (including `logs`/`down`) require the var to be set.
- **Kubernetes**: `kubectl create secret` / patch `glycemicgpt-secrets` with a non-empty `SIDECAR_API_KEY`; an empty value crash-loops the sidecar pod by design. The API degrades gracefully while the sidecar is down (AI features return errors; platform stays up).

## Validation

- Sidecar unit tests 62/62, `tsc --noEmit` clean, image builds.
- Live verification: dev stack zero-config boots with explicit warning; in-container guard exits 1 without key; keyed stack returns 401 (no/wrong key) and 200 (correct key), `/health` stays open for healthchecks; API-to-sidecar bearer path returns 200; prod compose and all four deploy examples fail `config` without the key and pass with it.
- Adversarial + senior code reviews completed; all HIGH/MEDIUM findings addressed (doc sweep, startup-guard test coverage, symlink-safe main detection, test env hygiene).
- CodeRabbit CLI: no findings. Security review: PASS.
- Sentry validation gate: stack run with DSNs enabled, auth paths + golden path exercised; glycemicgpt-ai-sidecar and glycemicgpt-web show zero issues in the run window. The single unresolved glycemicgpt-api issue (GLYCEMICGPT-API-3) pre-dates this change (first seen 12 days ago, last seen 2 days ago) and did not recur during validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI sidecar now requires SIDECAR_API_KEY in production; dev can opt out with SIDECAR_ALLOW_UNAUTHENTICATED.
  * Services will fail fast if the required key is missing.

* **Documentation**
  * Updated deployment examples, quick-starts, and install docs with required key guidance and generation instructions.
  * Dev health-check instructions updated to run via the API container.

* **Tests**
  * Added integration and startup tests covering authenticated and unauthenticated sidecar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->