### PR TITLE
fix(api): fail closed on Redis outage for single-use token consumption

### DIFF
--- a/apps/api/src/core/token_blacklist.py
+++ b/apps/api/src/core/token_blacklist.py
@@ -3,21 +3,40 @@
 Provides a Redis-backed token blacklist with TTL matching token expiry.
 Tokens are blacklisted on logout, password change, and token refresh.
 
-Graceful degradation: if Redis is unavailable, tokens are allowed through
-with an error log (fail-open to avoid locking users out).
+Degradation policy when Redis is unavailable (split deliberately):
+
+- ``is_token_blacklisted`` fails OPEN (token allowed, error logged): it guards
+  short-lived access tokens on every authenticated request, so failing closed
+  would lock every user out for the duration of an outage.
+- ``consume_token_once`` fails CLOSED by raising
+  ``TokenConsumeUnavailableError``: it is the only thing standing between a
+  captured refresh token (30-day lifetime) or pairing token and unlimited
+  replay. Single-use cannot be proven without Redis, so consumption must not
+  proceed -- but the outage is surfaced as a distinct error (not a False
+  "replayed" result) so endpoints can return a retryable 503 instead of a 401
+  that clients treat as revocation.
 
 During tests, an in-memory dict is used instead of Redis so that the
 blacklist logic is actually exercised by tests.
 """
 
-import logging
 import time
 
 import redis.asyncio as aioredis
 
 from src.config import settings
+from src.logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
+
+
+class TokenConsumeUnavailableError(Exception):
+    """Single-use consumption could not be performed because Redis is down.
+
+    Distinct from a ``False`` return (genuine replay) so callers can respond
+    with a retryable status instead of treating the token as revoked.
+    """
+
 
 _BLACKLIST_PREFIX = "token:blacklist:"
 
@@ -58,9 +77,7 @@ async def blacklist_token(jti: str, ttl_seconds: int) -> None:
         client = _get_redis()
         await client.setex(f"{_BLACKLIST_PREFIX}{jti}", ttl_seconds, "1")
     except aioredis.RedisError:
-        logger.error(
-            "Failed to blacklist token (Redis unavailable)", extra={"jti": jti}
-        )
+        logger.error("Failed to blacklist token (Redis unavailable)", jti=jti)
 
 
 async def consume_token_once(jti: str, ttl_seconds: int) -> bool:
@@ -77,6 +94,12 @@ async def consume_token_once(jti: str, ttl_seconds: int) -> bool:
     Returns:
         True if the token was successfully consumed (first caller wins).
         False if the token was already consumed (replay attempt).
+
+    Raises:
+        TokenConsumeUnavailableError: if Redis is unavailable. Single-use
+        cannot be proven, so consumption must be denied (fail-closed), but
+        callers should respond with a retryable status -- the token has NOT
+        been consumed and remains valid for a retry after the outage.
     """
     ttl_seconds = max(1, ttl_seconds)
 
@@ -93,12 +116,14 @@ async def consume_token_once(jti: str, ttl_seconds: int) -> bool:
             f"{_BLACKLIST_PREFIX}{jti}", "1", ex=ttl_seconds, nx=True
         )
         return result is not None
-    except aioredis.RedisError:
+    except aioredis.RedisError as e:
         logger.error(
-            "Redis unavailable for token consumption; allowing (fail-open)",
-            extra={"jti": jti},
+            "Redis unavailable for token consumption; denying (fail-closed)",
+            jti=jti,
         )
-        return True  # Fail-open: allow the refresh
+        raise TokenConsumeUnavailableError(
+            "Redis unavailable; single-use consumption denied"
+        ) from e
 
 
 async def is_token_blacklisted(jti: str) -> bool:
@@ -128,6 +153,6 @@ async def is_token_blacklisted(jti: str) -> bool:
     except aioredis.RedisError:
         logger.error(
             "Redis unavailable for blacklist check; allowing token (fail-open)",
-            extra={"jti": jti},
+            jti=jti,
         )
         return False

--- a/apps/api/src/middleware/rate_limit.py
+++ b/apps/api/src/middleware/rate_limit.py
@@ -1,7 +1,6 @@
 """Rate limiting middleware using slowapi.
 
 Protects auth and data push endpoints from abuse.
-Debug builds get relaxed limits via configuration.
 """
 
 import ipaddress
