### PR TITLE
fix(api): count non-pump insulin doses past the pump IoB anchor

### DIFF
--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -60,6 +60,7 @@ from src.services.integrations.nightscout.connection_test import (
 from src.services.integrations.nightscout.evaluate import (
     evaluate_nightscout_for_connection,
 )
+from src.services.integrations.nightscout.models import NIGHTSCOUT_SOURCE_PREFIX
 from src.services.integrations.nightscout.onboarding_derive import (
     derive_onboarding_proposals,
 )
@@ -1132,7 +1133,7 @@ async def read_connection_data(
     so callers don't have to track the cap.
     """
     conn = await _load_owned(db, connection_id, current_user.id)
-    source_tag = f"nightscout:{conn.id}"
+    source_tag = f"{NIGHTSCOUT_SOURCE_PREFIX}{conn.id}"
 
     # Defend against naive datetimes from clients: PostgreSQL's TIMESTAMP
     # WITH TIME ZONE compares against naive values using the session's

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -557,7 +557,7 @@ class NightscoutDiscoveryReport(BaseModel):
     # Treated as a HINT, not source-of-truth: a multi-uploader
     # sample (e.g. legacy Loop records still in retention plus
     # current Trio uploads) reports the first match across the
-    # `_LOOP_UPLOADERS` preference order. The wizard surfaces this
+    # `LOOP_UPLOADERS` preference order. The wizard surfaces this
     # for UI flavor / freshness expectations only.
     active_pump_loop: str | None = None
     # Names of upstream resources that a per-resource probe

--- a/apps/api/src/services/cgm_source.py
+++ b/apps/api/src/services/cgm_source.py
@@ -40,6 +40,7 @@ from src.models.integration import (
     IntegrationType,
 )
 from src.models.nightscout_connection import NightscoutConnection
+from src.services.integrations.nightscout.models import NIGHTSCOUT_SOURCE_PREFIX
 
 CGM_ROLE_PRIMARY = "primary"
 CGM_ROLE_SECONDARY = "secondary"
@@ -50,7 +51,6 @@ CGM_ROLE_SECONDARY = "secondary"
 CGM_ROLE_OFF = "off"
 
 DEXCOM_SOURCE = "dexcom"
-_NS_SOURCE_PREFIX = "nightscout:"
 
 
 def nightscout_source(connection_id: uuid.UUID | str) -> str:
@@ -60,7 +60,7 @@ def nightscout_source(connection_id: uuid.UUID | str) -> str:
     keeps the two in sync so the dedupe filter never silently stops
     matching real rows if the format changes.
     """
-    return f"{_NS_SOURCE_PREFIX}{connection_id}"
+    return f"{NIGHTSCOUT_SOURCE_PREFIX}{connection_id}"
 
 
 def glucose_source_exclusion_clause(excluded: list[str] | None) -> list:

--- a/apps/api/src/services/integrations/nightscout/evaluate.py
+++ b/apps/api/src/services/integrations/nightscout/evaluate.py
@@ -30,7 +30,7 @@ from src.schemas.nightscout import (
 
 from .client import NightscoutClient
 from .connection_test import test_connection
-from .models import NightscoutProfile, detect_uploader
+from .models import LOOP_UPLOADERS, NightscoutProfile, detect_uploader
 
 logger = get_logger(__name__)
 
@@ -44,11 +44,6 @@ _ENTRIES_RECENT_PROBE_COUNT = 2500
 _ENTRIES_OLDEST_PROBE_COUNT = 1000  # for earliest_entry_at lookup
 _TREATMENTS_PROBE_COUNT = 200
 _DEVICESTATUS_PROBE_COUNT = 50
-# Closed-loop labels we surface as `active_pump_loop`. Order is
-# preference -- if multiple are present in the uploader sample, the
-# first match wins. Anchors on the "real" loops; xdrip+ / xdrip4ios
-# are CGM uploaders, not loops, and stay out of this list.
-_LOOP_UPLOADERS = ("loop", "aaps", "trio", "oref0")
 
 
 async def evaluate_nightscout_for_connection(
@@ -208,7 +203,7 @@ async def evaluate_nightscout_for_connection(
 
     uploaders_detected = _detect_uploaders(recent_entries, treatments, devicestatuses)
     active_pump_loop = next(
-        (u for u in _LOOP_UPLOADERS if u in uploaders_detected), None
+        (u for u in LOOP_UPLOADERS if u in uploaders_detected), None
     )
 
     has_profile, profile_summary = _summarize_profile(profile_records)

--- a/apps/api/src/services/integrations/nightscout/models.py
+++ b/apps/api/src/services/integrations/nightscout/models.py
@@ -161,6 +161,19 @@ def _is_real_number(value: Any) -> bool:
 # Source attribution
 # ---------------------------------------------------------------------------
 
+# Table-level `source` prefix for every row a Nightscout connection writes
+# (`nightscout:<connection_id>`, built by the translator's `_build_source`).
+# Readers that classify rows by origin (cgm_source, iob_projection) match
+# on this prefix -- import it instead of re-declaring the literal.
+NIGHTSCOUT_SOURCE_PREFIX = "nightscout:"
+
+# Closed-loop uploader labels among `detect_uploader`'s return values.
+# Ordered by preference for consumers that pick one (evaluate.py surfaces
+# the first match as `active_pump_loop`); membership tests treat it as a
+# set. xdrip+ / xdrip4ios / spike / tidepool are data uploaders, not
+# loops, and stay out of this list.
+LOOP_UPLOADERS: tuple[str, ...] = ("loop", "aaps", "trio", "oref0")
+
 
 def detect_uploader(entered_by: str | None, device: str | None) -> str:
     """Identify the upstream uploader from `enteredBy` + `device` strings.

--- a/apps/api/src/services/integrations/nightscout/translator.py
+++ b/apps/api/src/services/integrations/nightscout/translator.py
@@ -93,6 +93,7 @@ from src.services.integrations.nightscout._pump_status_extractor import (
     fetch_initial_last_state,
 )
 from src.services.integrations.nightscout.models import (
+    NIGHTSCOUT_SOURCE_PREFIX,
     NightscoutDeviceStatus,
     NightscoutEntry,
     NightscoutProfile,
@@ -135,7 +136,7 @@ class TranslateOutcome:
 
 def _build_source(connection_id: str) -> str:
     """Build the `source` column value for this connection."""
-    return f"nightscout:{connection_id}"
+    return f"{NIGHTSCOUT_SOURCE_PREFIX}{connection_id}"
 
 
 # ---------------------------------------------------------------------------
@@ -355,7 +356,7 @@ async def translate_devicestatuses(
         parsed,
         key=lambda ds: ds.created_at or _NULL_CREATED_AT_SENTINEL,
     )
-    source = f"nightscout:{connection_id}"
+    source = _build_source(connection_id)
     # Wrap pump-event promotion in a SAVEPOINT so a DB-level error
     # here (constraint violation, connection hiccup, schema drift)
     # rolls back ONLY the pump-events work. Without the savepoint,

--- a/apps/api/src/services/iob_projection.py
+++ b/apps/api/src/services/iob_projection.py
@@ -12,10 +12,15 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import desc, select
+from sqlalchemy import desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.pump_data import PumpEvent, PumpEventType
+from src.services.integrations.glooko.mapper import SOURCE as GLOOKO_SOURCE
+from src.services.integrations.nightscout.models import (
+    LOOP_UPLOADERS,
+    NIGHTSCOUT_SOURCE_PREFIX,
+)
 
 
 async def get_user_dia(db: AsyncSession, user_id: uuid.UUID) -> float:
@@ -67,25 +72,24 @@ class IoBProjection:
 INSULIN_DIA_HOURS = 4.0  # Duration of Insulin Action
 INSULIN_PEAK_HOURS = 1.0  # Time to peak activity
 
-# The ONLY event types this engine sums as insulin doses. Pinned by test
-# (`TestDoseEventTypePin`): basal-family types must never enter dose
-# summation -- BASAL is already captured in the pump's IoB snapshot, and a
-# future long-acting type (e.g. BASAL_INJECTION, issue #728) follows a
-# multi-hour absorption profile this rapid-acting decay curve would badly
-# misrepresent. Add new types here only together with a matching curve.
+# The ONLY event types this engine sums as insulin doses (test-pinned).
+# Basal-family types must never enter dose summation -- BASAL is already
+# captured in the pump's IoB snapshot, and a future long-acting type
+# (e.g. BASAL_INJECTION, issue #728) follows a multi-hour absorption
+# profile this rapid-acting decay curve would badly misrepresent. Add new
+# types here only together with a matching curve.
 _DOSE_EVENT_TYPES: tuple[PumpEventType, ...] = (
     PumpEventType.BOLUS,
     PumpEventType.CORRECTION,
 )
 
-# Nightscout-sourced rows carry `source = "nightscout:<connection_id>"`.
-_NIGHTSCOUT_SOURCE_PREFIX = "nightscout:"
-
-# Closed-loop uploaders whose Nightscout BOLUS/CORRECTION treatments record
-# insulin the loop's pump actually delivered. Anything else writing a bolus
-# treatment (Care Portal UI, xDrip+/Spike/Tidepool manual logs, unknown) is
-# a human logging insulin by hand.
-_NS_LOOP_UPLOADERS = frozenset({"loop", "aaps", "trio", "oref0"})
+# Nightscout uploaders whose BOLUS/CORRECTION treatments record insulin a
+# device actually delivered (and which a pump IoB anchor therefore already
+# reflects): the closed loops, plus Tidepool, which mirrors pump uploads
+# rather than logging by hand. Anything else writing a bolus treatment
+# (Care Portal UI, xDrip+/xDrip4iOS/Spike, unrecognized) is a human
+# logging insulin manually.
+_NS_PUMP_VISIBLE_UPLOADERS = frozenset(LOOP_UPLOADERS) | {"tidepool"}
 
 
 class _AnchorVisibility(enum.Enum):
@@ -96,12 +100,19 @@ class _AnchorVisibility(enum.Enum):
     assumption only holds for insulin the anchor's writer knew about:
 
     - PUMP: pump-delivered insulin (direct integrations, Glooko/Medtronic
-      pump streams, loop-uploaded Nightscout boluses). Reflected in every
-      IoB anchor for that pump -- the anchor-timestamp cut applies.
+      pump streams, loop- or Tidepool-uploaded Nightscout boluses).
+      Reflected in every IoB anchor for that pump -- the anchor-timestamp
+      cut applies.
     - NEVER: Glooko ``insulins``-stream rows (smart-pen doses + manual
       Glooko logs). No anchor writer can see these: pump hardware only
       knows its own deliveries, and Nightscout loops have no Glooko link.
-      They must survive the cut regardless of anchor age.
+      They must survive the cut regardless of anchor age. Known residual:
+      a user who hand-logs the same pen dose into their loop app AND syncs
+      the pen via Glooko has created a genuine upstream duplicate; the
+      loop copy is inside the Nightscout anchor while the Glooko copy
+      counts here. That is a data-entry duplication this engine cannot
+      distinguish from two real doses (the source-blind treatment-safety
+      totals double it the same way).
     - NIGHTSCOUT_ONLY: manually-recorded Nightscout treatments (External
       Insulin, Care Portal / non-loop-uploader boluses). Invisible to pump
       hardware anchors, but possibly visible to a Nightscout-derived anchor:
@@ -110,7 +121,12 @@ class _AnchorVisibility(enum.Enum):
       the anchor is NOT Nightscout-derived; against a Nightscout anchor we
       conservatively keep the cut, because double-counting (overstated IoB,
       withheld corrections) is the failure mode that would make this
-      classification dangerous if wrong.
+      classification dangerous if wrong. Known limitation: a Loop user's
+      Care Portal entries are NOT actually imported by Loop, so for an
+      NS-only Loop user those doses still fall to the cut (pre-fix
+      behavior); distinguishing Loop from AAPS anchors needs uploader
+      attribution on devicestatus-derived anchor rows, which they don't
+      carry today.
     """
 
     PUMP = "pump"
@@ -132,18 +148,23 @@ def _classify_anchor_visibility(
 ) -> _AnchorVisibility:
     """Classify a dose row by which IoB anchors could already include it.
 
-    Conservative by construction: anything not positively identified as a
-    non-pump dose is treated as pump-delivered (subject to the anchor cut),
-    so an unexpected source/metadata shape degrades to the pre-fix behavior
-    (possible understatement) rather than risking double-counting.
+    Conservative by construction: a row is only treated as non-pump on a
+    positive marker its writer is known to set -- the Glooko ``insulins``
+    stream tag, or a Nightscout row whose recorded uploader is a non-device
+    one (Care Portal usernames detect as "unknown") / whose bolus subtype
+    is External Insulin. Anything else -- unexpected sources, absent
+    metadata, absent uploader attribution -- is treated as pump-delivered,
+    degrading to the pre-fix behavior (possible understatement) rather
+    than risking double-counting (overstated IoB, withheld corrections).
     """
     metadata = metadata_json or {}
-    if metadata.get("glooko_stream") == "insulins":
+    if source == GLOOKO_SOURCE and metadata.get("glooko_stream") == "insulins":
         return _AnchorVisibility.NEVER
-    if source.startswith(_NIGHTSCOUT_SOURCE_PREFIX):
+    if source.startswith(NIGHTSCOUT_SOURCE_PREFIX):
         if metadata.get("bolus_subtype") == "external":
             return _AnchorVisibility.NIGHTSCOUT_ONLY
-        if metadata.get("source_uploader") not in _NS_LOOP_UPLOADERS:
+        uploader = metadata.get("source_uploader")
+        if uploader is not None and uploader not in _NS_PUMP_VISIBLE_UPLOADERS:
             return _AnchorVisibility.NIGHTSCOUT_ONLY
     return _AnchorVisibility.PUMP
 
@@ -155,9 +176,12 @@ def _survives_anchor_cut(
 
     Doses after the anchor always count (the anchor predates them). At or
     before the anchor, only doses the anchor's writer could not have known
-    about count -- see `_AnchorVisibility`. Exactly-at-anchor pump doses are
-    excluded (the snapshot is assumed to include them; pinned by
-    `test_iob_same_timestamp_not_double_counted`).
+    about count -- see `_AnchorVisibility`. Exactly-at-anchor pump doses
+    are excluded: the snapshot is assumed to include them (test-pinned).
+    For Glooko bolus rows, whose `insulinOnBoard` may be the bolus
+    calculator's pre-delivery reading, that assumption is unverified
+    against live capture -- excluding remains the conservative choice
+    (understatement, never double-count).
     """
     if dose.timestamp > anchor_at:
         return True
@@ -273,12 +297,35 @@ def project_iob(
     return confirmed_iob * remaining_fraction
 
 
+@dataclass(frozen=True)
+class IobAnchor:
+    """The most recent pump-confirmed IoB snapshot for a user.
+
+    `source` is the anchor row's integration source -- needed to decide
+    which non-pump doses the anchor could already include (see
+    `_AnchorVisibility`).
+    """
+
+    iob: float
+    at: datetime
+    source: str
+
+
 async def get_last_iob(
     db: AsyncSession,
     user_id: uuid.UUID,
     max_hours: float | None = None,
-) -> tuple[float | None, datetime | None, str | None]:
+) -> IobAnchor | None:
     """Get the most recent IoB value for a user.
+
+    Nightscout-sourced BOLUS/CORRECTION rows are excluded from anchor
+    candidacy: loops post bolus treatments WITHOUT in-band IoB, so any
+    `iob_at_event` on those rows was backfilled by the translator from a
+    devicestatus snapshot up to 15 minutes older than the bolus
+    (`_backfill_bolus_context`). Anchoring on one would start the decay
+    clock at the bolus timestamp with a pre-bolus IoB value AND cut the
+    bolus itself. The devicestatus-derived BATTERY rows -- whose IoB and
+    timestamp genuinely belong together -- remain the Nightscout anchor.
 
     Args:
         db: Database session
@@ -287,10 +334,7 @@ async def get_last_iob(
                    Defaults to the user's configured DIA (up to 8h).
 
     Returns:
-        Tuple of (iob_value, timestamp, source) or (None, None, None)
-        if no data. `source` is the anchor row's integration source --
-        needed to decide which non-pump doses the anchor could already
-        include (see `_AnchorVisibility`).
+        The newest qualifying anchor, or None if no data.
     """
     if max_hours is None:
         max_hours = await get_user_dia(db, user_id)
@@ -302,15 +346,22 @@ async def get_last_iob(
             PumpEvent.user_id == user_id,
             PumpEvent.iob_at_event.isnot(None),
             PumpEvent.event_timestamp >= cutoff,
+            or_(
+                ~PumpEvent.source.startswith(NIGHTSCOUT_SOURCE_PREFIX),
+                PumpEvent.event_type.notin_(_DOSE_EVENT_TYPES),
+            ),
         )
-        .order_by(desc(PumpEvent.event_timestamp))
+        # `id` tiebreak so two rows at the same second (e.g. a tandem
+        # BG_READING and an NS BATTERY) anchor deterministically across
+        # calls instead of flipping value and source classification.
+        .order_by(desc(PumpEvent.event_timestamp), desc(PumpEvent.id))
         .limit(1)
     )
 
     row = result.first()
     if row:
-        return row[0], row[1], row[2]
-    return None, None, None
+        return IobAnchor(iob=row[0], at=row[1], source=row[2])
+    return None
 
 
 async def _fetch_insulin_doses(
@@ -406,38 +457,33 @@ async def get_iob_projection(
     now = datetime.now(UTC)
 
     # Step 1: Get last pump-confirmed IoB (any age within DIA window)
-    last_confirmed_iob, last_confirmed_at, anchor_source = await get_last_iob(
-        db, user_id, max_hours=dia_hours
-    )
+    anchor = await get_last_iob(db, user_id, max_hours=dia_hours)
 
     # Step 2: Fetch all bolus/correction doses within DIA window
     all_doses = await _fetch_insulin_doses(db, user_id, dia_hours, now)
 
     # No data at all
-    if last_confirmed_iob is None and not all_doses:
+    if anchor is None and not all_doses:
         return None
 
     # Step 3: Keep the doses the anchor cannot already include
     # (post-anchor doses + anchor-blind non-pump doses)
-    if last_confirmed_at is not None:
-        anchor_is_nightscout = (anchor_source or "").startswith(
-            _NIGHTSCOUT_SOURCE_PREFIX
-        )
-        counted_doses = [
-            (d.timestamp, d.units)
+    if anchor is not None:
+        anchor_is_nightscout = anchor.source.startswith(NIGHTSCOUT_SOURCE_PREFIX)
+        kept_doses = [
+            d
             for d in all_doses
-            if _survives_anchor_cut(d, last_confirmed_at, anchor_is_nightscout)
+            if _survives_anchor_cut(d, anchor.at, anchor_is_nightscout)
         ]
     else:
-        counted_doses = [(d.timestamp, d.units) for d in all_doses]
+        kept_doses = all_doses
+    counted_doses = [(d.timestamp, d.units) for d in kept_doses]
 
     # Step 4: Compute IoB at now, +30min, +60min
     def _compute_at(at_time: datetime) -> float:
         pump_component = 0.0
-        if last_confirmed_iob is not None and last_confirmed_at is not None:
-            pump_component = project_iob(
-                last_confirmed_iob, last_confirmed_at, at_time, dia_hours
-            )
+        if anchor is not None:
+            pump_component = project_iob(anchor.iob, anchor.at, at_time, dia_hours)
         dose_component = _sum_iob_from_doses(counted_doses, at_time, dia_hours)
         return max(0.0, pump_component + dose_component)
 
@@ -446,10 +492,13 @@ async def get_iob_projection(
     iob_60 = _compute_at(now + timedelta(minutes=60))
 
     # Step 5: Determine if this is a fallback (no pump confirmation)
-    is_estimated = last_confirmed_at is None
+    is_estimated = anchor is None
     if is_estimated:
         last_confirmed_iob = round(current_iob, 2)
         last_confirmed_at = now
+    else:
+        last_confirmed_iob = anchor.iob
+        last_confirmed_at = anchor.at
 
     # Step 6: Staleness check (based on last pump confirmation)
     elapsed_since = now - last_confirmed_at

--- a/apps/api/src/services/iob_projection.py
+++ b/apps/api/src/services/iob_projection.py
@@ -72,6 +72,19 @@ class IoBProjection:
 INSULIN_DIA_HOURS = 4.0  # Duration of Insulin Action
 INSULIN_PEAK_HOURS = 1.0  # Time to peak activity
 
+# Defensive ceiling on a single dose's contribution to projected IoB (units).
+# The engine sums `pump_events.units` read straight from the table; a corrupt
+# or unit-confused row (e.g. a future source without its own ingestion bound)
+# would otherwise propagate unbounded into projected IoB and silently suppress
+# a needed correction. 60 U is the largest single actuation of any supported
+# device -- the NovoPen 6; pumps cap lower (Tandem 25 U, Omnipod 30 U) -- so
+# this clips only implausible values, never a real single dose. Mirrors the
+# Glooko ingestion bound (`glooko.mapper._MAX_BOLUS_DOSE_U`) and the platform
+# single-bolus safety limit (`treatment_safety.MAX_BOLUS_DOSE_MILLIUNITS`),
+# applied here as defense-in-depth at the point of use. Concentrated insulin
+# (U-200/U-500) is out of scope until the platform models concentration.
+_MAX_SINGLE_DOSE_UNITS = 60.0
+
 # The ONLY event types this engine sums as insulin doses (test-pinned).
 # Basal-family types must never enter dose summation -- BASAL is already
 # captured in the pump's IoB snapshot, and a future long-acting type
@@ -413,7 +426,10 @@ def _sum_iob_from_doses(
     """Compute total IoB at a given time from a list of insulin doses.
 
     For each dose, applies the decay curve based on elapsed time and sums
-    the remaining insulin across all doses.
+    the remaining insulin across all doses. Each dose's units are clamped
+    to ``_MAX_SINGLE_DOSE_UNITS`` first, so a single corrupt row can't push
+    projected IoB to an implausible value that would suppress a needed
+    correction (defense-in-depth -- ingestion mappers already bound doses).
 
     Args:
         doses: List of (event_timestamp, units) tuples.
@@ -428,8 +444,9 @@ def _sum_iob_from_doses(
         elapsed = (at_time - event_time).total_seconds() / 3600
         if elapsed < 0:
             continue  # dose is in the future relative to at_time
+        bounded_units = min(units, _MAX_SINGLE_DOSE_UNITS)
         remaining = calculate_insulin_remaining(elapsed, dia_hours)
-        total += units * remaining
+        total += bounded_units * remaining
     return total
 
 

--- a/apps/api/src/services/iob_projection.py
+++ b/apps/api/src/services/iob_projection.py
@@ -1,10 +1,13 @@
 """Story 3.7: Insulin on Board (IoB) Projection Engine.
 
 Provides projected IoB calculations based on pump-confirmed snapshots
-combined with dose-summation for insulin delivered after the snapshot.
+combined with dose-summation for insulin the snapshot cannot account
+for: doses delivered after it, and non-pump doses (smart-pen / manual
+logs) the pump never knew about regardless of timing.
 Uses decay curves for rapid-acting insulins (Novolog/Humalog).
 """
 
+import enum
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -63,6 +66,107 @@ class IoBProjection:
 # Based on exponential decay model with 4-hour duration of insulin action (DIA)
 INSULIN_DIA_HOURS = 4.0  # Duration of Insulin Action
 INSULIN_PEAK_HOURS = 1.0  # Time to peak activity
+
+# The ONLY event types this engine sums as insulin doses. Pinned by test
+# (`TestDoseEventTypePin`): basal-family types must never enter dose
+# summation -- BASAL is already captured in the pump's IoB snapshot, and a
+# future long-acting type (e.g. BASAL_INJECTION, issue #728) follows a
+# multi-hour absorption profile this rapid-acting decay curve would badly
+# misrepresent. Add new types here only together with a matching curve.
+_DOSE_EVENT_TYPES: tuple[PumpEventType, ...] = (
+    PumpEventType.BOLUS,
+    PumpEventType.CORRECTION,
+)
+
+# Nightscout-sourced rows carry `source = "nightscout:<connection_id>"`.
+_NIGHTSCOUT_SOURCE_PREFIX = "nightscout:"
+
+# Closed-loop uploaders whose Nightscout BOLUS/CORRECTION treatments record
+# insulin the loop's pump actually delivered. Anything else writing a bolus
+# treatment (Care Portal UI, xDrip+/Spike/Tidepool manual logs, unknown) is
+# a human logging insulin by hand.
+_NS_LOOP_UPLOADERS = frozenset({"loop", "aaps", "trio", "oref0"})
+
+
+class _AnchorVisibility(enum.Enum):
+    """Whether a pump-confirmed IoB anchor can already include a dose row.
+
+    The hybrid model cuts dose summation at the anchor timestamp on the
+    assumption that the anchor already accounts for older doses. That
+    assumption only holds for insulin the anchor's writer knew about:
+
+    - PUMP: pump-delivered insulin (direct integrations, Glooko/Medtronic
+      pump streams, loop-uploaded Nightscout boluses). Reflected in every
+      IoB anchor for that pump -- the anchor-timestamp cut applies.
+    - NEVER: Glooko ``insulins``-stream rows (smart-pen doses + manual
+      Glooko logs). No anchor writer can see these: pump hardware only
+      knows its own deliveries, and Nightscout loops have no Glooko link.
+      They must survive the cut regardless of anchor age.
+    - NIGHTSCOUT_ONLY: manually-recorded Nightscout treatments (External
+      Insulin, Care Portal / non-loop-uploader boluses). Invisible to pump
+      hardware anchors, but possibly visible to a Nightscout-derived anchor:
+      Loop counts logged external insulin in its own IoB, and AAPS with NS
+      sync imports Care Portal treatments. They survive the cut only when
+      the anchor is NOT Nightscout-derived; against a Nightscout anchor we
+      conservatively keep the cut, because double-counting (overstated IoB,
+      withheld corrections) is the failure mode that would make this
+      classification dangerous if wrong.
+    """
+
+    PUMP = "pump"
+    NEVER = "never"
+    NIGHTSCOUT_ONLY = "nightscout_only"
+
+
+@dataclass(frozen=True)
+class _Dose:
+    """A single insulin dose row with its anchor-visibility classification."""
+
+    timestamp: datetime
+    units: float
+    anchor_visibility: _AnchorVisibility
+
+
+def _classify_anchor_visibility(
+    source: str, metadata_json: dict | None
+) -> _AnchorVisibility:
+    """Classify a dose row by which IoB anchors could already include it.
+
+    Conservative by construction: anything not positively identified as a
+    non-pump dose is treated as pump-delivered (subject to the anchor cut),
+    so an unexpected source/metadata shape degrades to the pre-fix behavior
+    (possible understatement) rather than risking double-counting.
+    """
+    metadata = metadata_json or {}
+    if metadata.get("glooko_stream") == "insulins":
+        return _AnchorVisibility.NEVER
+    if source.startswith(_NIGHTSCOUT_SOURCE_PREFIX):
+        if metadata.get("bolus_subtype") == "external":
+            return _AnchorVisibility.NIGHTSCOUT_ONLY
+        if metadata.get("source_uploader") not in _NS_LOOP_UPLOADERS:
+            return _AnchorVisibility.NIGHTSCOUT_ONLY
+    return _AnchorVisibility.PUMP
+
+
+def _survives_anchor_cut(
+    dose: _Dose, anchor_at: datetime, anchor_is_nightscout: bool
+) -> bool:
+    """Decide whether a dose still contributes IoB given a pump anchor.
+
+    Doses after the anchor always count (the anchor predates them). At or
+    before the anchor, only doses the anchor's writer could not have known
+    about count -- see `_AnchorVisibility`. Exactly-at-anchor pump doses are
+    excluded (the snapshot is assumed to include them; pinned by
+    `test_iob_same_timestamp_not_double_counted`).
+    """
+    if dose.timestamp > anchor_at:
+        return True
+    if dose.anchor_visibility is _AnchorVisibility.NEVER:
+        return True
+    return (
+        dose.anchor_visibility is _AnchorVisibility.NIGHTSCOUT_ONLY
+        and not anchor_is_nightscout
+    )
 
 
 def calculate_insulin_remaining(
@@ -173,7 +277,7 @@ async def get_last_iob(
     db: AsyncSession,
     user_id: uuid.UUID,
     max_hours: float | None = None,
-) -> tuple[float | None, datetime | None]:
+) -> tuple[float | None, datetime | None, str | None]:
     """Get the most recent IoB value for a user.
 
     Args:
@@ -183,14 +287,17 @@ async def get_last_iob(
                    Defaults to the user's configured DIA (up to 8h).
 
     Returns:
-        Tuple of (iob_value, timestamp) or (None, None) if no data
+        Tuple of (iob_value, timestamp, source) or (None, None, None)
+        if no data. `source` is the anchor row's integration source --
+        needed to decide which non-pump doses the anchor could already
+        include (see `_AnchorVisibility`).
     """
     if max_hours is None:
         max_hours = await get_user_dia(db, user_id)
     cutoff = datetime.now(UTC) - timedelta(hours=max_hours)
 
     result = await db.execute(
-        select(PumpEvent.iob_at_event, PumpEvent.event_timestamp)
+        select(PumpEvent.iob_at_event, PumpEvent.event_timestamp, PumpEvent.source)
         .where(
             PumpEvent.user_id == user_id,
             PumpEvent.iob_at_event.isnot(None),
@@ -202,8 +309,8 @@ async def get_last_iob(
 
     row = result.first()
     if row:
-        return row[0], row[1]
-    return None, None
+        return row[0], row[1], row[2]
+    return None, None, None
 
 
 async def _fetch_insulin_doses(
@@ -211,27 +318,25 @@ async def _fetch_insulin_doses(
     user_id: uuid.UUID,
     dia_hours: float,
     reference_time: datetime,
-) -> list[tuple[datetime, float]]:
+) -> list[_Dose]:
     """Fetch all insulin-delivering events within the DIA window.
 
-    Returns bolus and correction events with their timestamps and units.
-    Basal events are excluded because their insulin contribution is already
-    captured in the pump's IoB snapshot.
-
-    Returns:
-        List of (event_timestamp, units) tuples.
+    Returns bolus and correction events, each classified by which IoB
+    anchors could already include it (`_AnchorVisibility`). Basal events
+    are excluded because their insulin contribution is already captured
+    in the pump's IoB snapshot.
     """
     cutoff = reference_time - timedelta(hours=dia_hours)
     result = await db.execute(
-        select(PumpEvent.event_timestamp, PumpEvent.units)
+        select(
+            PumpEvent.event_timestamp,
+            PumpEvent.units,
+            PumpEvent.source,
+            PumpEvent.metadata_json,
+        )
         .where(
             PumpEvent.user_id == user_id,
-            PumpEvent.event_type.in_(
-                [
-                    PumpEventType.BOLUS,
-                    PumpEventType.CORRECTION,
-                ]
-            ),
+            PumpEvent.event_type.in_(_DOSE_EVENT_TYPES),
             PumpEvent.units.isnot(None),
             PumpEvent.units > 0,
             PumpEvent.event_timestamp >= cutoff,
@@ -239,7 +344,14 @@ async def _fetch_insulin_doses(
         )
         .order_by(PumpEvent.event_timestamp)
     )
-    return [(row[0], row[1]) for row in result.all()]
+    return [
+        _Dose(
+            timestamp=row[0],
+            units=row[1],
+            anchor_visibility=_classify_anchor_visibility(row[2], row[3]),
+        )
+        for row in result.all()
+    ]
 
 
 def _sum_iob_from_doses(
@@ -278,9 +390,10 @@ async def get_iob_projection(
     """Get projected IoB for a user using hybrid dose-summation.
 
     Uses pump-confirmed IoB as an anchor (captures all historical insulin
-    including basal), then adds insulin from bolus/correction doses
-    delivered after the confirmation. This prevents the projection from
-    ignoring new doses that occurred after the pump's last IoB snapshot.
+    including basal), then adds insulin from bolus/correction doses the
+    anchor cannot already include: doses delivered after the confirmation,
+    plus non-pump doses (smart-pen / manual logs) the anchor's writer never
+    saw regardless of timing -- see `_AnchorVisibility` for the rule.
 
     Args:
         db: Database session
@@ -293,7 +406,7 @@ async def get_iob_projection(
     now = datetime.now(UTC)
 
     # Step 1: Get last pump-confirmed IoB (any age within DIA window)
-    last_confirmed_iob, last_confirmed_at = await get_last_iob(
+    last_confirmed_iob, last_confirmed_at, anchor_source = await get_last_iob(
         db, user_id, max_hours=dia_hours
     )
 
@@ -304,11 +417,19 @@ async def get_iob_projection(
     if last_confirmed_iob is None and not all_doses:
         return None
 
-    # Step 3: Pre-filter to only post-confirmation doses (avoids re-scanning per call)
+    # Step 3: Keep the doses the anchor cannot already include
+    # (post-anchor doses + anchor-blind non-pump doses)
     if last_confirmed_at is not None:
-        post_doses = [(t, u) for t, u in all_doses if t > last_confirmed_at]
+        anchor_is_nightscout = (anchor_source or "").startswith(
+            _NIGHTSCOUT_SOURCE_PREFIX
+        )
+        counted_doses = [
+            (d.timestamp, d.units)
+            for d in all_doses
+            if _survives_anchor_cut(d, last_confirmed_at, anchor_is_nightscout)
+        ]
     else:
-        post_doses = all_doses
+        counted_doses = [(d.timestamp, d.units) for d in all_doses]
 
     # Step 4: Compute IoB at now, +30min, +60min
     def _compute_at(at_time: datetime) -> float:
@@ -317,8 +438,8 @@ async def get_iob_projection(
             pump_component = project_iob(
                 last_confirmed_iob, last_confirmed_at, at_time, dia_hours
             )
-        post_component = _sum_iob_from_doses(post_doses, at_time, dia_hours)
-        return max(0.0, pump_component + post_component)
+        dose_component = _sum_iob_from_doses(counted_doses, at_time, dia_hours)
+        return max(0.0, pump_component + dose_component)
 
     current_iob = _compute_at(now)
     iob_30 = _compute_at(now + timedelta(minutes=30))

--- a/apps/api/tests/test_iob_projection.py
+++ b/apps/api/tests/test_iob_projection.py
@@ -11,9 +11,15 @@ from httpx import ASGITransport, AsyncClient
 
 from src.config import settings
 from src.main import app
+from src.models.pump_data import PumpEventType
 from src.services.iob_projection import (
+    _DOSE_EVENT_TYPES,
     INSULIN_DIA_HOURS,
+    _AnchorVisibility,
+    _classify_anchor_visibility,
+    _Dose,
     _sum_iob_from_doses,
+    _survives_anchor_cut,
     calculate_insulin_remaining,
     calculate_iob_activity_curve,
     project_iob,
@@ -23,6 +29,16 @@ from src.services.iob_projection import (
 def unique_email(prefix: str) -> str:
     """Generate a unique email for tests."""
     return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+def _unique_ns_id(prefix: str) -> str:
+    """Generate a unique ns_id for tests.
+
+    The `ix_pump_events_source_nsid` unique index is global on
+    (source, ns_id) -- not per user -- and the shared test DB persists
+    rows across runs, so a hardcoded ns_id collides on re-run.
+    """
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
 
 
 class TestInsulinDecayCurve:
@@ -724,3 +740,524 @@ class TestIoBProjectionEndpoint:
         # Basal and suspend events should NOT contribute
         assert data["projected_iob"] == pytest.approx(0.75, rel=0.1)
         assert data["is_estimated"] is False
+
+
+class TestDoseEventTypePin:
+    """Pin the event types the IoB engine is allowed to sum as doses.
+
+    Guards against a future long-acting insulin type (e.g.
+    PumpEventType.BASAL_INJECTION, issue #728) silently entering the
+    rapid-acting decay model. If this test fails, do NOT widen the pin
+    without adding a matching absorption curve for the new type.
+    """
+
+    def test_only_bolus_and_correction_are_summed(self):
+        assert set(_DOSE_EVENT_TYPES) == {
+            PumpEventType.BOLUS,
+            PumpEventType.CORRECTION,
+        }
+
+    def test_future_basal_injection_type_never_summed(self):
+        """Explicit tripwire for issue #728's planned BASAL_INJECTION type."""
+        basal_injection = getattr(PumpEventType, "BASAL_INJECTION", None)
+        assert basal_injection is None or basal_injection not in _DOSE_EVENT_TYPES
+
+
+class TestAnchorVisibilityClassification:
+    """Tests for the pump-anchor visibility discriminator."""
+
+    def test_glooko_insulins_stream_is_never_visible(self):
+        """Smart-pen / manual Glooko doses are invisible to every anchor."""
+        visibility = _classify_anchor_visibility(
+            "glooko", {"glooko_stream": "insulins", "device_delivered": True}
+        )
+        assert visibility is _AnchorVisibility.NEVER
+
+    def test_glooko_pump_stream_is_pump_visible(self):
+        """Glooko pump-stream boluses are pump deliveries (anchor cut applies)."""
+        assert _classify_anchor_visibility("glooko", None) is _AnchorVisibility.PUMP
+
+    def test_direct_integrations_are_pump_visible(self):
+        for source in ("tandem", "mobile", "medtronic"):
+            assert _classify_anchor_visibility(source, None) is _AnchorVisibility.PUMP
+
+    def test_nightscout_external_insulin_is_nightscout_only(self):
+        """Logged external insulin: pump can't see it, but Loop's IoB can."""
+        visibility = _classify_anchor_visibility(
+            "nightscout:abc123",
+            {"source_uploader": "loop", "bolus_subtype": "external"},
+        )
+        assert visibility is _AnchorVisibility.NIGHTSCOUT_ONLY
+
+    def test_nightscout_careportal_bolus_is_nightscout_only(self):
+        """Care Portal manual entries detect as a non-loop uploader."""
+        visibility = _classify_anchor_visibility(
+            "nightscout:abc123",
+            {"source_uploader": "unknown", "bolus_subtype": "normal"},
+        )
+        assert visibility is _AnchorVisibility.NIGHTSCOUT_ONLY
+
+    def test_nightscout_xdrip_manual_log_is_nightscout_only(self):
+        visibility = _classify_anchor_visibility(
+            "nightscout:abc123",
+            {"source_uploader": "xdrip+", "bolus_subtype": "normal"},
+        )
+        assert visibility is _AnchorVisibility.NIGHTSCOUT_ONLY
+
+    def test_nightscout_loop_uploader_boluses_are_pump_visible(self):
+        """Closed-loop uploads record pump deliveries -- anchor cut applies."""
+        for uploader in ("loop", "aaps", "trio", "oref0"):
+            visibility = _classify_anchor_visibility(
+                "nightscout:abc123",
+                {"source_uploader": uploader, "bolus_subtype": "normal"},
+            )
+            assert visibility is _AnchorVisibility.PUMP, uploader
+
+    def test_nightscout_missing_metadata_is_nightscout_only(self):
+        """An NS row with no metadata cannot be proven loop-uploaded.
+
+        Conservative within Nightscout: without uploader attribution we
+        treat it as manual (still excluded against a Nightscout anchor).
+        """
+        visibility = _classify_anchor_visibility("nightscout:abc123", None)
+        assert visibility is _AnchorVisibility.NIGHTSCOUT_ONLY
+
+
+class TestSurvivesAnchorCut:
+    """Tests for the per-dose anchor-cut decision."""
+
+    ANCHOR_AT = datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
+
+    def _dose(self, minutes_offset: int, visibility: _AnchorVisibility) -> _Dose:
+        return _Dose(
+            timestamp=self.ANCHOR_AT + timedelta(minutes=minutes_offset),
+            units=1.0,
+            anchor_visibility=visibility,
+        )
+
+    def test_pump_dose_after_anchor_survives(self):
+        dose = self._dose(+5, _AnchorVisibility.PUMP)
+        assert _survives_anchor_cut(dose, self.ANCHOR_AT, False) is True
+
+    def test_pump_dose_at_anchor_is_cut(self):
+        dose = self._dose(0, _AnchorVisibility.PUMP)
+        assert _survives_anchor_cut(dose, self.ANCHOR_AT, False) is False
+
+    def test_pump_dose_before_anchor_is_cut(self):
+        dose = self._dose(-30, _AnchorVisibility.PUMP)
+        assert _survives_anchor_cut(dose, self.ANCHOR_AT, False) is False
+
+    def test_pen_dose_before_anchor_survives(self):
+        dose = self._dose(-30, _AnchorVisibility.NEVER)
+        assert _survives_anchor_cut(dose, self.ANCHOR_AT, False) is True
+
+    def test_pen_dose_survives_even_nightscout_anchor(self):
+        dose = self._dose(-30, _AnchorVisibility.NEVER)
+        assert _survives_anchor_cut(dose, self.ANCHOR_AT, True) is True
+
+    def test_ns_manual_dose_before_pump_anchor_survives(self):
+        dose = self._dose(-30, _AnchorVisibility.NIGHTSCOUT_ONLY)
+        assert _survives_anchor_cut(dose, self.ANCHOR_AT, False) is True
+
+    def test_ns_manual_dose_before_nightscout_anchor_is_cut(self):
+        """Conservative: an NS-derived anchor may already include it."""
+        dose = self._dose(-30, _AnchorVisibility.NIGHTSCOUT_ONLY)
+        assert _survives_anchor_cut(dose, self.ANCHOR_AT, True) is False
+
+    def test_ns_manual_dose_after_nightscout_anchor_survives(self):
+        """Post-anchor doses always count -- the anchor predates them."""
+        dose = self._dose(+5, _AnchorVisibility.NIGHTSCOUT_ONLY)
+        assert _survives_anchor_cut(dose, self.ANCHOR_AT, True) is True
+
+
+async def _create_user(db_session, prefix: str) -> tuple:
+    """Create a user directly in the database; returns (user, email, password)."""
+    from src.core.security import hash_password
+    from src.models.user import User, UserRole
+
+    email = unique_email(prefix)
+    password = "SecurePass123"
+    user = User(
+        email=email,
+        hashed_password=hash_password(password),
+        role=UserRole.DIABETIC,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user, email, password
+
+
+async def _fetch_projection(email: str, password: str):
+    """Login and GET the IoB projection endpoint; returns the response."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        login_response = await client.post(
+            "/api/auth/login",
+            json={"email": email, "password": password},
+        )
+        session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
+        return await client.get(
+            "/api/integrations/tandem/iob/projection",
+            cookies={settings.jwt_cookie_name: session_cookie},
+        )
+
+
+@pytest.mark.asyncio
+class TestNonPumpDoseProjection:
+    """Non-pump doses (smart-pen via Glooko, manual Nightscout entries)
+    must contribute to projected IoB even when a pump-confirmed anchor
+    exists -- the anchor's writer never knew about them.
+    """
+
+    # Decay reference (parabolic, DIA=4h): remaining(0.5h) = 0.984375,
+    # remaining(1h) = 0.9375, remaining(2h) = 0.75.
+
+    async def test_pen_dose_before_pump_anchor_counts(self, db_session):
+        """THE BUG: a pen dose at-or-before the anchor must not vanish.
+
+        Glooko pump+pen dual user: the pump bolus row carries the IoB
+        anchor, the pen dose predates it. Pre-fix the pen dose contributed
+        zero; post-fix it decays independently and adds on top.
+        """
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_pen_before")
+        now = datetime.now(UTC)
+
+        anchor_bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(minutes=30),
+            units=1.0,
+            iob_at_event=2.0,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("glooko-pump-bolus-1"),
+        )
+        pen_dose = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=1),
+            units=4.0,
+            iob_at_event=None,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("glooko-pen-dose-1"),
+            metadata_json={"glooko_stream": "insulins", "device_delivered": True},
+        )
+        db_session.add_all([anchor_bolus, pen_dose])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # pump anchor: 2.0 * remaining(0.5h) = 1.96875
+        # pen dose:    4.0 * remaining(1h)   = 3.75  (pre-fix: 0)
+        assert data["projected_iob"] == pytest.approx(5.72, rel=0.05)
+        assert data["is_estimated"] is False
+
+    async def test_pen_dose_exactly_at_anchor_counts(self, db_session):
+        """A pen dose at the exact anchor timestamp still counts -- the
+        anchor cannot include it no matter the timing."""
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_pen_at")
+        now = datetime.now(UTC)
+        anchor_time = now - timedelta(hours=1)
+
+        anchor = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BG_READING,
+            event_timestamp=anchor_time,
+            units=None,
+            iob_at_event=1.5,
+            received_at=now,
+            source="tandem",
+        )
+        pen_dose = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=anchor_time,
+            units=2.0,
+            iob_at_event=None,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("glooko-pen-dose-2"),
+            metadata_json={"glooko_stream": "insulins", "device_delivered": True},
+        )
+        db_session.add_all([anchor, pen_dose])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # anchor: 1.5 * 0.9375 = 1.40625; pen: 2.0 * 0.9375 = 1.875
+        assert data["projected_iob"] == pytest.approx(3.28, rel=0.05)
+
+    async def test_pen_dose_older_than_dia_contributes_zero(self, db_session):
+        """A pen dose beyond the DIA window is fully decayed -- no effect."""
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_pen_old")
+        now = datetime.now(UTC)
+
+        anchor = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BG_READING,
+            event_timestamp=now - timedelta(minutes=30),
+            units=None,
+            iob_at_event=1.0,
+            received_at=now,
+            source="tandem",
+        )
+        stale_pen_dose = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=5),
+            units=10.0,
+            iob_at_event=None,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("glooko-pen-dose-3"),
+            metadata_json={"glooko_stream": "insulins", "device_delivered": True},
+        )
+        db_session.add_all([anchor, stale_pen_dose])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Only the anchor: 1.0 * remaining(0.5h) = 0.984375
+        assert data["projected_iob"] == pytest.approx(0.98, rel=0.05)
+
+    async def test_glooko_pump_bolus_not_double_counted(self, db_session):
+        """DOUBLE-COUNT REGRESSION: a Glooko PUMP-stream bolus before the
+        anchor is already inside the pump's IoB snapshot and must stay cut.
+        Only the `insulins` stream is anchor-blind."""
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_nodup_glooko")
+        now = datetime.now(UTC)
+
+        old_pump_bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=2),
+            units=5.0,
+            iob_at_event=None,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("glooko-pump-bolus-2"),
+        )
+        anchor_bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(minutes=30),
+            units=0.5,
+            iob_at_event=3.0,  # pump total -- already includes the 5.0u bolus
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("glooko-pump-bolus-3"),
+        )
+        db_session.add_all([old_pump_bolus, anchor_bolus])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Anchor only: 3.0 * remaining(0.5h) = 2.953
+        # Double-counting would add 5.0 * 0.75 = 3.75 on top (~6.7)
+        assert data["projected_iob"] == pytest.approx(2.95, rel=0.05)
+
+    async def test_pen_dose_after_anchor_counted_once(self, db_session):
+        """A pen dose after the anchor passes both the timestamp rule and
+        the anchor-blind rule -- it must still be summed exactly once."""
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_pen_once")
+        now = datetime.now(UTC)
+
+        anchor = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BG_READING,
+            event_timestamp=now - timedelta(hours=1),
+            units=None,
+            iob_at_event=1.0,
+            received_at=now,
+            source="tandem",
+        )
+        pen_dose = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(minutes=30),
+            units=3.0,
+            iob_at_event=None,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("glooko-pen-dose-4"),
+            metadata_json={"glooko_stream": "insulins", "device_delivered": True},
+        )
+        db_session.add_all([anchor, pen_dose])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # anchor: 1.0 * 0.9375 = 0.9375; pen ONCE: 3.0 * 0.984375 = 2.953
+        # Summed twice it would be ~6.84.
+        assert data["projected_iob"] == pytest.approx(3.89, rel=0.05)
+
+    async def test_ns_manual_dose_with_pump_anchor_counts(self, db_session):
+        """A Care Portal manual entry is invisible to a pump-hardware anchor."""
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_ns_manual")
+        now = datetime.now(UTC)
+
+        anchor = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BG_READING,
+            event_timestamp=now - timedelta(minutes=30),
+            units=None,
+            iob_at_event=2.0,
+            received_at=now,
+            source="tandem",
+        )
+        careportal_dose = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=1),
+            units=2.0,
+            iob_at_event=None,
+            received_at=now,
+            source="nightscout:11111111-1111-1111-1111-111111111111",
+            ns_id=_unique_ns_id("ns-careportal-1"),
+            metadata_json={"source_uploader": "unknown", "bolus_subtype": "normal"},
+        )
+        db_session.add_all([anchor, careportal_dose])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # anchor: 2.0 * 0.984375 = 1.96875; manual: 2.0 * 0.9375 = 1.875
+        assert data["projected_iob"] == pytest.approx(3.84, rel=0.05)
+
+    async def test_ns_manual_dose_with_nightscout_anchor_excluded(self, db_session):
+        """Conservative rule: against a Nightscout-derived anchor (loop
+        devicestatus IoB), NS manual entries keep the anchor cut -- AAPS
+        NS-sync can import them into the loop's own IoB, so adding them
+        here would risk double-counting."""
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_ns_anchor")
+        now = datetime.now(UTC)
+        ns_source = "nightscout:22222222-2222-2222-2222-222222222222"
+
+        ns_anchor = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BATTERY,
+            event_timestamp=now - timedelta(minutes=30),
+            units=None,
+            iob_at_event=2.5,
+            received_at=now,
+            source=ns_source,
+            ns_id=_unique_ns_id("ns-devicestatus-1"),
+        )
+        careportal_dose = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=1),
+            units=3.0,
+            iob_at_event=None,
+            received_at=now,
+            source=ns_source,
+            ns_id=_unique_ns_id("ns-careportal-2"),
+            metadata_json={"source_uploader": "unknown", "bolus_subtype": "normal"},
+        )
+        db_session.add_all([ns_anchor, careportal_dose])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Anchor only: 2.5 * remaining(0.5h) = 2.4609
+        assert data["projected_iob"] == pytest.approx(2.46, rel=0.05)
+
+    async def test_ns_loop_bolus_before_pump_anchor_excluded(self, db_session):
+        """A loop-uploaded NS bolus records a pump delivery -- it is inside
+        the pump's IoB snapshot and must stay behind the anchor cut."""
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_ns_loop")
+        now = datetime.now(UTC)
+
+        anchor = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BG_READING,
+            event_timestamp=now - timedelta(minutes=30),
+            units=None,
+            iob_at_event=2.0,
+            received_at=now,
+            source="tandem",
+        )
+        loop_bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=1),
+            units=4.0,
+            iob_at_event=None,
+            received_at=now,
+            source="nightscout:33333333-3333-3333-3333-333333333333",
+            ns_id=_unique_ns_id("ns-loop-bolus-1"),
+            metadata_json={"source_uploader": "loop", "bolus_subtype": "normal"},
+        )
+        db_session.add_all([anchor, loop_bolus])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Anchor only: 2.0 * remaining(0.5h) = 1.96875
+        assert data["projected_iob"] == pytest.approx(1.97, rel=0.05)
+
+    async def test_pen_only_user_unaffected(self, db_session):
+        """Pen-only users (no anchor) keep the honest is_estimated path."""
+        from src.models.pump_data import PumpEvent, PumpEventType
+
+        user, email, password = await _create_user(db_session, "iob_pen_only")
+        now = datetime.now(UTC)
+
+        pen_dose = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=1),
+            units=4.0,
+            iob_at_event=None,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("glooko-pen-dose-5"),
+            metadata_json={"glooko_stream": "insulins", "device_delivered": True},
+        )
+        db_session.add(pen_dose)
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Pure dose sum: 4.0 * 0.9375 = 3.75
+        assert data["projected_iob"] == pytest.approx(3.75, rel=0.05)
+        assert data["is_estimated"] is True
+        assert "estimated" in data["stale_warning"].lower()

--- a/apps/api/tests/test_iob_projection.py
+++ b/apps/api/tests/test_iob_projection.py
@@ -16,6 +16,7 @@ from src.models.pump_data import PumpEvent, PumpEventType
 from src.models.user import User, UserRole
 from src.services.iob_projection import (
     _DOSE_EVENT_TYPES,
+    _MAX_SINGLE_DOSE_UNITS,
     INSULIN_DIA_HOURS,
     _AnchorVisibility,
     _classify_anchor_visibility,
@@ -248,6 +249,21 @@ class TestSumIoBFromDoses:
         doses = [(now, 3.0)]
         iob = _sum_iob_from_doses(doses, now)
         assert iob == pytest.approx(3.0, rel=0.01)
+
+    def test_plausible_max_dose_not_clamped(self):
+        """A real 60 U single dose (NovoPen 6 max) is summed in full."""
+        now = datetime.now(UTC)
+        doses = [(now, _MAX_SINGLE_DOSE_UNITS)]
+        iob = _sum_iob_from_doses(doses, now)
+        assert iob == pytest.approx(_MAX_SINGLE_DOSE_UNITS, rel=0.01)
+
+    def test_corrupt_dose_units_are_clamped(self):
+        """A corrupt/implausible units value can't poison projected IoB."""
+        now = datetime.now(UTC)
+        doses = [(now, 9999.0)]
+        iob = _sum_iob_from_doses(doses, now)
+        # Clamped to the physiological single-dose ceiling, not 9999.
+        assert iob == pytest.approx(_MAX_SINGLE_DOSE_UNITS, rel=0.01)
 
 
 class TestDoseEventTypePin:

--- a/apps/api/tests/test_iob_projection.py
+++ b/apps/api/tests/test_iob_projection.py
@@ -7,11 +7,13 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from httpx import ASGITransport, AsyncClient
+from httpx import ASGITransport, AsyncClient, Response
 
 from src.config import settings
+from src.core.security import hash_password
 from src.main import app
-from src.models.pump_data import PumpEventType
+from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.user import User, UserRole
 from src.services.iob_projection import (
     _DOSE_EVENT_TYPES,
     INSULIN_DIA_HOURS,
@@ -39,6 +41,39 @@ def _unique_ns_id(prefix: str) -> str:
     rows across runs, so a hardcoded ns_id collides on re-run.
     """
     return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+async def _create_user(db_session, prefix: str) -> tuple[User, str, str]:
+    """Create a user directly in the database; returns (user, email, password)."""
+    email = unique_email(prefix)
+    password = "SecurePass123"
+    user = User(
+        email=email,
+        hashed_password=hash_password(password),
+        role=UserRole.DIABETIC,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user, email, password
+
+
+async def _fetch_projection(email: str, password: str) -> Response:
+    """Login and GET the IoB projection endpoint; returns the response."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        login_response = await client.post(
+            "/api/auth/login",
+            json={"email": email, "password": password},
+        )
+        assert login_response.status_code == 200, login_response.text
+        session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
+        return await client.get(
+            "/api/integrations/tandem/iob/projection",
+            cookies={settings.jwt_cookie_name: session_cookie},
+        )
 
 
 class TestInsulinDecayCurve:
@@ -215,533 +250,6 @@ class TestSumIoBFromDoses:
         assert iob == pytest.approx(3.0, rel=0.01)
 
 
-@pytest.mark.asyncio
-class TestIoBProjectionEndpoint:
-    """Tests for the IoB projection API endpoint."""
-
-    async def test_iob_projection_requires_auth(self):
-        """IoB projection endpoint requires authentication."""
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            response = await client.get("/api/integrations/tandem/iob/projection")
-
-        assert response.status_code == 401
-
-    async def test_iob_projection_no_data(self):
-        """IoB projection returns 404 when no data available."""
-        email = unique_email("iob_no_data")
-        password = "SecurePass123"
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            # Register and login
-            await client.post(
-                "/api/auth/register",
-                json={"email": email, "password": password},
-            )
-
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 404
-        assert "No IoB data" in response.json()["detail"]
-
-    async def test_iob_projection_with_data(self, db_session):
-        """IoB projection returns data when pump events exist."""
-        from src.core.security import hash_password
-        from src.models.pump_data import PumpEvent, PumpEventType
-        from src.models.user import User, UserRole
-
-        email = unique_email("iob_with_data")
-        password = "SecurePass123"
-
-        # Create user directly in the database
-        user = User(
-            email=email,
-            hashed_password=hash_password(password),
-            role=UserRole.DIABETIC,
-        )
-        db_session.add(user)
-        await db_session.commit()
-        await db_session.refresh(user)
-
-        # Create a pump event with IoB data
-        now = datetime.now(UTC)
-        pump_event = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.BOLUS,
-            event_timestamp=now - timedelta(minutes=30),
-            units=2.0,
-            iob_at_event=2.5,
-            received_at=now,
-        )
-        db_session.add(pump_event)
-        await db_session.commit()
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 200
-
-        data = response.json()
-        assert data["confirmed_iob"] == 2.5
-        assert "projected_iob" in data
-        assert "projected_30min" in data
-        assert "projected_60min" in data
-        assert data["is_stale"] is False
-        assert data["stale_warning"] is None
-        assert data["is_estimated"] is False
-
-    async def test_iob_projection_stale_data(self, db_session):
-        """IoB projection shows stale warning for old data."""
-        from src.core.security import hash_password
-        from src.models.pump_data import PumpEvent, PumpEventType
-        from src.models.user import User, UserRole
-
-        email = unique_email("iob_stale")
-        password = "SecurePass123"
-
-        # Create user directly in the database
-        user = User(
-            email=email,
-            hashed_password=hash_password(password),
-            role=UserRole.DIABETIC,
-        )
-        db_session.add(user)
-        await db_session.commit()
-        await db_session.refresh(user)
-
-        # Create a pump event with IoB data from 3 hours ago
-        now = datetime.now(UTC)
-        pump_event = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.BOLUS,
-            event_timestamp=now - timedelta(hours=3),
-            units=2.0,
-            iob_at_event=2.5,
-            received_at=now - timedelta(hours=3),
-        )
-        db_session.add(pump_event)
-        await db_session.commit()
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 200
-
-        data = response.json()
-        assert data["is_stale"] is True
-        assert data["stale_warning"] is not None
-        assert "unreliable" in data["stale_warning"].lower()
-
-    async def test_iob_projection_decay_over_time(self, db_session):
-        """IoB projection correctly applies decay curve."""
-        from src.core.security import hash_password
-        from src.models.pump_data import PumpEvent, PumpEventType
-        from src.models.user import User, UserRole
-
-        email = unique_email("iob_decay")
-        password = "SecurePass123"
-
-        # Create user directly in the database
-        user = User(
-            email=email,
-            hashed_password=hash_password(password),
-            role=UserRole.DIABETIC,
-        )
-        db_session.add(user)
-        await db_session.commit()
-        await db_session.refresh(user)
-
-        # Create a pump event with IoB data from 2 hours ago
-        now = datetime.now(UTC)
-        pump_event = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.BOLUS,
-            event_timestamp=now - timedelta(hours=2),
-            units=2.0,
-            iob_at_event=4.0,
-            received_at=now - timedelta(hours=2),
-        )
-        db_session.add(pump_event)
-        await db_session.commit()
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 200
-
-        data = response.json()
-        # After 2 hours, ~75% should remain (4.0 * 0.75 = 3.0)
-        assert data["projected_iob"] == pytest.approx(3.0, rel=0.1)
-        # 30 min ahead should be less
-        assert data["projected_30min"] < data["projected_iob"]
-        # 60 min ahead should be even less
-        assert data["projected_60min"] < data["projected_30min"]
-
-    async def test_iob_includes_post_confirmation_bolus(self, db_session):
-        """Boluses delivered after the pump's IoB snapshot increase IoB."""
-        from src.core.security import hash_password
-        from src.models.pump_data import PumpEvent, PumpEventType
-        from src.models.user import User, UserRole
-
-        email = unique_email("iob_hybrid")
-        password = "SecurePass123"
-
-        user = User(
-            email=email,
-            hashed_password=hash_password(password),
-            role=UserRole.DIABETIC,
-        )
-        db_session.add(user)
-        await db_session.commit()
-        await db_session.refresh(user)
-
-        now = datetime.now(UTC)
-
-        # Pump-confirmed IoB snapshot: 2.0u at 1 hour ago
-        snapshot_event = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.CORRECTION,
-            event_timestamp=now - timedelta(hours=1),
-            units=0.5,
-            iob_at_event=2.0,
-            received_at=now - timedelta(hours=1),
-        )
-        # A 3.0u bolus delivered 30 minutes AFTER the snapshot
-        post_bolus = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.BOLUS,
-            event_timestamp=now - timedelta(minutes=30),
-            units=3.0,
-            iob_at_event=None,
-            received_at=now - timedelta(minutes=30),
-        )
-        db_session.add_all([snapshot_event, post_bolus])
-        await db_session.commit()
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 200
-        data = response.json()
-
-        # pump_component: 2.0 * remaining(1h, 4h) = 2.0 * 0.9375 = 1.875
-        # post_component: 3.0 * remaining(0.5h, 4h) = 3.0 * 0.984375 = 2.953
-        # total ≈ 4.83
-        # Without the fix, this would just be 1.875 (ignoring the 3.0u bolus)
-        assert data["projected_iob"] > 4.0
-        assert data["projected_iob"] == pytest.approx(4.83, rel=0.1)
-        assert data["confirmed_iob"] == 2.0
-
-    async def test_iob_no_double_counting(self, db_session):
-        """Doses before the pump confirmation are NOT double-counted."""
-        from src.core.security import hash_password
-        from src.models.pump_data import PumpEvent, PumpEventType
-        from src.models.user import User, UserRole
-
-        email = unique_email("iob_nodup")
-        password = "SecurePass123"
-
-        user = User(
-            email=email,
-            hashed_password=hash_password(password),
-            role=UserRole.DIABETIC,
-        )
-        db_session.add(user)
-        await db_session.commit()
-        await db_session.refresh(user)
-
-        now = datetime.now(UTC)
-
-        # A bolus from 2 hours ago (units=5.0)
-        old_bolus = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.BOLUS,
-            event_timestamp=now - timedelta(hours=2),
-            units=5.0,
-            iob_at_event=None,
-            received_at=now - timedelta(hours=2),
-        )
-        # Pump snapshot 1 hour ago already includes the old bolus's IoB
-        snapshot = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.CORRECTION,
-            event_timestamp=now - timedelta(hours=1),
-            units=0.5,
-            iob_at_event=3.0,  # pump's total IoB at that point
-            received_at=now - timedelta(hours=1),
-        )
-        db_session.add_all([old_bolus, snapshot])
-        await db_session.commit()
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 200
-        data = response.json()
-
-        # pump_component: 3.0 * remaining(1h, 4h) = 3.0 * 0.9375 = 2.8125
-        # post_component: 0 (old_bolus is BEFORE snapshot, so excluded)
-        # total ≈ 2.81
-        # If double-counted, it would be 2.81 + 5.0*0.75 = 6.56 (wrong!)
-        assert data["projected_iob"] == pytest.approx(2.81, rel=0.1)
-
-    async def test_iob_dose_only_fallback(self, db_session):
-        """When no pump confirmation exists, uses pure dose summation."""
-        from src.core.security import hash_password
-        from src.models.pump_data import PumpEvent, PumpEventType
-        from src.models.user import User, UserRole
-
-        email = unique_email("iob_fallback")
-        password = "SecurePass123"
-
-        user = User(
-            email=email,
-            hashed_password=hash_password(password),
-            role=UserRole.DIABETIC,
-        )
-        db_session.add(user)
-        await db_session.commit()
-        await db_session.refresh(user)
-
-        now = datetime.now(UTC)
-
-        # Bolus with no pump IoB snapshot
-        bolus = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.BOLUS,
-            event_timestamp=now - timedelta(hours=1),
-            units=4.0,
-            iob_at_event=None,
-            received_at=now - timedelta(hours=1),
-        )
-        db_session.add(bolus)
-        await db_session.commit()
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 200
-        data = response.json()
-
-        # Pure dose sum: 4.0 * remaining(1h, 4h) = 4.0 * 0.9375 = 3.75
-        assert data["projected_iob"] == pytest.approx(3.75, rel=0.1)
-        assert data["is_estimated"] is True
-        assert "estimated" in data["stale_warning"].lower()
-
-    async def test_iob_same_timestamp_not_double_counted(self, db_session):
-        """A dose at the exact same timestamp as the snapshot is not double-counted."""
-        from src.core.security import hash_password
-        from src.models.pump_data import PumpEvent, PumpEventType
-        from src.models.user import User, UserRole
-
-        email = unique_email("iob_same_ts")
-        password = "SecurePass123"
-
-        user = User(
-            email=email,
-            hashed_password=hash_password(password),
-            role=UserRole.DIABETIC,
-        )
-        db_session.add(user)
-        await db_session.commit()
-        await db_session.refresh(user)
-
-        now = datetime.now(UTC)
-        snapshot_time = now - timedelta(hours=1)
-
-        # Bolus and IoB snapshot at the exact same timestamp
-        event = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.BOLUS,
-            event_timestamp=snapshot_time,
-            units=5.0,
-            iob_at_event=3.0,  # pump's IoB already includes this bolus
-            received_at=snapshot_time,
-        )
-        db_session.add(event)
-        await db_session.commit()
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 200
-        data = response.json()
-
-        # Should only be the decayed snapshot (3.0 * 0.9375 = 2.81)
-        # NOT snapshot + dose (which would be 2.81 + 5.0*0.9375 = 7.5)
-        assert data["projected_iob"] == pytest.approx(2.81, rel=0.1)
-
-    async def test_iob_fetch_excludes_non_bolus_events(self, db_session):
-        """Basal and other non-bolus events are excluded from dose summation."""
-        from src.core.security import hash_password
-        from src.models.pump_data import PumpEvent, PumpEventType
-        from src.models.user import User, UserRole
-
-        email = unique_email("iob_excl")
-        password = "SecurePass123"
-
-        user = User(
-            email=email,
-            hashed_password=hash_password(password),
-            role=UserRole.DIABETIC,
-        )
-        db_session.add(user)
-        await db_session.commit()
-        await db_session.refresh(user)
-
-        now = datetime.now(UTC)
-
-        # Pump snapshot 2 hours ago
-        snapshot = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.CORRECTION,
-            event_timestamp=now - timedelta(hours=2),
-            units=0.5,
-            iob_at_event=1.0,
-            received_at=now - timedelta(hours=2),
-        )
-        # Basal event after snapshot (should NOT be added to IoB)
-        basal = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.BASAL,
-            event_timestamp=now - timedelta(hours=1),
-            units=0.8,
-            iob_at_event=None,
-            received_at=now - timedelta(hours=1),
-        )
-        # Suspend event after snapshot (should NOT be added)
-        suspend = PumpEvent(
-            user_id=user.id,
-            event_type=PumpEventType.SUSPEND,
-            event_timestamp=now - timedelta(minutes=30),
-            units=None,
-            iob_at_event=None,
-            received_at=now - timedelta(minutes=30),
-        )
-        db_session.add_all([snapshot, basal, suspend])
-        await db_session.commit()
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            login_response = await client.post(
-                "/api/auth/login",
-                json={"email": email, "password": password},
-            )
-            session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-            response = await client.get(
-                "/api/integrations/tandem/iob/projection",
-                cookies={settings.jwt_cookie_name: session_cookie},
-            )
-
-        assert response.status_code == 200
-        data = response.json()
-
-        # Should only be decayed snapshot: 1.0 * remaining(2h, 4h) = 1.0 * 0.75 = 0.75
-        # Basal and suspend events should NOT contribute
-        assert data["projected_iob"] == pytest.approx(0.75, rel=0.1)
-        assert data["is_estimated"] is False
-
-
 class TestDoseEventTypePin:
     """Pin the event types the IoB engine is allowed to sum as doses.
 
@@ -757,11 +265,6 @@ class TestDoseEventTypePin:
             PumpEventType.CORRECTION,
         }
 
-    def test_future_basal_injection_type_never_summed(self):
-        """Explicit tripwire for issue #728's planned BASAL_INJECTION type."""
-        basal_injection = getattr(PumpEventType, "BASAL_INJECTION", None)
-        assert basal_injection is None or basal_injection not in _DOSE_EVENT_TYPES
-
 
 class TestAnchorVisibilityClassification:
     """Tests for the pump-anchor visibility discriminator."""
@@ -772,6 +275,17 @@ class TestAnchorVisibilityClassification:
             "glooko", {"glooko_stream": "insulins", "device_delivered": True}
         )
         assert visibility is _AnchorVisibility.NEVER
