### PR TITLE
feat(api): meal correction loop + common foods

### DIFF
--- a/apps/api/migrations/versions/067_create_common_foods.py
+++ b/apps/api/migrations/versions/067_create_common_foods.py
@@ -1,0 +1,117 @@
+"""Create common_foods table + wire food_records correction/link seams.
+
+Meal-intelligence correction loop + common foods. Adds:
+  * ``common_foods`` -- a user-named carb/nutrition baseline for frequently-eaten
+    foods, deduped per user on a normalized name.
+  * the FK from ``food_records.common_food_id`` to ``common_foods.id``
+    (ON DELETE SET NULL, so deleting a baseline unlinks its records).
+  * ``food_records.corrected_nutrition_json`` -- the user-corrected-nutrition
+    seam, kept separate from the immutable AI ``nutrition_json``.
+
+Carb values carry DB-level CHECK constraints mirroring the reject-not-clamp
+bounds in src.vision.carb_contract (defense-in-depth, matching food_records).
+
+Revision ID: 067_common_foods
+Revises: 066_food_records
+Create Date: 2026-06-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "067_common_foods"
+down_revision = "066_food_records"
+branch_labels = None
+depends_on = None
+
+# Keep in sync with src.vision.carb_contract.CARB_GRAMS_MIN / CARB_GRAMS_MAX.
+CARB_GRAMS_MIN = 0
+CARB_GRAMS_MAX = 1000
+
+
+def upgrade() -> None:
+    op.create_table(
+        "common_foods",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("normalized_name", sa.String(length=120), nullable=False),
+        sa.Column("carbs_low", sa.Float(), nullable=False),
+        sa.Column("carbs_high", sa.Float(), nullable=False),
+        sa.Column("nutrition_json", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_common_foods_user_id", "common_foods", ["user_id"])
+    op.create_index(
+        "ix_common_foods_user_name", "common_foods", ["user_id", "normalized_name"]
+    )
+    # Dedupe: one baseline per (user, normalized name).
+    op.create_unique_constraint(
+        "uq_common_foods_user_normalized_name",
+        "common_foods",
+        ["user_id", "normalized_name"],
+    )
+    # Defense-in-depth carb bounds (reject-not-clamp enforced upstream).
+    op.create_check_constraint(
+        "ck_common_foods_carb_range",
+        "common_foods",
+        f"carbs_low >= {CARB_GRAMS_MIN} AND carbs_high <= {CARB_GRAMS_MAX} "
+        "AND carbs_low <= carbs_high",
+    )
+
+    # User-corrected nutrition seam on food_records (the AI ``nutrition_json``
+    # stays immutable; corrections land here).
+    op.add_column(
+        "food_records",
+        sa.Column("corrected_nutrition_json", postgresql.JSONB(), nullable=True),
+    )
+
+    # Promote the food_records.common_food_id seam (a plain nullable UUID since
+    # migration 066) to a real FK now that common_foods exists.
+    op.create_index(
+        "ix_food_records_common_food_id", "food_records", ["common_food_id"]
+    )
+    op.create_foreign_key(
+        "fk_food_records_common_food_id",
+        "food_records",
+        "common_foods",
+        ["common_food_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_food_records_common_food_id", "food_records", type_="foreignkey"
+    )
+    op.drop_index("ix_food_records_common_food_id", table_name="food_records")
+    op.drop_column("food_records", "corrected_nutrition_json")
+
+    op.drop_constraint("ck_common_foods_carb_range", "common_foods")
+    op.drop_constraint("uq_common_foods_user_normalized_name", "common_foods")
+    op.drop_index("ix_common_foods_user_name", table_name="common_foods")
+    op.drop_index("ix_common_foods_user_id", table_name="common_foods")
+    op.drop_table("common_foods")

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -28,6 +28,7 @@ from src.routers import (
     auth,
     briefs,
     caregivers,
+    common_foods,
     correction_analysis,
     device_registration,
     disclaimer,
@@ -200,6 +201,7 @@ app.include_router(ai.router)
 app.include_router(briefs.router)
 app.include_router(meal_analysis.router)
 app.include_router(food_records.router)
+app.include_router(common_foods.router)
 app.include_router(correction_analysis.router)
 app.include_router(safety.router)
 app.include_router(insights.router)

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -9,6 +9,7 @@ from src.models.brief_delivery_config import BriefDeliveryConfig
 from src.models.caregiver_invitation import CaregiverInvitation, InvitationStatus
 from src.models.caregiver_link import CaregiverLink
 from src.models.chat_message import ChatMessage
+from src.models.common_food import CommonFood
 from src.models.correction_analysis import CorrectionAnalysis
 from src.models.daily_brief import DailyBrief
 from src.models.data_retention_config import DataRetentionConfig
@@ -63,6 +64,7 @@ __all__ = [
     "CaregiverInvitation",
     "CaregiverLink",
     "ChatMessage",
+    "CommonFood",
     "ContactPriority",
     "CorrectionAnalysis",
     "DailyBrief",

--- a/apps/api/src/models/common_food.py
+++ b/apps/api/src/models/common_food.py
@@ -1,0 +1,110 @@
+"""Common-food model: a user-named baseline for foods eaten often.
+
+A ``common_food`` is the personalization seed of the meal-intelligence feature.
+When a user corrects an estimate or saves a meal they eat regularly, they can
+promote it to a named baseline so the platform remembers it instead of
+re-guessing every time. ``food_records.common_food_id`` links a logged meal back
+to the baseline it came from.
+
+Safety posture (NON-NEGOTIABLE, inherited from food_records): a common food is a
+descriptive baseline, never a dose. Carbs are stored as a low/high range, and
+nothing in this model is ever read by IoB, treatment_safety, or carb-ratio math.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+from src.vision.carb_contract import CARB_GRAMS_MAX, CARB_GRAMS_MIN
+
+
+def normalize_common_food_name(name: str) -> str:
+    """Return the dedupe key for a common-food name.
+
+    Case-insensitive and whitespace-collapsed so "Oatmeal", " oatmeal " and
+    "oatmeal  bowl" don't fragment into near-duplicate baselines. The user's
+    original casing/spacing is preserved separately in ``name``.
+    """
+    return " ".join(name.strip().lower().split())
+
+
+class CommonFood(Base):
+    """A user-named carb/nutrition baseline for a frequently-eaten food.
+
+    Deduped per user on ``normalized_name`` (a unique constraint) so promoting
+    "the same" food twice updates one baseline rather than creating duplicates.
+    """
+
+    __tablename__ = "common_foods"
+
+    __table_args__ = (
+        # Dedupe: one baseline per (user, normalized name). Promotion of a
+        # same-named food updates this row instead of fragmenting.
+        UniqueConstraint(
+            "user_id", "normalized_name", name="uq_common_foods_user_normalized_name"
+        ),
+        Index("ix_common_foods_user_name", "user_id", "normalized_name"),
+        # Defense-in-depth carb bounds, mirroring food_records (reject-not-clamp
+        # is enforced upstream; this stops any raw insert from storing an
+        # out-of-range or inverted baseline).
+        CheckConstraint(
+            f"carbs_low >= {CARB_GRAMS_MIN:g} AND carbs_high <= {CARB_GRAMS_MAX:g} "
+            "AND carbs_low <= carbs_high",
+            name="ck_common_foods_carb_range",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=func.gen_random_uuid(),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # User-facing label, exactly as the user typed it.
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    # Dedupe key derived from ``name`` (see ``normalize_common_food_name``).
+    normalized_name: Mapped[str] = mapped_column(String(120), nullable=False)
+
+    # Baseline carbohydrate range (reject-not-clamp bounds, like food_records).
+    carbs_low: Mapped[float] = mapped_column(Float, nullable=False)
+    carbs_high: Mapped[float] = mapped_column(Float, nullable=False)
+    nutrition_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CommonFood(id={self.id}, user_id={self.user_id}, "
+            f"name={self.name!r}, carbs={self.carbs_low}-{self.carbs_high}g)>"
+        )

--- a/apps/api/src/models/food_record.py
+++ b/apps/api/src/models/food_record.py
@@ -130,21 +130,26 @@ class FoodRecord(Base):
         server_default=FoodRecordSource.AI_ESTIMATE.value,
     )
 
-    # --- Correction seam (the later correction flow populates these; original
-    # estimate above is preserved) ---
+    # --- Correction seam (the correction flow populates these; the original
+    # estimate above is preserved for transparency/eval) ---
     corrected_carbs_low: Mapped[float | None] = mapped_column(Float, nullable=True)
     corrected_carbs_high: Mapped[float | None] = mapped_column(Float, nullable=True)
+    # User-corrected nutrition. Kept separate from ``nutrition_json`` (the AI
+    # original) so a correction never discards the model's estimate.
+    corrected_nutrition_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     corrected_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
     )
 
