### PR TITLE
fix(api): follow Glooko EU sub-cluster redirect when resolving the API host

### DIFF
--- a/apps/api/src/services/integrations/glooko/auth.py
+++ b/apps/api/src/services/integrations/glooko/auth.py
@@ -105,6 +105,26 @@ _CLUSTER_WEB_HOST_RE = re.compile(
     r"^(?P<cluster>[a-z0-9-]+)\.my\.glooko\.com$", re.IGNORECASE
 )
 
+_CLUSTER_API_HOST_RE = re.compile(r"^[a-z0-9-]+\.api\.glooko\.com$", re.IGNORECASE)
+
+
+def validate_glooko_api_host(url: str) -> str:
+    """SSRF-validate a DATA host: must be ``https://<cluster>.api.glooko.com``.
+
+    Stricter than ``validate_glooko_host`` (which also admits the ``*.my.*``
+    web hosts that the login flow legitimately touches): the authenticated
+    session cookie must only ever be replayed against an API host, over TLS.
+    Raises ``ValueError`` on anything else -- fail closed, same posture as
+    ``resolve_region``.
+    """
+    parsed = urlparse(url)
+    name = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not _CLUSTER_API_HOST_RE.match(name):
+        raise ValueError(
+            f"Refusing Glooko data host {url!r}; expected https://<cluster>.api.glooko.com"
+        )
+    return url
+
 
 def derive_api_host(web_url: str) -> str | None:
     """Map a (post-redirect) web URL to its cluster API host, or ``None``.

--- a/apps/api/src/services/integrations/glooko/auth.py
+++ b/apps/api/src/services/integrations/glooko/auth.py
@@ -21,6 +21,15 @@ The resulting ``_logbook-web_session`` cookie (domain ``.glooko.com``) is replay
 by ``GlookoClient`` on the region API host. There is no reliable session TTL from a
 single capture window, so we treat a later data-call 401 as "expired, re-login".
 
+EU sub-cluster routing (live finding, German account): the EU login POST 302s to a
+COUNTRY SUB-CLUSTER web host (e.g. ``de-fr.my.glooko.com``), and the ``eu.*`` /
+apex API hosts then reject every session/data call with ``421 Misdirected
+Request``. The working API host mirrors the sub-cluster web host
+(``de-fr.api.glooko.com``). So after login we derive the API host from the final
+post-redirect web host (``<cluster>.my.glooko.com`` -> ``<cluster>.api.glooko.com``
+-- a rule the US hosts also satisfy) and carry it on the session; the static
+region map is only the fallback when no redirect occurs.
+
 Clean-room attribution: the endpoint paths and form fields were observed
 first-hand from a live capture, not copied from the AGPL-3.0
 ``nightscout-connect`` / ``jpollock`` Glooko sources.
@@ -66,12 +75,51 @@ class GlookoRegion:
 
 
 # Region API/web clusters are REGION-PREFIXED (live finding -- the apex
-# ``api.glooko.com`` is not the per-account host and 422s). EU is exposed but
-# known-fragile (nightscout-connect issue #14) and untested here.
+# ``api.glooko.com`` is not the per-account host and 422s). The EU entry is the
+# LOGIN router only: EU accounts are re-homed to a country sub-cluster by the
+# login redirect (see module docstring), so the EU api_host here is just the
+# fallback for the no-redirect case.
 REGIONS: dict[str, GlookoRegion] = {
     "US": GlookoRegion("US", "https://us.my.glooko.com", "https://us.api.glooko.com"),
     "EU": GlookoRegion("EU", "https://eu.my.glooko.com", "https://eu.api.glooko.com"),
 }
+
+
+def validate_glooko_host(url: str) -> str:
+    """SSRF-validate that ``url``'s host lives under ``glooko.com``; returns ``url``.
+
+    Raises ``ValueError`` on anything else -- same posture as ``resolve_region``
+    (a bad host is a config/programming error, not a runtime auth failure).
+    """
+    name = (urlparse(url).hostname or "").lower()
+    if not (name == _ALLOWED_HOST_SUFFIX or name.endswith("." + _ALLOWED_HOST_SUFFIX)):
+        raise ValueError(
+            f"Refusing Glooko host {name!r} outside {_ALLOWED_HOST_SUFFIX}"
+        )
+    return url
+
+
+#: Post-login web hosts look like ``<cluster>.my.glooko.com`` (``us``, ``eu``,
+#: ``de-fr``, ...). The matching data host swaps the ``my`` label for ``api``.
+_CLUSTER_WEB_HOST_RE = re.compile(
+    r"^(?P<cluster>[a-z0-9-]+)\.my\.glooko\.com$", re.IGNORECASE
+)
+
+
+def derive_api_host(web_url: str) -> str | None:
+    """Map a (post-redirect) web URL to its cluster API host, or ``None``.
+
+    ``https://de-fr.my.glooko.com/...`` -> ``https://de-fr.api.glooko.com``.
+    Returns ``None`` when the host doesn't match the known web-host shape (the
+    caller falls back to the static region map) -- which also means a redirect
+    pointing outside ``*.my.glooko.com`` can never steer data calls anywhere
+    unexpected.
+    """
+    name = (urlparse(web_url).hostname or "").lower()
+    m = _CLUSTER_WEB_HOST_RE.match(name)
+    if m is None:
+        return None
+    return f"https://{m.group('cluster').lower()}.api.glooko.com"
 
 
 def resolve_region(region: str) -> GlookoRegion:
@@ -88,13 +136,7 @@ def resolve_region(region: str) -> GlookoRegion:
             f"Unknown Glooko region {region!r}; expected one of {sorted(REGIONS)}"
         )
     for host in (reg.web_host, reg.api_host):
-        name = (urlparse(host).hostname or "").lower()
-        if not (
-            name == _ALLOWED_HOST_SUFFIX or name.endswith("." + _ALLOWED_HOST_SUFFIX)
-        ):
-            raise ValueError(
-                f"Refusing Glooko host {name!r} outside {_ALLOWED_HOST_SUFFIX}"
-            )
+        validate_glooko_host(host)
     return reg
 
 
@@ -111,6 +153,10 @@ class GlookoSession:
     cookies: dict[str, str]
     patient_slug: str | None = None
     patient_oid: str | None = None
+    #: Cluster API host resolved from the post-login redirect (EU accounts are
+    #: re-homed to country sub-clusters, e.g. ``https://de-fr.api.glooko.com``).
+    #: ``None`` -> the static region api_host applies.
+    api_host: str | None = None
     created_at: float = field(default_factory=time.time)
 
     @property
@@ -221,11 +267,20 @@ async def glooko_login(
                 raise GlookoNetworkError(
                     f"Glooko login server error ({login.status_code})"
                 )
+            # The login may re-home the account to a country sub-cluster
+            # (eu.my -> de-fr.my, observed live); the data host must follow,
+            # or every call below 421s. With redirects followed, ``login.url``
+            # is the final web URL; with an injected no-redirect client, fall
+            # back to the Location header. Unknown host shapes -> region default.
+            final_web_url = str(login.url)
+            if login.is_redirect:
+                final_web_url = login.headers.get("location") or final_web_url
+            api_host = derive_api_host(final_web_url) or reg.api_host
             # The session-users call is the authoritative success oracle: a
             # pre-auth `_logbook-web_session` cookie exists even before login, so
             # cookie-presence alone is not proof. 401 here == bad credentials.
             verify = await http.get(
-                reg.api_host + _SESSION_USERS_PATH,
+                api_host + _SESSION_USERS_PATH,
                 headers={"Accept": "application/json"},
             )
         except httpx.HTTPError as exc:
@@ -266,6 +321,7 @@ async def glooko_login(
             cookies={SESSION_COOKIE_NAME: session_value},
             patient_slug=slug,
             patient_oid=oid,
+            api_host=api_host,
         )
     finally:
         if owns_client:

--- a/apps/api/src/services/integrations/glooko/client.py
+++ b/apps/api/src/services/integrations/glooko/client.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 
 import httpx
 
-from .auth import GlookoSession, resolve_region, validate_glooko_host
+from .auth import GlookoSession, resolve_region, validate_glooko_api_host
 from .errors import GlookoAuthError, GlookoNetworkError, GlookoSyncError
 
 #: First-page sentinel for the keyset cursor. The literal "0" yields a 500; an
@@ -115,10 +115,11 @@ class GlookoClient:
 
         EU accounts are re-homed to country sub-clusters (e.g.
         ``de-fr.api.glooko.com``); the ``eu.*`` hosts 421 every data call. The
-        session value is SSRF-validated like the region hosts.
+        session value must be a TLS API host (``https://<cluster>.api.glooko.com``)
+        -- the authenticated cookie is never replayed against a web host.
         """
         if session.api_host:
-            return validate_glooko_host(session.api_host)
+            return validate_glooko_api_host(session.api_host)
         return self._region.api_host
 
     def _apply_cookies(self) -> None:

--- a/apps/api/src/services/integrations/glooko/client.py
+++ b/apps/api/src/services/integrations/glooko/client.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 
 import httpx
 
-from .auth import GlookoSession, resolve_region
+from .auth import GlookoSession, resolve_region, validate_glooko_host
 from .errors import GlookoAuthError, GlookoNetworkError, GlookoSyncError
 
 #: First-page sentinel for the keyset cursor. The literal "0" yields a 500; an
@@ -102,12 +102,24 @@ class GlookoClient:
     ) -> None:
         self._region = resolve_region(session.region)  # also SSRF-validates the host
         self._session = session
+        self._api_host = self._resolve_api_host(session)
         self._reauth = reauth
         self._owns_client = client is None
         self._client = client or httpx.AsyncClient(
             timeout=httpx.Timeout(timeout_seconds)
         )
         self._apply_cookies()
+
+    def _resolve_api_host(self, session: GlookoSession) -> str:
+        """Prefer the sub-cluster host discovered at login over the region default.
+
+        EU accounts are re-homed to country sub-clusters (e.g.
+        ``de-fr.api.glooko.com``); the ``eu.*`` hosts 421 every data call. The
+        session value is SSRF-validated like the region hosts.
+        """
+        if session.api_host:
+            return validate_glooko_host(session.api_host)
+        return self._region.api_host
 
     def _apply_cookies(self) -> None:
         # The session is stored as ``{_logbook-web_session: value}``; its real domain