+
+    def test_insulins_marker_requires_glooko_source(self):
+        """The insulins-stream marker is only trusted on Glooko rows.
+
+        A future writer passing client-supplied metadata through must not
+        be able to flip a pump bolus into an always-counted dose.
+        """
+        visibility = _classify_anchor_visibility(
+            "mobile", {"glooko_stream": "insulins"}
+        )
+        assert visibility is _AnchorVisibility.PUMP
 
     def test_glooko_pump_stream_is_pump_visible(self):
         """Glooko pump-stream boluses are pump deliveries (anchor cut applies)."""
@@ -813,14 +327,29 @@ class TestAnchorVisibilityClassification:
             )
             assert visibility is _AnchorVisibility.PUMP, uploader
 
-    def test_nightscout_missing_metadata_is_nightscout_only(self):
-        """An NS row with no metadata cannot be proven loop-uploaded.
+    def test_nightscout_tidepool_bolus_is_pump_visible(self):
+        """Tidepool mirrors pump uploads -- treating its boluses as manual
+        would double-count them against a pump-hardware anchor."""
+        visibility = _classify_anchor_visibility(
+            "nightscout:abc123",
+            {"source_uploader": "tidepool", "bolus_subtype": "normal"},
+        )
+        assert visibility is _AnchorVisibility.PUMP
 
-        Conservative within Nightscout: without uploader attribution we
-        treat it as manual (still excluded against a Nightscout anchor).
-        """
-        visibility = _classify_anchor_visibility("nightscout:abc123", None)
-        assert visibility is _AnchorVisibility.NIGHTSCOUT_ONLY
+    def test_nightscout_missing_metadata_is_pump_visible(self):
+        """An NS row with no uploader attribution cannot be positively
+        identified as manual -- it degrades to the pre-fix anchor cut
+        (understatement) rather than risking double-counting."""
+        assert (
+            _classify_anchor_visibility("nightscout:abc123", None)
+            is _AnchorVisibility.PUMP
+        )
+        assert (
+            _classify_anchor_visibility(
+                "nightscout:abc123", {"bolus_subtype": "normal"}
+            )
+            is _AnchorVisibility.PUMP
+        )
 
 
 class TestSurvivesAnchorCut:
