### PR TITLE
feat(mobile): meal capture → estimate → correct → save (Meal Intelligence)

### DIFF
--- a/apps/mobile/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/app/src/main/AndroidManifest.xml
@@ -45,6 +45,13 @@
         android:name="android.hardware.bluetooth_le"
         android:required="true" />
 
+    <!-- Camera for meal-photo capture (Epic 50). Requested at runtime; optional hardware so
+         the app still installs on camera-less devices (gallery picker remains available). -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera.any"
+        android:required="false" />
+
     <application
         android:name=".GlycemicGptApp"
         android:allowBackup="false"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/ImageCompressor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/ImageCompressor.kt
@@ -1,0 +1,156 @@
+package com.glycemicgpt.mobile.data.meal
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.media.ExifInterface
+import android.net.Uri
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * Decodes a picked/captured image and re-encodes it as a downscaled JPEG that fits under the
+ * backend's upload cap. Re-encoding via [Bitmap.compress] discards all metadata (EXIF/GPS),
+ * which is defense-in-depth on top of the server-side EXIF stripping.
+ *
+ * The pure sizing helpers are split out so they can be unit-tested without an Android device.
+ */
+object ImageCompressor {
+
+    /** Longest-edge target for the uploaded image; plenty for vision estimation. */
+    const val MAX_DIMENSION = 1280
+
+    /** Hard ceiling on the encoded payload; must stay <= the server's 5 MiB cap. */
+    const val MAX_BYTES = 5 * 1024 * 1024
+
+    private const val INITIAL_QUALITY = 90
+    private const val MIN_QUALITY = 40
+    private const val QUALITY_STEP = 10
+
+    /**
+     * Read [uri], downscale, and JPEG-encode under [maxBytes].
+     *
+     * @throws IOException if the image cannot be opened or decoded.
+     */
+    fun compress(
+        resolver: ContentResolver,
+        uri: Uri,
+        maxDimension: Int = MAX_DIMENSION,
+        maxBytes: Int = MAX_BYTES,
+    ): ByteArray {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        // In inJustDecodeBounds mode decodeStream always returns null and only fills `bounds`, so the
+        // open must be null-checked on the stream itself; validity is then read off `bounds`.
+        (resolver.openInputStream(uri) ?: throw IOException("Could not open image")).use {
+            BitmapFactory.decodeStream(it, null, bounds)
+        }
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) {
+            throw IOException("Could not decode image")
+        }
+
+        val decodeOptions = BitmapFactory.Options().apply {
+            inSampleSize = calculateInSampleSize(bounds.outWidth, bounds.outHeight, maxDimension)
+        }
+        val decoded = resolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, decodeOptions)
+        } ?: throw IOException("Could not decode image")
+
+        // Bitmap ownership: each step either returns its input unchanged or returns a new bitmap
+        // and recycles the one it replaced (`createScaledBitmap`/`applyOrientation` guard `it != src`).
+        // So exactly one live bitmap (`oriented`) survives to the encode step, and the `finally`
+        // recycles it. No intermediate is leaked and nothing is double-recycled.
+        val (targetWidth, targetHeight) =
+            targetDimensions(decoded.width, decoded.height, maxDimension)
+        val scaled = if (targetWidth != decoded.width || targetHeight != decoded.height) {
+            Bitmap.createScaledBitmap(decoded, targetWidth, targetHeight, true)
+                .also { if (it != decoded) decoded.recycle() }
+        } else {
+            decoded
+        }
+        val oriented = applyOrientation(resolver, uri, scaled)
+
+        return try {
+            encodeUnderCap(oriented, maxBytes)
+        } finally {
+            oriented.recycle()
+        }
+    }
+
+    /**
+     * Power-of-two subsample factor that gets the longest edge at or below [maxDimension] without
+     * over-decoding. Matches the BitmapFactory contract (inSampleSize is rounded to a power of two).
+     */
+    fun calculateInSampleSize(width: Int, height: Int, maxDimension: Int): Int {
+        if (maxDimension <= 0) return 1
+        var sampleSize = 1
+        val longestEdge = max(width, height)
+        while (longestEdge / (sampleSize * 2) >= maxDimension) {
+            sampleSize *= 2
+        }
+        return sampleSize
+    }
+
+    /** Final dimensions after constraining the longest edge to [maxDimension], preserving aspect. */
+    fun targetDimensions(width: Int, height: Int, maxDimension: Int): Pair<Int, Int> {
+        if (maxDimension <= 0 || width <= 0 || height <= 0) return width to height
+        val longestEdge = max(width, height)
+        if (longestEdge <= maxDimension) return width to height
+        val scale = maxDimension.toDouble() / longestEdge
+        val scaledWidth = max(1, (width * scale).roundToInt())
+        val scaledHeight = max(1, (height * scale).roundToInt())
+        return scaledWidth to scaledHeight
+    }
+
+    private fun encodeUnderCap(bitmap: Bitmap, maxBytes: Int): ByteArray {
+        var quality = INITIAL_QUALITY
+        var bytes = bitmap.toJpeg(quality)
+        while (bytes.size > maxBytes && quality > MIN_QUALITY) {
+            quality -= QUALITY_STEP
+            bytes = bitmap.toJpeg(quality)
+        }
+        if (bytes.size > maxBytes) {
+            throw IOException("Image is too large to upload after compression")
+        }
+        return bytes
+    }
+
+    /**
+     * Re-apply the camera/gallery EXIF orientation (rotation and/or mirroring) before the metadata
+     * is dropped by JPEG encoding, so the uploaded pixels are upright.
+     */
+    private fun applyOrientation(resolver: ContentResolver, uri: Uri, bitmap: Bitmap): Bitmap {
+        val orientation = try {
+            resolver.openInputStream(uri)?.use { stream ->
+                ExifInterface(stream).getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_NORMAL,
+                )
+            } ?: ExifInterface.ORIENTATION_NORMAL
+        } catch (_: Exception) {
+            ExifInterface.ORIENTATION_NORMAL
+        }
+
+        val matrix = android.graphics.Matrix()
+        when (orientation) {
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.setScale(-1f, 1f)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.setScale(1f, -1f)
+            ExifInterface.ORIENTATION_ROTATE_90 -> matrix.setRotate(90f)
+            ExifInterface.ORIENTATION_ROTATE_180 -> matrix.setRotate(180f)
+            ExifInterface.ORIENTATION_ROTATE_270 -> matrix.setRotate(270f)
+            ExifInterface.ORIENTATION_TRANSPOSE -> { matrix.setRotate(90f); matrix.postScale(-1f, 1f) }
+            ExifInterface.ORIENTATION_TRANSVERSE -> { matrix.setRotate(270f); matrix.postScale(-1f, 1f) }
+            else -> return bitmap
+        }
+        val transformed = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+        if (transformed != bitmap) bitmap.recycle()
+        return transformed
+    }
+
+    private fun Bitmap.toJpeg(quality: Int): ByteArray =
+        ByteArrayOutputStream().use { out ->
+            compress(Bitmap.CompressFormat.JPEG, quality, out)
+            out.toByteArray()
+        }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealExceptions.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealExceptions.kt
@@ -1,0 +1,46 @@
+package com.glycemicgpt.mobile.data.meal
+
+/**
+ * Typed failures for the Meal Intelligence APIs, so ViewModels can render the right UI state
+ * (feature-off degradation, vision-unavailable message, etc.) instead of a generic error.
+ */
+sealed class MealException(message: String) : Exception(message) {
+
+    /** The meal_intelligence feature flag is off (backend returns 404 for the whole surface). */
+    class FeatureDisabled(message: String = "Meal intelligence is not enabled.") :
+        MealException(message)
+
+    /** The user's AI provider has no vision route (backend returns 422 vision_unavailable). */
+    class VisionUnavailable(
+        message: String = "Vision is not available on your current AI provider.",
+    ) : MealException(message)
+
+    /** No AI provider is configured for this user (backend returns 404). */
+    class NoAiProvider(message: String = "No AI provider configured.") : MealException(message)
+
+    /** The image exceeded the server's size cap (413). */
+    class ImageTooLarge(message: String = "That photo is too large. Try a smaller image.") :
+        MealException(message)
+
+    /** The image was not a supported format (415). */
+    class UnsupportedImage(
+        message: String = "Unsupported image type. Use a JPEG, PNG, or WebP photo.",
+    ) : MealException(message)
+
+    /** The estimate could not be produced or was out of range (400/422, non-vision). */
+    class EstimateFailed(message: String) : MealException(message)
+
+    /** Too many uploads in a short window (429). */
+    class RateLimited(message: String = "Too many photos at once. Please wait a moment.") :
+        MealException(message)
+
+    /** The record or common food was not found, or is owned by another user (404). */
+    class NotFound(message: String = "That item could not be found.") : MealException(message)
+
+    /** A common-food name collided with an existing one (409). */
+    class NameConflict(message: String = "A common food with that name already exists.") :
+        MealException(message)
+
+    /** A submitted carb value or name failed validation (422). */
+    class Validation(message: String) : MealException(message)
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealModels.kt
@@ -1,0 +1,169 @@
+package com.glycemicgpt.mobile.data.meal
+
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
+import java.time.Instant
+
+/**
+ * Domain models for Meal Intelligence (Epic 50).
+ *
+ * Safety posture (NON-NEGOTIABLE): a carb estimate is a descriptive observation of a
+ * photographed food, never a dose. Carbs are always a [CarbRange] plus a [CarbConfidence]
+ * signal; nothing here represents insulin, units, or a bolus.
+ */
+
+/** A low/high carbohydrate range in grams. Never collapsed to a single number for display. */
+data class CarbRange(val lowGrams: Double, val highGrams: Double)
+
+/**
+ * Client-side carb bounds, mirroring the backend's reject-not-clamp limits so a correction is
+ * validated before it leaves the device. These describe food, never a dose.
+ */
+object CarbBounds {
+    const val MIN_GRAMS = 0.0
+    const val MAX_GRAMS = 1000.0
+
+    /** Returns a human-readable reason a low/high range is invalid, or null if it is acceptable. */
+    fun validate(lowGrams: Double, highGrams: Double): String? = when {
+        lowGrams.isNaN() || highGrams.isNaN() -> "Enter a number of carbs in grams."
+        lowGrams < MIN_GRAMS || highGrams < MIN_GRAMS -> "Carbs can't be negative."
+        lowGrams > MAX_GRAMS || highGrams > MAX_GRAMS ->
+            "Carbs can't exceed ${MAX_GRAMS.toInt()} g."
+        lowGrams > highGrams -> "The low value must not exceed the high value."
+        else -> null
+    }
+
+    /**
+     * Parse two free-text gram inputs into a validated range. Shared by the food-record correction
+     * and common-food edit flows so the parsing rules and copy never drift between them.
+     */
+    fun parse(lowText: String, highText: String): CarbInputResult {
+        val low = lowText.trim().toDoubleOrNull()
+        val high = highText.trim().toDoubleOrNull()
+        if (low == null || high == null) {
+            return CarbInputResult.Invalid("Enter both carb values in grams.")
+        }
+        validate(low, high)?.let { return CarbInputResult.Invalid(it) }
+        return CarbInputResult.Valid(low, high)
+    }
+}
+
+/** Outcome of parsing user-entered carb inputs via [CarbBounds.parse]. */
+sealed interface CarbInputResult {
+    data class Valid(val lowGrams: Double, val highGrams: Double) : CarbInputResult
+    data class Invalid(val reason: String) : CarbInputResult
+}
+
+/** Model confidence in the estimate. Unknown when the provider returned nothing usable. */
+enum class CarbConfidence {
+    LOW,
+    MEDIUM,
+    HIGH,
+    UNKNOWN,
+    ;
+
+    companion object {
+        fun fromApi(value: String?): CarbConfidence = when (value?.trim()?.lowercase()) {
+            "low" -> LOW
+            "medium" -> MEDIUM
+            "high" -> HIGH
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** Provenance of the carb value, mirroring the backend's `source` enum. */
+enum class FoodRecordSource {
+    AI_ESTIMATE,
+    USER_CORRECTED,
+    EXTERNAL_GROUNDED,
+    UNKNOWN,
+    ;
+
+    companion object {
+        fun fromApi(value: String?): FoodRecordSource = when (value?.trim()?.lowercase()) {
+            "ai_estimate" -> AI_ESTIMATE
+            "user_corrected" -> USER_CORRECTED
+            "external_grounded" -> EXTERNAL_GROUNDED
+            else -> UNKNOWN
+        }
+    }
+}
+
+/** A persisted meal photo + carb estimate, optionally corrected by the user. */
+data class FoodRecord(
+    val id: String,
+    val mealTimestamp: Instant?,
+    val foodDescription: String?,
+    /** The original AI estimate. Always preserved, even after a correction. */
+    val estimate: CarbRange,
+    val confidence: CarbConfidence,
+    val source: FoodRecordSource,
+    /** The user's correction, if any. Null when the record has not been corrected. */
+    val correction: CarbRange?,
+    val correctedAt: Instant?,
+    val commonFoodId: String?,
+    val createdAt: Instant?,
+) {
+    /** Whether the user has corrected the AI estimate. */
+    val isCorrected: Boolean get() = correction != null
+
+    /** The carb range to show as the headline value: the correction if present, else the estimate. */
+    val displayRange: CarbRange get() = correction ?: estimate
+}
+
+/** A saved per-user food baseline that future estimates can be grounded against. */
+data class CommonFood(
+    val id: String,
+    val name: String,
+    val carbs: CarbRange,
+    val createdAt: Instant?,
+    val updatedAt: Instant?,
+)
+
+/**
+ * Parse an ISO-8601 timestamp defensively. Returns null on any unexpected format rather than
+ * throwing, so a single malformed field never breaks a whole list.
+ */
+internal fun parseInstantOrNull(value: String?): Instant? {
+    if (value.isNullOrBlank()) return null
+    return try {
+        Instant.parse(value)
+    } catch (_: Exception) {
+        try {
+            java.time.OffsetDateTime.parse(value).toInstant()
+        } catch (_: Exception) {
+            null
+        }
+    }
+}
+
+fun FoodRecordResponse.toDomain(): FoodRecord {
+    val correctionLow = correctedCarbsLow
+    val correctionHigh = correctedCarbsHigh
+    val correction = if (correctionLow != null && correctionHigh != null) {
+        CarbRange(correctionLow, correctionHigh)
+    } else {
+        null
+    }
+    return FoodRecord(
+        id = id,
+        mealTimestamp = parseInstantOrNull(mealTimestamp),
+        foodDescription = foodDescription,
+        estimate = CarbRange(carbsLow, carbsHigh),
+        confidence = CarbConfidence.fromApi(confidence),
+        source = FoodRecordSource.fromApi(source),
+        correction = correction,
+        correctedAt = parseInstantOrNull(correctedAt),
+        commonFoodId = commonFoodId,
+        createdAt = parseInstantOrNull(createdAt),
+    )
+}
+
+fun CommonFoodResponse.toDomain(): CommonFood = CommonFood(
+    id = id,
+    name = name,
+    carbs = CarbRange(carbsLow, carbsHigh),
+    createdAt = parseInstantOrNull(createdAt),
+    updatedAt = parseInstantOrNull(updatedAt),
+)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealPhotoFiles.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealPhotoFiles.kt
@@ -1,0 +1,37 @@
+package com.glycemicgpt.mobile.data.meal
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * Manages the transient cache files used to receive a full-resolution capture from the system
+ * camera app. The originals are downscaled and re-encoded before upload and deleted afterwards,
+ * so no untouched (EXIF-bearing) photo lingers on disk.
+ */
+object MealPhotoFiles {
+
+    private const val DIR = "meal_photos"
+
+    /** Create a FileProvider URI the camera app can write the captured photo into. */
+    fun createCaptureUri(context: Context): Uri {
+        val dir = File(context.cacheDir, DIR).apply { mkdirs() }
+        val file = File(dir, "capture_${System.currentTimeMillis()}.jpg")
+        return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+    }
+
+    /**
+     * Delete the single capture backing [uri] (a no-op for gallery URIs we don't own). Scoped to
+     * one file so an in-flight capture is never swept by another capture's cleanup. FileProvider
+     * supports delete-by-content-URI; any failure (e.g. a foreign gallery URI) is ignored.
+     */
+    fun deleteCapture(context: Context, uri: Uri) {
+        runCatching { context.contentResolver.delete(uri, null, null) }
+    }
+
+    /** Delete any captured originals left in the cache directory (orphan sweep between sessions). */
+    fun clearCaptures(context: Context) {
+        File(context.cacheDir, DIR).listFiles()?.forEach { it.delete() }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -20,11 +20,22 @@ import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionListDto
 import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
 import com.glycemicgpt.mobile.data.remote.dto.PumpPushResponse
 import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodListResponse
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodUpdateRequest
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordCorrectionRequest
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordListResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
+import com.glycemicgpt.mobile.data.remote.dto.SaveAsCommonFoodRequest
+import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Multipart
+import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Query
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -101,4 +112,47 @@ interface GlycemicGptApi {
         @Query("since") since: String?,
         @Query("limit") limit: Int,
     ): Response<NightscoutDataDto>
+
+    // Meal Intelligence (Epic 50). All endpoints return 404 when the
+    // meal_intelligence_enabled feature flag is off; the upload returns 422 when
+    // the user's AI provider has no vision route.
+    @Multipart
+    @POST("/api/food-records")
+    suspend fun uploadFoodPhoto(@Part file: MultipartBody.Part): Response<FoodRecordResponse>
+
+    @GET("/api/food-records")
+    suspend fun listFoodRecords(
+        @Query("limit") limit: Int = 50,
+        @Query("offset") offset: Int = 0,
+    ): Response<FoodRecordListResponse>
+
+    @DELETE("/api/food-records/{recordId}")
+    suspend fun deleteFoodRecord(@Path("recordId") recordId: String): Response<Unit>
+
+    @POST("/api/food-records/{recordId}/correct")
+    suspend fun correctFoodRecord(
+        @Path("recordId") recordId: String,
+        @Body request: FoodRecordCorrectionRequest,
+    ): Response<FoodRecordResponse>
+
+    @POST("/api/food-records/{recordId}/save-as-common-food")
+    suspend fun saveRecordAsCommonFood(
+        @Path("recordId") recordId: String,
+        @Body request: SaveAsCommonFoodRequest,
+    ): Response<CommonFoodResponse>
+
+    @GET("/api/common-foods")
+    suspend fun listCommonFoods(
+        @Query("limit") limit: Int = 50,
+        @Query("offset") offset: Int = 0,
+    ): Response<CommonFoodListResponse>
+
+    @PATCH("/api/common-foods/{commonFoodId}")
+    suspend fun updateCommonFood(
+        @Path("commonFoodId") commonFoodId: String,
+        @Body request: CommonFoodUpdateRequest,
+    ): Response<CommonFoodResponse>
+
+    @DELETE("/api/common-foods/{commonFoodId}")
+    suspend fun deleteCommonFood(@Path("commonFoodId") commonFoodId: String): Response<Unit>
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
@@ -69,13 +69,3 @@ data class CommonFoodUpdateRequest(
     @Json(name = "carbs_low") val carbsLow: Double? = null,
     @Json(name = "carbs_high") val carbsHigh: Double? = null,
 )
-
-/**
- * FastAPI error envelope. `detail` is a plain string for our hand-raised [HTTPException]s, but a
- * list of validation objects for Pydantic request-validation failures -- so it is typed [Any] and
- * narrowed at the call site.
- */
-@JsonClass(generateAdapter = true)
-data class ApiErrorBody(
-    val detail: Any? = null,
-)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
@@ -1,0 +1,81 @@
+package com.glycemicgpt.mobile.data.remote.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * DTOs for the Meal Intelligence (Epic 50) food-records and common-foods APIs.
+ *
+ * Timestamps are kept as raw ISO-8601 strings (matching [AlertResponse]) and parsed
+ * defensively in the mapper, so an unexpected offset format never crashes deserialization.
+ *
+ * Carbs are always a low/high range plus a confidence signal -- never a lone integer.
+ * No field in this contract carries insulin, dose, or bolus information by design.
+ * Fields the v1 UI does not consume (nutrition JSON, model/provider provenance) are omitted;
+ * Moshi tolerates the extra response keys.
+ */
+@JsonClass(generateAdapter = true)
+data class FoodRecordResponse(
+    val id: String,
+    @Json(name = "meal_timestamp") val mealTimestamp: String,
+    @Json(name = "food_description") val foodDescription: String? = null,
+    @Json(name = "carbs_low") val carbsLow: Double,
+    @Json(name = "carbs_high") val carbsHigh: Double,
+    val confidence: String? = null,
+    val source: String,
+    @Json(name = "corrected_carbs_low") val correctedCarbsLow: Double? = null,
+    @Json(name = "corrected_carbs_high") val correctedCarbsHigh: Double? = null,
+    @Json(name = "corrected_at") val correctedAt: String? = null,
+    @Json(name = "common_food_id") val commonFoodId: String? = null,
+    @Json(name = "created_at") val createdAt: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class FoodRecordListResponse(
+    val records: List<FoodRecordResponse>,
+    val total: Int,
+)
+
+@JsonClass(generateAdapter = true)
+data class FoodRecordCorrectionRequest(
+    @Json(name = "corrected_carbs_low") val correctedCarbsLow: Double,
+    @Json(name = "corrected_carbs_high") val correctedCarbsHigh: Double,
+)
+
+@JsonClass(generateAdapter = true)
+data class SaveAsCommonFoodRequest(
+    val name: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class CommonFoodResponse(
+    val id: String,
+    val name: String,
+    @Json(name = "carbs_low") val carbsLow: Double,
+    @Json(name = "carbs_high") val carbsHigh: Double,
+    @Json(name = "created_at") val createdAt: String,
+    @Json(name = "updated_at") val updatedAt: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class CommonFoodListResponse(
+    @Json(name = "common_foods") val commonFoods: List<CommonFoodResponse>,
+    val total: Int,
+)
+
+@JsonClass(generateAdapter = true)
+data class CommonFoodUpdateRequest(
+    val name: String? = null,
+    @Json(name = "carbs_low") val carbsLow: Double? = null,
+    @Json(name = "carbs_high") val carbsHigh: Double? = null,
+)
+
+/**
+ * FastAPI error envelope. `detail` is a plain string for our hand-raised [HTTPException]s, but a
+ * list of validation objects for Pydantic request-validation failures -- so it is typed [Any] and
+ * narrowed at the call site.
+ */
+@JsonClass(generateAdapter = true)
+data class ApiErrorBody(
+    val detail: Any? = null,
+)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/MealRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/MealRepository.kt
@@ -1,0 +1,180 @@
+package com.glycemicgpt.mobile.data.repository
+
+import com.glycemicgpt.mobile.data.meal.CommonFood
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.meal.toDomain
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.ApiErrorBody
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodUpdateRequest
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordCorrectionRequest
+import com.glycemicgpt.mobile.data.remote.dto.SaveAsCommonFoodRequest
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.CancellationException
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.ResponseBody
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Response
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+/**
+ * Data access for Meal Intelligence (Epic 50). Wraps the food-records / common-foods APIs and
+ * translates HTTP failures into typed [MealException]s so the UI can degrade gracefully
+ * (feature-off, vision-unavailable) rather than showing a raw error.
+ *
+ * The photo upload routes through the long-timeout [chatApi] because it triggers a vision-model
+ * inference that can take far longer than the standard 15s budget.
+ */
+@Singleton
+class MealRepository @Inject constructor(
+    private val api: GlycemicGptApi,
+    @Named("chat") private val chatApi: GlycemicGptApi,
+    moshi: Moshi,
+) {
+    private val errorAdapter = moshi.adapter(ApiErrorBody::class.java)
+
+    /** Upload a compressed JPEG and return the persisted estimate. */
+    suspend fun uploadPhoto(jpegBytes: ByteArray): Result<FoodRecord> {
+        val body = jpegBytes.toRequestBody(JPEG_MEDIA_TYPE)
+        val part = MultipartBody.Part.createFormData("file", "meal.jpg", body)
+        return body { chatApi.uploadFoodPhoto(part) }.map { it.toDomain() }
+    }
+
+    suspend fun listFoodRecords(limit: Int = DEFAULT_PAGE, offset: Int = 0): Result<List<FoodRecord>> =
+        body { api.listFoodRecords(limit = limit, offset = offset) }
+            .map { resp -> resp.records.map { it.toDomain() } }
+
+    /**
+     * Cheapest call that still exercises the flag-gated surface, used only to detect feature-off
+     * (404) vs reachable. Success/data is irrelevant -- callers inspect the failure type.
+     */
+    suspend fun probeAvailability(): Result<Unit> =
+        listFoodRecords(limit = 1).map { }
+
+    suspend fun deleteFoodRecord(recordId: String): Result<Unit> =
+        noContent { api.deleteFoodRecord(recordId) }
+
+    suspend fun correctRecord(
+        recordId: String,
+        correctedCarbsLow: Double,
+        correctedCarbsHigh: Double,
+    ): Result<FoodRecord> = body {
+        api.correctFoodRecord(
+            recordId,
+            FoodRecordCorrectionRequest(
+                correctedCarbsLow = correctedCarbsLow,
+                correctedCarbsHigh = correctedCarbsHigh,
+            ),
+        )
+    }.map { it.toDomain() }
+
+    suspend fun saveAsCommonFood(recordId: String, name: String): Result<CommonFood> =
+        body { api.saveRecordAsCommonFood(recordId, SaveAsCommonFoodRequest(name = name)) }
+            .map { it.toDomain() }
+
+    suspend fun listCommonFoods(limit: Int = DEFAULT_PAGE, offset: Int = 0): Result<List<CommonFood>> =
+        body { api.listCommonFoods(limit = limit, offset = offset) }
+            .map { resp -> resp.commonFoods.map { it.toDomain() } }
+
+    suspend fun updateCommonFood(
+        commonFoodId: String,
+        name: String? = null,
+        carbsLow: Double? = null,
+        carbsHigh: Double? = null,
+    ): Result<CommonFood> = body {
+        api.updateCommonFood(
+            commonFoodId,
+            CommonFoodUpdateRequest(name = name, carbsLow = carbsLow, carbsHigh = carbsHigh),
+        )
+    }.map { it.toDomain() }
+
+    suspend fun deleteCommonFood(commonFoodId: String): Result<Unit> =
+        noContent { api.deleteCommonFood(commonFoodId) }
+
+    /** Run a call expected to return a body, mapping HTTP/IO failures to typed [MealException]s. */
+    private suspend fun <T> body(block: suspend () -> Response<T>): Result<T> = guard {
+        val response = block()
+        if (response.isSuccessful) {
+            response.body()?.let { Result.success(it) }
+                ?: Result.failure(MealException.EstimateFailed("The server returned an empty response."))
+        } else {
+            Result.failure(mapError(response.code(), detailOf(response.errorBody())))
+        }
+    }
+
+    /** Run a call whose success is a 204/empty body. */
+    private suspend fun noContent(block: suspend () -> Response<Unit>): Result<Unit> = guard {
+        val response = block()
+        if (response.isSuccessful) {
+            Result.success(Unit)
+        } else {
+            Result.failure(mapError(response.code(), detailOf(response.errorBody())))
+        }
+    }
+
+    private inline fun <T> guard(block: () -> Result<T>): Result<T> = try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    /** Extract the human message from a FastAPI error body, tolerating both the string and the
+     *  Pydantic list-of-objects shapes of `detail`. */
+    private fun detailOf(errorBody: ResponseBody?): String? = try {
+        val parsed = errorBody?.string()?.takeIf { it.isNotBlank() }?.let { errorAdapter.fromJson(it) }
+        when (val detail = parsed?.detail) {
+            is String -> detail
+            is List<*> -> (detail.firstOrNull() as? Map<*, *>)?.get("msg") as? String
+            else -> null
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun mapError(code: Int, detail: String?): MealException {
+        val message = detail?.trim().orEmpty()
+        return when (code) {
+            // A decode failure on an already-re-encoded upload means the source was unusable;
+            // "try a different photo" is more honest than the generic "try again".
+            400 -> MealException.EstimateFailed(
+                message.ifEmpty { "That photo couldn't be processed. Try a different one." },
+            )
+            404 -> when {
+                message.contains(DETAIL_FEATURE_OFF, ignoreCase = true) -> MealException.FeatureDisabled()
+                message.contains(DETAIL_NO_PROVIDER, ignoreCase = true) -> MealException.NoAiProvider()
+                else -> MealException.NotFound(message.ifEmpty { "That item could not be found." })
+            }
+            409 -> MealException.NameConflict(message.ifEmpty { "A common food with that name already exists." })
+            413 -> MealException.ImageTooLarge()
+            415 -> MealException.UnsupportedImage()
+            422 -> when {
+                message.contains(DETAIL_VISION, ignoreCase = true) -> MealException.VisionUnavailable()
+                message.isNotEmpty() -> MealException.Validation(message)
+                else -> MealException.EstimateFailed("That request couldn't be processed. Please try again.")
+            }
+            429 -> MealException.RateLimited()
+            502 -> MealException.EstimateFailed(
+                "The AI vision service is temporarily unavailable. Please try again in a moment.",
+            )
+            else -> MealException.EstimateFailed(
+                message.ifEmpty { "Something went wrong (HTTP $code). Please try again." },
+            )
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_PAGE = 50
+        val JPEG_MEDIA_TYPE = "image/jpeg".toMediaType()
+
+        // Substrings of the backend's `detail` copy (apps/api/src/routers/_meal_intelligence.py
+        // and food_records.py). The MealRepositoryTest cases pin these exact strings.
+        const val DETAIL_FEATURE_OFF = "not enabled"
+        const val DETAIL_NO_PROVIDER = "provider"
+        const val DETAIL_VISION = "vision"
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/MealRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/MealRepository.kt
@@ -5,11 +5,11 @@ import com.glycemicgpt.mobile.data.meal.FoodRecord
 import com.glycemicgpt.mobile.data.meal.MealException
 import com.glycemicgpt.mobile.data.meal.toDomain
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
-import com.glycemicgpt.mobile.data.remote.dto.ApiErrorBody
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodUpdateRequest
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordCorrectionRequest
 import com.glycemicgpt.mobile.data.remote.dto.SaveAsCommonFoodRequest
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 import kotlinx.coroutines.CancellationException
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -34,7 +34,12 @@ class MealRepository @Inject constructor(
     @Named("chat") private val chatApi: GlycemicGptApi,
     moshi: Moshi,
 ) {
-    private val errorAdapter = moshi.adapter(ApiErrorBody::class.java)
+    // The FastAPI error envelope is parsed as a raw object map rather than a codegen DTO: its
+    // `detail` is a plain string for our HTTPExceptions but a list of objects for Pydantic
+    // request-validation failures, so a fixed-shape adapter can't model it.
+    private val errorBodyAdapter = moshi.adapter<Map<String, Any?>>(
+        Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java),
+    )
 
     /** Upload a compressed JPEG and return the persisted estimate. */
     suspend fun uploadPhoto(jpegBytes: ByteArray): Result<FoodRecord> {
@@ -126,8 +131,8 @@ class MealRepository @Inject constructor(
     /** Extract the human message from a FastAPI error body, tolerating both the string and the
      *  Pydantic list-of-objects shapes of `detail`. */
     private fun detailOf(errorBody: ResponseBody?): String? = try {
-        val parsed = errorBody?.string()?.takeIf { it.isNotBlank() }?.let { errorAdapter.fromJson(it) }
-        when (val detail = parsed?.detail) {
+        val parsed = errorBody?.string()?.takeIf { it.isNotBlank() }?.let { errorBodyAdapter.fromJson(it) }
+        when (val detail = parsed?.get("detail")) {
             is String -> detail
             is List<*> -> (detail.firstOrNull() as? Map<*, *>)?.get("msg") as? String
             else -> null
@@ -174,7 +179,9 @@ class MealRepository @Inject constructor(
         // Substrings of the backend's `detail` copy (apps/api/src/routers/_meal_intelligence.py
         // and food_records.py). The MealRepositoryTest cases pin these exact strings.
         const val DETAIL_FEATURE_OFF = "not enabled"
-        const val DETAIL_NO_PROVIDER = "provider"
+        // Specific enough to match "No AI provider configured." / "...for your AI provider."
+        // without catching an unrelated 404 whose copy merely mentions a "provider".
+        const val DETAIL_NO_PROVIDER = "ai provider"
         const val DETAIL_VISION = "vision"
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/CoroutinesModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/CoroutinesModule.kt
@@ -1,0 +1,23 @@
+package com.glycemicgpt.mobile.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+
+/** Marks the IO-bound [CoroutineDispatcher] so it can be injected and overridden in tests. */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoroutinesModule {
+
+    @Provides
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModel.kt
@@ -1,0 +1,63 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives the Home meal glance (the camera FAB + Recent-meal card) independently of the pump-data
+ * [HomeViewModel] so the two domains stay separate. One cheap call surfaces the most recent meal and
+ * tells us whether the feature is available.
+ */
+data class HomeMealUiState(
+    /** Most recent logged meal; null hides the Recent-meal card. */
+    val recentMeal: FoodRecord? = null,
+    /**
+     * Whether to offer meal logging (the FAB). False only when the server flag is known-off; on a
+     * transient/offline failure we keep the FAB so the meal screen can show its own degraded state.
+     */
+    val mealLoggingAvailable: Boolean = true,
+)
+
+@HiltViewModel
+class HomeMealViewModel @Inject constructor(
+    private val repository: MealRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeMealUiState())
+    val uiState: StateFlow<HomeMealUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    /** Re-fetch the most recent meal; safe to call on Home resume / pull-to-refresh. */
+    fun refresh() {
+        viewModelScope.launch {
+            repository.listFoodRecords(limit = 1)
+                .onSuccess { records ->
+                    _uiState.update {
+                        it.copy(recentMeal = records.firstOrNull(), mealLoggingAvailable = true)
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            recentMeal = null,
+                            // Hide the FAB only when the server explicitly disabled the feature.
+                            mealLoggingAvailable = e !is MealException.FeatureDisabled,
+                        )
+                    }
+                }
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.glycemicgpt.mobile.presentation.home
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -37,6 +38,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import com.glycemicgpt.mobile.presentation.meal.MealFab
+import com.glycemicgpt.mobile.presentation.meal.RecentMealCard
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.presentation.plugin.PluginDashboardCardRenderer
 import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
@@ -48,13 +53,19 @@ import java.time.Instant
 @Composable
 fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
+    mealViewModel: HomeMealViewModel = hiltViewModel(),
     onPluginCardTap: (pluginId: String, cardId: String) -> Unit = { _, _ -> },
     onNavigateToChartDetail: (() -> Unit)? = null,
     onNavigateToTirDetail: () -> Unit = {},
     onNavigateToInsulinDetail: () -> Unit = {},
     onNavigateToAlertHistory: () -> Unit = {},
     onNavigateToBolusHistory: (() -> Unit)? = null,
+    onNavigateToMealLog: () -> Unit = {},
+    onNavigateToMealHistory: () -> Unit = {},
 ) {
+    val mealState by mealViewModel.uiState.collectAsState()
+    // Keep the Recent-meal glance fresh after logging a meal and returning Home.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { mealViewModel.refresh() }
     val connectionState by viewModel.connectionState.collectAsState()
     val cgm by viewModel.cgm.collectAsState()
     val iob by viewModel.iob.collectAsState()
@@ -83,9 +94,13 @@ fun HomeScreen(
     val showPumpLabels by viewModel.showPumpLabels.collectAsState()
     val retentionDays by viewModel.dataRetentionDays.collectAsState()
 
+    Box(modifier = Modifier.fillMaxSize()) {
     PullToRefreshBox(
         isRefreshing = isRefreshing,
-        onRefresh = { viewModel.refreshData() },
+        onRefresh = {
+            viewModel.refreshData()
+            mealViewModel.refresh()
+        },
         modifier = Modifier.fillMaxSize(),
     ) {
         Column(
@@ -111,6 +126,12 @@ fun HomeScreen(
             )
 
             Spacer(modifier = Modifier.height(12.dp))
+
+            // Recent-meal glance (Epic 50): only once the user has logged at least one meal.
+            mealState.recentMeal?.let { recent ->
+                RecentMealCard(record = recent, onViewAll = onNavigateToMealHistory)
+                Spacer(modifier = Modifier.height(12.dp))
+            }
 
             // Glucose trend chart with IoB, basal, and bolus overlays
             GlucoseTrendChart(
@@ -201,6 +222,17 @@ fun HomeScreen(
                     color = MaterialTheme.colorScheme.tertiary,
                 )
             }
+        }
+    }
+
+        // Extended camera FAB (Epic 50) — hidden only when the server has the feature off.
+        if (mealState.mealLoggingAvailable) {
+            MealFab(
+                onClick = onNavigateToMealLog,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
+            )
         }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -64,8 +65,12 @@ fun HomeScreen(
     onNavigateToMealHistory: () -> Unit = {},
 ) {
     val mealState by mealViewModel.uiState.collectAsState()
-    // Keep the Recent-meal glance fresh after logging a meal and returning Home.
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { mealViewModel.refresh() }
+    // Refresh the Recent-meal glance when returning to Home (e.g. after logging a meal). Skip the
+    // first resume since the ViewModel already fetched in init, avoiding a redundant call.
+    var firstResume by remember { mutableStateOf(true) }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        if (firstResume) firstResume = false else mealViewModel.refresh()
+    }
     val connectionState by viewModel.connectionState.collectAsState()
     val cgm by viewModel.cgm.collectAsState()
     val iob by viewModel.iob.collectAsState()
@@ -94,7 +99,6 @@ fun HomeScreen(
     val showPumpLabels by viewModel.showPumpLabels.collectAsState()
     val retentionDays by viewModel.dataRetentionDays.collectAsState()
 
-    Box(modifier = Modifier.fillMaxSize()) {
     PullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = {
@@ -107,7 +111,8 @@ fun HomeScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .padding(16.dp),
+                // Extra bottom space so the camera FAB never overlaps the last item.
+                .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 88.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             // Compact connection + sync status row
@@ -223,9 +228,9 @@ fun HomeScreen(
                 )
             }
         }
-    }
 
-        // Extended camera FAB (Epic 50) — hidden only when the server has the feature off.
+        // Extended camera FAB (Epic 50) — overlaid in the pull-to-refresh BoxScope, hidden only
+        // when the server has the feature off.
         if (mealState.mealLoggingAvailable) {
             MealFab(
                 onClick = onNavigateToMealLog,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
@@ -179,9 +179,10 @@ private fun EditCommonFoodDialog(
     onSave: (name: String, low: String, high: String) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var name by remember { mutableStateOf(food.name) }
-    var lowText by remember { mutableStateOf(formatEditableGrams(food.carbs.lowGrams)) }
-    var highText by remember { mutableStateOf(formatEditableGrams(food.carbs.highGrams)) }
+    // Key on the food id so the fields re-initialize if the dialog is reused for a different food.
+    var name by remember(food.id) { mutableStateOf(food.name) }
+    var lowText by remember(food.id) { mutableStateOf(formatEditableGrams(food.carbs.lowGrams)) }
+    var highText by remember(food.id) { mutableStateOf(formatEditableGrams(food.carbs.highGrams)) }
 
     AlertDialog(
         onDismissRequest = onDismiss,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
@@ -1,0 +1,241 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.glycemicgpt.mobile.data.meal.CommonFood
+import com.glycemicgpt.mobile.presentation.detail.DetailScaffold
+
+@Composable
+fun CommonFoodsScreen(
+    onBack: () -> Unit,
+    viewModel: CommonFoodsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.actionError) {
+        uiState.actionError?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearActionError()
+        }
+    }
+
+    DetailScaffold(
+        title = "Common Foods",
+        onBack = onBack,
+    ) { padding ->
+      Box(modifier = Modifier.padding(padding).fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("common_foods_screen"),
+        ) {
+            when {
+                uiState.disabled -> MealCenteredMessage(
+                    "Meal intelligence is turned off for this server.",
+                    modifier = Modifier.testTag("common_foods_disabled"),
+                )
+                uiState.isLoading -> MealCenteredSpinner()
+                else -> {
+                    VerifyBeforeDosingQualifier(modifier = Modifier.padding(16.dp))
+                    uiState.errorMessage?.let { error ->
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                        )
+                    }
+                    if (uiState.items.isEmpty()) {
+                        MealCenteredMessage(
+                            "No common foods yet. Save a meal as a common food to build your list.",
+                            modifier = Modifier.testTag("common_foods_empty"),
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .testTag("common_foods_list"),
+                            contentPadding = PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            items(uiState.items, key = { it.id }) { food ->
+                                CommonFoodItem(
+                                    food = food,
+                                    onEdit = { viewModel.startEdit(food) },
+                                    onDelete = { viewModel.delete(food.id) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+      }
+    }
+
+    uiState.editing?.let { editing ->
+        EditCommonFoodDialog(
+            food = editing,
+            isSaving = uiState.isSaving,
+            error = uiState.editError,
+            onSave = viewModel::saveEdit,
+            onDismiss = viewModel::cancelEdit,
+        )
+    }
+}
+
+@Composable
+private fun CommonFoodItem(food: CommonFood, onEdit: () -> Unit, onDelete: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("common_food_item"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = food.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = formatCarbRange(food.carbs),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("common_food_carbs"),
+                )
+            }
+            IconButton(onClick = onEdit, modifier = Modifier.testTag("common_food_edit")) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = "Edit ${food.name}",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(onClick = onDelete, modifier = Modifier.testTag("common_food_delete")) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete ${food.name}",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditCommonFoodDialog(
+    food: CommonFood,
+    isSaving: Boolean,
+    error: String?,
+    onSave: (name: String, low: String, high: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf(food.name) }
+    var lowText by remember { mutableStateOf(formatEditableGrams(food.carbs.lowGrams)) }
+    var highText by remember { mutableStateOf(formatEditableGrams(food.carbs.highGrams)) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit common food") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("common_food_edit_name"),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    OutlinedTextField(
+                        value = lowText,
+                        onValueChange = { lowText = it },
+                        label = { Text("Low (g)") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("common_food_edit_low"),
+                    )
+                    OutlinedTextField(
+                        value = highText,
+                        onValueChange = { highText = it },
+                        label = { Text("High (g)") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("common_food_edit_high"),
+                    )
+                }
+                if (error != null) {
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onSave(name, lowText, highText) },
+                enabled = !isSaving,
+                modifier = Modifier.testTag("common_food_edit_save"),
+            ) { Text(if (isSaving) "Saving…" else "Save") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
@@ -4,19 +4,24 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -39,6 +44,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.glycemicgpt.mobile.data.meal.CarbConfidence
 import com.glycemicgpt.mobile.data.meal.CommonFood
 import com.glycemicgpt.mobile.presentation.detail.DetailScaffold
 
@@ -49,6 +55,7 @@ fun CommonFoodsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+    var reLogging by remember { mutableStateOf<CommonFood?>(null) }
 
     LaunchedEffect(uiState.actionError) {
         uiState.actionError?.let {
@@ -99,6 +106,7 @@ fun CommonFoodsScreen(
                             items(uiState.items, key = { it.id }) { food ->
                                 CommonFoodItem(
                                     food = food,
+                                    onReLog = { reLogging = food },
                                     onEdit = { viewModel.startEdit(food) },
                                     onDelete = { viewModel.delete(food.id) },
                                 )
@@ -124,10 +132,19 @@ fun CommonFoodsScreen(
             onDismiss = viewModel::cancelEdit,
         )
     }
+
+    reLogging?.let { food ->
+        ReLogDialog(food = food, onDismiss = { reLogging = null })
+    }
 }
 
 @Composable
-private fun CommonFoodItem(food: CommonFood, onEdit: () -> Unit, onDelete: () -> Unit) {
+private fun CommonFoodItem(
+    food: CommonFood,
+    onReLog: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -137,7 +154,7 @@ private fun CommonFoodItem(food: CommonFood, onEdit: () -> Unit, onDelete: () ->
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(modifier = Modifier.weight(1f)) {
@@ -152,6 +169,19 @@ private fun CommonFoodItem(food: CommonFood, onEdit: () -> Unit, onDelete: () ->
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.testTag("common_food_carbs"),
                 )
+            }
+            FilledTonalButton(
+                onClick = onReLog,
+                contentPadding = PaddingValues(horizontal = 12.dp),
+                modifier = Modifier.testTag("common_food_relog"),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text("Re-log")
             }
             IconButton(onClick = onEdit, modifier = Modifier.testTag("common_food_edit")) {
                 Icon(
@@ -169,6 +199,39 @@ private fun CommonFoodItem(food: CommonFood, onEdit: () -> Unit, onDelete: () ->
             }
         }
     }
+}
+
+/**
+ * Re-log surface for v1. The API has no create-record-from-common-food path (a record needs a photo
+ * upload), so this read-only sheet surfaces the saved carb range to verify, without persisting a new
+ * record. Lays the seam for record creation when the backend supports it.
+ */
+@Composable
+private fun ReLogDialog(food: CommonFood, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(food.name) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                VerifyBeforeDosingQualifier()
+                CarbEstimateContent(
+                    range = food.carbs,
+                    confidence = CarbConfidence.UNKNOWN,
+                )
+                Text(
+                    text = "Your saved estimate for this food. Use it to verify before dosing — " +
+                        "no new photo needed.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss, modifier = Modifier.testTag("common_food_relog_close")) {
+                Text("Close")
+            }
+        },
+    )
 }
 
 @Composable

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModel.kt
@@ -1,0 +1,134 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.meal.CarbBounds
+import com.glycemicgpt.mobile.data.meal.CarbInputResult
+import com.glycemicgpt.mobile.data.meal.CommonFood
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+import javax.inject.Inject
+
+data class CommonFoodsUiState(
+    val isLoading: Boolean = true,
+    val items: List<CommonFood> = emptyList(),
+    val errorMessage: String? = null,
+    /** Transient failure of a row action (e.g. delete), surfaced as a snackbar then cleared. */
+    val actionError: String? = null,
+    val disabled: Boolean = false,
+    /** The food currently open in the edit dialog, if any. */
+    val editing: CommonFood? = null,
+    val editError: String? = null,
+    val isSaving: Boolean = false,
+)
+
+@HiltViewModel
+class CommonFoodsViewModel @Inject constructor(
+    private val repository: MealRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CommonFoodsUiState())
+    val uiState: StateFlow<CommonFoodsUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        viewModelScope.launch {
+            repository.listCommonFoods()
+                .onSuccess { items ->
+                    _uiState.update { it.copy(isLoading = false, items = items, disabled = false) }
+                }
+                .onFailure { e -> _uiState.update { it.copy(isLoading = false).withError(e) } }
+        }
+    }
+
+    fun startEdit(food: CommonFood) {
+        _uiState.update { it.copy(editing = food, editError = null) }
+    }
+
+    fun cancelEdit() {
+        _uiState.update { it.copy(editing = null, editError = null) }
+    }
+
+    fun saveEdit(name: String, lowText: String, highText: String) {
+        val editing = _uiState.value.editing ?: return
+        val trimmedName = name.trim()
+        if (trimmedName.isEmpty()) {
+            _uiState.update { it.copy(editError = "Name can't be empty.") }
+            return
+        }
+        val parsed = when (val result = CarbBounds.parse(lowText, highText)) {
+            is CarbInputResult.Invalid -> {
+                _uiState.update { it.copy(editError = result.reason) }
+                return
+            }
+            is CarbInputResult.Valid -> result
+        }
+        _uiState.update { it.copy(isSaving = true, editError = null) }
+        viewModelScope.launch {
+            repository.updateCommonFood(
+                editing.id,
+                name = trimmedName,
+                carbsLow = parsed.lowGrams,
+                carbsHigh = parsed.highGrams,
+            )
+                .onSuccess { updated ->
+                    _uiState.update { s ->
+                        s.copy(
+                            isSaving = false,
+                            editing = null,
+                            items = s.items.map { if (it.id == updated.id) updated else it },
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isSaving = false, editError = editMessageFor(e)) }
+                }
+        }
+    }
+
+    fun delete(commonFoodId: String) {
+        viewModelScope.launch {
+            repository.deleteCommonFood(commonFoodId)
+                .onSuccess {
+                    _uiState.update { s -> s.copy(items = s.items.filterNot { it.id == commonFoodId }) }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(actionError = deleteMessageFor(e)) }
+                }
+        }
+    }
+
+    fun clearActionError() {
+        _uiState.update { it.copy(actionError = null) }
+    }
+
+    private fun deleteMessageFor(e: Throwable): String = when (e) {
+        is IOException -> "Check your connection and try again."
+        is MealException -> e.message ?: "Couldn't delete that common food."
+        else -> "Couldn't delete that common food."
+    }
+
+    private fun CommonFoodsUiState.withError(e: Throwable): CommonFoodsUiState = when (e) {
+        is MealException.FeatureDisabled -> copy(disabled = true, errorMessage = null)
+        is IOException -> copy(errorMessage = "Check your connection and try again.")
+        else -> copy(errorMessage = e.message ?: "Couldn't load your common foods.")
+    }
+
+    private fun editMessageFor(e: Throwable): String = when (e) {
+        is MealException.NameConflict -> e.message ?: "A common food with that name already exists."
+        is MealException -> e.message ?: "Couldn't save your changes."
+        is IOException -> "Check your connection and try again."
+        else -> e.message ?: "Couldn't save your changes."
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
@@ -1,10 +1,12 @@
 package com.glycemicgpt.mobile.presentation.meal
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,12 +24,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.glycemicgpt.mobile.data.meal.CarbConfidence
 import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.presentation.theme.MealConfidenceColors
+import com.glycemicgpt.mobile.presentation.theme.safetyPalette
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -46,11 +53,13 @@ const val TAG_SAFETY_QUALIFIER = "meal_safety_qualifier"
  */
 @Composable
 fun VerifyBeforeDosingQualifier(modifier: Modifier = Modifier) {
+    // Soft-amber "calm caution" strip, never error red -- a standing note, not an alarm.
+    val palette = safetyPalette()
     Surface(
         modifier = modifier
             .fillMaxWidth()
             .testTag(TAG_SAFETY_QUALIFIER),
-        color = MaterialTheme.colorScheme.tertiaryContainer,
+        color = palette.background,
         shape = RoundedCornerShape(8.dp),
     ) {
         Row(
@@ -60,14 +69,14 @@ fun VerifyBeforeDosingQualifier(modifier: Modifier = Modifier) {
             Icon(
                 imageVector = Icons.Default.Info,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                tint = palette.icon,
                 modifier = Modifier.size(18.dp),
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = VERIFY_BEFORE_DOSING_TEXT,
                 style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                color = palette.foreground,
                 fontWeight = FontWeight.Medium,
             )
         }
@@ -86,7 +95,13 @@ fun CarbEstimateContent(
     isCorrected: Boolean = false,
     originalRange: CarbRange? = null,
 ) {
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    // The qualifier is announced as part of the value so it's never separable from the carbs (§12).
+    val description = "${carbRangeForSpeech(range)}, ${confidenceLabel(confidence).lowercase()}. " +
+        "$VERIFY_BEFORE_DOSING_TEXT."
+    Column(
+        modifier = modifier.semantics { contentDescription = description },
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
         Text(
             text = formatCarbRange(range),
             style = MaterialTheme.typography.headlineMedium,
@@ -100,6 +115,7 @@ fun CarbEstimateContent(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.testTag("meal_confidence"),
         )
+        ConfidenceBar(confidence)
         if (isCorrected && originalRange != null) {
             Text(
                 text = "You corrected this. AI estimated ${formatCarbRange(originalRange)}.",
@@ -108,6 +124,33 @@ fun CarbEstimateContent(
                 modifier = Modifier.testTag("meal_corrected_note"),
             )
         }
+    }
+}
+
+/** Confidence shown as a short colored bar (color + length, never color alone). Hidden when unknown. */
+@Composable
+private fun ConfidenceBar(confidence: CarbConfidence) {
+    val (fraction, color) = when (confidence) {
+        CarbConfidence.HIGH -> 1f to MealConfidenceColors.High
+        CarbConfidence.MEDIUM -> 0.6f to MealConfidenceColors.Medium
+        CarbConfidence.LOW -> 0.3f to MealConfidenceColors.Low
+        CarbConfidence.UNKNOWN -> return
+    }
+    Box(
+        modifier = Modifier
+            .width(120.dp)
+            .height(6.dp)
+            .clip(RoundedCornerShape(3.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .testTag("meal_confidence_bar"),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(fraction)
+                .fillMaxHeight()
+                .clip(RoundedCornerShape(3.dp))
+                .background(color),
+        )
     }
 }
 
@@ -126,6 +169,17 @@ fun formatCarbRange(range: CarbRange): String {
 
 private fun formatGrams(value: Double): String =
     if (value % 1.0 == 0.0) value.toInt().toString() else String.format(Locale.US, "%.1f", value)
+
+/** Spoken form of a carb range for screen readers (avoids reading "≈" / "–" literally). */
+private fun carbRangeForSpeech(range: CarbRange): String {
+    val low = formatGrams(range.lowGrams)
+    val high = formatGrams(range.highGrams)
+    return if (low == high) {
+        "Estimated $low grams of carbs"
+    } else {
+        "Estimated $low to $high grams of carbs"
+    }
+}
 
 fun confidenceLabel(confidence: CarbConfidence): String = when (confidence) {
     CarbConfidence.LOW -> "Low confidence"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
@@ -1,0 +1,173 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.glycemicgpt.mobile.data.meal.CarbConfidence
+import com.glycemicgpt.mobile.data.meal.CarbRange
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+
+/** The text shown on every estimate surface. A single source of truth for the safety wording. */
+const val VERIFY_BEFORE_DOSING_TEXT = "Estimate — verify before dosing"
+
+/** testTag for the always-on safety qualifier. Present on result, history, and common-food surfaces. */
+const val TAG_SAFETY_QUALIFIER = "meal_safety_qualifier"
+
+/**
+ * The NON-NEGOTIABLE safety qualifier. It must accompany every carb estimate so a user never
+ * mistakes a guess about a photo for a dosing instruction. Carbs only — never insulin.
+ */
+@Composable
+fun VerifyBeforeDosingQualifier(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(TAG_SAFETY_QUALIFIER),
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = VERIFY_BEFORE_DOSING_TEXT,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+/**
+ * Carb range + confidence, the way every estimate is shown. Never a lone integer: a single-point
+ * estimate still renders as "≈ N g", and the confidence is always present alongside it.
+ */
+@Composable
+fun CarbEstimateContent(
+    range: CarbRange,
+    confidence: CarbConfidence,
+    modifier: Modifier = Modifier,
+    isCorrected: Boolean = false,
+    originalRange: CarbRange? = null,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = formatCarbRange(range),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.testTag("meal_carb_range"),
+        )
+        Text(
+            text = confidenceLabel(confidence),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag("meal_confidence"),
+        )
+        if (isCorrected && originalRange != null) {
+            Text(
+                text = "You corrected this. AI estimated ${formatCarbRange(originalRange)}.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("meal_corrected_note"),
+            )
+        }
+    }
+}
+
+private val timestampFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+
+fun formatMealTimestamp(instant: Instant?): String =
+    instant?.let { timestampFormatter.format(it) } ?: "Unknown time"
+
+/** Render a carb range as "≈ 40–55 g" (or "≈ 50 g" when low == high). Carbs only — no dose. */
+fun formatCarbRange(range: CarbRange): String {
+    val low = formatGrams(range.lowGrams)
+    val high = formatGrams(range.highGrams)
+    return if (low == high) "≈ $low g carbs" else "≈ $low–$high g carbs"
+}
+
+private fun formatGrams(value: Double): String =
+    if (value % 1.0 == 0.0) value.toInt().toString() else String.format(Locale.US, "%.1f", value)
+
+fun confidenceLabel(confidence: CarbConfidence): String = when (confidence) {
+    CarbConfidence.LOW -> "Low confidence"
+    CarbConfidence.MEDIUM -> "Medium confidence"
+    CarbConfidence.HIGH -> "High confidence"
+    CarbConfidence.UNKNOWN -> "Confidence unavailable"
+}
+
+/**
+ * Editable grams string for correction/edit text fields. Reuses the display rounding so a
+ * prefilled field never shows more precision than the value rendered elsewhere.
+ */
+internal fun formatEditableGrams(value: Double): String = formatGrams(value)
+
+/** Full-screen centered spinner with an optional caption, shared across the meal screens. */
+@Composable
+fun MealCenteredSpinner(message: String? = null, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            if (message != null) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/** Full-screen centered message (empty/disabled states), shared across the meal screens. */
+@Composable
+fun MealCenteredMessage(message: String, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(32.dp),
+        )
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
@@ -99,7 +99,8 @@ fun CarbEstimateContent(
     val description = "${carbRangeForSpeech(range)}, ${confidenceLabel(confidence).lowercase()}. " +
         "$VERIFY_BEFORE_DOSING_TEXT."
     Column(
-        modifier = modifier.semantics { contentDescription = description },
+        // Merge so the carb value + confidence + qualifier are announced as one phrase, not three.
+        modifier = modifier.semantics(mergeDescendants = true) { contentDescription = description },
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Text(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryScreen.kt
@@ -1,0 +1,149 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.presentation.detail.DetailScaffold
+
+@Composable
+fun MealHistoryScreen(
+    onBack: () -> Unit,
+    viewModel: MealHistoryViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.actionError) {
+        uiState.actionError?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearActionError()
+        }
+    }
+
+    DetailScaffold(title = "Meal History", onBack = onBack) { padding ->
+      Box(modifier = Modifier.padding(padding).fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("meal_history_screen"),
+        ) {
+            when {
+                uiState.disabled -> MealCenteredMessage(
+                    "Meal intelligence is turned off for this server.",
+                    modifier = Modifier.testTag("meal_history_disabled"),
+                )
+                uiState.isLoading -> MealCenteredSpinner()
+                else -> {
+                    // Persistent safety qualifier above the (scrolling) list.
+                    VerifyBeforeDosingQualifier(modifier = Modifier.padding(16.dp))
+                    uiState.errorMessage?.let { error ->
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                        )
+                    }
+                    if (uiState.records.isEmpty()) {
+                        MealCenteredMessage(
+                            "No meals logged yet.",
+                            modifier = Modifier.testTag("meal_history_empty"),
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .testTag("meal_history_list"),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            items(uiState.records, key = { it.id }) { record ->
+                                MealHistoryItem(record = record, onDelete = { viewModel.delete(record.id) })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+      }
+    }
+}
+
+@Composable
+private fun MealHistoryItem(record: FoodRecord, onDelete: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_history_item"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                if (!record.foodDescription.isNullOrBlank()) {
+                    Text(
+                        text = record.foodDescription,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+                CarbEstimateContent(
+                    range = record.displayRange,
+                    confidence = record.confidence,
+                    isCorrected = record.isCorrected,
+                    originalRange = record.estimate,
+                )
+                Text(
+                    text = formatMealTimestamp(record.mealTimestamp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier.testTag("meal_history_delete"),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete meal",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModel.kt
@@ -1,0 +1,79 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+import javax.inject.Inject
+
+data class MealHistoryUiState(
+    val isLoading: Boolean = true,
+    val records: List<FoodRecord> = emptyList(),
+    val errorMessage: String? = null,
+    /** Transient failure of a row action (e.g. delete), surfaced as a snackbar then cleared. */
+    val actionError: String? = null,
+    /** Backend feature flag is off; show a degraded message instead of an empty list. */
+    val disabled: Boolean = false,
+)
+
+@HiltViewModel
+class MealHistoryViewModel @Inject constructor(
+    private val repository: MealRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MealHistoryUiState())
+    val uiState: StateFlow<MealHistoryUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        viewModelScope.launch {
+            repository.listFoodRecords()
+                .onSuccess { records ->
+                    _uiState.update {
+                        it.copy(isLoading = false, records = records, disabled = false)
+                    }
+                }
+                .onFailure { e -> _uiState.update { it.copy(isLoading = false).withError(e) } }
+        }
+    }
+
+    fun delete(recordId: String) {
+        viewModelScope.launch {
+            repository.deleteFoodRecord(recordId)
+                .onSuccess {
+                    _uiState.update { s -> s.copy(records = s.records.filterNot { it.id == recordId }) }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(actionError = deleteMessageFor(e)) }
+                }
+        }
+    }
+
+    fun clearActionError() {
+        _uiState.update { it.copy(actionError = null) }
+    }
+
+    private fun deleteMessageFor(e: Throwable): String = when (e) {
+        is IOException -> "Check your connection and try again."
+        is MealException -> e.message ?: "Couldn't delete that meal."
+        else -> "Couldn't delete that meal."
+    }
+
+    private fun MealHistoryUiState.withError(e: Throwable): MealHistoryUiState = when (e) {
+        is MealException.FeatureDisabled -> copy(disabled = true, errorMessage = null)
+        is IOException -> copy(errorMessage = "Check your connection and try again.")
+        else -> copy(errorMessage = e.message ?: "Couldn't load your meal history.")
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHomeComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHomeComponents.kt
@@ -1,0 +1,127 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+
+/**
+ * Home "Recent meal" glance: the most recent logged meal with its carb range, confidence, and the
+ * persistent safety qualifier. Rendered only when at least one meal exists, so non-users never see it.
+ */
+@Composable
+fun RecentMealCard(
+    record: FoodRecord,
+    onViewAll: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("home_recent_meal_card"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Recent meal",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = onViewAll, modifier = Modifier.testTag("home_recent_meal_view_all")) {
+                    Text("View all")
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // No image is returned from the backend; show a neutral placeholder thumbnail.
+                Box(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Restaurant,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    if (!record.foodDescription.isNullOrBlank()) {
+                        Text(
+                            text = record.foodDescription,
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                    Text(
+                        text = formatCarbRange(record.displayRange),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "${formatMealTimestamp(record.mealTimestamp)} · " +
+                            confidenceLabel(record.confidence).lowercase(),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            VerifyBeforeDosingQualifier()
+        }
+    }
+}
+
+/** Extended camera FAB on Home that opens the meal capture screen. */
+@Composable
+fun MealFab(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    ExtendedFloatingActionButton(
+        onClick = onClick,
+        icon = { Icon(Icons.Default.PhotoCamera, contentDescription = null) },
+        text = { Text("Log a meal") },
+        modifier = modifier.testTag("home_meal_fab"),
+    )
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -1,7 +1,9 @@
 package com.glycemicgpt.mobile.presentation.meal
 
 import android.Manifest
+import android.content.ContentResolver
 import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -20,16 +22,22 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.LocalCafe
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -37,6 +45,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +53,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
@@ -54,6 +67,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.glycemicgpt.mobile.data.meal.FoodRecord
 import com.glycemicgpt.mobile.data.meal.MealPhotoFiles
 import com.glycemicgpt.mobile.presentation.detail.DetailScaffold
+import androidx.compose.foundation.shape.RoundedCornerShape
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.max
 
 @Composable
 fun MealLogScreen(
@@ -124,8 +141,9 @@ fun MealLogScreen(
             when (uiState.pageState) {
                 MealLogPageState.Loading -> MealCenteredSpinner("Loading…")
                 MealLogPageState.Disabled -> MealUnavailableMessage(
-                    title = "Meal logging isn't available",
-                    body = "Meal intelligence is turned off for this server.",
+                    title = "Meal logging isn't turned on",
+                    body = "Meal intelligence is turned off for this server. " +
+                        "Ask your server admin to enable it to estimate carbs from a photo.",
                     tag = "meal_feature_disabled",
                 )
                 MealLogPageState.Offline -> OfflineRetry(onRetry = viewModel::checkAvailability)
@@ -256,6 +274,28 @@ private fun IdleContent(
         )
     }
 
+    // No-photo path: re-log a saved common food.
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 4.dp)) {
+        HorizontalDivider(modifier = Modifier.weight(1f))
+        Text(
+            text = "OR",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f))
+    }
+    FilledTonalButton(
+        onClick = onNavigateToCommonFoods,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_relog_common"),
+    ) {
+        Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        Text("Re-log a common food")
+    }
+
     Spacer(Modifier.height(8.dp))
     Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
         OutlinedButton(
@@ -292,6 +332,8 @@ private fun ResultContent(
     onReset: () -> Unit,
 ) {
     var showSaveDialog by remember { mutableStateOf(false) }
+
+    uiState.photoUri?.let { MealPhotoThumbnail(uri = it) }
 
     Card(
         modifier = Modifier
@@ -557,7 +599,7 @@ private fun MealUnavailableMessage(title: String, body: String, tag: String) {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Icon(
-                imageVector = Icons.Default.Restaurant,
+                imageVector = Icons.Default.LocalCafe,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(48.dp),
@@ -626,3 +668,41 @@ private fun ErrorBanner(message: String, onDismiss: () -> Unit) {
         }
     }
 }
+
+/**
+ * The just-captured/picked photo, shown above the result. Decoded off the main thread to a small
+ * thumbnail; renders nothing (rather than a broken box) if the image can't be read.
+ */
+@Composable
+private fun MealPhotoThumbnail(uri: Uri) {
+    val resolver = LocalContext.current.contentResolver
+    var thumbnail by remember(uri) { mutableStateOf<ImageBitmap?>(null) }
+    LaunchedEffect(uri) {
+        thumbnail = withContext(Dispatchers.IO) { decodePhotoThumbnail(resolver, uri) }
+    }
+    thumbnail?.let { bitmap ->
+        Image(
+            bitmap = bitmap,
+            contentDescription = "Photo of your meal",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f / 9f)
+                .clip(RoundedCornerShape(12.dp))
+                .testTag("meal_result_photo"),
+        )
+    }
+}
+
+/** Decode [uri] to a downscaled [ImageBitmap] for preview, or null if it can't be read. */
+private fun decodePhotoThumbnail(resolver: ContentResolver, uri: Uri): ImageBitmap? = runCatching {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) } ?: return null
+    if (bounds.outWidth <= 0) return null
+    val options = BitmapFactory.Options().apply {
+        inSampleSize = Integer.highestOneBit(max(1, bounds.outWidth / THUMBNAIL_TARGET_PX))
+    }
+    resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }?.asImageBitmap()
+}.getOrNull()
+
+private const val THUMBNAIL_TARGET_PX = 1080

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -82,7 +83,8 @@ fun MealLogScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
 
-    var pendingCaptureUri by remember { mutableStateOf<Uri?>(null) }
+    // rememberSaveable so a rotation while the camera app is open doesn't lose the capture URI.
+    var pendingCaptureUri by rememberSaveable { mutableStateOf<Uri?>(null) }
     var cameraPermissionDenied by remember { mutableStateOf(false) }
 
     val galleryLauncher = rememberLauncherForActivityResult(
@@ -705,4 +707,5 @@ private fun decodePhotoThumbnail(resolver: ContentResolver, uri: Uri): ImageBitm
     resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }?.asImageBitmap()
 }.getOrNull()
 
-private const val THUMBNAIL_TARGET_PX = 1080
+// Preview only (renders in a 16:9 strip), so a modest decode target keeps memory low.
+private const val THUMBNAIL_TARGET_PX = 720

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -1,0 +1,627 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.MealPhotoFiles
+import com.glycemicgpt.mobile.presentation.detail.DetailScaffold
+
+@Composable
+fun MealLogScreen(
+    onBack: () -> Unit,
+    onNavigateToHistory: () -> Unit,
+    onNavigateToCommonFoods: () -> Unit,
+    viewModel: MealLogViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    var pendingCaptureUri by remember { mutableStateOf<Uri?>(null) }
+    var cameraPermissionDenied by remember { mutableStateOf(false) }
+
+    val galleryLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri: Uri? -> uri?.let { viewModel.onImagePicked(it) } }
+
+    val cameraLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicture(),
+    ) { success: Boolean ->
+        val uri = pendingCaptureUri
+        if (success && uri != null) {
+            viewModel.onImagePicked(uri)
+        } else if (uri != null) {
+            // Capture cancelled: drop just this empty temp file so it doesn't linger in the cache.
+            MealPhotoFiles.deleteCapture(context, uri)
+        }
+        pendingCaptureUri = null
+    }
+
+    fun launchCamera() {
+        cameraPermissionDenied = false
+        val uri = MealPhotoFiles.createCaptureUri(context)
+        pendingCaptureUri = uri
+        cameraLauncher.launch(uri)
+    }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted: Boolean ->
+        if (granted) launchCamera() else cameraPermissionDenied = true
+    }
+
+    fun onTakePhoto() {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            launchCamera()
+        } else {
+            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    fun onChooseFromGallery() {
+        galleryLauncher.launch(
+            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+        )
+    }
+
+    DetailScaffold(title = "Log a Meal", onBack = onBack) { padding ->
+        Box(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .testTag("meal_log_screen"),
+        ) {
+            when (uiState.pageState) {
+                MealLogPageState.Loading -> MealCenteredSpinner("Loading…")
+                MealLogPageState.Disabled -> MealUnavailableMessage(
+                    title = "Meal logging isn't available",
+                    body = "Meal intelligence is turned off for this server.",
+                    tag = "meal_feature_disabled",
+                )
+                MealLogPageState.Offline -> OfflineRetry(onRetry = viewModel::checkAvailability)
+                MealLogPageState.Ready -> ReadyContent(
+                    uiState = uiState,
+                    cameraPermissionDenied = cameraPermissionDenied,
+                    onTakePhoto = ::onTakePhoto,
+                    onChooseFromGallery = ::onChooseFromGallery,
+                    onNavigateToHistory = onNavigateToHistory,
+                    onNavigateToCommonFoods = onNavigateToCommonFoods,
+                    onStartCorrection = viewModel::startCorrection,
+                    onCancelCorrection = viewModel::cancelCorrection,
+                    onSubmitCorrection = viewModel::submitCorrection,
+                    onSaveAsCommonFood = viewModel::saveAsCommonFood,
+                    onReset = viewModel::reset,
+                    onClearError = viewModel::clearError,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReadyContent(
+    uiState: MealLogUiState,
+    cameraPermissionDenied: Boolean,
+    onTakePhoto: () -> Unit,
+    onChooseFromGallery: () -> Unit,
+    onNavigateToHistory: () -> Unit,
+    onNavigateToCommonFoods: () -> Unit,
+    onStartCorrection: () -> Unit,
+    onCancelCorrection: () -> Unit,
+    onSubmitCorrection: (String, String) -> Unit,
+    onSaveAsCommonFood: (String) -> Unit,
+    onReset: () -> Unit,
+    onClearError: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // Pinned above the scroll region so the safety qualifier is ALWAYS visible on the result
+        // surface, no matter how long the content below grows.
+        VerifyBeforeDosingQualifier()
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            when {
+                uiState.isUploading -> MealCenteredSpinner(
+                    message = "Estimating carbs…",
+                    modifier = Modifier.testTag("meal_uploading"),
+                )
+
+                uiState.unavailableReason != null ->
+                    UnavailableContent(reason = uiState.unavailableReason, onBack = onReset)
+
+                uiState.record != null -> ResultContent(
+                    record = uiState.record,
+                    uiState = uiState,
+                    onStartCorrection = onStartCorrection,
+                    onCancelCorrection = onCancelCorrection,
+                    onSubmitCorrection = onSubmitCorrection,
+                    onSaveAsCommonFood = onSaveAsCommonFood,
+                    onReset = onReset,
+                )
+
+                else -> IdleContent(
+                    cameraPermissionDenied = cameraPermissionDenied,
+                    onTakePhoto = onTakePhoto,
+                    onChooseFromGallery = onChooseFromGallery,
+                    onNavigateToHistory = onNavigateToHistory,
+                    onNavigateToCommonFoods = onNavigateToCommonFoods,
+                )
+            }
+
+            if (uiState.errorMessage != null) {
+                ErrorBanner(message = uiState.errorMessage, onDismiss = onClearError)
+            }
+        }
+    }
+}
+
+@Composable
+private fun IdleContent(
+    cameraPermissionDenied: Boolean,
+    onTakePhoto: () -> Unit,
+    onChooseFromGallery: () -> Unit,
+    onNavigateToHistory: () -> Unit,
+    onNavigateToCommonFoods: () -> Unit,
+) {
+    Text(
+        text = "Snap a photo of your meal to get an estimated carb range you can correct and save.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Button(
+        onClick = onTakePhoto,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_capture_camera"),
+    ) {
+        Icon(Icons.Default.PhotoCamera, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        Text("Take photo")
+    }
+    OutlinedButton(
+        onClick = onChooseFromGallery,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_capture_gallery"),
+    ) {
+        Icon(Icons.Default.PhotoLibrary, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        Text("Choose from gallery")
+    }
+    if (cameraPermissionDenied) {
+        Text(
+            text = "Camera permission is needed to take a photo. You can still choose one from your gallery.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier.testTag("meal_camera_permission_denied"),
+        )
+    }
+
+    Spacer(Modifier.height(8.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+        OutlinedButton(
+            onClick = onNavigateToHistory,
+            modifier = Modifier
+                .weight(1f)
+                .testTag("meal_history_button"),
+        ) {
+            Icon(Icons.Default.History, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("History")
+        }
+        OutlinedButton(
+            onClick = onNavigateToCommonFoods,
+            modifier = Modifier
+                .weight(1f)
+                .testTag("common_foods_button"),
+        ) {
+            Icon(Icons.Default.Restaurant, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("Common foods")
+        }
+    }
+}
+
+@Composable
+private fun ResultContent(
+    record: FoodRecord,
+    uiState: MealLogUiState,
+    onStartCorrection: () -> Unit,
+    onCancelCorrection: () -> Unit,
+    onSubmitCorrection: (String, String) -> Unit,
+    onSaveAsCommonFood: (String) -> Unit,
+    onReset: () -> Unit,
+) {
+    var showSaveDialog by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_result_card"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (!record.foodDescription.isNullOrBlank()) {
+                Text(
+                    text = record.foodDescription,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            CarbEstimateContent(
+                range = record.displayRange,
+                confidence = record.confidence,
+                isCorrected = record.isCorrected,
+                originalRange = record.estimate,
+            )
+            Text(
+                text = formatMealTimestamp(record.mealTimestamp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+
+    if (uiState.isCorrecting) {
+        CorrectionEditor(
+            initialLow = record.displayRange.lowGrams,
+            initialHigh = record.displayRange.highGrams,
+            isSaving = uiState.isSavingCorrection,
+            error = uiState.correctionError,
+            onSubmit = onSubmitCorrection,
+            onCancel = onCancelCorrection,
+        )
+    } else {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+            OutlinedButton(
+                onClick = onStartCorrection,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("meal_correct_button"),
+            ) { Text("Correct") }
+            Button(
+                onClick = { showSaveDialog = true },
+                enabled = !uiState.isSavingCommonFood,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("meal_save_common_button"),
+            ) { Text("Save as common food") }
+        }
+    }
+
+    if (uiState.savedCommonFoodName != null) {
+        Text(
+            text = "Saved \"${uiState.savedCommonFoodName}\" to your common foods.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.testTag("meal_saved_common_confirmation"),
+        )
+    }
+
+    TextButton(
+        onClick = onReset,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_log_another"),
+    ) { Text("Log another meal") }
+
+    if (showSaveDialog) {
+        SaveAsCommonFoodDialog(
+            isSaving = uiState.isSavingCommonFood,
+            onConfirm = { name ->
+                onSaveAsCommonFood(name)
+                showSaveDialog = false
+            },
+            onDismiss = { showSaveDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun CorrectionEditor(
+    initialLow: Double,
+    initialHigh: Double,
+    isSaving: Boolean,
+    error: String?,
+    onSubmit: (String, String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var lowText by remember { mutableStateOf(formatEditableGrams(initialLow)) }
+    var highText by remember { mutableStateOf(formatEditableGrams(initialHigh)) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_correction_editor"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Correct the carb estimate (grams)",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = lowText,
+                    onValueChange = { lowText = it },
+                    label = { Text("Low (g)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("meal_correct_low_input"),
+                )
+                OutlinedTextField(
+                    value = highText,
+                    onValueChange = { highText = it },
+                    label = { Text("High (g)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("meal_correct_high_input"),
+                )
+            }
+            if (error != null) {
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(
+                    onClick = onCancel,
+                    enabled = !isSaving,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Cancel") }
+                Button(
+                    onClick = { onSubmit(lowText, highText) },
+                    enabled = !isSaving,
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("meal_correct_save"),
+                ) { Text(if (isSaving) "Saving…" else "Save") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SaveAsCommonFoodDialog(
+    isSaving: Boolean,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Save as common food") },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("meal_save_common_name_input"),
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(name) },
+                enabled = name.isNotBlank() && !isSaving,
+                modifier = Modifier.testTag("meal_save_common_confirm"),
+            ) { Text(if (isSaving) "Saving…" else "Save") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun UnavailableContent(reason: MealUnavailableReason, onBack: () -> Unit) {
+    val (tag, title, body) = when (reason) {
+        MealUnavailableReason.VISION -> Triple(
+            "meal_vision_unavailable",
+            "Vision isn't available on your AI provider",
+            "Carb estimates from photos need a vision-capable AI provider. " +
+                "Switch to one in the web app Settings, then try again.",
+        )
+        MealUnavailableReason.NO_PROVIDER -> Triple(
+            "meal_no_provider",
+            "No AI provider configured",
+            "Set up an AI provider in the web app Settings to estimate carbs from a photo.",
+        )
+    }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(tag),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(40.dp),
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                textAlign = TextAlign.Center,
+            )
+            TextButton(onClick = onBack) { Text("Back") }
+        }
+    }
+}
+
+@Composable
+private fun MealUnavailableMessage(title: String, body: String, tag: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(tag),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier.padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Restaurant,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun OfflineRetry(onRetry: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            modifier = Modifier.padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                text = "Couldn't reach the server",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Button(onClick = onRetry) { Text("Retry") }
+        }
+    }
+}
+
+@Composable
+private fun ErrorBanner(message: String, onDismiss: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_error"),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.15f),
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(onClick = onDismiss) { Text("Dismiss", color = MaterialTheme.colorScheme.error) }
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -390,8 +390,9 @@ private fun CorrectionEditor(
     onSubmit: (String, String) -> Unit,
     onCancel: () -> Unit,
 ) {
-    var lowText by remember { mutableStateOf(formatEditableGrams(initialLow)) }
-    var highText by remember { mutableStateOf(formatEditableGrams(initialHigh)) }
+    // Key on the seed values so the fields reset if the editor reopens for a different estimate.
+    var lowText by remember(initialLow, initialHigh) { mutableStateOf(formatEditableGrams(initialLow)) }
+    var highText by remember(initialLow, initialHigh) { mutableStateOf(formatEditableGrams(initialHigh)) }
 
     Card(
         modifier = Modifier

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
@@ -51,6 +51,8 @@ data class MealLogUiState(
     val pageState: MealLogPageState = MealLogPageState.Loading,
     val isUploading: Boolean = false,
     val record: FoodRecord? = null,
+    /** The just-picked/captured image, shown as a thumbnail on the result. Null when none. */
+    val photoUri: Uri? = null,
     /** Set when the user's AI setup can't produce an estimate (vision-less or no provider). */
     val unavailableReason: MealUnavailableReason? = null,
     val errorMessage: String? = null,
@@ -93,17 +95,24 @@ class MealLogViewModel @Inject constructor(
 
     /** Compress and upload a captured/picked image, then surface the estimate. */
     fun onImagePicked(uri: Uri) {
+        val previousPhoto = _uiState.value.photoUri
         _uiState.update {
             it.copy(
                 isUploading = true,
                 errorMessage = null,
                 unavailableReason = null,
                 record = null,
+                photoUri = uri,
                 savedCommonFoodName = null,
                 isCorrecting = false,
             )
         }
         viewModelScope.launch {
+            // Drop the prior capture's original (scoped; no-op for gallery URIs). The current photo
+            // is kept so the result can show a thumbnail, and is swept on reset().
+            if (previousPhoto != null) {
+                withContext(ioDispatcher) { MealPhotoFiles.deleteCapture(context, previousPhoto) }
+            }
             val bytes = try {
                 withContext(ioDispatcher) {
                     ImageCompressor.compress(context.contentResolver, uri)
@@ -130,10 +139,6 @@ class MealLogViewModel @Inject constructor(
                     it.copy(isUploading = false, errorMessage = "Couldn't read that photo. Try another one.")
                 }
                 return@launch
-            } finally {
-                // Drop only this capture's full-resolution original; scoped so an overlapping
-                // capture's file is never swept. A no-op for gallery URIs we don't own.
-                withContext(ioDispatcher) { MealPhotoFiles.deleteCapture(context, uri) }
             }
 
             repository.uploadPhoto(bytes)
@@ -220,12 +225,13 @@ class MealLogViewModel @Inject constructor(
 
     /** Return to the idle capture state to log another meal. */
     fun reset() {
-        // No capture is in flight here, so sweep any orphaned originals from an earlier session.
+        // No capture is in flight here, so sweep the kept result thumbnail + any orphaned originals.
         viewModelScope.launch { withContext(ioDispatcher) { MealPhotoFiles.clearCaptures(context) } }
         _uiState.update {
             it.copy(
                 isUploading = false,
                 record = null,
+                photoUri = null,
                 unavailableReason = null,
                 errorMessage = null,
                 isCorrecting = false,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
@@ -14,6 +14,7 @@ import com.glycemicgpt.mobile.data.repository.MealRepository
 import com.glycemicgpt.mobile.di.IoDispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -107,7 +108,23 @@ class MealLogViewModel @Inject constructor(
                 withContext(ioDispatcher) {
                     ImageCompressor.compress(context.contentResolver, uri)
                 }
-            } catch (e: IOException) {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: OutOfMemoryError) {
+                // A very large source can exhaust heap during decode/scale; recover instead of
+                // leaving the upload spinner stuck (or crashing).
+                Timber.w(e, "Out of memory compressing meal photo")
+                _uiState.update {
+                    it.copy(
+                        isUploading = false,
+                        errorMessage = "That photo is too large to process. Try a smaller one.",
+                    )
+                }
+                return@launch
+            } catch (e: Exception) {
+                // IOException plus the unchecked IllegalArgument/IllegalState that
+                // BitmapFactory/createScaledBitmap can throw on a malformed image -- caught so the
+                // spinner can never get permanently stuck.
                 Timber.w(e, "Failed to read meal photo")
                 _uiState.update {
                     it.copy(isUploading = false, errorMessage = "Couldn't read that photo. Try another one.")

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
@@ -16,6 +16,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -73,6 +74,9 @@ class MealLogViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(MealLogUiState())
     val uiState: StateFlow<MealLogUiState> = _uiState.asStateFlow()
 
+    /** The in-flight compress+upload job, cancelled when a new photo supersedes it. */
+    private var uploadJob: Job? = null
+
     init {
         checkAvailability()
     }
@@ -95,6 +99,9 @@ class MealLogViewModel @Inject constructor(
 
     /** Compress and upload a captured/picked image, then surface the estimate. */
     fun onImagePicked(uri: Uri) {
+        // Cancel any in-flight compress/upload before superseding it, so the previous capture's
+        // file can't be deleted out from under an active read.
+        uploadJob?.cancel()
         val previousPhoto = _uiState.value.photoUri
         _uiState.update {
             it.copy(
@@ -107,7 +114,7 @@ class MealLogViewModel @Inject constructor(
                 isCorrecting = false,
             )
         }
-        viewModelScope.launch {
+        uploadJob = viewModelScope.launch {
             // Drop the prior capture's original (scoped; no-op for gallery URIs). The current photo
             // is kept so the result can show a thumbnail, and is swept on reset().
             if (previousPhoto != null) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
@@ -1,0 +1,232 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.meal.CarbBounds
+import com.glycemicgpt.mobile.data.meal.CarbInputResult
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.ImageCompressor
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.meal.MealPhotoFiles
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import com.glycemicgpt.mobile.di.IoDispatcher
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.IOException
+import javax.inject.Inject
+
+/** Availability of the meal feature, determined once when the screen opens. */
+sealed interface MealLogPageState {
+    data object Loading : MealLogPageState
+    data object Ready : MealLogPageState
+
+    /** The backend feature flag is off; the capture UI is hidden. */
+    data object Disabled : MealLogPageState
+
+    /** Could not reach the backend to determine availability; offer a retry. */
+    data object Offline : MealLogPageState
+}
+
+/** Why an estimate can't be produced for this user's AI setup -- a dead-end, not a retryable error. */
+enum class MealUnavailableReason {
+    /** AC5: the user's AI provider has no vision route (backend 422 vision_unavailable). */
+    VISION,
+
+    /** The user has no AI provider configured at all (backend 404). */
+    NO_PROVIDER,
+}
+
+data class MealLogUiState(
+    val pageState: MealLogPageState = MealLogPageState.Loading,
+    val isUploading: Boolean = false,
+    val record: FoodRecord? = null,
+    /** Set when the user's AI setup can't produce an estimate (vision-less or no provider). */
+    val unavailableReason: MealUnavailableReason? = null,
+    val errorMessage: String? = null,
+    val isCorrecting: Boolean = false,
+    val isSavingCorrection: Boolean = false,
+    val correctionError: String? = null,
+    val isSavingCommonFood: Boolean = false,
+    val savedCommonFoodName: String? = null,
+)
+
+@HiltViewModel
+class MealLogViewModel @Inject constructor(
+    private val repository: MealRepository,
+    @ApplicationContext private val context: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MealLogUiState())
+    val uiState: StateFlow<MealLogUiState> = _uiState.asStateFlow()
+
+    init {
+        checkAvailability()
+    }
+
+    /** Probe the feature flag via a cheap call so feature-off degrades to [Disabled]. */
+    fun checkAvailability() {
+        _uiState.update { it.copy(pageState = MealLogPageState.Loading) }
+        viewModelScope.launch {
+            repository.probeAvailability()
+                .onSuccess { _uiState.update { s -> s.copy(pageState = MealLogPageState.Ready) } }
+                .onFailure { e ->
+                    val next = when (e) {
+                        is MealException.FeatureDisabled -> MealLogPageState.Disabled
+                        else -> MealLogPageState.Offline
+                    }
+                    _uiState.update { s -> s.copy(pageState = next) }
+                }
+        }
+    }
+
+    /** Compress and upload a captured/picked image, then surface the estimate. */
+    fun onImagePicked(uri: Uri) {
+        _uiState.update {
+            it.copy(
+                isUploading = true,
+                errorMessage = null,
+                unavailableReason = null,
+                record = null,
+                savedCommonFoodName = null,
+                isCorrecting = false,
+            )
+        }
+        viewModelScope.launch {
+            val bytes = try {
+                withContext(ioDispatcher) {
+                    ImageCompressor.compress(context.contentResolver, uri)
+                }
+            } catch (e: IOException) {
+                Timber.w(e, "Failed to read meal photo")
+                _uiState.update {
+                    it.copy(isUploading = false, errorMessage = "Couldn't read that photo. Try another one.")
+                }
+                return@launch
+            } finally {
+                // Drop only this capture's full-resolution original; scoped so an overlapping
+                // capture's file is never swept. A no-op for gallery URIs we don't own.
+                withContext(ioDispatcher) { MealPhotoFiles.deleteCapture(context, uri) }
+            }
+
+            repository.uploadPhoto(bytes)
+                .onSuccess { record ->
+                    _uiState.update { it.copy(isUploading = false, record = record) }
+                }
+                .onFailure { e -> handleUploadFailure(e) }
+        }
+    }
+
+    private fun handleUploadFailure(e: Throwable) {
+        when (e) {
+            is MealException.VisionUnavailable ->
+                _uiState.update {
+                    it.copy(isUploading = false, unavailableReason = MealUnavailableReason.VISION)
+                }
+            is MealException.NoAiProvider ->
+                _uiState.update {
+                    it.copy(isUploading = false, unavailableReason = MealUnavailableReason.NO_PROVIDER)
+                }
+            is MealException.FeatureDisabled ->
+                _uiState.update {
+                    it.copy(isUploading = false, pageState = MealLogPageState.Disabled)
+                }
+            else ->
+                _uiState.update { it.copy(isUploading = false, errorMessage = messageFor(e)) }
+        }
+    }
+
+    fun startCorrection() {
+        // Drop any stale save-confirmation: it referred to the pre-correction baseline.
+        _uiState.update { it.copy(isCorrecting = true, correctionError = null, savedCommonFoodName = null) }
+    }
+
+    fun cancelCorrection() {
+        _uiState.update { it.copy(isCorrecting = false, correctionError = null) }
+    }
+
+    fun submitCorrection(lowText: String, highText: String) {
+        val record = _uiState.value.record ?: return
+        val parsed = when (val result = CarbBounds.parse(lowText, highText)) {
+            is CarbInputResult.Invalid -> {
+                _uiState.update { it.copy(correctionError = result.reason) }
+                return
+            }
+            is CarbInputResult.Valid -> result
+        }
+        _uiState.update { it.copy(isSavingCorrection = true, correctionError = null) }
+        viewModelScope.launch {
+            repository.correctRecord(record.id, parsed.lowGrams, parsed.highGrams)
+                .onSuccess { updated ->
+                    _uiState.update {
+                        it.copy(isSavingCorrection = false, isCorrecting = false, record = updated)
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(isSavingCorrection = false, correctionError = messageFor(e))
+                    }
+                }
+        }
+    }
+
+    fun saveAsCommonFood(name: String) {
+        val record = _uiState.value.record ?: return
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) {
+            _uiState.update { it.copy(errorMessage = "Give this food a name first.") }
+            return
+        }
+        _uiState.update { it.copy(isSavingCommonFood = true, errorMessage = null) }
+        viewModelScope.launch {
+            repository.saveAsCommonFood(record.id, trimmed)
+                .onSuccess { saved ->
+                    _uiState.update {
+                        it.copy(isSavingCommonFood = false, savedCommonFoodName = saved.name)
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isSavingCommonFood = false, errorMessage = messageFor(e)) }
+                }
+        }
+    }
+
+    /** Return to the idle capture state to log another meal. */
+    fun reset() {
+        // No capture is in flight here, so sweep any orphaned originals from an earlier session.
+        viewModelScope.launch { withContext(ioDispatcher) { MealPhotoFiles.clearCaptures(context) } }
+        _uiState.update {
+            it.copy(
+                isUploading = false,
+                record = null,
+                unavailableReason = null,
+                errorMessage = null,
+                isCorrecting = false,
+                isSavingCorrection = false,
+                correctionError = null,
+                isSavingCommonFood = false,
+                savedCommonFoodName = null,
+            )
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+
+    private fun messageFor(e: Throwable): String = when (e) {
+        is MealException -> e.message ?: "Something went wrong. Please try again."
+        is IOException -> "Check your connection and try again."
+        else -> e.message ?: "Something went wrong. Please try again."
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.automirrored.filled.ShowChart
@@ -52,6 +53,9 @@ import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.presentation.alerts.AlertsScreen
 import com.glycemicgpt.mobile.presentation.chat.AiChatScreen
 import com.glycemicgpt.mobile.presentation.home.HomeScreen
+import com.glycemicgpt.mobile.presentation.meal.CommonFoodsScreen
+import com.glycemicgpt.mobile.presentation.meal.MealHistoryScreen
+import com.glycemicgpt.mobile.presentation.meal.MealLogScreen
 import com.glycemicgpt.mobile.BuildConfig
 import com.glycemicgpt.mobile.presentation.debug.BleDebugScreen
 import com.glycemicgpt.mobile.presentation.detail.AlertHistoryScreen
@@ -79,6 +83,9 @@ sealed class Screen(val route: String, val label: String, val icon: ImageVector)
     data object InsulinDetail : Screen("insulin_detail", "Insulin", Icons.Default.Science)
     data object AlertHistory : Screen("alert_history", "Alert History", Icons.Default.History)
     data object BolusHistory : Screen("bolus_history", "Bolus History", Icons.Default.History)
+    data object MealLog : Screen("meal_log", "Log a Meal", Icons.Default.Restaurant)
+    data object MealHistory : Screen("meal_history", "Meal History", Icons.Default.History)
+    data object CommonFoods : Screen("common_foods", "Common Foods", Icons.Default.Restaurant)
 }
 
 private val bottomNavItems = listOf(Screen.Home, Screen.AiChat, Screen.Alerts, Screen.Settings)
@@ -93,6 +100,9 @@ private val spokeRoutes = setOf(
     Screen.PluginDetail.route,
     Screen.Pairing.route,
     Screen.BleDebug.route,
+    Screen.MealLog.route,
+    Screen.MealHistory.route,
+    Screen.CommonFoods.route,
 )
 
 @Composable
@@ -219,7 +229,21 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                         } else {
                             null
                         },
+                        onNavigateToMealLog = { navController.navigate(Screen.MealLog.route) },
                     )
+                }
+                composable(Screen.MealLog.route) {
+                    MealLogScreen(
+                        onBack = { navController.popBackStack() },
+                        onNavigateToHistory = { navController.navigate(Screen.MealHistory.route) },
+                        onNavigateToCommonFoods = { navController.navigate(Screen.CommonFoods.route) },
+                    )
+                }
+                composable(Screen.MealHistory.route) {
+                    MealHistoryScreen(onBack = { navController.popBackStack() })
+                }
+                composable(Screen.CommonFoods.route) {
+                    CommonFoodsScreen(onBack = { navController.popBackStack() })
                 }
                 composable(Screen.Pairing.route) {
                     PairingScreen(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -215,6 +215,8 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                         onNavigateToInsulinDetail = { navController.navigate(Screen.InsulinDetail.route) },
                         onNavigateToAlertHistory = { navController.navigate(Screen.AlertHistory.route) },
                         onNavigateToBolusHistory = { navController.navigate(Screen.BolusHistory.route) },
+                        onNavigateToMealLog = { navController.navigate(Screen.MealLog.route) },
+                        onNavigateToMealHistory = { navController.navigate(Screen.MealHistory.route) },
                     )
                 }
                 composable(Screen.AiChat.route) { AiChatScreen() }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.Fastfood
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Notifications
@@ -85,7 +86,7 @@ sealed class Screen(val route: String, val label: String, val icon: ImageVector)
     data object BolusHistory : Screen("bolus_history", "Bolus History", Icons.Default.History)
     data object MealLog : Screen("meal_log", "Log a Meal", Icons.Default.Restaurant)
     data object MealHistory : Screen("meal_history", "Meal History", Icons.Default.History)
-    data object CommonFoods : Screen("common_foods", "Common Foods", Icons.Default.Restaurant)
+    data object CommonFoods : Screen("common_foods", "Common Foods", Icons.Default.Fastfood)
 }
 
 private val bottomNavItems = listOf(Screen.Home, Screen.AiChat, Screen.Alerts, Screen.Settings)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Sync
@@ -90,6 +91,7 @@ import kotlin.math.roundToInt
 fun SettingsScreen(
     onNavigateToPairing: () -> Unit = {},
     onNavigateToBleDebug: (() -> Unit)? = null,
+    onNavigateToMealLog: () -> Unit = {},
     settingsViewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val state by settingsViewModel.uiState.collectAsState()
@@ -157,6 +159,31 @@ fun SettingsScreen(
             state = state,
             onBackendSyncToggle = settingsViewModel::setBackendSyncEnabled,
             onRetentionChange = settingsViewModel::setDataRetentionDays,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // -- Meal Intelligence Section (Epic 50) --
+        SectionHeader(title = "Meal Intelligence")
+        OutlinedButton(
+            onClick = onNavigateToMealLog,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("meal_log_button"),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Restaurant,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Log a meal (Beta)")
+        }
+        Text(
+            text = "Estimate a meal's carbs from a photo. Estimates are a guess to verify before dosing.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp),
         )
 
         Spacer(modifier = Modifier.height(20.dp))

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -177,7 +177,7 @@ fun SettingsScreen(
                 modifier = Modifier.size(18.dp),
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Text("Log a meal (Beta)")
+            Text("Log a meal")
         }
         Text(
             text = "Estimate a meal's carbs from a photo. Estimates are a guess to verify before dosing.",

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/theme/Theme.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/theme/Theme.kt
@@ -96,12 +96,17 @@ private val SafetyDark = SafetyPalette(
     icon = Color(0xFFF2C14E),
 )
 
-/** Theme-aware safety palette. Darkness is read off the active scheme so it tracks forced themes. */
+/**
+ * Theme-aware safety palette. Darkness is read off the active scheme (which tracks forced
+ * [ThemeMode] too, unlike `isSystemInDarkTheme`); the two schemes sit far from the 0.5 threshold
+ * (Slate950 vs Slate50), so the split is unambiguous.
+ */
 @Composable
 fun safetyPalette(): SafetyPalette =
     if (MaterialTheme.colorScheme.background.luminance() < 0.5f) SafetyDark else SafetyLight
 
-// Confidence-bar colors for carb estimates (§7): green = high, amber = medium/low.
+// Confidence-bar colors for carb estimates (§7): green = high, amber = medium/low. Medium and Low
+// intentionally share the amber hue; ConfidenceBar distinguishes them by length, not color alone.
 object MealConfidenceColors {
     val High = Green500
     val Medium = Yellow500

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/theme/Theme.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/theme/Theme.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import com.glycemicgpt.mobile.domain.model.BolusCategory
 
 // Matches the web app's dark theme palette
@@ -75,6 +76,36 @@ fun GlycemicGptTheme(
         colorScheme = colorScheme,
         content = content,
     )
+}
+
+/**
+ * Palette for the "Estimate — verify before dosing" qualifier strip. Deliberately a soft amber
+ * "calm caution" treatment, never the red error color, so a standing safety note is not mistaken
+ * for an alarm. Light/dark values per the mobile Meal Intelligence UX spec (§8).
+ */
+data class SafetyPalette(val background: Color, val foreground: Color, val icon: Color)
+
+private val SafetyLight = SafetyPalette(
+    background = Color(0xFFFFF8E1),
+    foreground = Color(0xFF5D4200),
+    icon = Color(0xFFB26A00),
+)
+private val SafetyDark = SafetyPalette(
+    background = Color(0xFF3A2E07),
+    foreground = Color(0xFFFCEFC7),
+    icon = Color(0xFFF2C14E),
+)
+
+/** Theme-aware safety palette. Darkness is read off the active scheme so it tracks forced themes. */
+@Composable
+fun safetyPalette(): SafetyPalette =
+    if (MaterialTheme.colorScheme.background.luminance() < 0.5f) SafetyDark else SafetyLight
+
+// Confidence-bar colors for carb estimates (§7): green = high, amber = medium/low.
+object MealConfidenceColors {
+    val High = Green500
+    val Medium = Yellow500
+    val Low = Yellow500
 }
 
 // Semantic colors for glucose ranges -- constant across themes

--- a/apps/mobile/app/src/main/res/xml/file_paths.xml
+++ b/apps/mobile/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <cache-path name="apk_updates" path="apk_updates/" />
+    <!-- Transient meal photos handed to the camera app for capture, then deleted after upload. -->
+    <cache-path name="meal_photos" path="meal_photos/" />
 </paths>

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/ImageCompressorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/ImageCompressorTest.kt
@@ -1,0 +1,52 @@
+package com.glycemicgpt.mobile.data.meal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit tests for the pure sizing helpers of [ImageCompressor] (no Android device needed). */
+class ImageCompressorTest {
+
+    @Test
+    fun `inSampleSize is 1 when image already fits`() {
+        assertEquals(1, ImageCompressor.calculateInSampleSize(800, 600, 1280))
+        assertEquals(1, ImageCompressor.calculateInSampleSize(1280, 1280, 1280))
+    }
+
+    @Test
+    fun `inSampleSize subsamples large images to a power of two`() {
+        // 4000 longest edge, target 1280: 4000/2=2000 still >= 1280, 4000/4=1000 < 1280 -> 2.
+        assertEquals(2, ImageCompressor.calculateInSampleSize(4000, 3000, 1280))
+        // 6000 longest edge: 6000/4=1500 >= 1280, 6000/8=750 < 1280 -> 4.
+        assertEquals(4, ImageCompressor.calculateInSampleSize(6000, 4000, 1280))
+    }
+
+    @Test
+    fun `inSampleSize never produces an edge below the target`() {
+        val width = 5000
+        val height = 4000
+        val maxDimension = 1280
+        val sample = ImageCompressor.calculateInSampleSize(width, height, maxDimension)
+        val longestAfter = maxOf(width, height) / sample
+        assertTrue("longest edge $longestAfter should stay >= $maxDimension", longestAfter >= maxDimension)
+    }
+
+    @Test
+    fun `targetDimensions keeps small images unchanged`() {
+        assertEquals(800 to 600, ImageCompressor.targetDimensions(800, 600, 1280))
+    }
+
+    @Test
+    fun `targetDimensions scales down preserving aspect ratio`() {
+        val (w, h) = ImageCompressor.targetDimensions(2560, 1920, 1280)
+        assertEquals(1280, w)
+        assertEquals(960, h)
+    }
+
+    @Test
+    fun `targetDimensions never returns a zero edge`() {
+        val (w, h) = ImageCompressor.targetDimensions(4000, 1, 1280)
+        assertEquals(1280, w)
+        assertTrue(h >= 1)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/MealModelsTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/MealModelsTest.kt
@@ -1,0 +1,114 @@
+package com.glycemicgpt.mobile.data.meal
+
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class MealModelsTest {
+
+    private fun record(
+        source: String = "ai_estimate",
+        confidence: String? = "high",
+        correctedLow: Double? = null,
+        correctedHigh: Double? = null,
+    ) = FoodRecordResponse(
+        id = "rec-1",
+        mealTimestamp = "2026-06-14T12:00:00Z",
+        foodDescription = "pasta bowl",
+        carbsLow = 40.0,
+        carbsHigh = 55.0,
+        confidence = confidence,
+        source = source,
+        correctedCarbsLow = correctedLow,
+        correctedCarbsHigh = correctedHigh,
+        createdAt = "2026-06-14T12:00:05Z",
+    )
+
+    @Test
+    fun `maps an uncorrected AI estimate`() {
+        val domain = record().toDomain()
+        assertEquals(CarbRange(40.0, 55.0), domain.estimate)
+        assertEquals(CarbConfidence.HIGH, domain.confidence)
+        assertEquals(FoodRecordSource.AI_ESTIMATE, domain.source)
+        assertFalse(domain.isCorrected)
+        assertEquals(domain.estimate, domain.displayRange)
+        assertEquals(Instant.parse("2026-06-14T12:00:00Z"), domain.mealTimestamp)
+    }
+
+    @Test
+    fun `correction is surfaced as the display range and preserves the original estimate`() {
+        val domain = record(
+            source = "user_corrected",
+            correctedLow = 45.0,
+            correctedHigh = 60.0,
+        ).toDomain()
+        assertTrue(domain.isCorrected)
+        assertEquals(CarbRange(45.0, 60.0), domain.correction)
+        assertEquals(CarbRange(45.0, 60.0), domain.displayRange)
+        // Original AI estimate is never overwritten.
+        assertEquals(CarbRange(40.0, 55.0), domain.estimate)
+        assertEquals(FoodRecordSource.USER_CORRECTED, domain.source)
+    }
+
+    @Test
+    fun `partial correction (only one bound) is treated as uncorrected`() {
+        val domain = record(correctedLow = 45.0, correctedHigh = null).toDomain()
+        assertFalse(domain.isCorrected)
+        assertNull(domain.correction)
+    }
+
+    @Test
+    fun `unknown confidence and source fall back to UNKNOWN`() {
+        val domain = record(source = "something_new", confidence = "weird").toDomain()
+        assertEquals(CarbConfidence.UNKNOWN, domain.confidence)
+        assertEquals(FoodRecordSource.UNKNOWN, domain.source)
+    }
+
+    @Test
+    fun `null confidence maps to UNKNOWN`() {
+        assertEquals(CarbConfidence.UNKNOWN, CarbConfidence.fromApi(null))
+    }
+
+    @Test
+    fun `malformed timestamps map to null rather than throwing`() {
+        val domain = record().copy(mealTimestamp = "not-a-date").toDomain()
+        assertNull(domain.mealTimestamp)
+    }
+
+    @Test
+    fun `offset timestamps are parsed`() {
+        assertEquals(
+            Instant.parse("2026-06-14T12:00:00Z"),
+            parseInstantOrNull("2026-06-14T12:00:00+00:00"),
+        )
+    }
+
+    @Test
+    fun `common food maps carbs range`() {
+        val domain = CommonFoodResponse(
+            id = "cf-1",
+            name = "Pasta Bowl",
+            carbsLow = 45.0,
+            carbsHigh = 60.0,
+            createdAt = "2026-06-14T12:00:00Z",
+            updatedAt = "2026-06-14T12:30:00Z",
+        ).toDomain()
+        assertEquals("Pasta Bowl", domain.name)
+        assertEquals(CarbRange(45.0, 60.0), domain.carbs)
+    }
+
+    @Test
+    fun `carb bounds validation rejects out-of-range and inverted ranges`() {
+        assertNull(CarbBounds.validate(40.0, 55.0))
+        assertNull(CarbBounds.validate(50.0, 50.0))
+        assertTrue(CarbBounds.validate(-1.0, 50.0)!!.contains("negative"))
+        assertTrue(CarbBounds.validate(0.0, 1001.0)!!.contains("exceed"))
+        assertTrue(CarbBounds.validate(60.0, 40.0)!!.contains("must not exceed"))
+        assertTrue(CarbBounds.validate(Double.NaN, 40.0)!!.isNotEmpty())
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/MealRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/MealRepositoryTest.kt
@@ -1,0 +1,225 @@
+package com.glycemicgpt.mobile.data.repository
+
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordListResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
+import com.squareup.moshi.Moshi
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+
+class MealRepositoryTest {
+
+    private val api = mockk<GlycemicGptApi>()
+    private val chatApi = mockk<GlycemicGptApi>()
+    private val moshi = Moshi.Builder().build()
+    private val repository = MealRepository(api, chatApi, moshi)
+
+    private fun errorBody(detail: String) =
+        """{"detail":"$detail"}""".toResponseBody("application/json".toMediaType())
+
+    private fun sampleRecord(source: String = "ai_estimate") = FoodRecordResponse(
+        id = "rec-1",
+        mealTimestamp = "2026-06-14T12:00:00Z",
+        foodDescription = "pasta",
+        carbsLow = 40.0,
+        carbsHigh = 55.0,
+        confidence = "high",
+        source = source,
+        createdAt = "2026-06-14T12:00:05Z",
+    )
+
+    @Test
+    fun `uploadPhoto returns the mapped record on success`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.success(sampleRecord())
+
+        val result = repository.uploadPhoto(ByteArray(16))
+
+        assertTrue(result.isSuccess)
+        assertEquals(40.0, result.getOrThrow().estimate.lowGrams, 0.0)
+    }
+
+    @Test
+    fun `uploadPhoto maps 422 vision detail to VisionUnavailable`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(422, errorBody("Vision is not available on your current AI provider."))
+
+        val result = repository.uploadPhoto(ByteArray(16))
+
+        assertTrue(result.exceptionOrNull() is MealException.VisionUnavailable)
+    }
+
+    @Test
+    fun `uploadPhoto maps 422 non-vision detail to Validation`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(422, errorBody("The estimate was outside the supported range."))
+
+        val e = repository.uploadPhoto(ByteArray(16)).exceptionOrNull()
+        assertTrue(e is MealException.Validation)
+        assertTrue(e!!.message!!.contains("supported range"))
+    }
+
+    @Test
+    fun `uploadPhoto maps 422 Pydantic list detail to Validation with the msg`() = runTest {
+        // FastAPI request-validation errors carry `detail` as a list of objects, not a string.
+        val body = """{"detail":[{"loc":["body","carbs_low"],"msg":"value is not a valid number","type":"x"}]}"""
+            .toResponseBody("application/json".toMediaType())
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns Response.error(422, body)
+
+        val e = repository.uploadPhoto(ByteArray(16)).exceptionOrNull()
+        assertTrue(e is MealException.Validation)
+        assertTrue(e!!.message!!.contains("not a valid number"))
+    }
+
+    @Test
+    fun `uploadPhoto maps 400 to a try-a-different-photo message`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(400, errorBody("Could not decode image."))
+
+        val e = repository.uploadPhoto(ByteArray(16)).exceptionOrNull()
+        assertTrue(e is MealException.EstimateFailed)
+        assertTrue(e!!.message!!.contains("Could not decode", ignoreCase = true))
+    }
+
+    @Test
+    fun `uploadPhoto maps 502 to a retryable vision-service message`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(502, errorBody("AI vision service is unreachable."))
+
+        val e = repository.uploadPhoto(ByteArray(16)).exceptionOrNull()
+        assertTrue(e is MealException.EstimateFailed)
+        assertTrue(e!!.message!!.contains("temporarily unavailable"))
+    }
+
+    @Test
+    fun `probeAvailability surfaces FeatureDisabled when the flag is off`() = runTest {
+        coEvery { api.listFoodRecords(any(), any()) } returns
+            Response.error(404, errorBody("Meal intelligence is not enabled."))
+
+        assertTrue(repository.probeAvailability().exceptionOrNull() is MealException.FeatureDisabled)
+    }
+
+    @Test
+    fun `uploadPhoto maps 404 not-enabled to FeatureDisabled`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(404, errorBody("Meal intelligence is not enabled."))
+
+        assertTrue(
+            repository.uploadPhoto(ByteArray(16)).exceptionOrNull() is MealException.FeatureDisabled,
+        )
+    }
+
+    @Test
+    fun `uploadPhoto maps 404 provider to NoAiProvider`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(404, errorBody("No AI provider configured."))
+
+        assertTrue(
+            repository.uploadPhoto(ByteArray(16)).exceptionOrNull() is MealException.NoAiProvider,
+        )
+    }
+
+    @Test
+    fun `uploadPhoto maps 413 to ImageTooLarge`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(413, errorBody("image exceeds 5242880 bytes"))
+
+        assertTrue(
+            repository.uploadPhoto(ByteArray(16)).exceptionOrNull() is MealException.ImageTooLarge,
+        )
+    }
+
+    @Test
+    fun `uploadPhoto maps 429 to RateLimited`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(429, errorBody("rate limit exceeded"))
+
+        assertTrue(
+            repository.uploadPhoto(ByteArray(16)).exceptionOrNull() is MealException.RateLimited,
+        )
+    }
+
+    @Test
+    fun `listFoodRecords maps records`() = runTest {
+        coEvery { api.listFoodRecords(any(), any()) } returns
+            Response.success(FoodRecordListResponse(records = listOf(sampleRecord()), total = 1))
+
+        val result = repository.listFoodRecords()
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrThrow().size)
+        assertEquals("rec-1", result.getOrThrow().first().id)
+    }
+
+    @Test
+    fun `listFoodRecords maps 404 not-enabled to FeatureDisabled`() = runTest {
+        coEvery { api.listFoodRecords(any(), any()) } returns
+            Response.error(404, errorBody("Meal intelligence is not enabled."))
+
+        assertTrue(
+            repository.listFoodRecords().exceptionOrNull() is MealException.FeatureDisabled,
+        )
+    }
+
+    @Test
+    fun `correctRecord returns the corrected record`() = runTest {
+        coEvery { api.correctFoodRecord(any(), any()) } returns Response.success(
+            sampleRecord(source = "user_corrected").copy(
+                correctedCarbsLow = 45.0,
+                correctedCarbsHigh = 60.0,
+            ),
+        )
+
+        val result = repository.correctRecord("rec-1", 45.0, 60.0)
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isCorrected)
+    }
+
+    @Test
+    fun `saveAsCommonFood returns the saved baseline`() = runTest {
+        coEvery { api.saveRecordAsCommonFood(any(), any()) } returns Response.success(
+            CommonFoodResponse(
+                id = "cf-1",
+                name = "pasta",
+                carbsLow = 45.0,
+                carbsHigh = 60.0,
+                createdAt = "2026-06-14T12:00:00Z",
+                updatedAt = "2026-06-14T12:00:00Z",
+            ),
+        )
+
+        val result = repository.saveAsCommonFood("rec-1", "pasta")
+
+        assertTrue(result.isSuccess)
+        assertEquals("pasta", result.getOrThrow().name)
+    }
+
+    @Test
+    fun `updateCommonFood maps 409 to NameConflict`() = runTest {
+        coEvery { api.updateCommonFood(any(), any()) } returns
+            Response.error(409, errorBody("A common food with that name already exists."))
+
+        assertTrue(
+            repository.updateCommonFood("cf-1", name = "pasta").exceptionOrNull()
+                is MealException.NameConflict,
+        )
+    }
+
+    @Test
+    fun `deleteFoodRecord succeeds on 204`() = runTest {
+        coEvery { api.deleteFoodRecord(any()) } returns Response.success(Unit)
+
+        assertTrue(repository.deleteFoodRecord("rec-1").isSuccess)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModelTest.kt
@@ -1,0 +1,92 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import com.glycemicgpt.mobile.data.meal.CarbConfidence
+import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.FoodRecordSource
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeMealViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = mockk<MealRepository>()
+
+    private fun record() = FoodRecord(
+        id = "rec-1",
+        mealTimestamp = null,
+        foodDescription = "rice bowl",
+        estimate = CarbRange(40.0, 50.0),
+        confidence = CarbConfidence.MEDIUM,
+        source = FoodRecordSource.AI_ESTIMATE,
+        correction = null,
+        correctedAt = null,
+        commonFoodId = null,
+        createdAt = null,
+    )
+
+    @Before fun setUp() = Dispatchers.setMain(testDispatcher)
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `surfaces the most recent meal and keeps logging available`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns Result.success(listOf(record()))
+        val vm = HomeMealViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals("rec-1", vm.uiState.value.recentMeal?.id)
+        assertTrue(vm.uiState.value.mealLoggingAvailable)
+    }
+
+    @Test
+    fun `no meals yet keeps the FAB but hides the card`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns Result.success(emptyList())
+        val vm = HomeMealViewModel(repository)
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.recentMeal)
+        assertTrue(vm.uiState.value.mealLoggingAvailable)
+    }
+
+    @Test
+    fun `feature-off hides the FAB`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.failure(MealException.FeatureDisabled())
+        val vm = HomeMealViewModel(repository)
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.recentMeal)
+        assertFalse(vm.uiState.value.mealLoggingAvailable)
+    }
+
+    @Test
+    fun `a transient failure keeps the FAB so the meal screen can degrade itself`() =
+        runTest(testDispatcher) {
+            coEvery { repository.listFoodRecords(any(), any()) } returns
+                Result.failure(IOException("offline"))
+            val vm = HomeMealViewModel(repository)
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.recentMeal)
+            assertTrue(vm.uiState.value.mealLoggingAvailable)
+        }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModelTest.kt
@@ -1,0 +1,113 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.data.meal.CommonFood
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommonFoodsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = mockk<MealRepository>()
+
+    private fun food(id: String, name: String) = CommonFood(
+        id = id,
+        name = name,
+        carbs = CarbRange(40.0, 55.0),
+        createdAt = null,
+        updatedAt = null,
+    )
+
+    @Before fun setUp() = Dispatchers.setMain(testDispatcher)
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `loads common foods on init`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.success(listOf(food("a", "pasta")))
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals(1, vm.uiState.value.items.size)
+    }
+
+    @Test
+    fun `edit validates carbs before calling the API`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.success(listOf(food("a", "pasta")))
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+
+        vm.startEdit(food("a", "pasta"))
+        vm.saveEdit("pasta", "60", "40")
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.editError!!.contains("must not exceed"))
+        coVerify(exactly = 0) { repository.updateCommonFood(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `successful edit updates the item and closes the dialog`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.success(listOf(food("a", "pasta")))
+        coEvery { repository.updateCommonFood("a", "penne", 30.0, 45.0) } returns
+            Result.success(food("a", "penne").copy(carbs = CarbRange(30.0, 45.0)))
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+
+        vm.startEdit(food("a", "pasta"))
+        vm.saveEdit("penne", "30", "45")
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.editing)
+        assertEquals("penne", vm.uiState.value.items.first().name)
+    }
+
+    @Test
+    fun `name conflict surfaces a clear edit error`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.success(listOf(food("a", "pasta")))
+        coEvery { repository.updateCommonFood(any(), any(), any(), any()) } returns
+            Result.failure(MealException.NameConflict())
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+
+        vm.startEdit(food("a", "pasta"))
+        vm.saveEdit("rice", "40", "55")
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.editError!!.contains("already exists"))
+    }
+
+    @Test
+    fun `delete removes the item`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.success(listOf(food("a", "pasta"), food("b", "rice")))
+        coEvery { repository.deleteCommonFood("a") } returns Result.success(Unit)
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+
+        vm.delete("a")
+        advanceUntilIdle()
+
+        assertEquals(listOf("b"), vm.uiState.value.items.map { it.id })
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealComponentsTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealComponentsTest.kt
@@ -1,0 +1,54 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import com.glycemicgpt.mobile.data.meal.CarbConfidence
+import com.glycemicgpt.mobile.data.meal.CarbRange
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the carb-display invariants behind the safety posture: an estimate is always shown as a
+ * range with units and an accompanying confidence label, never a bare/lone integer.
+ */
+class MealComponentsTest {
+
+    @Test
+    fun `a range renders low to high with units`() {
+        assertEquals("≈ 40–55 g carbs", formatCarbRange(CarbRange(40.0, 55.0)))
+    }
+
+    @Test
+    fun `a single-point estimate still renders with units, never a bare number`() {
+        val formatted = formatCarbRange(CarbRange(50.0, 50.0))
+        assertEquals("≈ 50 g carbs", formatted)
+        assertTrue("must carry units, not a lone integer", formatted.contains("g carbs"))
+    }
+
+    @Test
+    fun `fractional grams keep one decimal`() {
+        assertEquals("≈ 12.5–20 g carbs", formatCarbRange(CarbRange(12.5, 20.0)))
+    }
+
+    @Test
+    fun `every confidence level has a non-empty label, including unknown`() {
+        CarbConfidence.entries.forEach { level ->
+            assertTrue(
+                "confidence $level must have a visible label",
+                confidenceLabel(level).isNotBlank(),
+            )
+        }
+        assertEquals("Confidence unavailable", confidenceLabel(CarbConfidence.UNKNOWN))
+    }
+
+    @Test
+    fun `editable grams drops a trailing zero decimal`() {
+        assertEquals("40", formatEditableGrams(40.0))
+        assertEquals("12.5", formatEditableGrams(12.5))
+    }
+
+    @Test
+    fun `the verify-before-dosing qualifier text mentions both estimate and dosing`() {
+        assertTrue(VERIFY_BEFORE_DOSING_TEXT.contains("Estimate", ignoreCase = true))
+        assertTrue(VERIFY_BEFORE_DOSING_TEXT.contains("dosing", ignoreCase = true))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModelTest.kt
@@ -1,0 +1,82 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import com.glycemicgpt.mobile.data.meal.CarbConfidence
+import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.FoodRecordSource
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MealHistoryViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = mockk<MealRepository>()
+
+    private fun record(id: String) = FoodRecord(
+        id = id,
+        mealTimestamp = null,
+        foodDescription = "meal $id",
+        estimate = CarbRange(40.0, 55.0),
+        confidence = CarbConfidence.MEDIUM,
+        source = FoodRecordSource.AI_ESTIMATE,
+        correction = null,
+        correctedAt = null,
+        commonFoodId = null,
+        createdAt = null,
+    )
+
+    @Before fun setUp() = Dispatchers.setMain(testDispatcher)
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `loads records on init`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.success(listOf(record("a"), record("b")))
+        val vm = MealHistoryViewModel(repository)
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isLoading)
+        assertEquals(2, vm.uiState.value.records.size)
+    }
+
+    @Test
+    fun `feature-off marks the screen disabled`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.failure(MealException.FeatureDisabled())
+        val vm = MealHistoryViewModel(repository)
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.disabled)
+    }
+
+    @Test
+    fun `delete removes the record from the list`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.success(listOf(record("a"), record("b")))
+        coEvery { repository.deleteFoodRecord("a") } returns Result.success(Unit)
+        val vm = MealHistoryViewModel(repository)
+        advanceUntilIdle()
+
+        vm.delete("a")
+        advanceUntilIdle()
+
+        assertEquals(listOf("b"), vm.uiState.value.records.map { it.id })
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModelTest.kt
@@ -182,6 +182,38 @@ class MealLogViewModelTest {
     }
 
     @Test
+    fun `a non-IO compression failure recovers instead of leaving the spinner stuck`() =
+        runTest(testDispatcher) {
+            stubAvailable()
+            // BitmapFactory / createScaledBitmap can throw unchecked exceptions on a bad image.
+            every { ImageCompressor.compress(any(), any(), any(), any()) } throws
+                IllegalArgumentException("bad bitmap dimensions")
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onImagePicked(uri)
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.isUploading)
+            assertTrue(vm.uiState.value.errorMessage!!.contains("Couldn't read"))
+        }
+
+    @Test
+    fun `out-of-memory during compression recovers with a smaller-photo hint`() =
+        runTest(testDispatcher) {
+            stubAvailable()
+            every { ImageCompressor.compress(any(), any(), any(), any()) } throws OutOfMemoryError()
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.onImagePicked(uri)
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.isUploading)
+            assertTrue(vm.uiState.value.errorMessage!!.contains("too large"))
+        }
+
+    @Test
     fun `correction rejects an inverted range without calling the API`() = runTest(testDispatcher) {
         stubAvailable()
         every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModelTest.kt
@@ -1,0 +1,264 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import android.content.Context
+import android.net.Uri
+import com.glycemicgpt.mobile.data.meal.CarbConfidence
+import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.data.meal.CommonFood
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.FoodRecordSource
+import com.glycemicgpt.mobile.data.meal.ImageCompressor
+import com.glycemicgpt.mobile.data.meal.MealException
+import com.glycemicgpt.mobile.data.meal.MealPhotoFiles
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MealLogViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = mockk<MealRepository>()
+    private val context = mockk<Context>(relaxed = true)
+    private val uri = mockk<Uri>(relaxed = true)
+
+    private val record = FoodRecord(
+        id = "rec-1",
+        mealTimestamp = null,
+        foodDescription = "pasta",
+        estimate = CarbRange(40.0, 55.0),
+        confidence = CarbConfidence.HIGH,
+        source = FoodRecordSource.AI_ESTIMATE,
+        correction = null,
+        correctedAt = null,
+        commonFoodId = null,
+        createdAt = null,
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkObject(ImageCompressor)
+        mockkObject(MealPhotoFiles)
+        justRun { MealPhotoFiles.clearCaptures(any()) }
+        justRun { MealPhotoFiles.deleteCapture(any(), any()) }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkObject(ImageCompressor)
+        unmockkObject(MealPhotoFiles)
+    }
+
+    private fun viewModel(): MealLogViewModel =
+        MealLogViewModel(repository, context, testDispatcher)
+
+    private fun stubAvailable() {
+        coEvery { repository.probeAvailability() } returns Result.success(Unit)
+    }
+
+    @Test
+    fun `availability check resolves to Ready`() = runTest(testDispatcher) {
+        stubAvailable()
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertEquals(MealLogPageState.Ready, vm.uiState.value.pageState)
+    }
+
+    @Test
+    fun `feature-off resolves to Disabled`() = runTest(testDispatcher) {
+        coEvery { repository.probeAvailability() } returns
+            Result.failure(MealException.FeatureDisabled())
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertEquals(MealLogPageState.Disabled, vm.uiState.value.pageState)
+    }
+
+    @Test
+    fun `network failure resolves to Offline`() = runTest(testDispatcher) {
+        coEvery { repository.probeAvailability() } returns
+            Result.failure(IOException("down"))
+        val vm = viewModel()
+        advanceUntilIdle()
+        assertEquals(MealLogPageState.Offline, vm.uiState.value.pageState)
+    }
+
+    @Test
+    fun `successful upload surfaces the estimate`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns Result.success(record)
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        assertEquals(record, vm.uiState.value.record)
+        assertFalse(vm.uiState.value.isUploading)
+        coVerify { repository.uploadPhoto(any()) }
+    }
+
+    @Test
+    fun `vision-unavailable upload sets the dedicated state`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns
+            Result.failure(MealException.VisionUnavailable())
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        assertEquals(MealUnavailableReason.VISION, vm.uiState.value.unavailableReason)
+        assertNull(vm.uiState.value.record)
+    }
+
+    @Test
+    fun `no-provider upload sets the no-provider state`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns
+            Result.failure(MealException.NoAiProvider())
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        assertEquals(MealUnavailableReason.NO_PROVIDER, vm.uiState.value.unavailableReason)
+        assertNull(vm.uiState.value.record)
+    }
+
+    @Test
+    fun `feature-off discovered during upload flips the page to Disabled`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns
+            Result.failure(MealException.FeatureDisabled())
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        assertEquals(MealLogPageState.Disabled, vm.uiState.value.pageState)
+    }
+
+    @Test
+    fun `unreadable photo shows a friendly error`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } throws IOException("bad")
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isUploading)
+        assertTrue(vm.uiState.value.errorMessage!!.contains("Couldn't read"))
+    }
+
+    @Test
+    fun `correction rejects an inverted range without calling the API`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns Result.success(record)
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        vm.submitCorrection("60", "40")
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.correctionError!!.contains("must not exceed"))
+        coVerify(exactly = 0) { repository.correctRecord(any(), any(), any()) }
+    }
+
+    @Test
+    fun `valid correction updates the record`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns Result.success(record)
+        val corrected = record.copy(
+            source = FoodRecordSource.USER_CORRECTED,
+            correction = CarbRange(45.0, 60.0),
+        )
+        coEvery { repository.correctRecord("rec-1", 45.0, 60.0) } returns Result.success(corrected)
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        vm.submitCorrection("45", "60")
+        advanceUntilIdle()
+
+        assertEquals(corrected, vm.uiState.value.record)
+        assertFalse(vm.uiState.value.isCorrecting)
+    }
+
+    @Test
+    fun `save as common food requires a name`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns Result.success(record)
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        vm.saveAsCommonFood("   ")
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.errorMessage!!.contains("name"))
+        coVerify(exactly = 0) { repository.saveAsCommonFood(any(), any()) }
+    }
+
+    @Test
+    fun `save as common food confirms with the saved name`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns Result.success(record)
+        coEvery { repository.saveAsCommonFood("rec-1", "pasta") } returns Result.success(
+            CommonFood(
+                id = "cf-1",
+                name = "pasta",
+                carbs = CarbRange(40.0, 55.0),
+                createdAt = null,
+                updatedAt = null,
+            ),
+        )
+        val vm = viewModel()
+        advanceUntilIdle()
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        vm.saveAsCommonFood("pasta")
+        advanceUntilIdle()
+
+        assertEquals("pasta", vm.uiState.value.savedCommonFoodName)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModelTest.kt
@@ -18,6 +18,7 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -119,6 +120,39 @@ class MealLogViewModelTest {
         assertEquals(uri, vm.uiState.value.photoUri)
         assertFalse(vm.uiState.value.isUploading)
         coVerify { repository.uploadPhoto(any()) }
+    }
+
+    @Test
+    fun `a single upload keeps its photo for the result thumbnail`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns Result.success(record)
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+
+        // The current capture must NOT be swept (the result needs it); cleanup is deferred to reset.
+        verify(exactly = 0) { MealPhotoFiles.deleteCapture(any(), uri) }
+    }
+
+    @Test
+    fun `a second pick sweeps the previous photo but keeps the new one`() = runTest(testDispatcher) {
+        stubAvailable()
+        every { ImageCompressor.compress(any(), any(), any(), any()) } returns ByteArray(8)
+        coEvery { repository.uploadPhoto(any()) } returns Result.success(record)
+        val secondUri = mockk<Uri>(relaxed = true)
+        val vm = viewModel()
+        advanceUntilIdle()
+
+        vm.onImagePicked(uri)
+        advanceUntilIdle()
+        vm.onImagePicked(secondUri)
+        advanceUntilIdle()
+
+        verify { MealPhotoFiles.deleteCapture(any(), uri) }
+        verify(exactly = 0) { MealPhotoFiles.deleteCapture(any(), secondUri) }
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModelTest.kt
@@ -116,6 +116,7 @@ class MealLogViewModelTest {
         advanceUntilIdle()
 
         assertEquals(record, vm.uiState.value.record)
+        assertEquals(uri, vm.uiState.value.photoUri)
         assertFalse(vm.uiState.value.isUploading)
         coVerify { repository.uploadPhoto(any()) }
     }


### PR DESCRIPTION
## Summary

Android mobile UX for Epic 50 Meal Intelligence (milestone D) — the user-facing photo → carb-estimate → correct → save loop. Completes v1 (milestones A–D).

## What's included

- **Capture (AC1):** camera + gallery with runtime permissions; client-side downscale to a ≤5 MiB JPEG, EXIF stripped via re-encode.
- **Result (AC2):** carb **range + confidence** (never a lone integer) with an always-on **"estimate — verify before dosing"** qualifier; no dose or insulin anywhere on screen.
- **Correct (AC3):** inline edit → `POST /api/food-records/{id}/correct`.
- **Save + history (AC4):** save-as-common-food (`POST /{id}/save-as-common-food`), common-foods list (`GET /api/common-foods`), meal history (`GET /api/food-records`), edit/delete.
- **Provider fallback (AC5):** `422 vision_unavailable` → clear "vision not available on your provider" state; `404 no-provider` → "no AI provider configured" dead-end (non-retry).
- **Feature-off:** backend `404` (flag `meal_intelligence_enabled` off) hides/disables the meal UI gracefully.

## Safety posture

The verify-before-dosing qualifier (`meal_safety_qualifier` testTag) renders on the result, history, and common-foods surfaces, and is pinned above the scroll region on the result screen so it stays visible regardless of content length. Carbs are always shown as a range; no insulin/dose output exists anywhere in the surface.

## Implementation

- `data/meal/`: domain models + `CarbBounds` validation (shared `parse`), typed `MealException`, `ImageCompressor` (downscale + EXIF strip + orientation), `MealPhotoFiles` (scoped capture cleanup).
- `MealRepository` maps the food-records / common-foods API to typed errors (404 feature-off / no-provider, 422 vision / validation, 400, 409, 413, 415, 429, 502); the photo upload routes through the long-timeout client.
- `presentation/meal/`: screens + ViewModels with new testTags mirroring `cgm_card` / `hero_*`; `@IoDispatcher` qualifier for testable IO.

## Testing

- Unit: 58 meal tests (models/mappers, repository error-mapping incl. the Pydantic list-shaped `detail`, ViewModels). `testDebugUnitTest` + `lintDebug` + `assembleDebug` green.
- Emulator (API 35): verified feature-off degradation (real 404), capture UI + runtime camera permission, camera → compress → upload → no-provider state, client-decode-failure error banner, and the safety qualifier on all three estimate surfaces. Happy-path estimate/correct/save needs a vision-capable provider (not configured on the dev stack) and is covered by the unit tests.
- Mobile Sentry runtime gate: exercised the flow with Sentry enabled; no new issues and no PHI.

A latent bug where `ImageCompressor.compress` threw on **every** image (the elvis operator was bound to the always-null `inJustDecodeBounds` decode result rather than the stream open) was caught during emulator verification and fixed; the camera → compress → upload path was re-verified end-to-end afterward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added “Meal Intelligence” workflows: meal photo capture/upload, carb estimate + correction, and “Save as common food”.
  * Introduced Meal Log, Meal History, and Common Foods screens (with editing, re-log, and delete) and added navigation from Home and Settings.
  * Added optional camera support via manifest and transient photo capture handling.
* **Bug Fixes**
  * Improved photo handling with EXIF orientation, downscaling, and size-bound JPEG compression; better messaging for unavailable/feature-disabled/offline scenarios.
* **Tests**
  * Expanded unit tests for image compression, meal models, repository API mapping, view-model logic, and UI formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->