### PR TITLE
fix(api): harden Glooko host validation, 421 posture, and dose ingestion bounds

### DIFF
--- a/apps/api/src/services/integrations/glooko/auth.py
+++ b/apps/api/src/services/integrations/glooko/auth.py
@@ -12,7 +12,8 @@ one open productionization risk):
 
     1. GET  {web_host}/users/sign_in            -> pre-auth session cookie + CSRF <meta>
     2. POST {web_host}/users/sign_in?id=login_form  (form-urlencoded:
-           authenticity_token, user[email], user[password], commit, language, redirect_to)
+           authenticity_token, user[email], user[password], commit, language, redirect_to;
+           MUST send ``Accept: text/html`` -- see the US edge finding below)
        -> 302; rotates `_logbook-web_session` to an AUTHENTICATED cookie (domain .glooko.com)
     3. GET  {api_host}/api/v3/session/users      -> confirms the session + yields the
            patient slug (the param all data calls key on).
@@ -20,6 +21,16 @@ one open productionization risk):
 The resulting ``_logbook-web_session`` cookie (domain ``.glooko.com``) is replayed
 by ``GlookoClient`` on the region API host. There is no reliable session TTL from a
 single capture window, so we treat a later data-call 401 as "expired, re-login".
+
+US edge content-negotiation (live finding, 2026-06-12): Glooko's US web edge began
+routing the login POST by its ``Accept`` header. A request that admits HTML reaches
+the Devise handler (302/422 as expected); a request with ``*/*`` (httpx's default)
+or ``application/json`` is handed to the JSON API tier, which answers ``421
+Misdirected Request`` *before* checking credentials -- so the login never completes
+and the EU sub-cluster derivation below never runs. The fix is to send ``Accept:
+text/html`` on the POST (the GET already does). A real browser login confirmed US
+stays on ``us.my.glooko.com`` with no sub-cluster redirect, so this is purely an
+edge content-negotiation change, not a re-homing like EU's.
 
 EU sub-cluster routing (live finding, German account): the EU login POST 302s to a
 COUNTRY SUB-CLUSTER web host (e.g. ``de-fr.my.glooko.com``), and the ``eu.*`` /
@@ -292,6 +303,18 @@ async def glooko_login(
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded",
                     "Origin": reg.web_host,
+                    # ``Accept: text/html`` is REQUIRED (US live finding, 2026-06-12).
+                    # Glooko's edge now content-negotiates this POST: a request whose
+                    # Accept admits HTML (``text/html`` / ``application/xhtml+xml``)
+                    # reaches the Devise web handler (302 on success, 422 with the
+                    # "Invalid password or email" flash on bad creds); a request with
+                    # ``*/*`` (httpx's default) or ``application/json`` is routed to the
+                    # JSON API handler, which 421s ("Client tried to access the API
+                    # without proper credentials") before any credential check. Confirmed
+                    # against a real browser login (stays on us.my.glooko.com, no
+                    # sub-cluster redirect) -- so the EU ``derive_api_host`` path can't
+                    # help here; the login POST itself must look like a browser nav.
+                    "Accept": "text/html",
                 },
             )
             if 500 <= login.status_code < 600:

--- a/apps/api/src/services/integrations/glooko/auth.py
+++ b/apps/api/src/services/integrations/glooko/auth.py
@@ -114,12 +114,23 @@ def validate_glooko_api_host(url: str) -> str:
     Stricter than ``validate_glooko_host`` (which also admits the ``*.my.*``
     web hosts that the login flow legitimately touches): the authenticated
     session cookie must only ever be replayed against an API host, over TLS.