@@ -870,39 +399,295 @@ class TestSurvivesAnchorCut:
         assert _survives_anchor_cut(dose, self.ANCHOR_AT, True) is True
 
 
-async def _create_user(db_session, prefix: str) -> tuple:
-    """Create a user directly in the database; returns (user, email, password)."""
-    from src.core.security import hash_password
-    from src.models.user import User, UserRole
+@pytest.mark.asyncio
+class TestIoBProjectionEndpoint:
+    """Tests for the IoB projection API endpoint."""
 
-    email = unique_email(prefix)
-    password = "SecurePass123"
-    user = User(
-        email=email,
-        hashed_password=hash_password(password),
-        role=UserRole.DIABETIC,
-    )
-    db_session.add(user)
-    await db_session.commit()
-    await db_session.refresh(user)
-    return user, email, password
+    async def test_iob_projection_requires_auth(self):
+        """IoB projection endpoint requires authentication."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/api/integrations/tandem/iob/projection")
 
+        assert response.status_code == 401
 
-async def _fetch_projection(email: str, password: str):
-    """Login and GET the IoB projection endpoint; returns the response."""
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-    ) as client:
-        login_response = await client.post(
-            "/api/auth/login",
-            json={"email": email, "password": password},
+    async def test_iob_projection_no_data(self):
+        """IoB projection returns 404 when no data available."""
+        email = unique_email("iob_no_data")
+        password = "SecurePass123"
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            await client.post(
+                "/api/auth/register",
+                json={"email": email, "password": password},
+            )
+
+        response = await _fetch_projection(email, password)
+
+        assert response.status_code == 404
+        assert "No IoB data" in response.json()["detail"]
+
+    async def test_iob_projection_with_data(self, db_session):
+        """IoB projection returns data when pump events exist."""
+        user, email, password = await _create_user(db_session, "iob_with_data")
+
+        # Create a pump event with IoB data
+        now = datetime.now(UTC)
+        pump_event = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(minutes=30),
+            units=2.0,
+            iob_at_event=2.5,
+            received_at=now,
         )
-        session_cookie = login_response.cookies.get(settings.jwt_cookie_name)
-        return await client.get(
-            "/api/integrations/tandem/iob/projection",
-            cookies={settings.jwt_cookie_name: session_cookie},
+        db_session.add(pump_event)
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["confirmed_iob"] == 2.5
+        assert "projected_iob" in data
+        assert "projected_30min" in data
+        assert "projected_60min" in data
+        assert data["is_stale"] is False
+        assert data["stale_warning"] is None
+        assert data["is_estimated"] is False
+
+    async def test_iob_projection_stale_data(self, db_session):
+        """IoB projection shows stale warning for old data."""
+        user, email, password = await _create_user(db_session, "iob_stale")
+
+        # Create a pump event with IoB data from 3 hours ago
+        now = datetime.now(UTC)
+        pump_event = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=3),
+            units=2.0,
+            iob_at_event=2.5,
+            received_at=now - timedelta(hours=3),
         )
+        db_session.add(pump_event)
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["is_stale"] is True
+        assert data["stale_warning"] is not None
+        assert "unreliable" in data["stale_warning"].lower()
+
+    async def test_iob_projection_decay_over_time(self, db_session):
+        """IoB projection correctly applies decay curve."""
+        user, email, password = await _create_user(db_session, "iob_decay")
+
+        # Create a pump event with IoB data from 2 hours ago
+        now = datetime.now(UTC)
+        pump_event = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=2),
+            units=2.0,
+            iob_at_event=4.0,
+            received_at=now - timedelta(hours=2),
+        )
+        db_session.add(pump_event)
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+
+        data = response.json()
+        # After 2 hours, ~75% should remain (4.0 * 0.75 = 3.0)
+        assert data["projected_iob"] == pytest.approx(3.0, rel=0.1)
+        # 30 min ahead should be less
+        assert data["projected_30min"] < data["projected_iob"]
+        # 60 min ahead should be even less
+        assert data["projected_60min"] < data["projected_30min"]
+
+    async def test_iob_includes_post_confirmation_bolus(self, db_session):
+        """Boluses delivered after the pump's IoB snapshot increase IoB."""
+        user, email, password = await _create_user(db_session, "iob_hybrid")
+
+        now = datetime.now(UTC)
+
+        # Pump-confirmed IoB snapshot: 2.0u at 1 hour ago
+        snapshot_event = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.CORRECTION,
+            event_timestamp=now - timedelta(hours=1),
+            units=0.5,
+            iob_at_event=2.0,
+            received_at=now - timedelta(hours=1),
+        )
+        # A 3.0u bolus delivered 30 minutes AFTER the snapshot
+        post_bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(minutes=30),
+            units=3.0,
+            iob_at_event=None,
+            received_at=now - timedelta(minutes=30),
+        )
+        db_session.add_all([snapshot_event, post_bolus])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # pump_component: 2.0 * remaining(1h, 4h) = 2.0 * 0.9375 = 1.875
+        # post_component: 3.0 * remaining(0.5h, 4h) = 3.0 * 0.984375 = 2.953
+        # total ≈ 4.83
+        # Without the fix, this would just be 1.875 (ignoring the 3.0u bolus)
+        assert data["projected_iob"] > 4.0
+        assert data["projected_iob"] == pytest.approx(4.83, rel=0.1)
+        assert data["confirmed_iob"] == 2.0
+
+    async def test_iob_no_double_counting(self, db_session):
+        """Doses before the pump confirmation are NOT double-counted."""
+        user, email, password = await _create_user(db_session, "iob_nodup")
+
+        now = datetime.now(UTC)
+
+        # A bolus from 2 hours ago (units=5.0)
+        old_bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=2),
+            units=5.0,
+            iob_at_event=None,
+            received_at=now - timedelta(hours=2),
+        )
+        # Pump snapshot 1 hour ago already includes the old bolus's IoB
+        snapshot = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.CORRECTION,
+            event_timestamp=now - timedelta(hours=1),
+            units=0.5,
+            iob_at_event=3.0,  # pump's total IoB at that point
+            received_at=now - timedelta(hours=1),
+        )
+        db_session.add_all([old_bolus, snapshot])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # pump_component: 3.0 * remaining(1h, 4h) = 3.0 * 0.9375 = 2.8125
+        # post_component: 0 (old_bolus is BEFORE snapshot, so excluded)
+        # total ≈ 2.81
+        # If double-counted, it would be 2.81 + 5.0*0.75 = 6.56 (wrong!)
+        assert data["projected_iob"] == pytest.approx(2.81, rel=0.1)
+
+    async def test_iob_dose_only_fallback(self, db_session):
+        """When no pump confirmation exists, uses pure dose summation."""
+        user, email, password = await _create_user(db_session, "iob_fallback")
+
+        now = datetime.now(UTC)
+
+        # Bolus with no pump IoB snapshot
+        bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(hours=1),
+            units=4.0,
+            iob_at_event=None,
+            received_at=now - timedelta(hours=1),
+        )
+        db_session.add(bolus)
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Pure dose sum: 4.0 * remaining(1h, 4h) = 4.0 * 0.9375 = 3.75
+        assert data["projected_iob"] == pytest.approx(3.75, rel=0.1)
+        assert data["is_estimated"] is True
+        assert "estimated" in data["stale_warning"].lower()
+
+    async def test_iob_same_timestamp_not_double_counted(self, db_session):
+        """A dose at the exact same timestamp as the snapshot is not double-counted."""
+        user, email, password = await _create_user(db_session, "iob_same_ts")
+
+        now = datetime.now(UTC)
+        snapshot_time = now - timedelta(hours=1)
+
+        # Bolus and IoB snapshot at the exact same timestamp
+        event = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=snapshot_time,
+            units=5.0,
+            iob_at_event=3.0,  # pump's IoB already includes this bolus
+            received_at=snapshot_time,
+        )
+        db_session.add(event)
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should only be the decayed snapshot (3.0 * 0.9375 = 2.81)
+        # NOT snapshot + dose (which would be 2.81 + 5.0*0.9375 = 7.5)
+        assert data["projected_iob"] == pytest.approx(2.81, rel=0.1)
+
+    async def test_iob_fetch_excludes_non_bolus_events(self, db_session):
+        """Basal and other non-bolus events are excluded from dose summation."""
+        user, email, password = await _create_user(db_session, "iob_excl")
+
+        now = datetime.now(UTC)
+
+        # Pump snapshot 2 hours ago
+        snapshot = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.CORRECTION,
+            event_timestamp=now - timedelta(hours=2),
+            units=0.5,
+            iob_at_event=1.0,
+            received_at=now - timedelta(hours=2),
+        )
+        # Basal event after snapshot (should NOT be added to IoB)
+        basal = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BASAL,
+            event_timestamp=now - timedelta(hours=1),
+            units=0.8,
+            iob_at_event=None,
+            received_at=now - timedelta(hours=1),
+        )
+        # Suspend event after snapshot (should NOT be added)
+        suspend = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.SUSPEND,
+            event_timestamp=now - timedelta(minutes=30),
+            units=None,
+            iob_at_event=None,
+            received_at=now - timedelta(minutes=30),
+        )
+        db_session.add_all([snapshot, basal, suspend])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should only be decayed snapshot: 1.0 * remaining(2h, 4h) = 1.0 * 0.75 = 0.75
+        # Basal and suspend events should NOT contribute
+        assert data["projected_iob"] == pytest.approx(0.75, rel=0.1)
+        assert data["is_estimated"] is False
 
 
 @pytest.mark.asyncio