@@ -143,7 +155,7 @@ class GlookoClient:
         retry only fires on ``attempt == 0``), so the loop always returns; the trailing
         raise is an explicit unreachable guard rather than a fall-through ``return``.
         """
-        url = self._region.api_host + path
+        url = self._api_host + path
         for attempt in range(_MAX_RETRIES_429 + 1):
             try:
                 resp = await self._client.get(
@@ -199,6 +211,7 @@ class GlookoClient:
                 f"Glooko session expired on {path} and no reauth provider is configured"
             )
         self._session = await self._reauth()
+        self._api_host = self._resolve_api_host(self._session)
         self._apply_cookies()
         resp = await self._send(path, params)
         if resp.status_code in (401, 403):

--- a/apps/api/tests/test_glooko_client.py
+++ b/apps/api/tests/test_glooko_client.py
@@ -143,6 +143,106 @@ async def test_glooko_login_requires_credentials():
         await glooko_login("", "", "US")
 
 
+# ====================== auth: EU sub-cluster redirect =========================
+# Live finding: the EU login 302s to a country sub-cluster web host
+# (eu.my -> de-fr.my), and only the matching sub-cluster API host accepts
+# session/data calls -- the eu.* hosts answer 421 Misdirected Request.
+
+
+async def test_glooko_login_eu_follows_sub_cluster_redirect():
+    def handler(request: httpx.Request) -> httpx.Response:
+        host, path = request.url.host, request.url.path
+        if request.method == "GET" and path == "/users/sign_in":
+            assert host == "eu.my.glooko.com"
+            return httpx.Response(
+                200, html='<meta name="csrf-token" content="csrf-tok-eu" />'
+            )
+        if request.method == "POST" and path == "/users/sign_in":
+            assert host == "eu.my.glooko.com"
+            return httpx.Response(
+                302,
+                headers={
+                    "location": "https://de-fr.my.glooko.com",
+                    "set-cookie": f"{SESSION_COOKIE_NAME}=authed; Domain=glooko.com; Path=/",
+                },
+            )
+        if request.method == "GET" and host == "de-fr.my.glooko.com" and path == "/":
+            return httpx.Response(200, html="<html>landing</html>")
+        if path == "/api/v3/session/users":
+            # Reality check: only the sub-cluster API host works; eu.* 421s.
+            if host == "de-fr.api.glooko.com":
+                return httpx.Response(200, json=_SESSION_USERS_BODY)
+            return httpx.Response(421)
+        raise AssertionError(f"unexpected {request.method} {request.url}")
+
+    async with _mock_client(handler) as http:
+        session = await glooko_login("user@example.com", "pw", "EU", client=http)
+
+    assert session.is_authenticated
+    assert session.api_host == "https://de-fr.api.glooko.com"
+    assert session.patient_slug == "adjective-noun-1234"
+    assert session.region == "EU"
+
+
+async def test_glooko_login_without_redirect_derives_region_host():
+    # US flow: no sub-cluster redirect; the derived host equals the region host.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v3/session/users":
+            return httpx.Response(200, json=_SESSION_USERS_BODY)
+        if request.method == "POST":
+            return httpx.Response(
+                200,
+                headers={
+                    "set-cookie": f"{SESSION_COOKIE_NAME}=authed; Domain=glooko.com; Path=/"
+                },
+            )
+        return httpx.Response(200, html='<meta name="csrf-token" content="t" />')
+
+    async with _mock_client(handler) as http:
+        session = await glooko_login("user@example.com", "pw", "US", client=http)
+
+    assert session.api_host == "https://us.api.glooko.com"
+
+
+async def test_glooko_login_redirect_to_foreign_host_falls_back_to_region():
+    # A redirect outside *.my.glooko.com must NOT steer data calls there: the
+    # derivation returns None and the verify call uses the region default.
+    def handler(request: httpx.Request) -> httpx.Response:
+        host, path = request.url.host, request.url.path
+        if request.method == "POST" and path == "/users/sign_in":
+            return httpx.Response(
+                302,
+                headers={
+                    "location": "https://attacker.example.com",
+                    "set-cookie": f"{SESSION_COOKIE_NAME}=authed; Domain=glooko.com; Path=/",
+                },
+            )
+        if host == "attacker.example.com":
+            return httpx.Response(200, html="<html>not glooko</html>")
+        if path == "/api/v3/session/users":
+            assert host == "eu.api.glooko.com"
+            return httpx.Response(200, json=_SESSION_USERS_BODY)
+        return httpx.Response(200, html='<meta name="csrf-token" content="t" />')
+
+    async with _mock_client(handler) as http:
+        session = await glooko_login("user@example.com", "pw", "EU", client=http)
+
+    assert session.api_host == "https://eu.api.glooko.com"
+
+
+def test_derive_api_host_shapes():
+    from src.services.integrations.glooko.auth import derive_api_host
+
+    assert (
+        derive_api_host("https://de-fr.my.glooko.com/dashboard")
+        == "https://de-fr.api.glooko.com"
+    )
+    assert derive_api_host("https://us.my.glooko.com") == "https://us.api.glooko.com"
+    assert derive_api_host("https://api.glooko.com") is None
+    assert derive_api_host("https://evil.example.com") is None
+    assert derive_api_host("/relative/path") is None
+
+
 # =============================== client: cursor ===============================
 
 
@@ -185,6 +285,33 @@ async def test_fetch_stream_single_page_returns_records_and_cursor():
     assert page.pages_fetched == 1
     assert page.last_page is True
     assert page.records == [{"insulinDelivered": 1.0}]
+
+
+async def test_client_replays_on_session_sub_cluster_host():
+    # A session carrying a sub-cluster api_host (EU live finding) must steer
+    # every data call there, not to the static region host.
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "de-fr.api.glooko.com"
+        return httpx.Response(
+            200,
+            json=_page("normalBoluses", [{"insulinDelivered": 2.0}], last_page=True),
+        )
+
+    async with _mock_client(handler) as http:
+        client = GlookoClient(
+            _session(region="EU", api_host="https://de-fr.api.glooko.com"),
+            client=http,
+        )
+        page = await client.fetch_stream("normal_boluses")
+
+    assert page.records == [{"insulinDelivered": 2.0}]
+
+
+def test_client_rejects_session_host_outside_allowlist():
+    # Defense in depth: a session host outside glooko.com is a config/programming
+    # error and must fail closed at construction (same posture as resolve_region).
+    with pytest.raises(ValueError):
+        GlookoClient(_session(api_host="https://evil.example.com"))
 
 
 async def test_fetch_stream_paginates_until_last_page_and_advances_cursor():

--- a/apps/api/tests/test_glooko_client.py
+++ b/apps/api/tests/test_glooko_client.py
@@ -218,15 +218,23 @@ async def test_glooko_login_redirect_to_foreign_host_falls_back_to_region():
                 },
             )
         if host == "attacker.example.com":
+            # The redirect-following GET itself is browser-equivalent and
+            # unavoidable with follow_redirects -- what must NEVER happen is the
+            # .glooko.com-scoped session cookie travelling along with it.
+            foreign_cookie_headers.append(request.headers.get("cookie"))
             return httpx.Response(200, html="<html>not glooko</html>")
         if path == "/api/v3/session/users":
             assert host == "eu.api.glooko.com"
             return httpx.Response(200, json=_SESSION_USERS_BODY)
         return httpx.Response(200, html='<meta name="csrf-token" content="t" />')
 
+    foreign_cookie_headers: list[str | None] = []
     async with _mock_client(handler) as http:
         session = await glooko_login("user@example.com", "pw", "EU", client=http)
 
+    # No session cookie ever reached the foreign host, and data calls fell back
+    # to the region API host instead of following the rogue redirect.
+    assert foreign_cookie_headers == [None]
     assert session.api_host == "https://eu.api.glooko.com"
 
 
@@ -308,10 +316,18 @@ async def test_client_replays_on_session_sub_cluster_host():
 
 
 def test_client_rejects_session_host_outside_allowlist():
-    # Defense in depth: a session host outside glooko.com is a config/programming
-    # error and must fail closed at construction (same posture as resolve_region).
-    with pytest.raises(ValueError):
-        GlookoClient(_session(api_host="https://evil.example.com"))
+    # Defense in depth: the session data host must be exactly
+    # https://<cluster>.api.glooko.com -- anything else (foreign host, a
+    # *.my.* WEB host, plain http) is a config/programming error and must
+    # fail closed at construction (same posture as resolve_region).
+    for bad in (
+        "https://evil.example.com",
+        "https://us.my.glooko.com",  # legit web host, but NOT a data host
+        "https://api.glooko.com",  # apex, not a per-cluster host
+        "http://us.api.glooko.com",  # right host, no TLS
+    ):
+        with pytest.raises(ValueError):
+            GlookoClient(_session(api_host=bad))
 
 
 async def test_fetch_stream_paginates_until_last_page_and_advances_cursor():


### PR DESCRIPTION
## 📋 Summary

EU Glooko connections always failed at the session check with a 421. Live capture (German account) shows the EU Devise login 302s to a **country sub-cluster** web host (`eu.my` → `de-fr.my.glooko.com`), and only the matching sub-cluster API host (`de-fr.api.glooko.com`) accepts session/data calls — the static `eu.api.glooko.com` answers `421 Misdirected Request` to everything. This PR derives the API host from the post-login redirect and uses it for all data calls.

## 🔗 Related Issues

Fixes #723

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔨 Changes Made

- `auth.py`: new `derive_api_host()` maps the final post-login web host to its cluster API host (`<cluster>.my.glooko.com` → `<cluster>.api.glooko.com` — a rule the US hosts also satisfy). `glooko_login` runs the session-check against the derived host and stores it on a new `GlookoSession.api_host` field. Hosts that don't match the known web-host shape return `None` → fall back to the static region map, so an unexpected redirect can never steer data calls off `*.api.glooko.com`.
- `auth.py`: extracted the existing SSRF suffix check into `validate_glooko_host()` (used by `resolve_region` as before, and now by the client for session-supplied hosts).
- `client.py`: `GlookoClient` replays against `session.api_host` when present (SSRF-validated, fail-closed at construction), refreshed after re-auth; falls back to the region default otherwise. US behavior is unchanged.
- Tests: EU redirect flow (asserting `eu.api` would 421 and the sub-cluster host is used), no-redirect fallback, foreign-host redirect falls back to the region host, `derive_api_host` shapes, client replay on the session host, and fail-closed validation of out-of-allowlist session hosts.

## 🧪 Test Plan

- [x] Unit tests pass (`tests/test_glooko_client.py` 28/28; full Glooko suite 73/73 with Postgres up)
- [x] New tests added for new functionality
- [x] Manual/visual testing performed — **live verification against a real German Glooko account**: `glooko_login(..., "EU")` previously raised `Glooko session check failed (421)`; with this change it resolves `api_host=https://de-fr.api.glooko.com`, discovers the patient slug, and `fetch_stream` paginates normally
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [x] Self-review completed
- [x] Code follows project style guidelines (`ruff check` + `ruff format --check` clean)
- [x] No hardcoded secrets, API keys, or credentials
- [x] Changes generate no new warnings
- [x] Documentation updated (if applicable) — module docstring + REGIONS comment now document the sub-cluster routing; clean-room note: all findings from my own live capture

## 📸 Screenshots (if applicable)

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EU account login now follows post-login redirects and routes data requests to the correct regional API cluster, preventing misdirected requests and login failures due to regional host mismatches.
  * Stricter validation of allowed Glooko hosts to block invalid or foreign hosts.

* **Tests**
  * Added tests covering redirect handling, host validation, and correct API endpoint selection across regional scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->