+    The value must be a bare origin -- no userinfo, port, path, query, or
+    fragment -- because the client builds request URLs as ``api_host + path``,
+    where any trailing component would silently corrupt every data call.
     Raises ``ValueError`` on anything else -- fail closed, same posture as
     ``resolve_region``.
     """
     parsed = urlparse(url)
     name = (parsed.hostname or "").lower()
-    if parsed.scheme != "https" or not _CLUSTER_API_HOST_RE.match(name):
+    if (
+        parsed.scheme != "https"
+        or not _CLUSTER_API_HOST_RE.match(name)
+        or parsed.netloc.lower() != name  # rejects userinfo@ and :port
+        or parsed.path
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
         raise ValueError(
             f"Refusing Glooko data host {url!r}; expected https://<cluster>.api.glooko.com"
         )
@@ -310,6 +321,18 @@ async def glooko_login(
 
         if verify.status_code in (401, 403):
             raise GlookoAuthError("Glooko login rejected -- check email/password")
+        if verify.status_code == 421:
+            # Misdirected Request: the credentials are fine, the HOST is wrong --
+            # the account lives on a cluster we didn't resolve (e.g. Glooko changed
+            # the sub-cluster redirect shape and we fell back to the region map).
+            # That is a routing problem, not bad credentials: surfacing it as an
+            # auth error would permanently disconnect the user with a misleading
+            # "check email/password" message, when retrying (or a code update)
+            # is the actual remedy.
+            raise GlookoNetworkError(
+                f"Glooko session check misdirected (421) on {api_host}; the "
+                "account may have been re-homed to a cluster we did not resolve"
+            )
         if 500 <= verify.status_code < 600:
             # A server-side error during the session check is transient, not an
             # auth failure -- the orchestrator should retry, not mark for re-auth.

--- a/apps/api/src/services/integrations/glooko/client.py
+++ b/apps/api/src/services/integrations/glooko/client.py
@@ -13,9 +13,10 @@ CGM is NOT in the v2 cursor for an Omnipod-5 account:
     raw per-reading series (``graph/data?series[]=...``) is deferred to a follow-up.
 
 The ``_logbook-web_session`` cookie from ``auth.glooko_login`` is replayed on the
-region API host. A data-call 401 means the session expired; if a ``reauth``
-callback is supplied the client re-logs-in once and retries, else it raises
-``GlookoAuthError`` so the orchestrator can mark the connection for re-auth.
+cluster API host. A data-call 401/403 means the session expired and a 421 means
+the account was re-homed to another cluster; if a ``reauth`` callback is supplied
+the client re-logs-in once (re-deriving the cluster host) and retries, else it
+raises ``GlookoAuthError`` so the orchestrator can mark the connection for re-auth.
 
 Clean-room: endpoints/params observed first-hand (live capture), not copied from
 the AGPL-3.0 nightscout-connect / jpollock Glooko sources.
@@ -90,10 +91,11 @@ class CursorPage:
 
 
 class GlookoClient:
-    """Replays a ``GlookoSession`` against the region API host.
+    """Replays a ``GlookoSession`` against the cluster API host.
 
     ``reauth`` (optional) returns a fresh authenticated session; the client uses
-    it to recover from a single 401 (the sync orchestrator supplies it from stored creds).
+    it to recover from a single auth-recoverable response (401/403/421 -- the
+    sync orchestrator supplies it from stored creds).
     """
 
     def __init__(
@@ -187,10 +189,16 @@ class GlookoClient:
         return min(2.0 * (2**attempt), 30.0) + random.random()
 
     async def _get_json(self, path: str, params: Params) -> dict:
-        """GET returning parsed JSON, recovering from a single 401 via ``reauth``."""
+        """GET returning parsed JSON, recovering from a single 401/403/421 via ``reauth``.
+
+        421 (Misdirected Request) joins the re-auth triggers because it means the
+        account was re-homed to a different cluster mid-session (the EU sub-cluster
+        live finding): a fresh login re-derives the cluster host from the redirect,
+        so the recovery path is identical to an expired session.
+        """
         resp = await self._send(path, params)
-        if resp.status_code in (401, 403):
-            resp = await self._reauth_and_retry(path, params)
+        if resp.status_code in (401, 403, 421):
+            resp = await self._reauth_and_retry(path, params, trigger=resp.status_code)
         # A 5xx (or a 429 that survived the retry budget) is transient -> the typed
         # GlookoNetworkError tells the orchestrator to retry with backoff, not to mark
         # the connection for re-auth. Genuine 4xx/shape problems are GlookoSyncError.
@@ -210,10 +218,13 @@ class GlookoClient:
             )
         return body
 
-    async def _reauth_and_retry(self, path: str, params: Params) -> httpx.Response:
+    async def _reauth_and_retry(
+        self, path: str, params: Params, *, trigger: int
+    ) -> httpx.Response:
         if self._reauth is None:
             raise GlookoAuthError(
-                f"Glooko session expired on {path} and no reauth provider is configured"
+                f"Glooko auth-recoverable response ({trigger}) on {path} and no "
+                "reauth provider is configured"
             )
         self._session = await self._reauth()
         self._api_host = self._resolve_api_host(self._session)
@@ -222,6 +233,13 @@ class GlookoClient:
         if resp.status_code in (401, 403):
             raise GlookoAuthError(
                 f"Glooko re-auth did not recover the session on {path}"
+            )
+        if resp.status_code == 421:
+            # Still misdirected after re-deriving the host: transient posture
+            # (see the 421 rationale in auth.glooko_login).
+            raise GlookoNetworkError(
+                f"Glooko GET {path} still misdirected (421) after re-auth on "
+                f"{self._api_host}"
             )
         return resp
 

--- a/apps/api/src/services/integrations/glooko/mapper.py
+++ b/apps/api/src/services/integrations/glooko/mapper.py
@@ -27,10 +27,15 @@ from src.models.pump_data import PumpEventType
 
 SOURCE = "glooko"
 