@@ -922,8 +707,6 @@ class TestNonPumpDoseProjection:
         anchor, the pen dose predates it. Pre-fix the pen dose contributed
         zero; post-fix it decays independently and adds on top.
         """
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_pen_before")
         now = datetime.now(UTC)
 
@@ -935,7 +718,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=2.0,
             received_at=now,
             source="glooko",
-            ns_id=_unique_ns_id("glooko-pump-bolus-1"),
+            ns_id=_unique_ns_id("glooko-pump-bolus"),
         )
         pen_dose = PumpEvent(
             user_id=user.id,
@@ -945,7 +728,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source="glooko",
-            ns_id=_unique_ns_id("glooko-pen-dose-1"),
+            ns_id=_unique_ns_id("glooko-pen-dose"),
             metadata_json={"glooko_stream": "insulins", "device_delivered": True},
         )
         db_session.add_all([anchor_bolus, pen_dose])
@@ -963,8 +746,6 @@ class TestNonPumpDoseProjection:
     async def test_pen_dose_exactly_at_anchor_counts(self, db_session):
         """A pen dose at the exact anchor timestamp still counts -- the
         anchor cannot include it no matter the timing."""
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_pen_at")
         now = datetime.now(UTC)
         anchor_time = now - timedelta(hours=1)
@@ -986,7 +767,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source="glooko",
-            ns_id=_unique_ns_id("glooko-pen-dose-2"),
+            ns_id=_unique_ns_id("glooko-pen-dose"),
             metadata_json={"glooko_stream": "insulins", "device_delivered": True},
         )
         db_session.add_all([anchor, pen_dose])
@@ -1001,8 +782,6 @@ class TestNonPumpDoseProjection:
 
     async def test_pen_dose_older_than_dia_contributes_zero(self, db_session):
         """A pen dose beyond the DIA window is fully decayed -- no effect."""
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_pen_old")
         now = datetime.now(UTC)
 
@@ -1023,7 +802,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source="glooko",
-            ns_id=_unique_ns_id("glooko-pen-dose-3"),
+            ns_id=_unique_ns_id("glooko-pen-dose"),
             metadata_json={"glooko_stream": "insulins", "device_delivered": True},
         )
         db_session.add_all([anchor, stale_pen_dose])
@@ -1040,8 +819,6 @@ class TestNonPumpDoseProjection:
         """DOUBLE-COUNT REGRESSION: a Glooko PUMP-stream bolus before the
         anchor is already inside the pump's IoB snapshot and must stay cut.
         Only the `insulins` stream is anchor-blind."""
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_nodup_glooko")
         now = datetime.now(UTC)
 
@@ -1053,7 +830,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source="glooko",
-            ns_id=_unique_ns_id("glooko-pump-bolus-2"),
+            ns_id=_unique_ns_id("glooko-pump-bolus"),
         )
         anchor_bolus = PumpEvent(
             user_id=user.id,
@@ -1063,7 +840,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=3.0,  # pump total -- already includes the 5.0u bolus
             received_at=now,
             source="glooko",
-            ns_id=_unique_ns_id("glooko-pump-bolus-3"),
+            ns_id=_unique_ns_id("glooko-pump-bolus"),
         )
         db_session.add_all([old_pump_bolus, anchor_bolus])
         await db_session.commit()
@@ -1079,8 +856,6 @@ class TestNonPumpDoseProjection:
     async def test_pen_dose_after_anchor_counted_once(self, db_session):
         """A pen dose after the anchor passes both the timestamp rule and
         the anchor-blind rule -- it must still be summed exactly once."""
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_pen_once")
         now = datetime.now(UTC)
 
@@ -1101,7 +876,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source="glooko",
-            ns_id=_unique_ns_id("glooko-pen-dose-4"),
+            ns_id=_unique_ns_id("glooko-pen-dose"),
             metadata_json={"glooko_stream": "insulins", "device_delivered": True},
         )
         db_session.add_all([anchor, pen_dose])
@@ -1117,8 +892,6 @@ class TestNonPumpDoseProjection:
 
     async def test_ns_manual_dose_with_pump_anchor_counts(self, db_session):
         """A Care Portal manual entry is invisible to a pump-hardware anchor."""
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_ns_manual")
         now = datetime.now(UTC)
 
@@ -1139,7 +912,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source="nightscout:11111111-1111-1111-1111-111111111111",
-            ns_id=_unique_ns_id("ns-careportal-1"),
+            ns_id=_unique_ns_id("ns-careportal"),
             metadata_json={"source_uploader": "unknown", "bolus_subtype": "normal"},
         )
         db_session.add_all([anchor, careportal_dose])
@@ -1157,8 +930,6 @@ class TestNonPumpDoseProjection:
         devicestatus IoB), NS manual entries keep the anchor cut -- AAPS
         NS-sync can import them into the loop's own IoB, so adding them
         here would risk double-counting."""
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_ns_anchor")
         now = datetime.now(UTC)
         ns_source = "nightscout:22222222-2222-2222-2222-222222222222"