-    # Optional link to a saved common food. A later change creates the
-    # ``common_foods`` table and adds the FK constraint; stored now as a plain
-    # nullable UUID so the column (the schema seam) already exists.
+    # Optional link to a saved common food (the personalization baseline this
+    # record was promoted to / linked against). ON DELETE SET NULL so deleting a
+    # common food unlinks its records rather than cascading their deletion.
     common_food_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
+        ForeignKey("common_foods.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/apps/api/src/routers/_meal_intelligence.py
+++ b/apps/api/src/routers/_meal_intelligence.py
@@ -1,0 +1,47 @@
+"""Shared dependencies for the meal-intelligence routers.
+
+Both the food-record and common-food routers gate on the same feature flag and
+need owner-scoped lookups of a common food. These live here (rather than in one
+router importing the other) so the import graph stays acyclic and the
+owner-scoping logic has a single home.
+"""
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.models.common_food import CommonFood
+
+
+def require_meal_intelligence() -> None:
+    """Reject (as 404) when the meal-intelligence feature flag is off.
+
+    A 404 (rather than 403) keeps the whole feature surface invisible while the
+    flag is off, consistent across every meal-intelligence endpoint.
+    """
+    if not settings.meal_intelligence_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Meal intelligence is not enabled.",
+        )
+
+
+async def get_owned_common_food(
+    common_food_id: uuid.UUID,
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> CommonFood:
+    """Fetch a common food scoped to its owner; 404 if missing (no existence leak)."""
+    common_food = await db.scalar(
+        select(CommonFood).where(
+            CommonFood.id == common_food_id, CommonFood.user_id == user_id
+        )
+    )
+    if common_food is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Common food not found."
+        )
+    return common_food

