### PR TITLE
feat(api): add per-connection Glooko cgm_sync_enabled toggle (doses-only mode)

### DIFF
--- a/apps/api/migrations/versions/065_glooko_cgm_sync_enabled.py
+++ b/apps/api/migrations/versions/065_glooko_cgm_sync_enabled.py
@@ -1,0 +1,36 @@
+"""Add glooko_sync_state.cgm_sync_enabled (doses-only toggle).
+
+Per-connection switch to skip Glooko CGM ingestion (issue #727) so a user with a
+direct CGM source can run Glooko as a doses-only integration. Server default true
+preserves current behavior for existing connections.
+
+Revision ID: 065_glooko_cgm_sync_enabled
+Revises: 064_cgm_role
+Create Date: 2026-06-13
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "065_glooko_cgm_sync_enabled"
+down_revision: str | None = "064_cgm_role"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "glooko_sync_state",
+        sa.Column(
+            "cgm_sync_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("glooko_sync_state", "cgm_sync_enabled")

--- a/apps/api/src/models/glooko_sync_state.py
+++ b/apps/api/src/models/glooko_sync_state.py
@@ -114,6 +114,17 @@ class GlookoSyncState(Base, TimestampMixin):
         server_default="true",
     )
 
+    # Whether to ingest Glooko's CGM trace. Default on; set false to run Glooko as
+    # a doses-only source when a direct CGM (e.g. Dexcom) already provides glucose --
+    # Glooko's retrospectively-smoothed copy diverges from the real-time stream and
+    # can't be deduped against it (issue #727). Doses/events sync regardless.
+    cgm_sync_enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default="true",
+    )
+
     sync_interval_minutes: Mapped[int] = mapped_column(
         Integer,
         nullable=False,

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -2956,11 +2956,13 @@ def _glooko_status_response(
             connected=False,
             status="not_configured",
             enabled=False,
+            cgm_sync_enabled=True,
         )
     return GlookoStatusResponse(
         connected=state.status == GLOOKO_STATUS_CONNECTED,
         status=state.status,
         enabled=state.enabled,
+        cgm_sync_enabled=state.cgm_sync_enabled,
         region=state.region,
         sync_interval_minutes=state.sync_interval_minutes,
         last_sync_at=state.last_sync_at,
@@ -3169,12 +3171,14 @@ async def update_glooko_sync_settings(
             detail="Glooko is not configured. Connect it first.",
         )
     state.enabled = body.enabled
+    state.cgm_sync_enabled = body.cgm_sync_enabled
     state.sync_interval_minutes = body.sync_interval_minutes
     await db.commit()
     logger.info(
         "Glooko sync settings updated",
         user_id=str(current_user.id),
         enabled=body.enabled,
+        cgm_sync_enabled=body.cgm_sync_enabled,
         interval_minutes=body.sync_interval_minutes,
     )
     return _glooko_status_response(state)

--- a/apps/api/src/schemas/glooko.py
+++ b/apps/api/src/schemas/glooko.py
@@ -91,6 +91,7 @@ class GlookoStatusResponse(BaseModel):
     connected: bool
     status: str
     enabled: bool
+    cgm_sync_enabled: bool = True
     region: str | None = None
     sync_interval_minutes: int = SYNC_INTERVAL_DEFAULT_MINUTES
     last_sync_at: datetime | None = None
@@ -101,6 +102,7 @@ class GlookoStatusResponse(BaseModel):
 
 class GlookoSyncSettingsRequest(BaseModel):
     enabled: bool
+    cgm_sync_enabled: bool = True
     sync_interval_minutes: int = Field(
         default=SYNC_INTERVAL_DEFAULT_MINUTES,
         ge=SYNC_INTERVAL_MIN_MINUTES,

--- a/apps/api/src/services/integrations/glooko/sync.py
+++ b/apps/api/src/services/integrations/glooko/sync.py
@@ -299,7 +299,11 @@ async def _sync_glooko_for_user_locked(
                 "last_updated_at": page.last_updated_at,
                 "last_guid": page.last_guid,
             }
-        cgm_points = await client.fetch_cgm_points(_iso_z(cgm_start), _iso_z(cgm_end))
+        cgm_points = (
+            await client.fetch_cgm_points(_iso_z(cgm_start), _iso_z(cgm_end))
+            if state.cgm_sync_enabled
+            else []
+        )
         return stream_records, cgm_points
 
     store = await _execute_cycle(db, state, now, _fetch)
@@ -364,7 +368,9 @@ async def _import_glooko_history_locked(
             stream_records[stream] = page.records
             if not page.last_page:
                 truncated.append(stream)
-        cgm_points = await _import_cgm_points(client, now)
+        cgm_points = (
+            await _import_cgm_points(client, now) if state.cgm_sync_enabled else []
+        )
         return stream_records, cgm_points
 
     store = await _execute_cycle(db, state, now, _fetch)

--- a/apps/api/tests/test_glooko_endpoints.py
+++ b/apps/api/tests/test_glooko_endpoints.py
@@ -284,6 +284,55 @@ async def test_settings_update_and_404_when_not_configured():
         assert data["sync_interval_minutes"] == 120
 
 
+async def test_settings_toggle_cgm_sync_enabled():
+    async with _client() as client:
+        cookies = await _login(client)
+        await _connect(client, cookies)
+        # Default on after connect (server_default).
+        assert (await client.get(STATUS, cookies=cookies)).json()[
+            "cgm_sync_enabled"
+        ] is True
+
+        # Flip CGM ingestion off (doses-only) -- response + later status reflect it.
+        r = await client.put(
+            SETTINGS,
+            json={
+                "enabled": True,
+                "cgm_sync_enabled": False,
+                "sync_interval_minutes": 30,
+            },
+            cookies=cookies,
+        )
+        assert r.status_code == 200
+        assert r.json()["cgm_sync_enabled"] is False
+        assert (await client.get(STATUS, cookies=cookies)).json()[
+            "cgm_sync_enabled"
+        ] is False
+
+
+async def test_settings_cgm_sync_enabled_defaults_true_when_omitted():
+    # Back-compat: a client that only sends enabled + interval leaves CGM on.
+    async with _client() as client:
+        cookies = await _login(client)
+        await _connect(client, cookies)
+        await client.put(
+            SETTINGS,
+            json={
+                "enabled": True,
+                "cgm_sync_enabled": False,
+                "sync_interval_minutes": 30,
+            },
+            cookies=cookies,
+        )
+        r = await client.put(
+            SETTINGS,
+            json={"enabled": True, "sync_interval_minutes": 30},
+            cookies=cookies,
+        )
+        assert r.status_code == 200
+        assert r.json()["cgm_sync_enabled"] is True
+
+
 async def test_settings_out_of_range_422():
     async with _client() as client:
         cookies = await _login(client)

--- a/apps/api/tests/test_glooko_endpoints.py
+++ b/apps/api/tests/test_glooko_endpoints.py
@@ -315,7 +315,7 @@ async def test_settings_cgm_sync_enabled_defaults_true_when_omitted():
     async with _client() as client:
         cookies = await _login(client)
         await _connect(client, cookies)
-        await client.put(
+        r0 = await client.put(
             SETTINGS,
             json={
                 "enabled": True,
@@ -324,6 +324,10 @@ async def test_settings_cgm_sync_enabled_defaults_true_when_omitted():
             },
             cookies=cookies,
         )
+        # Assert the precondition took: otherwise a no-op first PUT would let the
+        # "defaults true when omitted" assertion below pass for the wrong reason.
+        assert r0.status_code == 200
+        assert r0.json()["cgm_sync_enabled"] is False
         r = await client.put(
             SETTINGS,
             json={"enabled": True, "sync_interval_minutes": 30},

--- a/apps/api/tests/test_glooko_sync.py
+++ b/apps/api/tests/test_glooko_sync.py
@@ -48,6 +48,7 @@ def _state(**overrides) -> GlookoSyncState:
         "encrypted_email": encrypt_credential("user@example.com"),
         "encrypted_password": encrypt_credential("SecurePass123"),
         "enabled": True,
+        "cgm_sync_enabled": True,
         "sync_interval_minutes": 30,
         "status": "pending",
         "readings_synced_total": 0,
@@ -179,6 +180,24 @@ async def test_success_updates_state_and_advances_cursor(patched):
     assert map_kwargs["normal_boluses"] == [{"stream": "normal_boluses"}]
     assert map_kwargs["events"] == [{"stream": "events"}]
     assert map_kwargs["cgm_points"] == [{"y": 120, "timestamp": "2025-01-31T12:00:00Z"}]
+
+
+async def test_cgm_disabled_skips_cgm_fetch_on_tick(patched):
+    # cgm_sync_enabled=False -> Glooko is a doses-only source: no CGM is fetched
+    # or mapped, but the dose/pump streams still sync (issue #727).
+    state = _state(cgm_sync_enabled=False)
+    db = _FakeDB()
+
+    result = await sync_glooko_for_user(db, state, now=_NOW)
+
+    assert patched["cgm_windows"] == []
+    assert patched["map_kwargs"]["cgm_points"] == []
+    # Dose/pump streams are still fetched.
+    assert [c["stream"] for c in patched["fetch_calls"]] == list(gs.SYNC_PUMP_STREAMS)
+    assert result.events_stored == 3
+    # Per O2 the CGM high-water mark is NOT frozen -- it still advances to "now",
+    # so re-enabling resumes from a bounded recent window (not the disabled span).
+    assert state.last_cgm_window_end == _NOW
 
 
 async def test_first_sync_uses_recent_window_not_epoch(patched):
@@ -375,6 +394,22 @@ async def test_import_does_not_bump_sync_or_cursor(patched):
     assert state.last_attempt_at is None
     assert state.stream_cursors == {"events": {}}
     assert state.last_cgm_window_end is None
+
+
+async def test_cgm_disabled_skips_cgm_on_import(patched):
+    # The maintainer's explicitly-required test: the one-time import has its own
+    # fetch plan, so the flag must gate it too -- no CGM fetched/mapped, doses do.
+    state = _state(cgm_sync_enabled=False)
+    db = _FakeDB()
+
+    await import_glooko_history_for_user(db, state, now=_NOW)
+
+    assert patched["cgm_windows"] == []
+    assert patched["map_kwargs"]["cgm_points"] == []
+    pump_calls = [
+        c for c in patched["fetch_calls"] if c["stream"] in gs.SYNC_PUMP_STREAMS
+    ]
+    assert pump_calls  # dose/pump streams still backfilled
 
 
 async def test_import_paginates_from_epoch(patched):

--- a/apps/web/src/components/integrations/glooko-sync-card.tsx
+++ b/apps/web/src/components/integrations/glooko-sync-card.tsx
@@ -58,6 +58,7 @@ export function GlookoSyncCard({ isOffline }: { isOffline: boolean }) {
   // Settings + actions state.
   const [interval, setIntervalMinutes] = useState<number>(30);
   const [enabled, setEnabled] = useState<boolean>(true);
+  const [cgmSyncEnabled, setCgmSyncEnabled] = useState<boolean>(true);
   const [isSavingSettings, setIsSavingSettings] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
@@ -77,6 +78,7 @@ export function GlookoSyncCard({ isOffline }: { isOffline: boolean }) {
   const applyStatus = useCallback((s: GlookoStatus) => {
     setStatus(s);
     setEnabled(s.enabled);
+    setCgmSyncEnabled(s.cgm_sync_enabled ?? true);
     if (s.sync_interval_minutes) setIntervalMinutes(s.sync_interval_minutes);
   }, []);
 
@@ -146,13 +148,15 @@ export function GlookoSyncCard({ isOffline }: { isOffline: boolean }) {
     setError(null);
     setIsSavingSettings(true);
     try {
-      applyStatus(await updateGlookoSyncSettings(enabled, interval));
+      applyStatus(
+        await updateGlookoSyncSettings(enabled, interval, cgmSyncEnabled)
+      );
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to save settings");
     } finally {
       setIsSavingSettings(false);
     }
-  }, [enabled, interval, applyStatus]);
+  }, [enabled, interval, cgmSyncEnabled, applyStatus]);
 
   const syncNow = useCallback(async () => {
     setError(null);
@@ -486,6 +490,19 @@ export function GlookoSyncCard({ isOffline }: { isOffline: boolean }) {
                 className="h-4 w-4"
               />
               Automatic sync enabled
+            </label>
+            <label
+              className="flex items-center gap-2 text-sm text-slate-300"
+              title="Turn off to keep insulin doses but skip Glooko's CGM trace -- use when a direct CGM (e.g. Dexcom) already provides your glucose."
+            >
+              <input
+                type="checkbox"
+                checked={cgmSyncEnabled}
+                onChange={(e) => setCgmSyncEnabled(e.target.checked)}
+                disabled={isOffline || isSavingSettings}
+                className="h-4 w-4"
+              />
+              Sync CGM from Glooko
             </label>
             <div>
               <label

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3991,6 +3991,9 @@ export interface GlookoStatus {
     | "error"
     | "disconnected";
   enabled: boolean;
+  /** Whether Glooko's CGM trace is ingested. False = doses-only source
+   * (skip CGM, keep insulin doses) when a direct CGM already provides glucose. */
+  cgm_sync_enabled?: boolean;
   region?: string | null;
   /** Minutes between scheduled syncs (15-1440). */
   sync_interval_minutes?: number;
@@ -4083,10 +4086,11 @@ export async function syncGlookoNow(): Promise<GlookoSyncResult> {
   return response.json();
 }
 
-/** Update the Glooko sync toggle + interval. */
+/** Update the Glooko sync toggle + interval + CGM-ingestion toggle. */
 export async function updateGlookoSyncSettings(
   enabled: boolean,
-  syncIntervalMinutes: number
+  syncIntervalMinutes: number,
+  cgmSyncEnabled: boolean
 ): Promise<GlookoStatus> {
   const response = await apiFetch(
     `${API_BASE_URL}/api/integrations/glooko/sync/settings`,
@@ -4095,6 +4099,7 @@ export async function updateGlookoSyncSettings(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         enabled,
+        cgm_sync_enabled: cgmSyncEnabled,
         sync_interval_minutes: syncIntervalMinutes,
       }),
     }


### PR DESCRIPTION
## 📋 Summary

Lets a user run Glooko as a **doses-only** source. When a direct CGM (e.g. Dexcom) and Glooko are both connected, Glooko re-ingests the same sensor trace and the two copies conflict: retrospectively-smoothed Glooko values diverge from the real-time stream (observed up to **77 mg/dL** on a live deployment) and sub-second timestamp differences defeat the exact `(user_id, reading_timestamp)` dedupe. As discussed on the issue, a hash/fuzzy dedupe can't fix this ("which pipeline wins is policy, not uniqueness"), so this is an **ingestion-skip toggle**, not a dedupe.

New non-null boolean `glooko_sync_state.cgm_sync_enabled` (server default `true`) — existing connections are unaffected. When off, the incremental tick **and** the one-time import skip the Glooko CGM fetch; doses/events sync regardless. The read-only availability probe stays active so the Cloud Sync card is still honest about whether CGM exists in the account. Includes the dashboard card UI so it's usable end-to-end.

## 🔗 Related Issues

Fixes #727

## 🏷️ Type of Change

- [x] ✨ New feature (non-breaking; existing connections default to CGM-on)

## 🔨 Changes Made

**Backend**
- `models/glooko_sync_state.py`: `cgm_sync_enabled` boolean (mirrors `enabled`; `server_default="true"`).
- `migrations/versions/065_glooko_cgm_sync_enabled.py`: revises `064_cgm_role`; `add_column` with `server_default=sa.true()`; working `downgrade`.
- `schemas/glooko.py`: `cgm_sync_enabled: bool = True` on `GlookoSyncSettingsRequest` (back-compat default) and `GlookoStatusResponse`.
- `routers/integrations.py`: `update_glooko_sync_settings` persists + logs it; `_glooko_status_response` returns it.
- `services/integrations/glooko/sync.py`: gate the CGM fetch on `state.cgm_sync_enabled` in **both** the incremental `_fetch` and the import `_fetch`. The availability probe is left ungated. `last_cgm_window_end` is intentionally left advancing (see below).

**Web**
- `lib/api.ts`: `cgm_sync_enabled` on `GlookoStatus`; third arg on `updateGlookoSyncSettings`.
- `components/integrations/glooko-sync-card.tsx`: "Sync CGM from Glooko" checkbox wired through load/save.

## 🧪 Test Plan

- [x] Unit tests added — `test_cgm_disabled_skips_cgm_fetch_on_tick` and `test_cgm_disabled_skips_cgm_on_import` (the import path has its own fetch plan and is the one people forget); endpoint tests for the PUT toggle + the omitted-field-defaults-true back-compat case. Also added `cgm_sync_enabled: True` to the sync test's `_state` helper (transient ORM objects don't get the column `default`, only `server_default` applies at insert).
- [x] Targeted backend suite: `test_glooko_sync test_glooko_endpoints test_glooko_mapper test_glooko_client` — **87 passed**.
- [x] `ruff check` + `ruff format --check` clean; migration round-trip (`upgrade`/`downgrade`/`upgrade`) verified, column lands `NOT NULL DEFAULT true`.
- [x] Web: `tsc --noEmit` clean for `src/`, `next lint` clean on both files, Jest 36/36 on the suites that render the card.

## ✅ Checklist

- [x] Self-review completed
- [x] Style guidelines (ruff + eslint clean)
- [x] No hardcoded secrets
- [x] No new warnings
- [x] Docs n/a (the Cloud Sync card already documents CGM behavior; happy to add a line if you'd like)

## Reviewer notes / decisions

- **`last_cgm_window_end` not frozen while disabled (deliberate):** the incremental CGM fetch is a single un-chunked request, so freezing a stale mark would make the next re-enabled tick fire one unbounded multi-week window. Letting the mark track ~now means re-enabling resumes from a small bounded window; the chunked one-time import backfills history on demand.
- **Relationship to `cgm_role` (#064):** that's a display-time primary/secondary mechanism for Dexcom/Nightscout and does not govern Glooko. This is ingestion-time skip for the doses-focused Glooko integration — complementary, not overlapping.
- **Pre-existing Glooko CGM rows** when a user disables: left in place (no cleanup), consistent with the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can independently enable/disable CGM syncing for Glooko; doses/events continue syncing when CGM is off.
  * Added "Sync CGM from Glooko" checkbox in integration settings (defaults to enabled, persists, reflects status, disabled while offline/saving).
* **Chores**
  * Database updated to store per-connection CGM sync preference with a safe default of enabled.
* **Tests**
  * Added endpoint and sync tests covering CGM toggle behavior and backward-compatible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->