@@ -1171,7 +942,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=2.5,
             received_at=now,
             source=ns_source,
-            ns_id=_unique_ns_id("ns-devicestatus-1"),
+            ns_id=_unique_ns_id("ns-devicestatus"),
         )
         careportal_dose = PumpEvent(
             user_id=user.id,
@@ -1181,7 +952,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source=ns_source,
-            ns_id=_unique_ns_id("ns-careportal-2"),
+            ns_id=_unique_ns_id("ns-careportal"),
             metadata_json={"source_uploader": "unknown", "bolus_subtype": "normal"},
         )
         db_session.add_all([ns_anchor, careportal_dose])
@@ -1197,8 +968,6 @@ class TestNonPumpDoseProjection:
     async def test_ns_loop_bolus_before_pump_anchor_excluded(self, db_session):
         """A loop-uploaded NS bolus records a pump delivery -- it is inside
         the pump's IoB snapshot and must stay behind the anchor cut."""
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_ns_loop")
         now = datetime.now(UTC)
 
@@ -1219,7 +988,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source="nightscout:33333333-3333-3333-3333-333333333333",
-            ns_id=_unique_ns_id("ns-loop-bolus-1"),
+            ns_id=_unique_ns_id("ns-loop-bolus"),
             metadata_json={"source_uploader": "loop", "bolus_subtype": "normal"},
         )
         db_session.add_all([anchor, loop_bolus])
