### PR TITLE
fix(api): show large pen doses (60U bound) and dedupe Glooko doses across sources

### DIFF
--- a/apps/api/src/models/pump_data.py
+++ b/apps/api/src/models/pump_data.py
@@ -6,6 +6,7 @@ Models for storing pump data from Tandem t:connect with pump activity tracking.
 import enum
 import uuid
 from datetime import datetime
+from typing import Final
 
 from sqlalchemy import (
     Boolean,
@@ -72,6 +73,21 @@ class PumpActivityMode(str, enum.Enum):
 
 # Backwards-compat alias -- remove once all consumers migrate
 ControlIQMode = PumpActivityMode
+
+
+# Platform-wide upper bound (U) on a single insulin dose any supported device
+# can record. The largest single actuation of any supported device is the
+# NovoPen 6 at 60 U (pumps cap lower: Tandem 25 U, Omnipod 30 U); anything above
+# is a corrupt or unit-confused record. This is the canonical bound -- consumers
+# import it instead of hard-coding 60: the Glooko ingestion mapper, the
+# IoB-projection dose clamp, the display/stats read filters in
+# `routers.integrations`, and the `BolusReviewItem` response-schema validator --
+# so a legitimate large pen dose accepted at ingest is not silently dropped or
+# hidden downstream, and a corrupt record is rejected uniformly. This is the
+# device-recording bound; the *delivery-command* safety limit is lower and lives
+# in `core.treatment_safety` (`MAX_BOLUS_DOSE_MILLIUNITS` = 25 U) -- we never
+# command a pump to deliver 60 U.
+MAX_INSULIN_DOSE_UNITS: Final[float] = 60.0
 
 
 class PumpEvent(Base):

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -78,7 +78,11 @@ from src.models.medtronic_connect_state import (
     STATUS_DISCONNECTED,
     MedtronicConnectState,
 )
-from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.pump_data import (
+    MAX_INSULIN_DOSE_UNITS,
+    PumpEvent,
+    PumpEventType,
+)
 from src.models.tandem_sync_state import (
     SYNC_INTERVAL_DEFAULT_MINUTES,
     TandemSyncState,
@@ -3862,8 +3866,15 @@ async def push_pump_events(
 
 # Maximum rows to load into memory for percentile calculation
 _AGP_MAX_ROWS = 50_000
-# Hard safety cap for insulin units (Tandem X2/Mobi max single bolus = 25U)
-_MAX_BOLUS_UNITS = 25
+# Hard safety cap for displayed/aggregated insulin units. Shares the platform
+# `MAX_INSULIN_DOSE_UNITS` bound (NovoPen 6 max actuation = 60U) with the
+# ingestion mappers so a legitimate large single dose -- e.g. a >25U pen dose,
+# routine for insulin-resistant users -- that was accepted at ingest is also
+# shown in the bolus-history table and counted in displayed TDD. Pump-commanded
+# boluses cap lower (Tandem 25U), but pump_events also holds smart-pen/manual
+# doses since #726; bounding the display at 25U silently hid them while IoB and
+# safety totals still counted them. The bound excludes only corrupt rows.
+_MAX_BOLUS_UNITS = MAX_INSULIN_DOSE_UNITS
 # Maximum basal rate (Tandem X2/Mobi max = 15 U/hr)
 _MAX_BASAL_RATE = 15.0
 # Maximum gap between basal records before capping (handles disconnections).

--- a/apps/api/src/schemas/pump.py
+++ b/apps/api/src/schemas/pump.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from src.models.pump_data import PumpEventType
+from src.models.pump_data import MAX_INSULIN_DOSE_UNITS, PumpEventType
 
 
 class PumpEventResponse(BaseModel):
@@ -470,7 +470,10 @@ class BolusReviewItem(BaseModel):
 
     event_timestamp: datetime
     units: float = Field(
-        ..., ge=0, le=25, description="Bolus units (hard safety cap 25U)"
+        ...,
+        ge=0,
+        le=MAX_INSULIN_DOSE_UNITS,
+        description="Bolus units (hard safety cap = platform max single dose, 60U)",
     )
     is_automated: bool = False
     control_iq_reason: str | None = None

--- a/apps/api/src/services/integrations/glooko/mapper.py
+++ b/apps/api/src/services/integrations/glooko/mapper.py
@@ -23,7 +23,7 @@ import math
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 
-from src.models.pump_data import PumpEventType
+from src.models.pump_data import MAX_INSULIN_DOSE_UNITS, PumpEventType
 
 SOURCE = "glooko"
 
@@ -41,14 +41,15 @@ _SG_MAX_MGDL = 500
 # multiply into a catastrophic daily total.
 _MAX_BASAL_RATE_UH = 35.0
 
-# Sanity bound on a single bolus/pen dose (U). The largest single actuation of
-# any supported device is the NovoPen 6 at 60 U (pumps cap lower: Tandem 25 U,
-# Omnipod 30 U); anything above is a corrupt or unit-confused record that would
-# poison IoB projection and safety totals (same stance as the basal/CGM bounds).
-# Manual Glooko logs share the bound as corrupt-record protection -- logging
-# concentrated (U-200/U-500) doses above 60 U is out of scope until the
-# platform models insulin concentration.
-_MAX_BOLUS_DOSE_U = 60.0
+# Sanity bound on a single bolus/pen dose (U). The platform-wide
+# ``MAX_INSULIN_DOSE_UNITS`` (NovoPen 6 max actuation = 60 U; pumps cap lower);
+# anything above is a corrupt or unit-confused record that would poison IoB
+# projection and safety totals (same stance as the basal/CGM bounds). Manual
+# Glooko logs share the bound as corrupt-record protection -- logging
+# concentrated (U-200/U-500) doses above 60 U is out of scope until the platform
+# models insulin concentration. Aliased locally to keep the bounds-checking
+# helpers reading in single-letter units.
+_MAX_BOLUS_DOSE_U = MAX_INSULIN_DOSE_UNITS
 
 
 # Glooko pump-events ``type`` -> our PumpEventType. Pod/cartridge/prime lifecycle

--- a/apps/api/src/services/integrations/glooko/storage.py
+++ b/apps/api/src/services/integrations/glooko/storage.py
@@ -1,18 +1,28 @@
 """Persist mapped Glooko records into glucose_readings + pump_events. Idempotent.
 
-Conflict targets match the existing per-source dedupe indexes so overlapping
+Conflict handling matches the existing per-source dedupe indexes so overlapping
 continuous-sync and one-time-import windows are safe to re-run:
 
 - glucose:   ``ON CONFLICT (user_id, reading_timestamp) DO NOTHING`` (graph/data
              CGM points carry no per-reading id, so the timestamp is the key).
-- pump events that carry a Glooko ``guid``: ``ON CONFLICT (source, ns_id) WHERE
-             ns_id IS NOT NULL DO NOTHING`` -- ``ns_id`` = the stable ``guid``, so
-             two boluses in the same second never collide (the natural-key index
-             would have dropped one). Any event without a guid falls back to the
-             ``(user_id, event_timestamp, event_type) WHERE ns_id IS NULL`` index.
+- pump events: a *bare* ``ON CONFLICT DO NOTHING`` (no explicit target) so a row
+             is arbitrated against whichever of the three partial unique indexes
+             it violates: ``(source, ns_id) WHERE ns_id IS NOT NULL`` (a Glooko
+             ``guid`` re-sync), ``(user_id, event_timestamp, event_type) WHERE
+             ns_id IS NULL`` (a guid-less event re-sync), and the cross-source
+             ``(user_id, dedupe_hash) WHERE dedupe_hash IS NOT NULL`` (Story
+             43.11 -- the same physical dose typed into Glooko AND logged via
+             Nightscout careportal collapses to one row instead of double-
+             counting in IoB / TDD). A *targeted* clause would arbitrate only its
+             named index and raise unique_violation on the others, so the bare
+             form is required now that a row can violate more than one index --
+             same mechanism Tandem sync, mobile push, and the Nightscout
+             translator use.
 
-Rows are de-duplicated on those keys within each batch first so a single
-multi-row INSERT can't hit an intra-statement conflict.
+Rows are de-duplicated on the guid / natural keys within each batch first so a
+single multi-row INSERT can't hit an intra-statement conflict; Postgres also
+collapses remaining within-statement duplicates (incl. dedupe-hash near-matches)
+under DO NOTHING.
 
 Timestamps must already be tz-aware UTC (the mapper resolves the pump local-time
 + offset footgun); we coerce to UTC defensively and refuse naive values rather
@@ -25,12 +35,12 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.pump_data import PumpEvent
+from src.services.pump_event_dedupe import compute_pump_event_dedupe_hash
 
 from .mapper import MappedRecords
 
@@ -120,21 +130,34 @@ async def store_glooko_records(
             "received_at": now,
             "source": e.source,
             "ns_id": e.ns_id,
+            # Cross-source dedupe key (Story 43.11): a dose typed into Glooko
+            # collapses against the same physical dose relayed via Nightscout
+            # careportal / a direct integration. The helper returns None for
+            # non-delivery events (suspend/resume, reservoir/battery telemetry),
+            # so only BOLUS/CORRECTION/BASAL rows participate in the index.
+            "dedupe_hash": compute_pump_event_dedupe_hash(
+                user_id=user_id,
+                event_type=e.event_type,
+                event_timestamp=ts,
+                units=e.units,
+                duration_minutes=e.duration_minutes,
+            ),
         }
         if e.ns_id:
             with_guid.setdefault(e.ns_id, row)
         else:
             without_guid.setdefault((ts, e.event_type), row)
 
+    # Bare ON CONFLICT DO NOTHING for both batches (see module docstring): a row
+    # may now violate the (source, ns_id), natural-key, OR (user_id, dedupe_hash)
+    # partial unique index, and only the untargeted form skips a conflict on any
+    # of them rather than raising unique_violation on the unnamed ones.
     guid_rows = list(with_guid.values())
     for start in range(0, len(guid_rows), _CHUNK):
         stmt = (
             insert(PumpEvent)
             .values(guid_rows[start : start + _CHUNK])
-            .on_conflict_do_nothing(
-                index_elements=["source", "ns_id"],
-                index_where=text("ns_id IS NOT NULL"),
-            )
+            .on_conflict_do_nothing()
             .returning(PumpEvent.id)
         )
         res = await db.execute(stmt)
@@ -145,10 +168,7 @@ async def store_glooko_records(
         stmt = (
             insert(PumpEvent)
             .values(natural_rows[start : start + _CHUNK])
-            .on_conflict_do_nothing(
-                index_elements=["user_id", "event_timestamp", "event_type"],
-                index_where=text("ns_id IS NULL"),
-            )
+            .on_conflict_do_nothing()
             .returning(PumpEvent.id)
         )
         res = await db.execute(stmt)

--- a/apps/api/src/services/integrations/medtronic/storage.py
+++ b/apps/api/src/services/integrations/medtronic/storage.py
@@ -1,14 +1,22 @@
 """Persist mapped CareLink records into glucose_readings + pump_events.
 
-Batched, idempotent bulk upserts using the same conflict targets the other
-direct integrations use:
+Batched, idempotent bulk upserts:
 - glucose: ``ON CONFLICT (user_id, reading_timestamp) DO NOTHING`` (as Dexcom)
-- pump events: ``ON CONFLICT (user_id, event_timestamp, event_type) WHERE
-  ns_id IS NULL DO NOTHING`` (as Tandem)
+- pump events: a *bare* ``ON CONFLICT DO NOTHING`` (no explicit target) so a row
+  is arbitrated against whichever partial unique index it violates: the
+  natural-key ``(user_id, event_timestamp, event_type) WHERE ns_id IS NULL``
+  (re-import idempotency, as Tandem) and the cross-source ``(user_id,
+  dedupe_hash) WHERE dedupe_hash IS NOT NULL`` (Story 43.11 -- the same physical
+  dose reported by CareLink AND relayed via Nightscout careportal collapses to
+  one row instead of double-counting in IoB / TDD). A *targeted* clause would
+  arbitrate only its named index and raise unique_violation on the other, so the
+  bare form is required -- same mechanism Tandem sync, mobile push, the
+  Nightscout translator, and Glooko use.
 
-so re-importing an overlapping range is safe. Rows are de-duplicated on those
-keys within each batch first, so a single multi-row INSERT can't hit an
-intra-statement conflict.
+Re-importing an overlapping range is therefore safe. Rows are de-duplicated on
+the natural key within each batch first, so a single multi-row INSERT can't hit
+an intra-statement conflict; Postgres also collapses remaining within-statement
+duplicates (incl. dedupe-hash near-matches) under DO NOTHING.
 
 Timezone note: CareLink CSV timestamps are naive *pump-local* time (the export
 carries no offset). Localizing them to UTC correctly requires the user's
@@ -24,12 +32,12 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.pump_data import PumpEvent
+from src.services.pump_event_dedupe import compute_pump_event_dedupe_hash
 
 from .carelink_mapper import MappedRecords
 
@@ -99,9 +107,13 @@ async def store_carelink_records(
             insert(GlucoseReading)
             .values(g_rows[start : start + _CHUNK])
             .on_conflict_do_nothing(index_elements=["user_id", "reading_timestamp"])
+            # RETURNING yields one row per ACTUAL insert (conflicts return
+            # nothing), so the count is exact regardless of driver rowcount
+            # support -- rowcount is unreliable under ON CONFLICT DO NOTHING.
+            .returning(GlucoseReading.id)
         )
         res = await db.execute(stmt)
-        result.glucose_stored += max(res.rowcount, 0)
+        result.glucose_stored += len(res.fetchall())
 
     # --- Pump events: dedupe on (event_timestamp, event_type), keep first ---
     events_by_key: dict[tuple, dict] = {}
@@ -124,19 +136,34 @@ async def store_carelink_records(
             "bg_at_event": e.bg_at_event,
             "received_at": now,
             "source": e.source,
+            # Cross-source dedupe key (Story 43.11): a CareLink dose collapses
+            # against the same physical dose relayed via Nightscout careportal /
+            # a direct integration. The helper returns None for non-delivery
+            # events (suspend/resume, telemetry), so only BOLUS/CORRECTION/BASAL
+            # rows participate in the index.
+            "dedupe_hash": compute_pump_event_dedupe_hash(
+                user_id=user_id,
+                event_type=e.event_type,
+                event_timestamp=ts,
+                units=e.units,
+                duration_minutes=e.duration_minutes,
+            ),
         }
     e_rows = list(events_by_key.values())
     for start in range(0, len(e_rows), _CHUNK):
+        # Bare ON CONFLICT DO NOTHING (see module docstring): a row may violate
+        # the natural-key OR the (user_id, dedupe_hash) partial unique index, and
+        # only the untargeted form skips a conflict on either rather than raising
+        # unique_violation on the unnamed one. RETURNING gives a reliable insert
+        # count -- rowcount is unreliable under ON CONFLICT DO NOTHING (asyncpg).
         stmt = (
             insert(PumpEvent)
             .values(e_rows[start : start + _CHUNK])
-            .on_conflict_do_nothing(
-                index_elements=["user_id", "event_timestamp", "event_type"],
-                index_where=text("ns_id IS NULL"),
-            )
+            .on_conflict_do_nothing()
+            .returning(PumpEvent.id)
         )
         res = await db.execute(stmt)
-        result.events_stored += max(res.rowcount, 0)
+        result.events_stored += len(res.fetchall())
 
     if commit:
         await db.commit()

--- a/apps/api/src/services/iob_projection.py
+++ b/apps/api/src/services/iob_projection.py
@@ -15,7 +15,11 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.pump_data import (
+    MAX_INSULIN_DOSE_UNITS,
+    PumpEvent,
+    PumpEventType,
+)
 from src.services.integrations.glooko.mapper import SOURCE as GLOOKO_SOURCE
 from src.services.integrations.nightscout.models import (
     LOOP_UPLOADERS,
@@ -78,12 +82,13 @@ INSULIN_PEAK_HOURS = 1.0  # Time to peak activity
 # would otherwise propagate unbounded into projected IoB and silently suppress
 # a needed correction. 60 U is the largest single actuation of any supported
 # device -- the NovoPen 6; pumps cap lower (Tandem 25 U, Omnipod 30 U) -- so
-# this clips only implausible values, never a real single dose. Mirrors the
-# Glooko ingestion bound (`glooko.mapper._MAX_BOLUS_DOSE_U`) and the platform
-# single-bolus safety limit (`treatment_safety.MAX_BOLUS_DOSE_MILLIUNITS`),
-# applied here as defense-in-depth at the point of use. Concentrated insulin
+# this clips only implausible values, never a real single dose. Shares the
+# platform `MAX_INSULIN_DOSE_UNITS` bound (the same constant the ingestion
+# mappers and display/stats filters use) -- distinct from the lower
+# delivery-command safety limit (`treatment_safety.MAX_BOLUS_DOSE_MILLIUNITS`)
+# -- applied here as defense-in-depth at the point of use. Concentrated insulin
 # (U-200/U-500) is out of scope until the platform models concentration.
-_MAX_SINGLE_DOSE_UNITS = 60.0
+_MAX_SINGLE_DOSE_UNITS = MAX_INSULIN_DOSE_UNITS
 
 # The ONLY event types this engine sums as insulin doses (test-pinned).
 # Basal-family types must never enter dose summation -- BASAL is already

--- a/apps/api/tests/test_aggregate_stats.py
+++ b/apps/api/tests/test_aggregate_stats.py
@@ -1640,3 +1640,89 @@ class TestSourceFilteringAndDedup:
         # Both rows render -- source no longer filters at the read layer.
         assert data["total_count"] == 2
         assert len(data["boluses"]) == 2
+
+
+@pytest.mark.asyncio
+class TestPenDoseDisplayBound:
+    """The display/stats bound matches the ingestion bound (60U, NovoPen 6
+    max actuation) so a large but legitimate pen dose accepted at ingest is
+    not silently hidden from the history table / TDD while it still counts in
+    IoB and safety totals.
+
+    Pre-fix: the bound was 25U (Tandem max bolus), so a 30U pen dose stored
+    via Glooko (#726) was excluded from `/bolus/review` and `/insulin/summary`
+    yet counted everywhere else -- the displayed TDD disagreed with the safety
+    engine.
+    """
+
+    async def _seed(self, db: AsyncSession, user_id: str) -> None:
+        uid = uuid.UUID(user_id)
+        ts = _stable_test_ts(days=1)
+        # 30U: above the old 25U bound, within the 60U pen bound -> must show.
+        db.add(
+            PumpEvent(
+                user_id=uid,
+                event_type=PumpEventType.BOLUS,
+                event_timestamp=ts,
+                units=30.0,
+                is_automated=False,
+                received_at=ts,
+                source="glooko",
+            )
+        )
+        # 70U: above the 60U pen bound -> corrupt/unit-confused, still excluded.
+        # Kept 1s before the 30U dose so it stays inside the days=1 window even
+        # when the test runs near the UTC boundary -- the exclusion must be the
+        # bound doing the work, not the time filter.
+        db.add(
+            PumpEvent(
+                user_id=uid,
+                event_type=PumpEventType.BOLUS,
+                event_timestamp=ts - timedelta(seconds=1),
+                units=70.0,
+                is_automated=False,
+                received_at=ts,
+                source="glooko",
+            )
+        )
+        await db.commit()
+
+    async def test_large_pen_dose_appears_in_bolus_review(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie, user_id = await register_and_login(client)
+            async for db in get_db():
+                await self._seed(db, user_id)
+                break
+
+            resp = await client.get(
+                "/api/integrations/bolus/review?days=1&limit=10",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        units = sorted(b["units"] for b in data["boluses"])
+        assert units == [30.0], f"expected only the 30U dose, got {units}"
+        assert data["total_count"] == 1
+
+    async def test_large_pen_dose_counted_in_summary(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie, user_id = await register_and_login(client)
+            async for db in get_db():
+                await self._seed(db, user_id)
+                break
+
+            resp = await client.get(
+                "/api/integrations/insulin/summary?days=1",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Only the 30U dose is a valid bolus; the 70U row is excluded.
+        assert data["bolus_count"] == 1
+        # bolus_units reflects the 30U dose (per-day divisor may scale it, but
+        # it must be well above the old 25U ceiling and not include the 70U row).
+        assert data["bolus_units"] >= 30.0

--- a/apps/api/tests/test_carelink_storage.py
+++ b/apps/api/tests/test_carelink_storage.py
@@ -1,11 +1,12 @@
 """Tests for CareLink record storage (idempotent upserts) against the DB."""
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import pytest
 from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
 
 from src.database import get_session_maker
 from src.models.glucose import GlucoseReading
@@ -17,6 +18,11 @@ from src.services.integrations.medtronic.carelink_mapper import (
     MappedRecords,
 )
 from src.services.integrations.medtronic.storage import store_carelink_records
+from src.services.pump_event_dedupe import compute_pump_event_dedupe_hash
+
+# Anchor on a 30-second epoch boundary (HH:MM:00) so timestamp offsets land in
+# the dedupe bucket we intend regardless of when the suite runs.
+_BUCKET_BASE = datetime(2025, 1, 31, 12, 0, 0, tzinfo=UTC)
 
 
 async def _make_user(db) -> uuid.UUID:
@@ -36,6 +42,48 @@ async def _count(db, model, user_id) -> int:
             select(func.count()).select_from(model).where(model.user_id == user_id)
         )
     ).scalar_one()
+
+
+async def _bolus_count(db, user_id) -> int:
+    return (
+        await db.execute(
+            select(func.count())
+            .select_from(PumpEvent)
+            .where(
+                PumpEvent.user_id == user_id,
+                PumpEvent.event_type == PumpEventType.BOLUS,
+            )
+        )
+    ).scalar_one()
+
+
+async def _insert_other_source(db, user_id, *, ts, units, source):
+    """Insert a non-CareLink delivery row via the production bare insert path."""
+    row = {
+        "id": uuid.uuid4(),
+        "user_id": user_id,
+        "event_type": PumpEventType.BOLUS,
+        "event_timestamp": ts,
+        "units": units,
+        "duration_minutes": None,
+        "is_automated": False,
+        "received_at": datetime.now(UTC),
+        "source": source,
+        "ns_id": f"other-{uuid.uuid4().hex}",
+        "dedupe_hash": compute_pump_event_dedupe_hash(
+            user_id=user_id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=ts,
+            units=units,
+            duration_minutes=None,
+        ),
+    }
+    stmt = (
+        insert(PumpEvent).values([row]).on_conflict_do_nothing().returning(PumpEvent.id)
+    )
+    res = await db.execute(stmt)
+    await db.commit()
+    return len(res.fetchall())
 
 
 def _sample(ts: datetime) -> MappedRecords:
@@ -125,3 +173,92 @@ async def test_aware_timestamp_normalized_to_utc():
         ).scalar_one()
         assert row.value == 99
         assert row.reading_timestamp.astimezone(UTC).hour == 14
+
+
+async def test_same_dose_two_sources_collapses():
+    # A dose relayed via Nightscout careportal then the same physical dose synced
+    # from CareLink (0.03 U apart, same 30 s bucket, distinct seconds so the
+    # natural key would NOT collapse them) -> one row, first writer wins.
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        t_ns = _BUCKET_BASE + timedelta(seconds=4)
+        t_cl = _BUCKET_BASE + timedelta(seconds=12)
+        assert (
+            await _insert_other_source(
+                db, uid, ts=t_ns, units=2.50, source="nightscout:1"
+            )
+            == 1
+        )
+
+        res = await store_carelink_records(
+            db,
+            uid,
+            MappedRecords(
+                pump_events=[
+                    MappedPumpEvent(PumpEventType.BOLUS, t_cl, units=2.53),
+                ]
+            ),
+        )
+        assert res.events_stored == 0  # suppressed by dedupe_hash
+        assert await _bolus_count(db, uid) == 1
+        kept = await db.execute(
+            select(PumpEvent.source).where(PumpEvent.user_id == uid)
+        )
+        assert kept.scalar_one() == "nightscout:1"
+
+
+async def test_distinct_doses_31s_apart_both_persist():
+    # 31 s apart -> different 30 s buckets -> different hashes -> both kept.
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        t_ns = _BUCKET_BASE
+        t_cl = _BUCKET_BASE + timedelta(seconds=31)
+        assert (
+            await _insert_other_source(
+                db, uid, ts=t_ns, units=2.50, source="nightscout:1"
+            )
+            == 1
+        )
+
+        res = await store_carelink_records(
+            db,
+            uid,
+            MappedRecords(
+                pump_events=[MappedPumpEvent(PumpEventType.BOLUS, t_cl, units=2.50)]
+            ),
+        )
+        assert res.events_stored == 1
+        assert await _bolus_count(db, uid) == 2
+
+
+async def test_delivery_rows_hashed_telemetry_opts_out():
+    # BOLUS/BASAL participate in the cross-source index; a no-units SUSPEND
+    # opts out (dedupe_hash is None).
+    async with get_session_maker()() as db:
+        uid = await _make_user(db)
+        await store_carelink_records(
+            db,
+            uid,
+            MappedRecords(
+                pump_events=[
+                    MappedPumpEvent(PumpEventType.BOLUS, _BUCKET_BASE, units=3.0),
+                    MappedPumpEvent(
+                        PumpEventType.BASAL,
+                        _BUCKET_BASE + timedelta(minutes=5),
+                        units=0.8,
+                    ),
+                    MappedPumpEvent(
+                        PumpEventType.SUSPEND, _BUCKET_BASE + timedelta(minutes=10)
+                    ),
+                ]
+            ),
+        )
+        rows = await db.execute(
+            select(PumpEvent.event_type, PumpEvent.dedupe_hash).where(
+                PumpEvent.user_id == uid
+            )
+        )
+        by_type = dict(rows.all())
+        assert by_type[PumpEventType.BOLUS] is not None
+        assert by_type[PumpEventType.BASAL] is not None
+        assert by_type[PumpEventType.SUSPEND] is None

--- a/apps/api/tests/test_glooko_storage.py
+++ b/apps/api/tests/test_glooko_storage.py
@@ -1,0 +1,308 @@
+"""Tests for Glooko record persistence (cross-source dedupe + idempotency).
+
+Focus: ``store_glooko_records`` now stamps every insulin-delivery row with the
+shared cross-source ``dedupe_hash`` (Story 43.11) and upserts via a bare
+``ON CONFLICT DO NOTHING`` so a dose typed into Glooko collapses against the
+same physical dose relayed via Nightscout careportal -- without breaking the
+existing ``(source, ns_id)`` / natural-key re-sync idempotency.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+
+from src.config import settings
+from src.database import get_db
+from src.main import app
+from src.models.pump_data import PumpEvent, PumpEventType
+from src.services.integrations.glooko.mapper import (
+    SOURCE,
+    MappedPumpEvent,
+    MappedRecords,
+)
+from src.services.integrations.glooko.storage import store_glooko_records
+from src.services.pump_event_dedupe import compute_pump_event_dedupe_hash
+
+# Anchor on a 30-second epoch boundary so timestamp offsets land in the bucket
+# we intend regardless of when the suite runs.
+_BUCKET_BASE = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+
+
+async def _register(client: AsyncClient) -> uuid.UUID:
+    email = f"glstore-{uuid.uuid4().hex[:10]}@example.com"
+    reg = await client.post(
+        "/api/auth/register", json={"email": email, "password": "SecurePass123"}
+    )
+    assert reg.status_code == 201, reg.text
+    login = await client.post(
+        "/api/auth/login", json={"email": email, "password": "SecurePass123"}
+    )
+    assert login.status_code == 200, login.text
+    cookie = login.cookies.get(settings.jwt_cookie_name)
+    me = await client.get("/api/auth/me", cookies={settings.jwt_cookie_name: cookie})
+    return uuid.UUID(me.json()["id"])
+
+
+async def _insert_other_source(db, uid, *, ts, units, source, event_type="bolus"):
+    """Insert a non-Glooko delivery row via the production bare insert path."""
+    row = {
+        "id": uuid.uuid4(),
+        "user_id": uid,
+        "event_type": event_type,
+        "event_timestamp": ts,
+        "units": units,
+        "duration_minutes": None,
+        "is_automated": False,
+        "received_at": datetime.now(UTC),
+        "source": source,
+        "ns_id": f"other-{uuid.uuid4().hex}",
+        "dedupe_hash": compute_pump_event_dedupe_hash(
+            user_id=uid,
+            event_type=event_type,
+            event_timestamp=ts,
+            units=units,
+            duration_minutes=None,
+        ),
+    }
+    stmt = (
+        insert(PumpEvent).values([row]).on_conflict_do_nothing().returning(PumpEvent.id)
+    )
+    res = await db.execute(stmt)
+    await db.commit()
+    return len(res.scalars().all())
+
+
+async def _bolus_count(db, uid) -> int:
+    res = await db.execute(
+        select(func.count())
+        .select_from(PumpEvent)
+        .where(
+            PumpEvent.user_id == uid,
+            PumpEvent.event_type == PumpEventType.BOLUS,
+        )
+    )
+    return res.scalar_one()
+
+
+def _glooko_bolus(*, ts, units, guid=None):
+    return MappedPumpEvent(
+        event_type=PumpEventType.BOLUS,
+        timestamp=ts,
+        ns_id=guid,
+        units=units,
+    )
+
+
+@pytest.mark.asyncio
+class TestGlookoCrossSourceDedupe:
+    async def test_same_dose_two_sources_collapses(self):
+        # A dose relayed via Nightscout careportal then the same physical dose
+        # typed into Glooko (0.03 U apart, same 30 s bucket, distinct seconds so
+        # the natural key would NOT collapse them) -> one row, first writer wins.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            uid = await _register(client)
+            async for db in get_db():
+                t_ns = _BUCKET_BASE + timedelta(seconds=4)
+                t_glooko = _BUCKET_BASE + timedelta(seconds=12)
+                assert (
+                    await _insert_other_source(
+                        db, uid, ts=t_ns, units=2.50, source="nightscout:1"
+                    )
+                    == 1
+                )
+
+                records = MappedRecords(
+                    pump_events=[
+                        _glooko_bolus(
+                            ts=t_glooko, units=2.53, guid=f"g-{uuid.uuid4().hex}"
+                        )
+                    ]
+                )
+                result = await store_glooko_records(db, uid, records)
+
+                assert result.events_stored == 0  # suppressed by dedupe_hash
+                assert await _bolus_count(db, uid) == 1
+                kept = await db.execute(
+                    select(PumpEvent.source).where(PumpEvent.user_id == uid)
+                )
+                assert kept.scalar_one() == "nightscout:1"
+                break
+
+    async def test_distinct_doses_31s_apart_both_persist(self):
+        # 31 s apart -> different 30 s buckets -> different hashes -> both kept.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            uid = await _register(client)
+            async for db in get_db():
+                t_ns = _BUCKET_BASE
+                t_glooko = _BUCKET_BASE + timedelta(seconds=31)
+                assert (
+                    await _insert_other_source(
+                        db, uid, ts=t_ns, units=2.50, source="nightscout:1"
+                    )
+                    == 1
+                )
+
+                records = MappedRecords(
+                    pump_events=[
+                        _glooko_bolus(
+                            ts=t_glooko, units=2.50, guid=f"g-{uuid.uuid4().hex}"
+                        )
+                    ]
+                )
+                result = await store_glooko_records(db, uid, records)
+
+                assert result.events_stored == 1
+                assert await _bolus_count(db, uid) == 2
+                break
+
+    async def test_same_hash_two_guids_one_batch_collapses(self):
+        # Two distinct Glooko guids in ONE sync batch that quantize to the same
+        # dedupe bucket (same units, distinct seconds inside one 30 s window).
+        # Both land in the guid batch, so a single multi-row INSERT under bare
+        # ON CONFLICT DO NOTHING must collapse them on the (user_id, dedupe_hash)
+        # index rather than raise unique_violation.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            uid = await _register(client)
+            async for db in get_db():
+                records = MappedRecords(
+                    pump_events=[
+                        _glooko_bolus(
+                            ts=_BUCKET_BASE + timedelta(seconds=4),
+                            units=2.5,
+                            guid=f"g-{uuid.uuid4().hex}",
+                        ),
+                        _glooko_bolus(
+                            ts=_BUCKET_BASE + timedelta(seconds=12),
+                            units=2.5,
+                            guid=f"g-{uuid.uuid4().hex}",
+                        ),
+                    ]
+                )
+                result = await store_glooko_records(db, uid, records)
+
+                assert result.events_stored == 1
+                assert await _bolus_count(db, uid) == 1
+                break
+
+
+@pytest.mark.asyncio
+class TestGlookoResyncIdempotency:
+    async def test_guid_bolus_resync_is_idempotent(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            uid = await _register(client)
+            async for db in get_db():
+                guid = f"g-{uuid.uuid4().hex}"
+                records = MappedRecords(
+                    pump_events=[_glooko_bolus(ts=_BUCKET_BASE, units=4.0, guid=guid)]
+                )
+                first = await store_glooko_records(db, uid, records)
+                assert first.events_stored == 1
+
+                # Re-sync the exact same record: the (source, ns_id) index must
+                # still arbitrate even though dedupe_hash is now populated.
+                second = await store_glooko_records(
+                    db,
+                    uid,
+                    MappedRecords(
+                        pump_events=[
+                            _glooko_bolus(ts=_BUCKET_BASE, units=4.0, guid=guid)
+                        ]
+                    ),
+                )
+                assert second.events_stored == 0
+                assert await _bolus_count(db, uid) == 1
+                break
+
+    async def test_guidless_event_resync_is_idempotent(self):
+        # SUSPEND carries no units and no guid -> dedupe_hash is None (opts out
+        # of the cross-source index); the natural key must still dedupe re-syncs.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            uid = await _register(client)
+            async for db in get_db():
+                event = MappedPumpEvent(
+                    event_type=PumpEventType.SUSPEND, timestamp=_BUCKET_BASE
+                )
+                first = await store_glooko_records(
+                    db, uid, MappedRecords(pump_events=[event])
+                )
+                assert first.events_stored == 1
+                second = await store_glooko_records(
+                    db,
+                    uid,
+                    MappedRecords(
+                        pump_events=[
+                            MappedPumpEvent(
+                                event_type=PumpEventType.SUSPEND, timestamp=_BUCKET_BASE
+                            )
+                        ]
+                    ),
+                )
+                assert second.events_stored == 0
+                res = await db.execute(
+                    select(func.count())
+                    .select_from(PumpEvent)
+                    .where(
+                        PumpEvent.user_id == uid,
+                        PumpEvent.event_type == PumpEventType.SUSPEND,
+                    )
+                )
+                assert res.scalar_one() == 1
+                break
+
+
+@pytest.mark.asyncio
+class TestGlookoDedupeHashPopulation:
+    """BOLUS and BASAL get a hash; non-delivery telemetry opts out (None)."""
+
+    async def test_delivery_rows_hashed_telemetry_opts_out(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            uid = await _register(client)
+            async for db in get_db():
+                records = MappedRecords(
+                    pump_events=[
+                        _glooko_bolus(
+                            ts=_BUCKET_BASE, units=3.0, guid=f"g-{uuid.uuid4().hex}"
+                        ),
+                        MappedPumpEvent(
+                            event_type=PumpEventType.BASAL,
+                            timestamp=_BUCKET_BASE + timedelta(minutes=5),
+                            ns_id=f"g-{uuid.uuid4().hex}",
+                            units=0.8,
+                            duration_minutes=30,
+                        ),
+                        MappedPumpEvent(
+                            event_type=PumpEventType.DEVICE_EVENT,
+                            timestamp=_BUCKET_BASE + timedelta(minutes=10),
+                            ns_id=f"g-{uuid.uuid4().hex}",
+                            metadata_json={"glooko_type": "reservoir_change"},
+                        ),
+                    ]
+                )
+                await store_glooko_records(db, uid, records)
+
+                rows = await db.execute(
+                    select(PumpEvent.event_type, PumpEvent.dedupe_hash).where(
+                        PumpEvent.user_id == uid, PumpEvent.source == SOURCE
+                    )
+                )
+                by_type = dict(rows.all())
+                assert by_type[PumpEventType.BOLUS] is not None
+                assert by_type[PumpEventType.BASAL] is not None
+                assert by_type[PumpEventType.DEVICE_EVENT] is None
+                break


### PR DESCRIPTION
## Summary

Three related backend fixes around insulin-dose handling.

### 1. Pump-derived 25U cap hid legitimate pen doses

The display/stats path bounded insulin units at 25U (the Tandem max single bolus), but since #726 `pump_events` also holds smart-pen doses (NovoPen 6 max actuation = 60U; >25U rapid doses are routine for insulin-resistant users). A 30U pen dose was stored and counted in IoB/safety totals yet was **invisible in the bolus-history table and excluded from displayed TDD** — the widget disagreed with the safety engine.

This adds a single canonical platform bound `MAX_INSULIN_DOSE_UNITS = 60.0` in `models/pump_data.py` and consumes it everywhere a *recorded* dose is bounded — the display/stats read filters (`routers/integrations.py`), the `BolusReviewItem` response-schema validator (`schemas/pump.py`), the Glooko ingestion mapper, and the IoB-projection clamp — replacing three duplicated `60.0` literals and the 25U display cap. The lower **delivery-command** safety limit (`treatment_safety.MAX_BOLUS_DOSE_MILLIUNITS` = 25U) is intentionally unchanged; we never command a pump to deliver 60U.

### 2. Glooko rows never got a cross-source `dedupe_hash`

Every other write path (`tandem_sync`, the Nightscout translator, mobile push) stamps a cross-source `dedupe_hash` so the same physical dose reported by two integrations collapses to one row via the `(user_id, dedupe_hash)` partial unique index. Glooko's row dict omitted it, so a dose typed into Glooko **and** logged in Nightscout careportal landed twice in IoB summation and TDD.

This computes `dedupe_hash` for Glooko rows with the existing shared helper (BOLUS/CORRECTION/BASAL participate; telemetry opts out) and switches both pump-event inserts from targeted `ON CONFLICT` to the **bare** form — required now that a row can violate any of three partial unique indexes; a targeted clause arbitrates only its named index and raises `unique_violation` on the others. The existing `(source, ns_id)` and natural-key re-sync idempotency is preserved by the same bare `DO NOTHING`.

### 3. Medtronic CareLink had the same dedupe gap

CareLink storage was the last ingestion path still on a targeted `ON CONFLICT` with no `dedupe_hash`, so a CareLink dose double-counted against a Nightscout-careportal copy. This applies the identical pattern (`dedupe_hash` + bare `ON CONFLICT DO NOTHING`) to `integrations/medtronic/storage.py`, and switches its insert counts to RETURNING (rowcount is unreliable under `ON CONFLICT DO NOTHING` on asyncpg) for both the event and glucose paths, matching the other write paths. **Every ingestion path is now on the cross-source dedupe pattern.**

## Tests

- New `tests/test_glooko_storage.py` and additions to `tests/test_carelink_storage.py`: same-dose-via-two-sources collapses; distinct doses 31s apart both persist; same-hash two-rows-in-one-batch collapse intra-statement; guid and guid-less / natural-key re-sync idempotency unchanged; BASAL hashed / telemetry opts out.
- `tests/test_aggregate_stats.py`: a >25U ≤60U dose now appears in `/bolus/review` and `/insulin/summary`; a >60U dose is still excluded (both seeded inside the query window).
- Full ruff lint + format clean; IoB-projection, dedupe, CareLink sync/mapper suites re-run green.

## Validation

Reviewed via adversarial, senior code-quality, security, and CodeRabbit CLI gates (CareLink addition included). Exercised `/bolus/review`, `/insulin/summary`, and `/pump/push` against a Sentry-enabled local stack — endpoints return 200, the >60U dose is correctly filtered, the app boots cleanly with the new shared-constant and dedupe imports, and no new Sentry issues are attributable to the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized platform max single insulin dose (60U) applied to bolus review and insulin analytics displays.

* **Improvements**
  * Robust cross-source deduplication for insulin delivery records and idempotent storage to prevent duplicate entries and ensure accurate summaries.

* **Tests**
  * Added coverage for dose display bounds and cross-source delivery deduplication and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->