### PR TITLE
test(api): assert a single Alembic head (CI guard)

### DIFF
--- a/apps/api/tests/test_alembic_single_head.py
+++ b/apps/api/tests/test_alembic_single_head.py
@@ -1,0 +1,27 @@
+"""Guard: the Alembic migration graph must have exactly one head.
+
+A second head means two migrations declare the same ``down_revision`` (a merge
+was missed). That ambiguity has repeatedly bitten us here -- ``alembic upgrade
+head`` errors out and ``current`` / ``heads`` disagree. This test fails the
+moment a real second head appears, inside the existing Backend Tests gate (no
+DB and no new CI job required).
+"""
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+# tests/ -> apps/api. Resolve from the file so the check is independent of the
+# process working directory (alembic.ini's ``script_location`` is otherwise
+# resolved relative to cwd).
+_API_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_single_alembic_head() -> None:
+    config = Config(str(_API_ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(_API_ROOT / "migrations"))
+
+    heads = ScriptDirectory.from_config(config).get_heads()
+
+    assert len(heads) == 1, f"expected exactly one Alembic head, found {heads}"


### PR DESCRIPTION
## Summary

Adds a guard test that asserts the Alembic migration graph has exactly one head, so an accidental second head fails CI immediately.

## Why

Migration-head ambiguity has repeatedly caused confusion here. `develop` is currently clean — exactly one head (`067_common_foods`), linear chain. A real second head means two migrations branch from the same parent: `alembic upgrade head` errors out and `current` / `heads` disagree.

## How

- New `apps/api/tests/test_alembic_single_head.py` builds the Alembic `ScriptDirectory` and asserts `len(get_heads()) == 1`.
- Runs inside the existing **Backend Tests** gate — no DB, no new CI job.
- Resolves `alembic.ini` / `migrations` relative to the test file so the check is independent of the pytest working directory.

## Verification

- Passes on `develop` today (one head).
- Confirmed it goes **red** when a dummy migration branches off a non-tip revision (forcing two heads), then removed the dummy and confirmed it passes again.
- `ruff check src/ tests/` and `ruff format --check src/ tests/` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for database migrations to ensure a single migration path and prevent potential conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->