@@ -1232,10 +1001,55 @@ class TestNonPumpDoseProjection:
         # Anchor only: 2.0 * remaining(0.5h) = 1.96875
         assert data["projected_iob"] == pytest.approx(1.97, rel=0.05)
 
+    async def test_ns_backfilled_bolus_is_not_the_anchor(self, db_session):
+        """An NS bolus whose iob_at_event was backfilled from an older
+        devicestatus snapshot must not anchor the projection: its IoB
+        value predates its own timestamp. The devicestatus-derived
+        BATTERY row anchors instead, and the bolus -- now after that
+        anchor -- contributes via the timestamp rule."""
+        user, email, password = await _create_user(db_session, "iob_ns_backfill")
+        now = datetime.now(UTC)
+        ns_source = "nightscout:44444444-4444-4444-4444-444444444444"
+
+        battery_anchor = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BATTERY,
+            event_timestamp=now - timedelta(minutes=40),
+            units=None,
+            iob_at_event=1.0,
+            received_at=now,
+            source=ns_source,
+            ns_id=_unique_ns_id("ns-devicestatus"),
+        )
+        # Newest row with iob_at_event -- but it's a backfilled bolus
+        # (translator copied 1.0 from the 40-min-old devicestatus).
+        backfilled_bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(minutes=30),
+            units=2.0,
+            iob_at_event=1.0,
+            received_at=now,
+            source=ns_source,
+            ns_id=_unique_ns_id("ns-careportal"),
+            metadata_json={"source_uploader": "unknown", "bolus_subtype": "normal"},
+        )
+        db_session.add_all([battery_anchor, backfilled_bolus])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Anchor = BATTERY row: 1.0 * remaining(40min) = 0.9722
+        # Bolus is AFTER that anchor: 2.0 * remaining(30min) = 1.96875
+        # Anchoring on the backfilled bolus instead would yield only
+        # 1.0 * remaining(30min) = 0.984 (the bolus cut against itself).
+        assert data["confirmed_iob"] == 1.0
+        assert data["projected_iob"] == pytest.approx(2.94, rel=0.05)
+
     async def test_pen_only_user_unaffected(self, db_session):
         """Pen-only users (no anchor) keep the honest is_estimated path."""
