### PR TITLE
chore(ci): stop auto-labeler flagging templated PRs as breaking changes

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -116,8 +116,16 @@ jobs:
               if (typeLabels[commitType]) {
                 labelsToAdd.add(typeLabels[commitType]);
               }
-              // Breaking change detection
-              if (prTitle.includes('!:') || prBody.toLowerCase().includes('breaking change')) {
+              // Breaking change detection: a `!:` title marker (e.g. `feat!:`)
+              // or a Conventional Commits `BREAKING CHANGE:` footer in the body.
+              // A *checked* "Breaking change" template checkbox is handled
+              // separately below. We deliberately avoid a loose
+              // `includes('breaking change')` -- the PR template's own descriptor
+              // text ("non-breaking change which fixes an issue") would
+              // false-positive on every templated PR (it mislabelled #725/#726).
+              // The `(^|\n)\s*` anchor keeps "non-breaking change" from matching.
+              const breakingFooter = /(^|\n)\s*BREAKING[ -]CHANGE:/i.test(prBody);
+              if (prTitle.includes('!:') || breakingFooter) {
                 labelsToAdd.add('breaking-change');
               }
             }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -124,7 +124,7 @@ jobs:
               // text ("non-breaking change which fixes an issue") would
               // false-positive on every templated PR (it mislabelled #725/#726).
               // The `(^|\n)\s*` anchor keeps "non-breaking change" from matching.
-              const breakingFooter = /(^|\n)\s*BREAKING[ -]CHANGE:/i.test(prBody);
+              const breakingFooter = /(^|\n)\s*BREAKING[ \-]CHANGE:/i.test(prBody);
               if (prTitle.includes('!:') || breakingFooter) {
                 labelsToAdd.add('breaking-change');
               }


### PR DESCRIPTION
## Summary

The auto-labeler's breaking-change detector used:

```js
prBody.toLowerCase().includes('breaking change')
```

which matches the PR template's own checkbox descriptors — `🐛 Bug fix (non-breaking change which fixes an issue)`, `✨ New feature (non-breaking change which adds functionality)`, and the (even unchecked) `💥 Breaking change (...)` option. So **every templated PR** was labelled `breaking-change` regardless of intent, polluting #725/#726 and feeding the label-based changelog.

## Fix

Replace the loose body substring check with a precise Conventional Commits footer match:

```js
const breakingFooter = /(^|\n)\s*BREAKING[ -]CHANGE:/i.test(prBody);
if (prTitle.includes('!:') || breakingFooter) { ... }
```

The line-start anchor plus the colon-terminated `BREAKING CHANGE:` token cannot match the template's "non-breaking change" descriptor text.

## True positives preserved

- `!:` title marker (e.g. `feat(api)!:`) — unchanged.
- `BREAKING CHANGE:` / `BREAKING-CHANGE:` body footer — now matched precisely (incl. CRLF bodies via the `\s*` in the anchor).
- A **checked** `💥 Breaking change` template checkbox — still labelled by the existing checkbox-mapping loop (`- [x] ... Breaking change`), unchanged.

## Validation

- `actionlint` clean; YAML parses.
- Regex truth-table verified: template descriptors (checked/unchecked) do **not** label; real `!:` titles and `BREAKING CHANGE:` footers do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the precision of breaking change detection in pull request automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->