--- a/apps/api/src/routers/common_foods.py
+++ b/apps/api/src/routers/common_foods.py
@@ -1,0 +1,144 @@
+"""Common-foods API: user-named carb/nutrition baselines.
+
+Manage the baselines a user saves for foods they eat often: list, fetch,
+rename + update baseline values, and delete. Promotion ("save as common food")
+and linking live on the food-records router, since they act on a record.
+
+The feature is flag-gated (``meal_intelligence_enabled``) and BETA. Every query
+is scoped to the authenticated owner.
+
+Safety: a common food is a descriptive baseline, never a dose. No endpoint here
+returns or computes insulin, and common-food values never flow into IoB /
+treatment_safety / carb-ratio math.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import DiabeticOrAdminUser
+from src.database import get_db
+from src.logging_config import get_logger
+from src.models.common_food import CommonFood
+from src.routers._meal_intelligence import (
+    get_owned_common_food,
+    require_meal_intelligence,
+)
+from src.schemas.auth import ErrorResponse
+from src.schemas.common_food import (
+    CommonFoodListResponse,
+    CommonFoodResponse,
+    CommonFoodUpdateRequest,
+)
+from src.services import common_food as common_food_service
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/common-foods", tags=["common-foods"])
+
+
+@router.get(
+    "",
+    response_model=CommonFoodListResponse,
+    responses={401: {"model": ErrorResponse, "description": "Not authenticated"}},
+)
+async def list_common_foods(
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+    limit: int = 50,
+    offset: int = 0,
+) -> CommonFoodListResponse:
+    """List the current user's common foods, most recently updated first."""
+    require_meal_intelligence()
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+
+    total = await db.scalar(
+        select(func.count())
+        .select_from(CommonFood)
+        .where(CommonFood.user_id == current_user.id)
+    )
+    result = await db.execute(
+        select(CommonFood)
+        .where(CommonFood.user_id == current_user.id)
+        .order_by(CommonFood.updated_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    foods = [CommonFoodResponse.model_validate(f) for f in result.scalars().all()]
+    return CommonFoodListResponse(common_foods=foods, total=total or 0)
+
+
+@router.get(
+    "/{common_food_id}",
+    response_model=CommonFoodResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Common food not found"},
+    },
+)
+async def get_common_food(
+    common_food_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> CommonFoodResponse:
+    """Get one of the current user's common foods."""
+    require_meal_intelligence()
+    common_food = await get_owned_common_food(common_food_id, current_user.id, db)
+    return CommonFoodResponse.model_validate(common_food)
+
+
+@router.patch(
+    "/{common_food_id}",
+    response_model=CommonFoodResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Common food not found"},
+        409: {"model": ErrorResponse, "description": "Name already in use"},
+        422: {"model": ErrorResponse, "description": "Carb value out of range"},
+    },
+)
+async def update_common_food(
+    common_food_id: uuid.UUID,
+    update: CommonFoodUpdateRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> CommonFoodResponse:
+    """Rename and/or update a common food's baseline carbs/nutrition."""
+    require_meal_intelligence()
+    common_food = await get_owned_common_food(common_food_id, current_user.id, db)
+    try:
+        common_food = await common_food_service.update_common_food(
+            db, common_food, update
+        )
+    except common_food_service.DuplicateCommonFoodError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(exc)
+        ) from exc
+    except common_food_service.CarbValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    return CommonFoodResponse.model_validate(common_food)
+
+
+@router.delete(
+    "/{common_food_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Common food not found"},
+    },
+)
+async def delete_common_food(
+    common_food_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete a common food. Linked records are unlinked (FK ON DELETE SET NULL)."""
+    require_meal_intelligence()
+    common_food = await get_owned_common_food(common_food_id, current_user.id, db)
+    await db.delete(common_food)
+    await db.commit()

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -21,8 +21,22 @@ from src.database import get_db
 from src.logging_config import get_logger
 from src.middleware.rate_limit import limiter
 from src.models.food_record import FoodRecord
+from src.routers._meal_intelligence import (
+    get_owned_common_food,
+    require_meal_intelligence,
+)
 from src.schemas.auth import ErrorResponse
-from src.schemas.food_record import FoodRecordListResponse, FoodRecordResponse
+from src.schemas.common_food import (
+    CommonFoodResponse,
+    LinkCommonFoodRequest,
+    SaveAsCommonFoodRequest,
+)
+from src.schemas.food_record import (
+    FoodRecordCorrectionRequest,
+    FoodRecordListResponse,
+    FoodRecordResponse,
+)
+from src.services import common_food as common_food_service
 from src.services import food_image, food_vision
 
 logger = get_logger(__name__)
@@ -33,14 +47,6 @@ router = APIRouter(prefix="/api/food-records", tags=["food-records"])
 # byte-level decoding in `food_image.process_upload`; this just rejects obvious
 # mismatches early with a clear 415.
 _ACCEPTED_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
-
-
-def _require_enabled() -> None:
-    if not settings.meal_intelligence_enabled:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Meal intelligence is not enabled.",
-        )
 
 
 @router.post(
@@ -71,7 +77,7 @@ async def upload_food_photo(
     configured AI provider's vision route. If that provider has no vision route,
     a clear 422 is returned -- never a silent failure or a fabricated estimate.
     """
-    _require_enabled()
+    require_meal_intelligence()
 
     if file.content_type and file.content_type not in _ACCEPTED_CONTENT_TYPES:
         raise HTTPException(
@@ -131,7 +137,7 @@ async def list_food_records(
     offset: int = 0,
 ) -> FoodRecordListResponse:
     """List the current user's food records, most recent meal first."""
-    _require_enabled()
+    require_meal_intelligence()
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
 
@@ -184,7 +190,7 @@ async def get_food_record(
     db: AsyncSession = Depends(get_db),
 ) -> FoodRecordResponse:
     """Get one of the current user's food records."""
-    _require_enabled()
+    require_meal_intelligence()
     record = await _get_owned_record(record_id, current_user.id, db)
     return FoodRecordResponse.model_validate(record)
 
@@ -203,10 +209,104 @@ async def delete_food_record(
     db: AsyncSession = Depends(get_db),
 ) -> None:
     """Delete a food record and its stored photo (user-initiated)."""
-    _require_enabled()
+    require_meal_intelligence()
     record = await _get_owned_record(record_id, current_user.id, db)
     storage_path = record.storage_path
     await db.delete(record)
     await db.commit()
     # Unlink after the row is gone so a failed unlink can't strand a dangling row.
     food_image.delete_stored_image(storage_path)
+
+
+@router.post(
+    "/{record_id}/correct",
+    response_model=FoodRecordResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Food record not found"},
+        422: {"model": ErrorResponse, "description": "Carb value out of range"},
+    },
+)
+async def correct_food_record(
+    record_id: uuid.UUID,
+    correction: FoodRecordCorrectionRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> FoodRecordResponse:
+    """Correct a food record's carbs/nutrition.
+
+    Fixes the *description of the food* -- never a dose. The user's values are
+    written to the record's correction columns and provenance flips to
+    ``user_corrected``; the original AI estimate is preserved. Corrected values
+    are never read by IoB / treatment_safety / carb-ratio math.
+    """
+    require_meal_intelligence()
+    record = await _get_owned_record(record_id, current_user.id, db)
+    try:
+        record = await common_food_service.correct_food_record(db, record, correction)
+    except common_food_service.CarbValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    return FoodRecordResponse.model_validate(record)
+
+
+@router.post(
+    "/{record_id}/save-as-common-food",
+    response_model=CommonFoodResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Food record not found"},
+        422: {"model": ErrorResponse, "description": "Carb value out of range"},
+    },
+)
+async def save_record_as_common_food(
+    record_id: uuid.UUID,
+    body: SaveAsCommonFoodRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> CommonFoodResponse:
+    """Promote a food record to a named common-food baseline and link it.
+
+    Uses the record's corrected values when present, else the AI estimate.
+    Saving under an existing name updates that baseline (dedupe by name) rather
+    than creating a near-duplicate.
+    """
+    require_meal_intelligence()
+    record = await _get_owned_record(record_id, current_user.id, db)
+    try:
+        common_food = await common_food_service.promote_to_common_food(
+            db, record, body.name
+        )
+    except common_food_service.CarbValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    return CommonFoodResponse.model_validate(common_food)
+
+
+@router.post(
+    "/{record_id}/link-common-food",
+    response_model=FoodRecordResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Record or common food not found"},
+    },
+)
+async def link_record_to_common_food(
+    record_id: uuid.UUID,
+    body: LinkCommonFoodRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> FoodRecordResponse:
+    """Link an existing food record to one of the user's existing common foods."""
+    require_meal_intelligence()
+    record = await _get_owned_record(record_id, current_user.id, db)
+    # Both sides are owner-scoped: a missing or cross-user baseline 404s with no
+    # existence leak.
+    common_food = await get_owned_common_food(body.common_food_id, current_user.id, db)
+    record = await common_food_service.link_record_to_common_food(
+        db, record, common_food
+    )
+    return FoodRecordResponse.model_validate(record)

--- a/apps/api/src/schemas/common_food.py
+++ b/apps/api/src/schemas/common_food.py
@@ -1,0 +1,90 @@
+"""Common-food request/response schemas.
+
+A common food is a user-named carb/nutrition baseline. It is a descriptive
+baseline only -- there is deliberately no dose/insulin/units field, and these
+values never flow into IoB / treatment_safety / carb-ratio math.
+"""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+from src.schemas.food_record import validate_nutrition
+from src.vision.carb_contract import CARB_GRAMS_MAX, CARB_GRAMS_MIN
+
+# Keep in sync with CommonFood.name / common_foods.name length (String(120)).
+_NAME_MAX = 120
+
+
+class CommonFoodResponse(BaseModel):
+    """A saved common-food baseline returned to the client."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    name: str
+    carbs_low: float = Field(ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
+    carbs_high: float = Field(ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
+    nutrition_json: dict | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class CommonFoodListResponse(BaseModel):
+    """A page of common foods (most recently updated first)."""
+
+    common_foods: list[CommonFoodResponse]
+    total: int
+
+
+class SaveAsCommonFoodRequest(BaseModel):
+    """Promote a food record to a named common-food baseline.
+
+    Carbs/nutrition are taken from the record (its corrected values if present,
+    else the AI estimate); the user supplies the name. Saving under a name that
+    already exists updates that baseline rather than creating a duplicate.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    name: str = Field(min_length=1, max_length=_NAME_MAX)
+
+
+class LinkCommonFoodRequest(BaseModel):
+    """Link an existing food record to an existing common food."""
+
+    model_config = {"extra": "forbid"}
+
+    common_food_id: uuid.UUID
+
+
+class CommonFoodUpdateRequest(BaseModel):
+    """Rename a common food and/or update its baseline carbs/nutrition.
+
+    All fields optional; only those provided are changed. Renaming to a name
+    that collides with another of the user's common foods is rejected (409).
+    """
+
+    model_config = {"extra": "forbid"}
+
+    name: str | None = Field(default=None, min_length=1, max_length=_NAME_MAX)
+    carbs_low: float | None = Field(default=None, ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
+    carbs_high: float | None = Field(default=None, ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
+    nutrition_json: dict | None = None
+
+    @model_validator(mode="after")
+    def validate_update(self) -> "CommonFoodUpdateRequest":
+        # Carb bounds must be set together so the stored range is always valid.
+        if (self.carbs_low is None) != (self.carbs_high is None):
+            msg = "carbs_low and carbs_high must be provided together"
+            raise ValueError(msg)
+        if (
+            self.carbs_low is not None
+            and self.carbs_high is not None
+            and self.carbs_low > self.carbs_high
+        ):
+            msg = "carbs_low must not exceed carbs_high"
+            raise ValueError(msg)
+        validate_nutrition(self.nutrition_json)
+        return self

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -5,6 +5,7 @@ carb *range*, confidence, nutrition, and provenance -- and deliberately carry no
 dose/insulin field. Nothing here computes or returns dosing guidance.
 """
 
+import json
 import uuid
 from datetime import datetime
 
@@ -39,6 +40,9 @@ class FoodRecordResponse(BaseModel):
     corrected_carbs_high: float | None = Field(
         default=None, ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX
     )
+    corrected_nutrition_json: dict | None = None
+    corrected_at: datetime | None = None
+    common_food_id: uuid.UUID | None = None
     ai_model: str | None = None
     ai_provider: str | None = None
     created_at: datetime
@@ -64,3 +68,53 @@ class FoodRecordListResponse(BaseModel):
 
     records: list[FoodRecordResponse]
     total: int
+
+
+# Cap user-supplied nutrition so a correction can't store an unbounded JSON blob.
+# Bound both the field count and the serialized size: the key count alone does
+# not stop a single key holding a deeply-nested / multi-MB value.
+_MAX_NUTRITION_KEYS = 30
+_MAX_NUTRITION_SERIALIZED_CHARS = 2000
+
+
+def validate_nutrition(nutrition: dict | None) -> dict | None:
+    """Reject an oversized nutrition object; otherwise return it unchanged.
+
+    Shared by the food-record correction and common-food schemas so user-supplied
+    nutrition is bounded identically everywhere it is accepted.
+    """
+    if nutrition is None:
+        return None
+    if len(nutrition) > _MAX_NUTRITION_KEYS:
+        msg = f"nutrition has too many fields (max {_MAX_NUTRITION_KEYS})"
+        raise ValueError(msg)
+    if len(json.dumps(nutrition, default=str)) > _MAX_NUTRITION_SERIALIZED_CHARS:
+        msg = "nutrition is too large"
+        raise ValueError(msg)
+    return nutrition
+
+
+class FoodRecordCorrectionRequest(BaseModel):
+    """A user correction of a food record's carbs/nutrition.
+
+    Correction fixes a *description of the food*, never a dose. There is
+    deliberately no insulin/units/dose field here, and the corrected values are
+    never read by IoB / treatment_safety / carb-ratio math. The original AI
+    estimate is preserved on the record; these values land in the
+    ``corrected_*`` columns and flip provenance to ``user_corrected``.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    # Reject-not-clamp bounds, identical to the create path.
+    corrected_carbs_low: float = Field(ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
+    corrected_carbs_high: float = Field(ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
+    corrected_nutrition: dict | None = None
+
+    @model_validator(mode="after")
+    def validate_correction(self) -> "FoodRecordCorrectionRequest":
+        if self.corrected_carbs_low > self.corrected_carbs_high:
+            msg = "corrected_carbs_low must not exceed corrected_carbs_high"
+            raise ValueError(msg)
+        validate_nutrition(self.corrected_nutrition)
+        return self

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -1,0 +1,237 @@
+"""Correction loop + common-food promotion service.
+
+This is the truth-correction and personalization layer on top of the meal-photo
+estimation pipeline:
+
+  * ``correct_food_record`` applies a user's carb/nutrition correction to a
+    record -- writing the ``corrected_*`` seams, flipping provenance to
+    ``USER_CORRECTED``, and preserving the original AI estimate.
+  * ``promote_to_common_food`` saves a record's (corrected, else AI) values as a
+    user-named, deduped baseline and links the record to it.
+  * ``link_record_to_common_food`` / ``update_common_food`` handle explicit
+    linking and baseline edits.
+
+Safety posture (NON-NEGOTIABLE): a correction fixes a *description of the food*,
+never a dose. Nothing here returns or computes insulin, and neither corrected
+records nor common foods are ever read by IoB / treatment_safety / carb-ratio
+math. All work is scoped to the authenticated owner by the caller.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.logging_config import get_logger
+from src.models.common_food import CommonFood, normalize_common_food_name
+from src.models.food_record import FoodRecord, FoodRecordSource
+from src.schemas.common_food import CommonFoodUpdateRequest
+from src.schemas.food_record import FoodRecordCorrectionRequest
+from src.vision.carb_contract import CarbBoundsError, validate_carb_range
+
+logger = get_logger(__name__)
+
+
+class CommonFoodError(Exception):
+    """Base class for correction / common-food service failures."""
+
+
+class CarbValidationError(CommonFoodError):
+    """A user-supplied carb range fell outside the reject-not-clamp bounds."""
+
+
+class DuplicateCommonFoodError(CommonFoodError):
+    """A common food with the same (normalized) name already exists."""
+
+
+async def correct_food_record(
+    db: AsyncSession,
+    record: FoodRecord,
+    correction: FoodRecordCorrectionRequest,
+) -> FoodRecord:
+    """Apply a user correction to ``record`` and flip provenance.
+
+    The original AI estimate (``carbs_low`` / ``carbs_high`` / ``nutrition_json``
+    / ``food_description``) is left untouched; the user's values land in the
+    ``corrected_*`` columns. Carb bounds are enforced reject-not-clamp, matching
+    the create path.
+    """
+    try:
+        low, high = validate_carb_range(
+            correction.corrected_carbs_low, correction.corrected_carbs_high
+        )
+    except CarbBoundsError as exc:
+        raise CarbValidationError(str(exc)) from exc
+
+    record.corrected_carbs_low = low
+    record.corrected_carbs_high = high
+    record.corrected_nutrition_json = correction.corrected_nutrition or None
+    record.corrected_at = datetime.now(UTC)
+    record.source = FoodRecordSource.USER_CORRECTED
+
+    await db.commit()
+    await db.refresh(record)
+    return record
+
+
+def _effective_values(record: FoodRecord) -> tuple[float, float, dict | None]:
+    """Return the carbs/nutrition to baseline from a record.
+
+    Prefers the user's corrected values (the truth the platform stores) and
+    falls back to the original AI estimate when the record was never corrected.
+
+    Nutrition fallback is intentional: a user who corrects only carbs (the common
+    case -- ``corrected_nutrition`` is optional) keeps the AI's nutrition, which
+    is still the best available figure, rather than dropping it. So a corrected
+    record can baseline corrected carbs alongside the original nutrition.
+    """
+    if (
+        record.corrected_carbs_low is not None
+        and record.corrected_carbs_high is not None
+    ):
+        nutrition = record.corrected_nutrition_json or record.nutrition_json
+        return record.corrected_carbs_low, record.corrected_carbs_high, nutrition
+    return record.carbs_low, record.carbs_high, record.nutrition_json
+
+
+async def promote_to_common_food(
+    db: AsyncSession,
+    record: FoodRecord,
+    name: str,
+) -> CommonFood:
+    """Promote ``record`` to a named common-food baseline and link it.
+
+    Deduped per user on the normalized name: saving under an existing name
+    updates that baseline (its carbs/nutrition + display name) rather than
+    creating a near-duplicate. The record is linked to the resulting baseline.
+
+    Must be called with no other pending session state: the unique-constraint
+    race path below rolls the session back, which would discard any unrelated
+    in-flight changes. The sole caller passes a freshly-loaded record.
+    """
+    low, high, nutrition = _effective_values(record)
+    try:
+        low, high = validate_carb_range(low, high)
+    except CarbBoundsError as exc:  # pragma: no cover - record values are pre-bounded
+        raise CarbValidationError(str(exc)) from exc
+
+    normalized = normalize_common_food_name(name)
+    if not normalized:
+        raise CarbValidationError("Common food name must not be empty.")
+
+    existing = await db.scalar(
+        select(CommonFood).where(
+            CommonFood.user_id == record.user_id,
+            CommonFood.normalized_name == normalized,
+        )
+    )
+    if existing is not None:
+        common_food = existing
+        common_food.name = name.strip()
+        common_food.carbs_low = low
+        common_food.carbs_high = high
+        common_food.nutrition_json = nutrition
+    else:
+        common_food = CommonFood(
+            user_id=record.user_id,
+            name=name.strip(),
+            normalized_name=normalized,
+            carbs_low=low,
+            carbs_high=high,
+            nutrition_json=nutrition,
+        )
+        db.add(common_food)
+
+    try:
+        await db.flush()
+    except IntegrityError:
+        # Lost a race on the unique constraint: re-fetch and update the winner.
+        await db.rollback()
+        common_food = await db.scalar(
+            select(CommonFood).where(
+                CommonFood.user_id == record.user_id,
+                CommonFood.normalized_name == normalized,
+            )
+        )
+        if common_food is None:  # pragma: no cover - defensive
+            raise
+        # Re-bind the record (the rollback expired it) before linking below.
+        record = await db.get(FoodRecord, record.id)
+        common_food.name = name.strip()
+        common_food.carbs_low = low
+        common_food.carbs_high = high
+        common_food.nutrition_json = nutrition
+
+    record.common_food_id = common_food.id
+    await db.commit()
+    await db.refresh(common_food)
+    return common_food
+
+
+async def link_record_to_common_food(
+    db: AsyncSession,
+    record: FoodRecord,
+    common_food: CommonFood,
+) -> FoodRecord:
+    """Link an existing record to an existing (owned) common food."""
+    record.common_food_id = common_food.id
+    await db.commit()
+    await db.refresh(record)
+    return record
+
+
+async def update_common_food(
+    db: AsyncSession,
+    common_food: CommonFood,
+    update: CommonFoodUpdateRequest,
+) -> CommonFood:
+    """Rename and/or update a common food's baseline.
+
+    Renaming to a name that collides with another of the user's common foods is
+    rejected with ``DuplicateCommonFoodError``.
+    """
+    if update.name is not None:
+        normalized = normalize_common_food_name(update.name)
+        if not normalized:
+            raise CarbValidationError("Common food name must not be empty.")
+        if normalized != common_food.normalized_name:
+            clash = await db.scalar(
+                select(func.count())
+                .select_from(CommonFood)
+                .where(
+                    CommonFood.user_id == common_food.user_id,
+                    CommonFood.normalized_name == normalized,
+                    CommonFood.id != common_food.id,
+                )
+            )
+            if clash:
+                raise DuplicateCommonFoodError(
+                    "A common food with that name already exists."
+                )
+        common_food.name = update.name.strip()
+        common_food.normalized_name = normalized
+
+    if update.carbs_low is not None and update.carbs_high is not None:
+        # Defense-in-depth: the request schema already enforces these bounds, so
+        # this mirrors the create/correct paths and the DB CHECK rather than
+        # being the primary gate (the except branch is not normally reachable).
+        try:
+            low, high = validate_carb_range(update.carbs_low, update.carbs_high)
+        except CarbBoundsError as exc:
+            raise CarbValidationError(str(exc)) from exc
+        common_food.carbs_low = low
+        common_food.carbs_high = high
+
+    if "nutrition_json" in update.model_fields_set:
+        common_food.nutrition_json = update.nutrition_json
+
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise DuplicateCommonFoodError(
+            "A common food with that name already exists."
+        ) from exc
+    await db.refresh(common_food)
+    return common_food

--- a/apps/api/src/services/data_purge.py
+++ b/apps/api/src/services/data_purge.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.logging_config import get_logger
 from src.models.alert import Alert
 from src.models.chat_message import ChatMessage
+from src.models.common_food import CommonFood
 from src.models.correction_analysis import CorrectionAnalysis
 from src.models.daily_brief import DailyBrief
 from src.models.escalation_event import EscalationEvent
@@ -153,6 +154,14 @@ async def purge_all_user_data(
         food_photo_paths = [sp for (sp,) in deleted_food_rows if sp]
         deleted["food_records"] = len(deleted_food_rows)
 
+        # Common foods are deleted after food_records: the records are already
+        # gone, so the food_records.common_food_id FK (ON DELETE SET NULL) has
+        # nothing left to unlink and the baselines drop cleanly.
+        result = await db.execute(
+            delete(CommonFood).where(CommonFood.user_id == user_id)
+        )
+        deleted["common_foods"] = result.rowcount
+
         await db.commit()
     except Exception:
         await db.rollback()
@@ -164,9 +173,17 @@ async def purge_all_user_data(
 
     # The rows are gone and committed; now best-effort unlink the photo files.
     # A failure here leaves a stray file (reclaimable later), never an orphaned
-    # row -- the safe failure direction.
+    # row -- the safe failure direction. Guard each unlink so one failure can't
+    # abort the loop and skip the completion log / return below.
     for storage_path in food_photo_paths:
-        delete_stored_image(storage_path)
+        try:
+            delete_stored_image(storage_path)
+        except Exception:
+            logger.warning(
+                "Failed to delete food photo file during purge (continuing)",
+                user_id=str(user_id),
+                exc_info=True,
+            )
 
     total = sum(deleted.values())
     logger.warning(

--- a/apps/api/tests/test_data_purge.py
+++ b/apps/api/tests/test_data_purge.py
@@ -98,17 +98,17 @@ class TestPurgeAllUserData:
         with patch("src.services.data_purge.delete_stored_image") as mock_unlink:
             result = await purge_all_user_data(user_id, db)
 
-        # 14 execute calls: 13 row deletes (glucose, pump, brief, meal,
+        # 15 execute calls: 13 row deletes (glucose, pump, brief, meal,
         # correction, suggestion, safety, escalation, alert, chat_messages,
-        # knowledge_chunks, user_documents, research_sources) plus the single
-        # food_records DELETE ... RETURNING.
-        assert db.execute.call_count == 14
+        # knowledge_chunks, user_documents, research_sources), the single
+        # food_records DELETE ... RETURNING, and the common_foods delete.
+        assert db.execute.call_count == 15
         assert db.commit.call_count == 1
         # Photos are unlinked only after the commit, one per returned row.
         assert mock_unlink.call_count == 10
 
-        # All 14 categories should be in result
-        assert len(result) == 14
+        # All 15 categories should be in result
+        assert len(result) == 15
         assert result["glucose_readings"] == 10
         assert result["pump_events"] == 10
         assert result["daily_briefs"] == 10
@@ -119,6 +119,31 @@ class TestPurgeAllUserData:
         assert result["escalation_events"] == 10
         assert result["alerts"] == 10
         assert result["food_records"] == 10
+        assert result["common_foods"] == 10
+
+    @pytest.mark.asyncio
+    async def test_photo_unlink_failure_does_not_abort_purge(self):
+        """A failed photo unlink is logged and skipped, not propagated."""
+        from src.services.data_purge import purge_all_user_data
+
+        user_id = uuid.uuid4()
+        db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.rowcount = 1
+        mock_result.all.return_value = [("/uploads/food/u/a.jpg",), ("/u/b.jpg",)]
+        db.execute.return_value = mock_result
+
+        with patch(
+            "src.services.data_purge.delete_stored_image",
+            side_effect=OSError("disk gone"),
+        ) as mock_unlink:
+            result = await purge_all_user_data(user_id, db)
+
+        # Both unlinks were attempted despite the first raising; the function
+        # still committed and returned its counts.
+        assert mock_unlink.call_count == 2
+        assert db.commit.call_count == 1
+        assert result["common_foods"] == 1
 
     @pytest.mark.asyncio
     async def test_returns_zero_counts_when_empty(self):

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -16,6 +16,7 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from PIL import Image
+from sqlalchemy import func, select
 
 from src.config import settings
 from src.main import app
@@ -369,6 +370,8 @@ class TestNoTherapyCoupling:
             text = path.read_text()
             assert "food_record" not in text.lower(), f"{path} references food records"
             assert "FoodRecord" not in text, f"{path} references FoodRecord"
+            assert "common_food" not in text.lower(), f"{path} references common foods"
+            assert "CommonFood" not in text, f"{path} references CommonFood"
 
     async def test_food_record_does_not_change_iob(self):
         """A logged meal must not produce or alter insulin-on-board."""
@@ -528,3 +531,434 @@ class TestFoodRecordsApi:
             other.cookies.set(settings.jwt_cookie_name, cookie)
             resp = await other.get(f"/api/food-records/{record_id}")
         assert resp.status_code == 404
+
+
+async def _create_record(client: AsyncClient, low=40, high=55) -> dict:
+    """Create a food record through the API (mocking the vision call)."""
+    with patch.object(
+        food_vision, "_call_vision", AsyncMock(return_value=_estimate_json(low, high))
+    ):
+        resp = await client.post(
+            "/api/food-records",
+            files={"file": ("meal.png", _png_bytes(), "image/png")},
+        )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# --------------------------------------------------------------------------- #
+# Correction loop (AC1) -- provenance flip, original estimate preserved
+# --------------------------------------------------------------------------- #
+class TestCorrection:
+    async def test_correction_flips_provenance_and_preserves_original(
+        self, auth_client
+    ):
+        client, _ = auth_client
+        created = await _create_record(client, 40, 55)
+        record_id = created["id"]
+
+        resp = await client.post(
+            f"/api/food-records/{record_id}/correct",
+            json={
+                "corrected_carbs_low": 70,
+                "corrected_carbs_high": 80,
+                "corrected_nutrition": {"protein_grams": 20},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Provenance flips; corrected values become the stored truth.
+        assert body["source"] == "user_corrected"
+        assert body["corrected_carbs_low"] == 70
+        assert body["corrected_carbs_high"] == 80
+        assert body["corrected_nutrition_json"] == {"protein_grams": 20}
+        assert body["corrected_at"] is not None
+        # Original AI estimate is retained, not overwritten.
+        assert body["carbs_low"] == 40
+        assert body["carbs_high"] == 55
+
+    async def test_correction_rejects_out_of_bounds_not_clamped(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        resp = await client.post(
+            f"/api/food-records/{record_id}/correct",
+            json={"corrected_carbs_low": 10, "corrected_carbs_high": 99999},
+        )
+        assert resp.status_code == 422
+
+    async def test_correction_rejects_inverted_range(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        resp = await client.post(
+            f"/api/food-records/{record_id}/correct",
+            json={"corrected_carbs_low": 80, "corrected_carbs_high": 20},
+        )
+        assert resp.status_code == 422
+
+    async def test_correction_rejects_dose_fields(self, auth_client):
+        # extra=forbid: a smuggled dose/units field is rejected at the boundary.
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        resp = await client.post(
+            f"/api/food-records/{record_id}/correct",
+            json={
+                "corrected_carbs_low": 30,
+                "corrected_carbs_high": 40,
+                "insulin_units": 5,
+            },
+        )
+        assert resp.status_code == 422
+
+    async def test_correction_rejects_oversized_nutrition(self, auth_client):
+        # A single huge nutrition value (not just many keys) is rejected.
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        resp = await client.post(
+            f"/api/food-records/{record_id}/correct",
+            json={
+                "corrected_carbs_low": 30,
+                "corrected_carbs_high": 40,
+                "corrected_nutrition": {"note": "x" * 5000},
+            },
+        )
+        assert resp.status_code == 422
+
+    async def test_cannot_correct_other_users_record(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as other:
+            cookie = await _register_login(other)
+            other.cookies.set(settings.jwt_cookie_name, cookie)
+            resp = await other.post(
+                f"/api/food-records/{record_id}/correct",
+                json={"corrected_carbs_low": 30, "corrected_carbs_high": 40},
+            )
+        assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Common foods: promotion, dedupe, linking, management (AC2/AC3)
+# --------------------------------------------------------------------------- #
+class TestCommonFoods:
+    async def test_save_as_common_food_uses_corrected_values(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client, 40, 55)
+        record_id = created["id"]
+        # Correct first; the promotion should baseline the corrected values.
+        await client.post(
+            f"/api/food-records/{record_id}/correct",
+            json={"corrected_carbs_low": 70, "corrected_carbs_high": 75},
+        )
+        resp = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal Bowl"},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["name"] == "Oatmeal Bowl"
+        assert body["carbs_low"] == 70
+        assert body["carbs_high"] == 75
+
+        # The record is now linked to the baseline.
+        record = await client.get(f"/api/food-records/{record_id}")
+        assert record.json()["common_food_id"] == body["id"]
+
+    async def test_save_as_common_food_uses_ai_values_when_uncorrected(
+        self, auth_client
+    ):
+        client, _ = auth_client
+        created = await _create_record(client, 30, 45)
+        resp = await client.post(
+            f"/api/food-records/{created['id']}/save-as-common-food",
+            json={"name": "Toast"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["carbs_low"] == 30
+        assert resp.json()["carbs_high"] == 45
+
+    async def test_dedupe_same_name_updates_single_baseline(self, auth_client):
+        client, _ = auth_client
+        first = await _create_record(client, 30, 40)
+        second = await _create_record(client, 50, 60)
+
+        r1 = await client.post(
+            f"/api/food-records/{first['id']}/save-as-common-food",
+            json={"name": "Pasta"},
+        )
+        # Same name (different casing/spacing) -> updates the same baseline.
+        r2 = await client.post(
+            f"/api/food-records/{second['id']}/save-as-common-food",
+            json={"name": "  pasta  "},
+        )
+        assert r1.json()["id"] == r2.json()["id"]
+        assert r2.json()["carbs_low"] == 50
+        assert r2.json()["carbs_high"] == 60
+
+        listing = await client.get("/api/common-foods")
+        names = [f["name"] for f in listing.json()["common_foods"]]
+        assert names.count("Pasta") + names.count("pasta") == 1
+
+    async def test_link_existing_record_to_common_food(self, auth_client):
+        client, _ = auth_client
+        seed = await _create_record(client, 30, 40)
+        cf = await client.post(
+            f"/api/food-records/{seed['id']}/save-as-common-food",
+            json={"name": "Rice"},
+        )
+        common_food_id = cf.json()["id"]
+
+        other_record = await _create_record(client, 35, 45)
+        resp = await client.post(
+            f"/api/food-records/{other_record['id']}/link-common-food",
+            json={"common_food_id": common_food_id},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["common_food_id"] == common_food_id
+
+    async def test_rename_and_update_baseline(self, auth_client):
+        client, _ = auth_client
+        seed = await _create_record(client, 30, 40)
+        cf = await client.post(
+            f"/api/food-records/{seed['id']}/save-as-common-food",
+            json={"name": "Cereal"},
+        )
+        cf_id = cf.json()["id"]
+        resp = await client.patch(
+            f"/api/common-foods/{cf_id}",
+            json={"name": "Granola", "carbs_low": 45, "carbs_high": 50},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Granola"
+        assert resp.json()["carbs_low"] == 45
+
+    async def test_rename_collision_returns_409(self, auth_client):
+        client, _ = auth_client
+        a = await _create_record(client, 30, 40)
+        b = await _create_record(client, 30, 40)
+        cf_a = await client.post(
+            f"/api/food-records/{a['id']}/save-as-common-food", json={"name": "Apple"}
+        )
+        await client.post(
+            f"/api/food-records/{b['id']}/save-as-common-food", json={"name": "Banana"}
+        )
+        resp = await client.patch(
+            f"/api/common-foods/{cf_a.json()['id']}", json={"name": "banana"}
+        )
+        assert resp.status_code == 409
+
+    async def test_promote_corrected_carbs_keeps_ai_nutrition(self, auth_client):
+        # Correct carbs only (no corrected nutrition) -> the promoted baseline
+        # carries the corrected carbs but the original AI nutrition.
+        client, _ = auth_client
+        created = await _create_record(client, 40, 55)
+        record_id = created["id"]
+        await client.post(
+            f"/api/food-records/{record_id}/correct",
+            json={"corrected_carbs_low": 70, "corrected_carbs_high": 75},
+        )
+        resp = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Burrito"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["carbs_low"] == 70
+        # _estimate_json seeds AI nutrition {"protein_grams": 12, "calories": 520}.
+        assert body["nutrition_json"] == {"protein_grams": 12, "calories": 520}
+
+    async def test_update_rejects_partial_carb_range(self, auth_client):
+        client, _ = auth_client
+        seed = await _create_record(client, 30, 40)
+        cf = await client.post(
+            f"/api/food-records/{seed['id']}/save-as-common-food",
+            json={"name": "Soup"},
+        )
+        # Only one carb bound -> schema rejects (can't form a valid range).
+        resp = await client.patch(
+            f"/api/common-foods/{cf.json()['id']}", json={"carbs_low": 20}
+        )
+        assert resp.status_code == 422
+
+    async def test_delete_common_food_unlinks_records(self, auth_client):
+        client, _ = auth_client
+        seed = await _create_record(client, 30, 40)
+        cf = await client.post(
+            f"/api/food-records/{seed['id']}/save-as-common-food",
+            json={"name": "Yogurt"},
+        )
+        cf_id = cf.json()["id"]
+        resp = await client.delete(f"/api/common-foods/{cf_id}")
+        assert resp.status_code == 204
+        # The previously-linked record survives, now unlinked (SET NULL).
+        record = await client.get(f"/api/food-records/{seed['id']}")
+        assert record.status_code == 200
+        assert record.json()["common_food_id"] is None
+
+    async def test_cannot_link_other_users_common_food(self, auth_client, db_session):
+        client, _ = auth_client
+        my_record = await _create_record(client, 30, 40)
+
+        # Another user's baseline, seeded directly (the IDOR target).
+        from src.models.common_food import CommonFood
+
+        other = await _new_user(db_session, "link-idor")
+        their_cf = CommonFood(
+            user_id=other.id,
+            name="Secret",
+            normalized_name="secret",
+            carbs_low=30,
+            carbs_high=40,
+        )
+        db_session.add(their_cf)
+        await db_session.commit()
+
+        resp = await client.post(
+            f"/api/food-records/{my_record['id']}/link-common-food",
+            json={"common_food_id": str(their_cf.id)},
+        )
+        assert resp.status_code == 404
+
+    async def test_cannot_access_other_users_common_food(self, auth_client):
+        client, _ = auth_client
+        seed = await _create_record(client, 30, 40)
+        cf = await client.post(
+            f"/api/food-records/{seed['id']}/save-as-common-food",
+            json={"name": "Mine"},
+        )
+        cf_id = cf.json()["id"]
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as other:
+            cookie = await _register_login(other)
+            other.cookies.set(settings.jwt_cookie_name, cookie)
+            assert (await other.get(f"/api/common-foods/{cf_id}")).status_code == 404
+            assert (
+                await other.patch(f"/api/common-foods/{cf_id}", json={"name": "Hijack"})
+            ).status_code == 404
+            assert (await other.delete(f"/api/common-foods/{cf_id}")).status_code == 404
+            # The owner's baseline is untouched.
+        assert (await client.get(f"/api/common-foods/{cf_id}")).json()["name"] == "Mine"
+
+    async def test_common_foods_listing_is_owner_scoped(self, auth_client):
+        client, _ = auth_client
+        seed = await _create_record(client, 30, 40)
+        await client.post(
+            f"/api/food-records/{seed['id']}/save-as-common-food",
+            json={"name": "OnlyMine"},
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as other:
+            cookie = await _register_login(other)
+            other.cookies.set(settings.jwt_cookie_name, cookie)
+            listing = await other.get("/api/common-foods")
+        names = [f["name"] for f in listing.json()["common_foods"]]
+        assert "OnlyMine" not in names
+
+    async def test_common_foods_disabled_when_flag_off(self, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "meal_intelligence_enabled", False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            cookie = await _register_login(client)
+            client.cookies.set(settings.jwt_cookie_name, cookie)
+            resp = await client.get("/api/common-foods")
+        assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Safety: corrected + common-food values never flow into dosing math (AC4)
+# --------------------------------------------------------------------------- #
+class TestCorrectionNoTherapyCoupling:
+    async def test_correction_does_not_change_iob(self, _uploads_tmp):
+        """Correcting a meal must not produce or alter insulin-on-board."""
+        from src.database import get_session_maker
+        from src.models.user import User, UserRole
+        from src.schemas.food_record import FoodRecordCorrectionRequest
+        from src.services import common_food as common_food_service
+        from src.services.iob_projection import get_iob_projection
+
+        async with get_session_maker()() as db:
+            user = User(
+                email=unique_email("c-iob"),
+                hashed_password="x",
+                role=UserRole.DIABETIC,
+            )
+            db.add(user)
+            await db.commit()
+
+            before = await get_iob_projection(db, user.id)
+
+            record = FoodRecord(
+                user_id=user.id,
+                filename="x.png",
+                file_type="png",
+                file_size_bytes=10,
+                storage_path="/uploads/food/x/x.png",
+                carbs_low=40,
+                carbs_high=55,
+                confidence="high",
+                source=FoodRecordSource.AI_ESTIMATE,
+            )
+            db.add(record)
+            await db.commit()
+
+            await common_food_service.correct_food_record(
+                db,
+                record,
+                FoodRecordCorrectionRequest(
+                    corrected_carbs_low=120, corrected_carbs_high=150
+                ),
+            )
+            await common_food_service.promote_to_common_food(db, record, "Big Meal")
+
+            after = await get_iob_projection(db, user.id)
+            # No insulin doses exist -> IoB is None before and after; neither the
+            # correction nor the common-food baseline created an IoB contribution.
+            assert before is None
+            assert after is None
+
+    def test_common_food_schema_has_no_dose_field(self):
+        from src.schemas.common_food import CommonFoodResponse
+
+        fields = set(CommonFoodResponse.model_fields)
+        for forbidden in ("dose", "units", "bolus", "insulin", "carb_ratio"):
+            assert not any(forbidden in f for f in fields)
+
+
+# --------------------------------------------------------------------------- #
+# Account purge clears common foods (and unlinks)
+# --------------------------------------------------------------------------- #
+class TestPurgeClearsCommonFoods:
+    async def test_purge_deletes_common_foods(self, _uploads_tmp):
+        from src.database import get_session_maker
+        from src.models.common_food import CommonFood
+        from src.services.data_purge import purge_all_user_data
+
+        async with get_session_maker()() as db:
+            user = await _new_user(db, "purge-cf")
+            db.add(
+                CommonFood(
+                    user_id=user.id,
+                    name="Sandwich",
+                    normalized_name="sandwich",
+                    carbs_low=40,
+                    carbs_high=50,
+                )
+            )
+            await db.commit()
+
+            deleted = await purge_all_user_data(user.id, db)
+            assert deleted["common_foods"] == 1
+
+            remaining = await db.scalar(
+                select(func.count())
+                .select_from(CommonFood)
+                .where(CommonFood.user_id == user.id)
+            )
+            assert remaining == 0


### PR DESCRIPTION
## Summary

Adds a user-driven **correction loop** on food records and a **common foods** baseline for frequently-eaten meals, building on the food-photo carb estimation pipeline. Lets a user fix an estimate when it's clearly wrong and save foods they eat often so the platform reflects reality instead of re-guessing.

Backend-only, flag-gated behind `meal_intelligence_enabled` (the whole surface 404s when off).

## What's included

- **Correction API** — `POST /api/food-records/{id}/correct`: override carbs/nutrition. Provenance flips to `user_corrected` and the corrected value becomes the stored truth, while the **original AI estimate is preserved** (corrected values land in `corrected_*` columns). Same reject-not-clamp carb validation as the create path.
- **`common_foods`** — new table + model + migration `067_common_foods` (chained off the current head `066_food_records`). A user-named carb/nutrition baseline, **deduped per user** on a normalized name (`UniqueConstraint(user_id, normalized_name)`). `food_records.common_food_id` promoted to a real FK with `ON DELETE SET NULL`.
- **Promote / link** — `POST /{id}/save-as-common-food` (uses corrected values, else the AI estimate; saving under an existing name updates that baseline) and `POST /{id}/link-common-food`.
- **Management** — list / get / rename + update (409 on name collision) / delete on `/api/common-foods`. Deleting a baseline unlinks its records (FK SET NULL).
- **Account purge** — extended to clear common foods after food records.

## Safety

A correction fixes a *description of the food*, never a dose. No endpoint returns or computes insulin, and corrected / common-food values never flow into IoB, treatment_safety, or carb-ratio math — asserted by tests (the static guard now also covers common foods).

## Security

Every correction / link / rename / delete / list / get query is scoped to the authenticated `user_id`; missing or cross-user ids return 404 (no existence leak). Carb values are reject-not-clamp at the schema, service, and DB-CHECK layers; user-supplied nutrition is bounded by field count and serialized size.

## Testing

- Unit/integration tests for correction (provenance flip + original retention + reject-not-clamp), promotion, dedupe, linking, rename/collision, delete-unlink, ownership/IDOR on every endpoint, and the no-dosing-coupling invariant.
- `ruff check` + `ruff format --check` clean; migration up/down round-trips.

## Out of scope

Own-history RAG recall / image matching, mobile UI, and grounding-attribution fields are later slices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save frequently-eaten foods as personal baselines with customizable carb ranges and nutrition data for quick future reference.
  * Correct food record nutritional information after AI analysis to improve baseline accuracy.
  * Link food records to saved common foods to streamline future meal logging.

* **Tests**
  * Added comprehensive test coverage for food record correction and common foods functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->