-        from src.models.pump_data import PumpEvent, PumpEventType
-
         user, email, password = await _create_user(db_session, "iob_pen_only")
         now = datetime.now(UTC)
 
@@ -1247,7 +1061,7 @@ class TestNonPumpDoseProjection:
             iob_at_event=None,
             received_at=now,
             source="glooko",
-            ns_id=_unique_ns_id("glooko-pen-dose-5"),
+            ns_id=_unique_ns_id("glooko-pen-dose"),
             metadata_json={"glooko_stream": "insulins", "device_delivered": True},
         )
         db_session.add(pen_dose)

--- a/apps/api/tests/test_nightscout_evaluate.py
+++ b/apps/api/tests/test_nightscout_evaluate.py
@@ -272,7 +272,7 @@ async def test_orchestrator_happy_path_with_loop_profile():
     assert "loop" in report.uploaders_detected
     assert "aaps" in report.uploaders_detected
     assert "xdrip+" in report.uploaders_detected
-    # Loop wins the active_pump_loop tiebreak (first in _LOOP_UPLOADERS).
+    # Loop wins the active_pump_loop tiebreak (first in LOOP_UPLOADERS).
     assert report.active_pump_loop == "loop"
     assert report.has_profile is True
     assert report.profile_summary is not None


### PR DESCRIPTION
## Problem