-# Physiologic CGM bounds (mg/dL). Drop anything outside so a corrupt/unit-confused
-# value can't poison TIR/alerts/AI context (same defensive stance as Medtronic).
-_SG_MIN_MGDL = 10
-_SG_MAX_MGDL = 600
+# CGM bounds (mg/dL). Drop anything outside so a corrupt/unit-confused value can't
+# poison TIR/alerts/AI context. 20-500 is the platform-wide glucose safety
+# invariant: ``core.treatment_safety.models`` (MIN/MAX_GLUCOSE_MGDL = 20/500) and
+# the AI-context / TIR / stats read filters in ``routers.integrations`` (all clamp
+# to 20..500), plus the ``GlucoseReading`` storage ``ge=20`` floor. A wider
+# Glooko-only bound would just admit values those consumers silently drop, so keep
+# this source consistent with where the data is actually validated and used.
+_SG_MIN_MGDL = 20
+_SG_MAX_MGDL = 500
 
 # Sanity bound on basal rate (U/h) -- reject implausible rates a TDD calc would
 # multiply into a catastrophic daily total.

--- a/apps/api/src/services/integrations/glooko/mapper.py
+++ b/apps/api/src/services/integrations/glooko/mapper.py
@@ -19,6 +19,7 @@ no code copied.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 
@@ -34,6 +35,16 @@ _SG_MAX_MGDL = 600
 # Sanity bound on basal rate (U/h) -- reject implausible rates a TDD calc would
 # multiply into a catastrophic daily total.
 _MAX_BASAL_RATE_UH = 35.0
+
+# Sanity bound on a single bolus/pen dose (U). The largest single actuation of
+# any supported device is the NovoPen 6 at 60 U (pumps cap lower: Tandem 25 U,
+# Omnipod 30 U); anything above is a corrupt or unit-confused record that would
+# poison IoB projection and safety totals (same stance as the basal/CGM bounds).
+# Manual Glooko logs share the bound as corrupt-record protection -- logging
+# concentrated (U-200/U-500) doses above 60 U is out of scope until the
+# platform models insulin concentration.
+_MAX_BOLUS_DOSE_U = 60.0
+
 
 # Glooko pump-events ``type`` -> our PumpEventType. Pod/cartridge/prime lifecycle
 # events all become DEVICE_EVENT (the specific Glooko type is preserved in
@@ -125,6 +136,36 @@ def _is_soft_deleted(r: dict) -> bool:
     return bool(r.get("softDeleted") or r.get("soft_deleted"))
 
 
+def _finite_or_none(value: object) -> float | None:
+    """A finite real number, else ``None``.
+
+    Rejects non-numerics, ``bool`` (an ``int`` in Python, so ``True`` would
+    otherwise ingest as 1.0), and NaN/inf (NaN slips through ``<``/``>`` bounds
+    because every comparison on it is False).
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(value):
+        return None
+    return float(value)
+
+
+def _dose_or_none(value: object, *, allow_zero: bool = False) -> float | None:
+    """A plausible insulin dose in units, else ``None``.
+
+    Bounds a finite number to ``(0, _MAX_BOLUS_DOSE_U]``. ``allow_zero`` admits
+    exactly 0: a suggested pump bolus fully reduced by IoB records 0 delivered
+    while still carrying the meal's carb/BG context worth keeping -- a pen
+    record has no such context and its smallest real actuation is 0.5 U.
+    """
+    dose = _finite_or_none(value)
+    if dose is None:
+        return None
+    if 0 < dose <= _MAX_BOLUS_DOSE_U or (allow_zero and dose == 0):
+        return dose
+    return None
+
+
 def map_cgm_points(points: list[dict]) -> list[MappedGlucose]:
     """Map merged graph/data CGM points (``cgmHigh``∪``cgmNormal``∪``cgmLow``).
 
@@ -153,23 +194,18 @@ def map_scheduled_basals(records: list[dict]) -> list[MappedPumpEvent]:
         if not isinstance(r, dict) or _is_soft_deleted(r):
             continue
         ts = _parse_pump_ts(r.get("pumpTimestamp"), r.get("pumpTimestampUtcOffset"))
-        rate = r.get("rate")
-        if (
-            ts is None
-            or not isinstance(rate, (int, float))
-            or rate < 0
-            or rate > _MAX_BASAL_RATE_UH
-        ):
+        rate = _finite_or_none(r.get("rate"))
+        if ts is None or rate is None or rate < 0 or rate > _MAX_BASAL_RATE_UH:
             continue