@@ -72,6 +71,14 @@ limiter = Limiter(
     key_func=_get_real_client_ip,
     default_limits=["120/minute"],  # Global default: 120 req/min per IP
     storage_uri=_storage_uri,
+    # Keep limiter Redis I/O bounded like token_blacklist's client; without
+    # timeouts a black-holing Redis blocks the event loop for the OS TCP
+    # timeout before the fallback engages.
+    storage_options={"socket_connect_timeout": 2, "socket_timeout": 2},
+    # Degrade to per-process in-memory counters during a Redis outage instead
+    # of failing every rate-limited request with a 500. Endpoints then surface
+    # their real responses (e.g. the retryable 503 from token refresh).
+    in_memory_fallback_enabled=True,
     enabled=not settings.testing,
 )
 

--- a/apps/api/src/observability.py
+++ b/apps/api/src/observability.py
@@ -204,6 +204,14 @@ def init_sentry() -> None:
     if release in ("", "unknown"):
         release = None
 
+    # Report 5xx as errors EXCEPT 503: we raise 503 deliberately as a
+    # retryable "service temporarily unavailable" response (e.g. token refresh
+    # during a Redis outage). Those are expected degradation, not defects, and
+    # would otherwise flood Sentry with error-grade events during an outage and
+    # mask real issues. The underlying cause still surfaces via the
+    # logger.error breadcrumb/event from the failing component.
+    failed_request_status_codes = set(range(500, 600)) - {503}
+
     sentry_sdk.init(
         dsn=dsn,
         environment=settings.glycemicgpt_sentry_environment,
@@ -217,8 +225,14 @@ def init_sentry() -> None:
         # Route patterns (not raw paths) in transaction names, so path-param
         # values (potential PHI) don't land in transaction names / issue titles.
         integrations=[
-            StarletteIntegration(transaction_style="endpoint"),
-            FastApiIntegration(transaction_style="endpoint"),
+            StarletteIntegration(
+                transaction_style="endpoint",
+                failed_request_status_codes=failed_request_status_codes,
+            ),
+            FastApiIntegration(
+                transaction_style="endpoint",
+                failed_request_status_codes=failed_request_status_codes,
+            ),
         ],
         # --- products we deliberately never enable ---
         enable_logs=False,

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -23,6 +23,7 @@ from src.core.security import (
     verify_password,
 )
 from src.core.token_blacklist import (
+    TokenConsumeUnavailableError,
     blacklist_token,
     consume_token_once,
 )
@@ -53,7 +54,8 @@ router = APIRouter(prefix="/api/auth", tags=["authentication"])
 async def _blacklist_current_token(request: Request) -> None:
     """Extract and blacklist the JWT from the current request.
 
-    Best-effort: silently does nothing if the token cannot be extracted.
+    Best-effort: a token that cannot be revoked here stays valid until
+    expiry, so failures are logged at WARNING rather than swallowed.
     """
     token = None
     cookie_val = request.cookies.get(settings.jwt_cookie_name)
@@ -67,12 +69,22 @@ async def _blacklist_current_token(request: Request) -> None:
     if not token:
         return
 
+    client_ip = request.client.host if request.client else "unknown"
+
     payload = decode_access_token(token)
     if not payload:
+        logger.warning(
+            "Logout: presented token could not be decoded for revocation",
+            client_ip=client_ip,
+        )
         return
 
     jti = payload.get("jti")
     if not jti:
+        logger.warning(
+            "Logout: token has no jti and stays valid until expiry",
+            client_ip=client_ip,
+        )
         return
 
     # TTL = remaining token lifetime (seconds)
@@ -392,6 +404,13 @@ async def mobile_login(
             "model": ErrorResponse,
             "description": "Invalid or expired refresh token",
         },
+        503: {
+            "model": ErrorResponse,
+            "description": (
+                "Token service temporarily unavailable; the refresh token "
+                "was not consumed and the client should retry"
+            ),
+        },
     },
 )
 @limiter.limit("30/minute")
@@ -418,21 +437,46 @@ async def mobile_refresh(
             detail="Invalid or expired refresh token",
         )
 