The hybrid IoB projection engine (`apps/api/src/services/iob_projection.py`) anchors on the latest pump-confirmed IoB snapshot and then sums only doses *after* that anchor timestamp:

```python
post_doses = [(t, u) for t, u in all_doses if t > last_confirmed_at]
```

A pump's IoB snapshot knows nothing about insulin it didn't deliver — smart-pen doses synced via Glooko's `insulins` stream, or manual Nightscout entries. Because pump anchors refresh every few minutes (Tandem BLE pushes constantly; Glooko's `map_normal_boluses` carries `insulinOnBoard`), virtually every pen dose for a pump+pen dual user lands at-or-before the anchor and silently contributed **zero** to projected IoB — while the source-blind treatment-safety daily totals *did* count it. The error direction is unsafe: understated IoB invites correction stacking. Pen-only users were unaffected (no anchor → honest `is_estimated` dose-summation path).

Found in adversarial review of #726, confirmed by code trace.

## Fix

Each bolus/correction dose is classified by which IoB anchors could already include it (`_AnchorVisibility`):

- **PUMP** — pump-delivered insulin (direct integrations, Glooko/Medtronic pump streams, loop-/Tidepool-uploaded Nightscout boluses). The existing strict post-anchor cut applies unchanged.
- **NEVER** — Glooko `insulins`-stream rows (`metadata_json.glooko_stream == "insulins"`, on `source == "glooko"` only). No anchor writer can see these; they survive the cut regardless of anchor age, within the DIA window.
- **NIGHTSCOUT_ONLY** — manually-recorded Nightscout treatments (External Insulin, non-loop-uploader / Care Portal boluses). Invisible to pump-hardware anchors, so they survive the cut against a pump anchor; against a Nightscout-derived anchor the cut is conservatively kept (Loop/AAPS may already count them), because double-counting is the dangerous direction.

Rows that can't be positively identified as non-pump (unexpected source, absent metadata, absent uploader attribution) default to PUMP — degrading to the pre-fix behavior (possible understatement) rather than risking double-counting.

Additional hardening from adversarial + senior review:

- `get_last_iob` excludes Nightscout `BOLUS`/`CORRECTION` rows from anchor candidacy. Their `iob_at_event` is backfilled from a devicestatus snapshot up to 15 min older than the bolus, so anchoring on one would mis-start the decay clock and cut the bolus against itself. Devicestatus-derived `BATTERY` rows remain the Nightscout anchor.
- Deterministic `id` tiebreak on anchor selection so same-second rows don't flip the anchor value/source classification between calls.
- `get_last_iob` returns a frozen `IobAnchor` dataclass instead of a positional optional-tuple.
- Hoisted the duplicated `nightscout:` source prefix and the loop-uploader set into shared constants (`NIGHTSCOUT_SOURCE_PREFIX`, `LOOP_UPLOADERS` in `nightscout/models.py`), reused by `cgm_source`, `translator`, the NS router, `evaluate`, and `iob_projection`.

The dose-type filter (`_DOSE_EVENT_TYPES`) is test-pinned to `BOLUS`/`CORRECTION` so a future long-acting type (`BASAL_INJECTION`, #728) cannot enter the rapid-acting decay model.

All consumers inherit the fix: dashboard SSE IoB, the IoB endpoint, predictive alerts, diabetes context, caregiver views, and the Telegram `/iob` command.

## Tests

Added pump-only / pen-only / dual-source / dose-exactly-at-anchor / dose-older-than-DIA coverage, an explicit double-count regression (Glooko pump-stream bolus before the anchor stays cut), Tidepool/missing-metadata/insulins-marker classification cases, a backfilled-bolus-not-the-anchor regression, and the `BASAL_INJECTION` tripwire. Full API suite: 2484 passed.

## Validation

Exercised against real Postgres in an isolated Sentry-enabled API container: a dual-source user (Tandem anchor + Glooko pen dose + NS Care Portal entry + NS loop bolus) returned 7.43 U — anchor 1.97 + pen 3.75 + manual 1.72, with the loop bolus correctly cut — versus 1.97 U pre-fix. Pen-only user returned the honest `is_estimated` path. No Sentry issues attributable to the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced insulin-on-board (IoB) projection engine with anchor-aware projections and improved handling of non-pump insulin sources.

* **Bug Fixes**
  * Prevented double-counting of Nightscout-derived doses and refined survival rules around anchors for more accurate IoB.

* **Tests**
  * Expanded test coverage for IoB projection logic, anchor visibility, dose classification, and non-pump dose scenarios.

* **Quality**
  * More reliable detection of active pump-loop uploads from Nightscout sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issues

- Part of #724 — smart-pen doses ingested via Glooko (#726) were silently dropped from projected IoB whenever a pump anchor existed; this makes them count. The downstream completion of that feature.
- Relates to #728 — the `BOLUS`/`CORRECTION` dose-type pin is a guardrail for the planned `BASAL_INJECTION` type: a long-acting injection must never enter this rapid-acting decay model.
- Relates to #343 — the per-dose clamp partially mitigates the IoB impact of unbounded ingested `units` at the point of use. Does not close it: that issue asks for caps at the Tandem ingestion write path, and TDD / treatment-safety totals still see the raw value.
- Relates to #574 — same family (Nightscout-sourced pump events being ignored), different consumer: #574 is the dashboard insulin/bolus widgets, this is the IoB projection engine. Not a fix for the widgets.