-        duration = r.get("duration")
+        duration = _finite_or_none(r.get("duration"))
         out.append(
             MappedPumpEvent(
                 event_type=PumpEventType.BASAL,
                 timestamp=ts,
                 ns_id=_str_or_none(r.get("guid")),
-                units=float(rate),
+                units=rate,
                 duration_minutes=int(duration // 60)
-                if isinstance(duration, (int, float))
+                if duration is not None and duration >= 0
                 else None,
             )
         )
@@ -183,29 +219,25 @@ def map_normal_boluses(records: list[dict]) -> list[MappedPumpEvent]:
         if not isinstance(r, dict) or _is_soft_deleted(r):
             continue
         ts = _parse_pump_ts(r.get("pumpTimestamp"), r.get("pumpTimestampUtcOffset"))
-        delivered = r.get("insulinDelivered")
-        # Reject negative delivery the same way basal rejects negative rates --
-        # a negative dose is impossible and would corrupt insulin totals.
-        if ts is None or not isinstance(delivered, (int, float)) or delivered < 0:
+        # allow_zero: a suggested bolus fully reduced by IoB records 0 delivered
+        # while still carrying the meal's carb/BG context (see _dose_or_none).
+        dose = _dose_or_none(r.get("insulinDelivered"), allow_zero=True)
+        if ts is None or dose is None:
             continue
-        bg = r.get("bloodGlucoseInput")
-        carbs = r.get("carbsInput")
-        iob = r.get("insulinOnBoard")
+        bg = _finite_or_none(r.get("bloodGlucoseInput"))
+        carbs = _finite_or_none(r.get("carbsInput"))
+        iob = _finite_or_none(r.get("insulinOnBoard"))
         out.append(
             MappedPumpEvent(
                 event_type=PumpEventType.BOLUS,
                 timestamp=ts,
                 ns_id=_str_or_none(r.get("guid")),
-                units=float(delivered),
+                units=dose,
                 # Omnipod 5 SmartAdjust auto-bolus shows as type "automatic".
                 is_automated=str(r.get("type", "")).lower() == "automatic",
-                iob_at_event=float(iob) if isinstance(iob, (int, float)) else None,
-                cob_at_event=float(carbs)
-                if isinstance(carbs, (int, float)) and carbs > 0
-                else None,
-                bg_at_event=int(bg)
-                if isinstance(bg, (int, float)) and bg > 0
-                else None,
+                iob_at_event=iob,
+                cob_at_event=carbs if carbs is not None and carbs > 0 else None,
+                bg_at_event=int(bg) if bg is not None and bg > 0 else None,
             )
         )
     return out
@@ -258,6 +290,18 @@ def map_insulins(records: list[dict]) -> list[MappedPumpEvent]:
     * non-``bolus`` ``insulinType`` -- long-acting pen doses don't fit the
       BASAL event's rate (U/h) semantics; deferred like ``extended_boluses``
       (add modeling + mapping together, never one without the other)
+    * a ``units`` field that is present but not ``"units"`` -- an unknown unit
+      of measure would be mis-ingested as insulin units
+    * non-positive or implausibly large doses (``_dose_or_none``; the 60 U
+      single-actuation bound also applies to manual logs -- see the
+      ``_MAX_BOLUS_DOSE_U`` rationale)
+
+    Dose value: ``currentValue`` is preferred whenever PRESENT (falling back to
+    ``value`` only when it is absent). The capture only ever showed them equal,
+    but Glooko carries override fields (``overrideValue`` / ``overriddenAt``)
+    suggesting an edit lands in ``currentValue`` while ``value`` keeps the
+    original -- preferring the current reading is correct in both worlds, and a
+    present-but-implausible ``currentValue`` refuses the record outright.
     """
     out: list[MappedPumpEvent] = []
     for r in records:
@@ -269,10 +313,14 @@ def map_insulins(records: list[dict]) -> list[MappedPumpEvent]:
             continue
         if str(r.get("insulinType", "")).lower() != "bolus":
             continue
+        unit_of_measure = r.get("units")
+        if unit_of_measure is not None and str(unit_of_measure).lower() != "units":
+            continue
         ts = _parse_utc(r.get("timestamp"))
-        value = r.get("value")
-        # Negative doses are impossible -- same guard as map_normal_boluses.
-        if ts is None or not isinstance(value, (int, float)) or value < 0:
+        # currentValue when present, else value (see docstring).
+        current = r.get("currentValue")
+        dose = _dose_or_none(current if current is not None else r.get("value"))
+        if ts is None or dose is None:
             continue
         metadata: dict = {"glooko_stream": "insulins"}
         medication = _str_or_none(r.get("name")) or _str_or_none(
@@ -291,7 +339,7 @@ def map_insulins(records: list[dict]) -> list[MappedPumpEvent]:
                 event_type=PumpEventType.BOLUS,
                 timestamp=ts,
                 ns_id=_str_or_none(r.get("guid")),
-                units=float(value),
+                units=dose,
                 metadata_json=metadata,
             )
         )

--- a/apps/api/src/services/integrations/medtronic/connect_mapper.py
+++ b/apps/api/src/services/integrations/medtronic/connect_mapper.py
@@ -43,12 +43,16 @@ _MARKER_BG_TYPES = {"BG_READING", "BG", "CALIBRATION"}
 # entire sync by days -- this path can't be validated live, so we fail safe.
 _MAX_SKEW_HOURS = 26
 
-# Physiologic sensor-glucose bounds (mg/dL). Medtronic CGM clamps to 40-400;
-# we accept a slightly wider band and DROP anything outside it so a corrupt or
-# unit-confused follower value can't poison TIR/alerts/AI context. (We can't
-# validate this feed against a live pump, so be strict at the boundary.)
-_SG_MIN_MGDL = 10
-_SG_MAX_MGDL = 600
+# Sensor-glucose bounds (mg/dL). Medtronic CGM clamps to 40-400; we DROP anything
+# outside 20-500 so a corrupt or unit-confused follower value can't poison
+# TIR/alerts/AI context (this feed can't be validated against a live pump, so be
+# strict at the boundary). 20-500 is the platform-wide glucose safety invariant:
+# ``core.treatment_safety.models`` (MIN/MAX_GLUCOSE_MGDL = 20/500) and the
+# AI-context / TIR / stats read filters in ``routers.integrations`` (all clamp to
+# 20..500), plus the ``GlucoseReading`` storage ``ge=20`` floor. A wider per-source
+# bound would just admit values those consumers silently drop.
+_SG_MIN_MGDL = 20
+_SG_MAX_MGDL = 500
 
 # Sanity bound on the scheduled basal RATE (U/h). A real basal rate is a few
 # U/h; reject an implausible value rather than store a U/h rate the rate-based

--- a/apps/api/tests/fixtures/glooko/cgm_points.json
+++ b/apps/api/tests/fixtures/glooko/cgm_points.json
@@ -2,9 +2,10 @@
   {"x": 1685577728, "y": 204, "value": 20400, "mealTag": "none", "timestamp": "2023-06-01T00:02:08.000Z", "calculated": false},
   {"x": 1685584628, "y": 180, "value": 18000, "mealTag": "none", "timestamp": "2023-06-01T01:57:08.000Z", "calculated": false},
   {"x": 1685688433, "y": 69, "value": 6900, "mealTag": "none", "timestamp": "2023-06-02T06:47:13.000Z", "calculated": false},
-  {"x": 1685688733, "y": 700, "value": 70000, "mealTag": "none", "timestamp": "2023-06-02T06:52:13.000Z", "calculated": false},
+  {"x": 1685688733, "y": 19, "value": 1900, "mealTag": "none", "timestamp": "2023-06-02T06:52:13.000Z", "calculated": false},
   {"x": 1685688999, "y": null, "value": null, "mealTag": "none", "timestamp": "2023-06-02T06:56:39.000Z", "calculated": true},
-  {"x": 1685689200, "y": 10, "value": 1000, "mealTag": "none", "timestamp": "2023-06-02T07:00:00.000Z", "calculated": false},
-  {"x": 1685689500, "y": 600, "value": 60000, "mealTag": "none", "timestamp": "2023-06-02T07:05:00.000Z", "calculated": false},
-  {"x": 1685689800, "y": 9, "value": 900, "mealTag": "none", "timestamp": "2023-06-02T07:10:00.000Z", "calculated": false}
+  {"x": 1685689200, "y": 20, "value": 2000, "mealTag": "none", "timestamp": "2023-06-02T07:00:00.000Z", "calculated": false},
+  {"x": 1685689500, "y": 500, "value": 50000, "mealTag": "none", "timestamp": "2023-06-02T07:05:00.000Z", "calculated": false},
+  {"x": 1685689800, "y": 501, "value": 50100, "mealTag": "none", "timestamp": "2023-06-02T07:10:00.000Z", "calculated": false},
+  {"x": 1685690100, "y": 700, "value": 70000, "mealTag": "none", "timestamp": "2023-06-02T07:15:00.000Z", "calculated": false}
 ]

--- a/apps/api/tests/test_connect_mapper.py
+++ b/apps/api/tests/test_connect_mapper.py
@@ -287,11 +287,22 @@ def test_implausible_sg_values_are_dropped():
             sgs=[
                 {"sg": 5000, "datetime": "2025-01-31T12:00:00-05:00"},  # absurd high
                 {"sg": 3, "datetime": "2025-01-31T12:05:00-05:00"},  # absurd low
-                {"sg": 120, "datetime": "2025-01-31T12:10:00-05:00"},  # valid
+                {"sg": 19, "datetime": "2025-01-31T12:10:00-05:00"},  # <20 -> drop
+                {
+                    "sg": 20,
+                    "datetime": "2025-01-31T12:15:00-05:00",
+                },  # lower bound -> keep
+                {
+                    "sg": 500,
+                    "datetime": "2025-01-31T12:20:00-05:00",
+                },  # upper bound -> keep
+                {"sg": 501, "datetime": "2025-01-31T12:25:00-05:00"},  # >500 -> drop
+                {"sg": 120, "datetime": "2025-01-31T12:30:00-05:00"},  # valid
             ]
         )
     )
-    assert [g.value_mgdl for g in rec.glucose] == [120]
+    # Bounds match the platform-wide 20-500 glucose invariant (treatment_safety).
+    assert [g.value_mgdl for g in rec.glucose] == [20, 500, 120]
 
 
 def test_large_negative_skew_is_not_applied():

--- a/apps/api/tests/test_glooko_client.py
+++ b/apps/api/tests/test_glooko_client.py
@@ -109,6 +109,26 @@ async def test_glooko_login_bad_credentials_raises_auth_error():
             await glooko_login("user@example.com", "wrong", "US", client=http)
 
 
+async def test_glooko_login_421_is_network_error_not_auth_error():
+    # 421 = wrong host (account re-homed), not bad creds -- must stay retryable,
+    # never a permanent disconnect with a "check email/password" message.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v3/session/users":
+            return httpx.Response(421)
+        if request.method == "POST":
+            return httpx.Response(
+                200,
+                headers={
+                    "set-cookie": f"{SESSION_COOKIE_NAME}=authed; Domain=glooko.com; Path=/"
+                },
+            )
+        return httpx.Response(200, html='<meta name="csrf-token" content="t" />')
+
+    async with _mock_client(handler) as http:
+        with pytest.raises(GlookoNetworkError):
+            await glooko_login("user@example.com", "pw", "EU", client=http)
+
+
 async def test_glooko_login_missing_session_cookie_raises_auth_error():
     # session/users says 200 but no _logbook-web_session cookie was ever set.
     def handler(request: httpx.Request) -> httpx.Response:
@@ -325,6 +345,14 @@ def test_client_rejects_session_host_outside_allowlist():
         "https://us.my.glooko.com",  # legit web host, but NOT a data host
         "https://api.glooko.com",  # apex, not a per-cluster host
         "http://us.api.glooko.com",  # right host, no TLS
+        # A bare origin is required: the client builds URLs as api_host + path,
+        # so userinfo/port/path/query/fragment would corrupt every data call.
+        "https://user:pass@us.api.glooko.com",
+        "https://us.api.glooko.com:9999",
+        "https://us.api.glooko.com/",
+        "https://us.api.glooko.com/some/path",
+        "https://us.api.glooko.com?q=1",
+        "https://us.api.glooko.com#frag",
     ):
         with pytest.raises(ValueError):
             GlookoClient(_session(api_host=bad))
@@ -488,6 +516,47 @@ async def test_second_401_after_reauth_raises_auth_error():
     async with _mock_client(handler) as http:
         client = GlookoClient(_session(), reauth=reauth, client=http)
         with pytest.raises(GlookoAuthError):
+            await client.fetch_stream("normal_boluses")
+
+
+async def test_reauth_on_421_re_derives_cluster_host_and_recovers():
+    # Mid-session cluster re-home: re-auth re-derives the host and the SAME
+    # data call succeeds there in-cycle -- no failed sync tick.
+    state = {"reauths": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "eu.api.glooko.com":
+            return httpx.Response(421)
+        assert request.url.host == "de-fr.api.glooko.com"
+        return httpx.Response(
+            200,
+            json=_page("normalBoluses", [{"insulinDelivered": 1.5}], last_page=True),
+        )
+
+    async def reauth() -> GlookoSession:
+        state["reauths"] += 1
+        return _session(region="EU", api_host="https://de-fr.api.glooko.com")
+
+    async with _mock_client(handler) as http:
+        client = GlookoClient(_session(region="EU"), reauth=reauth, client=http)
+        page = await client.fetch_stream("normal_boluses")
+
+    assert state["reauths"] == 1
+    assert page.records == [{"insulinDelivered": 1.5}]
+
+
+async def test_persistent_421_after_reauth_is_network_error_not_auth_error():
+    # 421 surviving re-auth = Glooko routing problem -- retryable, not a
+    # disconnect.
+    async def reauth() -> GlookoSession:
+        return _session(region="EU")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(421)
+
+    async with _mock_client(handler) as http:
+        client = GlookoClient(_session(region="EU"), reauth=reauth, client=http)
+        with pytest.raises(GlookoNetworkError):
             await client.fetch_stream("normal_boluses")
 
 

--- a/apps/api/tests/test_glooko_client.py
+++ b/apps/api/tests/test_glooko_client.py
@@ -96,6 +96,34 @@ async def test_glooko_login_runs_full_devise_flow_and_discovers_patient():
     assert session.region == "US"
 
 
+async def test_glooko_login_post_sends_html_accept_header():
+    # US live finding (2026-06-12): Glooko's edge content-negotiates the login POST
+    # by Accept. Without an HTML-admitting Accept it routes to the JSON API tier and
+    # 421s before checking credentials, so the login can never succeed. Pin that the
+    # POST advertises text/html (the GET already does).
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST" and path == "/users/sign_in":
+            seen["accept"] = request.headers.get("accept")
+            return httpx.Response(
+                200,
+                headers={
+                    "set-cookie": f"{SESSION_COOKIE_NAME}=authed; Domain=glooko.com; Path=/"
+                },
+            )
+        if path == "/api/v3/session/users":
+            return httpx.Response(200, json=_SESSION_USERS_BODY)
+        return httpx.Response(200, html='<meta name="csrf-token" content="t" />')
+
+    async with _mock_client(handler) as http:
+        await glooko_login("user@example.com", "pw", "US", client=http)
+
+    assert seen["accept"] is not None
+    assert "text/html" in seen["accept"].lower()
+
+
 async def test_glooko_login_bad_credentials_raises_auth_error():
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/api/v3/session/users":

--- a/apps/api/tests/test_glooko_mapper.py
+++ b/apps/api/tests/test_glooko_mapper.py
@@ -36,9 +36,10 @@ def _load(name: str) -> list[dict]:
 
 def test_map_cgm_points_value_unit_and_utc():
     points = mapper.map_cgm_points(_load("cgm_points.json"))
-    # 204/180/69 valid; the 10 and 600 mg/dL records exercise the exact lower and
-    # upper sensor bounds (both kept); 700 (>600), 9 (<10), and null are dropped.
-    assert [p.value_mgdl for p in points] == [204, 180, 69, 10, 600]
+    # 204/180/69 valid; 20 and 500 mg/dL exercise the exact lower/upper safety
+    # bounds (both kept); 19 (<20), 501 (>500), 700 (>>500), and null are dropped.
+    # Bounds match the platform-wide 20-500 glucose invariant (treatment_safety).
+    assert [p.value_mgdl for p in points] == [204, 180, 69, 20, 500]
     first = points[0]
     assert first.timestamp == datetime(
         2023, 6, 1, 0, 2, 8, tzinfo=UTC

--- a/apps/api/tests/test_glooko_mapper.py
+++ b/apps/api/tests/test_glooko_mapper.py
@@ -143,6 +143,90 @@ def test_map_insulins_skips_accepted_prime():
     assert mapper.map_insulins([accepted]) == []
 
 
+def test_map_insulins_rejects_implausible_doses_and_foreign_units():
+    base = _load("insulins.json")[0]
+    cases = {
+        # Above the largest single pen actuation (60 U) -- corrupt/unit-confused.
+        "oversized": {**base, "value": 950.0, "currentValue": 950.0},
+        # Zero: a pen's smallest real actuation is 0.5 U, and unlike a pump's
+        # 0-delivered suggested bolus there is no carb/BG context worth keeping.
+        "zero": {**base, "value": 0, "currentValue": 0},
+        # bool is an int in Python; a True dose must not become 1.0 U.
+        "bool": {**base, "value": True, "currentValue": None},
+        # NaN slips through </> bounds (every comparison on it is False).
+        "nan": {**base, "value": float("nan"), "currentValue": float("nan")},
+        # A present-but-foreign unit of measure must refuse, not mis-ingest.
+        "foreign units": {**base, "units": "mL"},
+    }
+    for label, corrupt in cases.items():
+        assert mapper.map_insulins([corrupt]) == [], label
+    # Bound edge: exactly 60 U (largest single actuation) is a real dose.
+    assert (
+        mapper.map_insulins([{**base, "value": 60.0, "currentValue": 60.0}])[0].units
+        == 60.0
+    )
+    # An absent units field stays ingestible (observed records always carry it,
+    # but its absence is not evidence of a foreign unit); casing is folded.
+    no_units = {k: v for k, v in base.items() if k != "units"}
+    assert mapper.map_insulins([no_units])[0].units == 3.0
+    assert mapper.map_insulins([{**base, "units": "Units"}])[0].units == 3.0
+
+
+def test_map_insulins_prefers_current_value_over_original():
+    base = _load("insulins.json")[0]
+    # An edited dose: Glooko keeps the original in `value` and the correction
+    # in `currentValue` -- the corrected number must win.
+    edited = {**base, "value": 3.0, "currentValue": 9.0, "overrideValue": 9.0}
+    assert mapper.map_insulins([edited])[0].units == 9.0
+    # currentValue absent -> fall back to value.
+    absent = {**base, "currentValue": None}
+    assert mapper.map_insulins([absent])[0].units == 3.0
+    # currentValue PRESENT but implausible -> refuse the record outright rather
+    # than fall back to the possibly-stale pre-edit value.
+    implausible = {**base, "value": 3.0, "currentValue": 950.0}
+    assert mapper.map_insulins([implausible]) == []
+
+
+def test_map_normal_boluses_bounds_dose_but_keeps_zero():
+    base = _load("normal_boluses.json")[0]
+    # Above the single-dose bound: corrupt/unit-confused, rejected.
+    assert mapper.map_normal_boluses([{**base, "insulinDelivered": 950.0}]) == []
+    # bool must not become a 1.0 U dose; NaN slips through </> bounds.
+    assert mapper.map_normal_boluses([{**base, "insulinDelivered": True}]) == []
+    assert mapper.map_normal_boluses([{**base, "insulinDelivered": float("nan")}]) == []
+    # Zero stays ingestible for pumps: a suggested bolus fully reduced by IoB
+    # records 0 delivered while still carrying the meal's carb/BG context.
+    zero = mapper.map_normal_boluses([{**base, "insulinDelivered": 0}])
+    assert len(zero) == 1
+    assert zero[0].units == 0.0
+
+
+def test_map_context_and_basal_fields_reject_bool_and_nan():
+    bolus = _load("normal_boluses.json")[0]
+    # A bool context field must become None, not 1.0/True-as-number.
+    mapped = mapper.map_normal_boluses(
+        [
+            {
+                **bolus,
+                "insulinOnBoard": True,
+                "carbsInput": True,
+                "bloodGlucoseInput": True,
+            }
+        ]
+    )[0]
+    assert mapped.iob_at_event is None
+    assert mapped.cob_at_event is None
+    assert mapped.bg_at_event is None
+
+    basal = _load("scheduled_basals.json")[0]
+    # rate=True must not become a 1.0 U/h basal; NaN rate is corrupt.
+    assert mapper.map_scheduled_basals([{**basal, "rate": True}]) == []
+    assert mapper.map_scheduled_basals([{**basal, "rate": float("nan")}]) == []
+    # A NaN duration must drop the duration, not crash the mapper (int(nan) raises).
+    nan_duration = mapper.map_scheduled_basals([{**basal, "duration": float("nan")}])[0]
+    assert nan_duration.duration_minutes is None
+
+
 def test_map_glooko_combines_all_series():
     rec = mapper.map_glooko(
         cgm_points=_load("cgm_points.json"),


### PR DESCRIPTION
## Summary

Maintainer follow-up to the Glooko contributions in #725 and #726, hardening the integration on the platform side as committed in those reviews. Three areas: the cluster API host validator now enforces exactly what it documents, 421 Misdirected Request is treated as the routing problem it is (instead of a fake credentials failure), and insulin dose ingestion gets consistent numeric plausibility bounds.

## Related Issues

Follow-up to #725 / #726 (review commitments). Resolves the open CodeRabbit thread from #726 (validator strictness).

## Type of Change

- [x] Bug fix (backward compatible; no API or schema changes)

## Changes Made

- `auth.py`: `validate_glooko_api_host` requires a bare https origin -- userinfo, explicit port, path, params, query, and fragment are rejected, because `GlookoClient` builds request URLs as `api_host + path` and any trailing component would silently corrupt every data call. All previous rejections (foreign host, web host, apex, plain http) still hold.
- `auth.py`: a 421 on the login session check now raises `GlookoNetworkError` (retryable) instead of `GlookoAuthError`. A 421 means the host is wrong (account re-homed to a cluster we did not resolve), not that the credentials are bad -- the old posture permanently disconnected the user with a misleading "check email/password" message.
- `client.py`: a data-call 421 now triggers the reauth path, which re-derives the cluster host from a fresh login -- a mid-session account re-home recovers in-cycle instead of failing the sync tick. A 421 that survives reauth stays retryable (`GlookoNetworkError`). Stale 401-only docstrings updated; the no-reauth-provider error message now names the actual trigger status.
- `mapper.py`: new `_finite_or_none` / `_dose_or_none` helpers reject bool (an `int` in Python -- `True` must not ingest as 1.0 U), NaN (slips through `<`/`>` bounds since every comparison on it is False), and inf. Bolus/pen doses are bounded to (0, 60 U] -- the largest single pen actuation; manual logs share the bound as corrupt-record protection. The stance is applied consistently: basal rate and duration (fixing a latent `int(NaN)` crash) and the bolus IOB/carbs/BG context fields. Pump boluses keep zero ingestible (a suggested bolus fully reduced by IoB still carries the meal's carb/BG context); pen doses refuse it.
- `mapper.py`: pen doses prefer `currentValue` over `value` when present, so a dose corrected in Glooko is honored on first sync; a present-but-implausible `currentValue` refuses the record rather than falling back to the possibly-stale original. The pen `units` field check is case-folded.
- Tests for every new rejection and posture: 6 new validator shapes, the three 421 behaviors (login, in-cycle re-home recovery, persistent), dose bounds/NaN/bool/zero-policy split, `currentValue` preference matrix, and the basal/context-field guards.

## Test Plan

- [x] Unit tests pass (Glooko suite 82/82; full backend suite locally)
- [x] New tests added for new functionality
- [x] Manual/visual testing performed -- Sentry-enabled stack validation (golden-path smoke + Glooko sync tick through the new client/mapper code)
- [ ] Docker integration tested (if applicable)

## Checklist

- [x] Self-review completed
- [x] Code follows project style guidelines (`ruff check` + `ruff format --check` clean)
- [x] No hardcoded secrets, API keys, or credentials
- [x] Changes generate no new warnings
- [x] Documentation updated (if applicable) -- docstrings updated in place


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of misrouted Glooko requests (HTTP 421): login POSTs now mimic browser navigation (HTML Accept), 421 triggers re-auth and persistent 421 surfaces as a network error.

* **Data Validation**
  * Stricter numeric checks for doses/basals (max bolus 60U, allow explicit zero), tighter insulin/unit/timestamp rules, and tightened CGM safety bounds to 20–500 mg/dL.
  * API host validation now requires a bare HTTPS origin.

* **Tests**
  * Expanded tests for login flow, 421 re-auth behavior, host validation, mapper dose/coercion, and updated CGM fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->