-    # Atomically consume the refresh token (Story 28.3 -- prevents replay races)
+    # Atomically consume the refresh token (Story 28.3 -- prevents replay races).
+    # A token without a jti cannot be consumed, so it would be infinitely
+    # replayable -- reject it outright.
     old_jti = payload.get("jti")
-    if old_jti:
-        old_exp = payload.get("exp", 0)
-        remaining = int(old_exp - datetime.now(UTC).timestamp())
+    if not old_jti:
+        logger.warning(
+            "Refresh token without jti rejected",
+            client_ip=client_ip,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+    old_exp = payload.get("exp", 0)
+    remaining = int(old_exp - datetime.now(UTC).timestamp())
+    # Fail-closed: a Redis outage denies the refresh rather than letting the
+    # same token mint unlimited new pairs. The outage maps to 503 (not 401)
+    # because mobile clients treat a refresh 401 as revocation and delete
+    # their stored token; on 5xx they keep it and retry -- the token was NOT
+    # consumed and stays valid.
+    try:
         consumed = await consume_token_once(old_jti, max(1, remaining))
-        if not consumed:
-            logger.warning(
-                "Replayed refresh token used",
-                client_ip=client_ip,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid or expired refresh token",
-            )
+    except TokenConsumeUnavailableError:
+        logger.warning(
+            "Refresh denied: token service unavailable (fail-closed)",
+            client_ip=client_ip,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Token service temporarily unavailable. Please retry.",
+        ) from None
+    if not consumed:
+        logger.warning(
+            "Replayed refresh token used",
+            client_ip=client_ip,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
 
     # Look up the user to ensure they still exist and are active
     user_id = uuid_mod.UUID(payload["sub"])

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -50,7 +50,11 @@ from src.core.tandem_regions import (
     country_to_cloud,
     is_legacy_tandem_region,
 )
-from src.core.token_blacklist import consume_token_once, is_token_blacklisted
+from src.core.token_blacklist import (
+    TokenConsumeUnavailableError,
+    consume_token_once,
+    is_token_blacklisted,
+)
 from src.database import get_db
 from src.logging_config import get_logger
 from src.middleware.rate_limit import limiter
@@ -2675,9 +2679,21 @@ async def exchange_medtronic_connect_code(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid or expired pairing token.",
             ) from e
-        if not await consume_token_once(
-            f"medtronic_pair:{jti}", PAIR_TOKEN_TTL_SECONDS
-        ):
+        try:
+            consumed = await consume_token_once(
+                f"medtronic_pair:{jti}", PAIR_TOKEN_TTL_SECONDS
+            )
+        except TokenConsumeUnavailableError:
+            # Fail-closed, but retryable: the token was NOT consumed, so the
+            # same helper command works once the token service is back.
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Pairing service temporarily unavailable. Try again in a "
+                    "few minutes; your pairing token is still valid."
+                ),
+            ) from None
+        if not consumed:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail=(

--- a/apps/api/src/services/integrations/medtronic/connect_pairing.py
+++ b/apps/api/src/services/integrations/medtronic/connect_pairing.py
@@ -21,9 +21,11 @@ token (e.g. a user pasting the helper command somewhere public) from later being
 replayed to attach a different CareLink account. ``/authorize-url`` does not
 consume the token (it only returns an authorize URL and is harmless to repeat).
 The token itself is stateless (Fernet) apart from that one consumed marker.
-Single-use is enforced via Redis and is **best-effort**: ``consume_token_once``
-fails open if Redis is unavailable, so during a Redis outage replay protection
-degrades to the short TTL + user binding alone (we don't lock users out).
+Single-use is enforced via Redis and **fails closed**: ``consume_token_once``
+raises if Redis is unavailable and the exchange returns a retryable 503
+(the token is not consumed, so the same helper command works once Redis is
+back) rather than degrading replay protection to the short TTL + user
+binding alone.
 """
 
 from __future__ import annotations

--- a/apps/api/tests/test_observability.py
+++ b/apps/api/tests/test_observability.py
@@ -81,6 +81,27 @@ def test_init_treats_unknown_release_as_none(monkeypatch):
     assert mock_init.call_args.kwargs["release"] is None
 
 
+def test_init_excludes_503_from_error_reporting(monkeypatch):
+    """503 is a deliberate retryable degradation response (e.g. token refresh
+    during a Redis outage), so it must not be reported as a Sentry error event
+    -- but other 5xx must still be captured."""
+    monkeypatch.setattr(settings, "glycemicgpt_sentry_dsn", _FAKE_DSN)
+    with patch("sentry_sdk.init") as mock_init:
+        init_sentry()
+
+    integrations = mock_init.call_args.kwargs["integrations"]
+    codes_per_integration = [
+        i.failed_request_status_codes
+        for i in integrations
+        if hasattr(i, "failed_request_status_codes")
+    ]
+    assert codes_per_integration, "expected request integrations to be configured"
+    for codes in codes_per_integration:
+        assert 503 not in codes
+        assert 500 in codes
+        assert 504 in codes
+
+
 def test_scrub_text_redacts_secrets_and_identifiers():
     # Assert BOTH that the marker appears AND that the original secret is gone,
     # so a buggy scrubber that only appends a marker (without removing the

--- a/apps/api/tests/test_token_blacklist.py
+++ b/apps/api/tests/test_token_blacklist.py
@@ -1,0 +1,74 @@
+"""Tests for the token blacklist degradation policy (Story 28.3 hardening).
+
+The split policy under Redis failure:
+- ``is_token_blacklisted`` fails OPEN (access-token gate; outage must not lock
+  every user out).
+- ``consume_token_once`` fails CLOSED by raising
+  ``TokenConsumeUnavailableError`` (single-use guard for refresh/pairing
+  tokens; an outage must not grant unlimited replay, but callers must be able
+  to tell it apart from a replay so they can return a retryable status).
+"""
+
+import uuid
+
+import pytest
+import redis.asyncio as aioredis
+
+from src.config import settings
+from src.core import token_blacklist
+from src.core.token_blacklist import (
+    TokenConsumeUnavailableError,
+    blacklist_token,
+    consume_token_once,
+    is_token_blacklisted,
+)
+
+
+def _jti() -> str:
+    return uuid.uuid4().hex
+
+
+class _FailingRedis:
+    """Stub client whose every operation raises RedisError."""
+
+    async def set(self, *args, **kwargs):
+        raise aioredis.RedisError("redis down")
+
+    async def setex(self, *args, **kwargs):
+        raise aioredis.RedisError("redis down")
+
+    async def exists(self, *args, **kwargs):
+        raise aioredis.RedisError("redis down")
+
+
+@pytest.fixture
+def redis_down(monkeypatch):
+    """Route the module at a failing Redis client, bypassing test mode."""
+    monkeypatch.setattr(settings, "testing", False)
+    monkeypatch.setattr(token_blacklist, "_get_redis", lambda: _FailingRedis())
+
+
+class TestRedisUnavailable:
+    async def test_consume_token_once_fails_closed(self, redis_down):
+        with pytest.raises(TokenConsumeUnavailableError):
+            await consume_token_once(_jti(), 60)
+
+    async def test_is_token_blacklisted_fails_open(self, redis_down):
+        assert await is_token_blacklisted(_jti()) is False
+
+    async def test_blacklist_token_swallows_error(self, redis_down):
+        # Best-effort: must not raise.
+        await blacklist_token(_jti(), 60)
+
+
+class TestSingleUseSemantics:
+    async def test_consume_token_once_first_use_wins(self):
+        jti = _jti()
+        assert await consume_token_once(jti, 60) is True
+        assert await consume_token_once(jti, 60) is False
+
+    async def test_blacklisted_token_is_detected(self):
+        jti = _jti()
+        await blacklist_token(jti, 60)
+        assert await is_token_blacklisted(jti) is True
+        assert await is_token_blacklisted(_jti()) is False

--- a/apps/api/tests/test_token_refresh.py
+++ b/apps/api/tests/test_token_refresh.py
@@ -180,28 +180,32 @@ class TestMobileRefreshEndpoint:
 
     async def test_refresh_token_without_jti_returns_401(self):
         """A refresh token lacking a jti cannot be consumed once, so it must
-        be rejected rather than skipping replay protection."""
+        be rejected rather than skipping replay protection. Use a real,
+        active user so the 401 can only come from the missing-jti gate, not
+        from the later user-existence check."""
         from datetime import UTC, datetime, timedelta
 
         from jose import jwt
 
         from src.config import settings
 
-        payload = {
-            "sub": str(uuid.uuid4()),
-            "email": "nojti@test.com",
-            "role": "diabetic",
-            "exp": datetime.now(UTC) + timedelta(days=1),
-            "iat": datetime.now(UTC),
-            "type": "refresh",
-            # no "jti"
-        }
-        token = jwt.encode(
-            payload, settings.secret_key, algorithm=settings.jwt_algorithm
-        )
+        email = _email()
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         ) as c:
+            login_body = await _register_and_mobile_login(c, email)
+            payload = {
+                "sub": login_body["user"]["id"],
+                "email": email,
+                "role": "diabetic",
+                "exp": datetime.now(UTC) + timedelta(days=1),
+                "iat": datetime.now(UTC),
+                "type": "refresh",
+                # no "jti"
+            }
+            token = jwt.encode(
+                payload, settings.secret_key, algorithm=settings.jwt_algorithm
+            )
             resp = await c.post(
                 "/api/auth/mobile/refresh",
                 json={"refresh_token": token},

--- a/apps/api/tests/test_token_refresh.py
+++ b/apps/api/tests/test_token_refresh.py
@@ -137,6 +137,77 @@ class TestMobileRefreshEndpoint:
             )
         assert resp.status_code == 401
 
+    async def test_refresh_token_replay_returns_401(self):
+        """Rotation: a refresh token that was already exchanged is rejected."""
+        email = _email()
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            login_body = await _register_and_mobile_login(c, email)
+            refresh_token = login_body["refresh_token"]
+
+            first = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": refresh_token},
+            )
+            replay = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": refresh_token},
+            )
+        assert first.status_code == 200
+        assert replay.status_code == 401
+
+    async def test_refresh_returns_503_when_consumption_unavailable(self, monkeypatch):
+        """A Redis outage must map to a retryable 503, not a 401 -- mobile
+        clients treat refresh-401 as revocation and delete their token."""
+        from src.core.token_blacklist import TokenConsumeUnavailableError
+        from src.routers import auth as auth_router
+
+        async def _unavailable(jti: str, ttl_seconds: int) -> bool:
+            raise TokenConsumeUnavailableError("redis down")
+
+        email = _email()
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            login_body = await _register_and_mobile_login(c, email)
+            monkeypatch.setattr(auth_router, "consume_token_once", _unavailable)
+            resp = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": login_body["refresh_token"]},
+            )
+        assert resp.status_code == 503
+
+    async def test_refresh_token_without_jti_returns_401(self):
+        """A refresh token lacking a jti cannot be consumed once, so it must
+        be rejected rather than skipping replay protection."""
+        from datetime import UTC, datetime, timedelta
+
+        from jose import jwt
+
+        from src.config import settings
+
+        payload = {
+            "sub": str(uuid.uuid4()),
+            "email": "nojti@test.com",
+            "role": "diabetic",
+            "exp": datetime.now(UTC) + timedelta(days=1),
+            "iat": datetime.now(UTC),
+            "type": "refresh",
+            # no "jti"
+        }
+        token = jwt.encode(
+            payload, settings.secret_key, algorithm=settings.jwt_algorithm
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.post(
+                "/api/auth/mobile/refresh",
+                json={"refresh_token": token},
+            )
+        assert resp.status_code == 401
+
 
 class TestRefreshTokenFunctions:
     def test_create_and_decode_refresh_token(self):

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -710,7 +710,7 @@ wheels = [
 
 [[package]]
 name = "glycemicgpt-api"
-version = "0.8.2"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

`consume_token_once()` -- the Redis SET-NX guard that enforces single-use on refresh tokens and Medtronic pairing tokens -- previously returned `True` (allow) on **any** Redis error. During a Redis outage a captured refresh token could be replayed to mint unlimited new token pairs for the remainder of its 30-day lifetime, defeating rotation (the only protection a long-lived refresh token has). This is audit finding #2 from the 2026-06-10 deep audit.

## Changes

- **`consume_token_once()` now fails closed**: raises `TokenConsumeUnavailableError` on Redis errors instead of allowing. The token is **not** consumed and remains valid for a later retry.
- **`mobile_refresh` maps the outage to 503, not 401.** This distinction matters: the mobile client treats a refresh `401` as definitive revocation and **deletes its stored refresh token**, so returning 401 during a Redis blip would force-log-out the active device fleet. On `5xx` the client keeps its tokens and retries on schedule. A genuine replay still returns 401.
- **Reject refresh tokens without a `jti`** outright -- previously they skipped consumption entirely and were infinitely replayable. (All tokens issued since Epic 28 carry a jti; none in circulation lack one.)
- **Medtronic Connect `/exchange`** gets the same 503-on-outage treatment with an honest "still valid, retry" message; its genuine-replay 401 message is unchanged.
- **Rate limiter** gains `in_memory_fallback_enabled=True` + 2s socket timeouts. Without this, every `@limiter.limit` endpoint returned 500 during a Redis outage (the limiter's Redis storage raised before the handler ran), which would have masked the fail-closed 503. Verified `slowapi` 0.1.9 supports both kwargs.
- **Sentry**: exclude 503 from `failed_request_status_codes` so the deliberate retryable degradation response doesn't flood Sentry with error-grade events during an outage (caught by the Sentry validation gate -- see below). Other 5xx still reported; the underlying cause still surfaces via the component's `logger.error`.
- **`token_blacklist.py` converted to the project `StructuredLogger`** so `jti` context fields actually reach JSON logs (stdlib `extra={}` was silently dropped by `JsonFormatter` -- a separate audit finding).
- **Logout** token-revocation failures are now logged instead of silently swallowed.

`is_token_blacklisted` deliberately **stays fail-open**: it gates short-lived (60 min) access tokens on every authenticated request, so failing closed would lock all users out during an outage. The split policy is documented in the module docstring.

## Validation

- Full API suite green (2437 passed; one unrelated flaky scheduler test confirmed flaky on clean `develop` and passing in isolation). Both ruff gates clean.
- New tests: Redis-outage degradation policy (fail-open check vs fail-closed consume), refresh replay → 401, jti-less → 401, outage → 503 at the endpoint, and the Sentry 503-exclusion config.
- **Live end-to-end**: happy refresh 200 → replay 401; during `docker compose stop redis`: refresh **503** (token not consumed), access token 200 (fail-open preserved), login 200 (no 500 from limiter); after Redis returns, the same refresh token succeeds (200) and a subsequent replay is 401.
- Adversarial + senior reviews completed; all HIGH/MEDIUM findings fixed -- including the mobile force-logout risk (the 401→503 change) and the dropped-`jti`-log finding.
- CodeRabbit CLI: no findings. Security review: PASS (no exploitable oracle; the 503 path is not attacker-inducible; jti-less rejection not bypassable; both `consume_token_once` call sites handle the new exception).
- **Sentry validation gate passed.** The gate caught a real quality regression: the new 503 was being captured as a Sentry *error* event (would flood Sentry on every Redis blip) -- fixed via `failed_request_status_codes`, then re-validated to confirm it no longer reports. All synthetic issues from the induced outage resolved; sidecar and web projects clean.

## Note for reviewers

A pre-existing `CancelledError` in `scheduler.check_escalations_all_users` (background APScheduler job, same `AsyncExitStackMiddleware` family as the existing `GLYCEMICGPT-API-3`) surfaced when Redis was bounced under the live scheduler during validation. It is **not** touched by this change and is tracked separately as a scheduler-robustness follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rate limiting uses an in-memory fallback during Redis outages to avoid 500s
  * Token consumption outages now surface as 503 (retryable) instead of allowing consumption or returning 500
  * Token exchange/refresh flows now enforce replay protection and return 401 for reused or malformed tokens

* **Improvements**
  * Clearer logging for auth token revocation and consumption failures
  * Error reporting updated to exclude 503 from being treated as system errors

* **Tests**
  * New tests covering observability, token-blacklist outage behavior, and mobile refresh scenarios

* **Documentation**
  * Clarified operational degradation behavior for blacklist vs single-use token checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->