### PR TITLE
feat(api): record long-acting (basal) pen injections from Glooko

### DIFF
--- a/apps/api/migrations/versions/068_basal_injection_event_type.py
+++ b/apps/api/migrations/versions/068_basal_injection_event_type.py
@@ -1,0 +1,30 @@
+"""Add basal_injection pump event type (MDI long-acting injections).
+
+Adds 'basal_injection' to the pumpeventtype enum so the Glooko mapper can record
+MDI long-acting (basal) pen injections -- e.g. Lantus, Tresiba -- as a discrete
+event. BASAL means a pump rate (U/h) and BOLUS would pollute rapid-acting IoB/TDD,
+so neither fits a once-daily injection (issue #728). The new value is added here
+but not used until runtime; the Postgres enum requires the value to be committed
+before any row can reference it.
+
+Revision ID: 068_basal_injection_event_type
+Revises: 067_common_foods
+"""
+
+from alembic import op
+
+revision = "068_basal_injection_event_type"
+down_revision = "067_common_foods"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ALTER TYPE ... ADD VALUE must run outside a transaction in PostgreSQL
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE pumpeventtype ADD VALUE IF NOT EXISTS 'basal_injection'")
+
+
+def downgrade() -> None:
+    # Cannot remove enum values in PostgreSQL without recreating the type
+    pass

--- a/apps/api/src/models/pump_data.py
+++ b/apps/api/src/models/pump_data.py
@@ -36,12 +36,17 @@ class PumpEventType(str, enum.Enum):
     cloud-mediated integrations (carbs, overrides, profile switches,
     combo boluses, temp targets, notes, device events, APS-offline
     markers); type-specific extras that don't fit the column schema
-    land in `metadata_json`.
+    land in `metadata_json`. `basal_injection` is written by the Glooko
+    mapper for MDI long-acting pen injections (see below).
     """
 
-    BASAL = "basal"  # Basal insulin delivery
+    BASAL = "basal"  # Basal insulin delivery (pump rate, U/h)
     BOLUS = "bolus"  # Manual bolus
     CORRECTION = "correction"  # Control-IQ automated correction
+    # Long-acting (basal) insulin INJECTION from an MDI pen -- e.g. Lantus,
+    # Tresiba. ``units`` is the injected amount (U), NOT a U/h rate like BASAL,
+    # and it is deliberately excluded from rapid-acting IoB (issue #728).
+    BASAL_INJECTION = "basal_injection"
     SUSPEND = "suspend"  # Insulin delivery suspended
     RESUME = "resume"  # Insulin delivery resumed
     BG_READING = "bg_reading"  # CGM reading from pump (has IoB)

--- a/apps/api/src/services/integrations/glooko/mapper.py
+++ b/apps/api/src/services/integrations/glooko/mapper.py
@@ -51,6 +51,13 @@ _MAX_BASAL_RATE_UH = 35.0
 # helpers reading in single-letter units.
 _MAX_BOLUS_DOSE_U = MAX_INSULIN_DOSE_UNITS
 
+# Sanity bound on a single long-acting (basal) pen INJECTION (U). Larger than the
+# bolus bound because once-daily basal doses are bigger: 160 U is the max single
+# injection of the Tresiba U-200 FlexTouch (the highest-capacity supported pen);
+# anything above is a corrupt or unit-confused record. This bounds the discrete
+# injected amount, NOT a U/h rate (that is _MAX_BASAL_RATE_UH).
+_MAX_BASAL_INJECTION_U = 160.0
+
 
 # Glooko pump-events ``type`` -> our PumpEventType. Pod/cartridge/prime lifecycle
 # events all become DEVICE_EVENT (the specific Glooko type is preserved in
@@ -156,18 +163,25 @@ def _finite_or_none(value: object) -> float | None:
     return float(value)
 
 
-def _dose_or_none(value: object, *, allow_zero: bool = False) -> float | None:
+def _dose_or_none(
+    value: object,
+    *,
+    allow_zero: bool = False,
+    max_units: float = _MAX_BOLUS_DOSE_U,
+) -> float | None:
     """A plausible insulin dose in units, else ``None``.
 
-    Bounds a finite number to ``(0, _MAX_BOLUS_DOSE_U]``. ``allow_zero`` admits
-    exactly 0: a suggested pump bolus fully reduced by IoB records 0 delivered
-    while still carrying the meal's carb/BG context worth keeping -- a pen
-    record has no such context and its smallest real actuation is 0.5 U.
+    Bounds a finite number to ``(0, max_units]`` (default the bolus/pen
+    actuation bound; long-acting injections pass ``_MAX_BASAL_INJECTION_U``).
+    ``allow_zero`` admits exactly 0: a suggested pump bolus fully reduced by IoB
+    records 0 delivered while still carrying the meal's carb/BG context worth
+    keeping -- a pen record has no such context and its smallest real actuation
+    is 0.5 U.
     """
     dose = _finite_or_none(value)
     if dose is None:
         return None
-    if 0 < dose <= _MAX_BOLUS_DOSE_U or (allow_zero and dose == 0):
+    if 0 < dose <= max_units or (allow_zero and dose == 0):
         return dose
     return None
 
@@ -280,7 +294,7 @@ def map_events(records: list[dict]) -> list[MappedPumpEvent]:
 
 
 def map_insulins(records: list[dict]) -> list[MappedPumpEvent]:
-    """Map ``insulins`` (smart-pen doses + manual insulin logs) -> BOLUS events.
+    """Map ``insulins`` (smart-pen doses + manual logs) -> BOLUS / BASAL_INJECTION.
 
     Live finding (NovoPen 6 / Echo Plus capture): the record ``timestamp`` is
     genuine UTC -- verified against known dose times on a CEST wall clock --
@@ -293,9 +307,9 @@ def map_insulins(records: list[dict]) -> list[MappedPumpEvent]:
     * priming shots (``suspectedPrime`` / ``acceptedPrime``) -- pen actuations
       that never enter the body; ingesting them inflates dose totals and IoB
     * ``incomplete`` -- Glooko marks the dose value unconfirmed
-    * non-``bolus`` ``insulinType`` -- long-acting pen doses don't fit the
-      BASAL event's rate (U/h) semantics; deferred like ``extended_boluses``
-      (add modeling + mapping together, never one without the other)
+    * an unrecognized ``insulinType`` -- ``bolus`` maps to BOLUS and ``basal``
+      (long-acting, e.g. Lantus/Tresiba) to BASAL_INJECTION (the injected
+      amount, NOT a U/h rate); any third value is skipped rather than guessed
     * a ``units`` field that is present but not ``"units"`` -- an unknown unit
       of measure would be mis-ingested as insulin units
     * non-positive or implausibly large doses (``_dose_or_none``; the 60 U
@@ -317,15 +331,24 @@ def map_insulins(records: list[dict]) -> list[MappedPumpEvent]:
             continue
         if r.get("incomplete"):
             continue
-        if str(r.get("insulinType", "")).lower() != "bolus":
-            continue
+        insulin_type = str(r.get("insulinType", "")).lower()
+        if insulin_type == "bolus":
+            event_type = PumpEventType.BOLUS
+            max_units = _MAX_BOLUS_DOSE_U
+        elif insulin_type == "basal":
+            event_type = PumpEventType.BASAL_INJECTION
+            max_units = _MAX_BASAL_INJECTION_U
+        else:
+            continue  # unrecognized insulinType -> skip, don't guess
         unit_of_measure = r.get("units")
         if unit_of_measure is not None and str(unit_of_measure).lower() != "units":
             continue
         ts = _parse_utc(r.get("timestamp"))
         # currentValue when present, else value (see docstring).
         current = r.get("currentValue")
-        dose = _dose_or_none(current if current is not None else r.get("value"))
+        dose = _dose_or_none(
+            current if current is not None else r.get("value"), max_units=max_units
+        )
         if ts is None or dose is None:
             continue
         metadata: dict = {"glooko_stream": "insulins"}
@@ -342,7 +365,7 @@ def map_insulins(records: list[dict]) -> list[MappedPumpEvent]:
         metadata["device_delivered"] = bool(r.get("deviceDelivered"))
         out.append(
             MappedPumpEvent(
-                event_type=PumpEventType.BOLUS,
+                event_type=event_type,
                 timestamp=ts,
                 ns_id=_str_or_none(r.get("guid")),
                 units=dose,

--- a/apps/api/tests/test_glooko_mapper.py
+++ b/apps/api/tests/test_glooko_mapper.py
@@ -112,14 +112,15 @@ def test_map_events_pod_suspend_resume_and_unknown_skipped():
 
 def test_map_insulins_pen_doses_and_safety_skips():
     events = mapper.map_insulins(_load("insulins.json"))
-    # 7 fixture records -> 2 ingested: the device-read pen dose and the manual
-    # log. Skipped: prime (never entered the body), soft-deleted, incomplete
-    # (unconfirmed value), basal-type Tresiba (no BASAL rate semantics for a
-    # long-acting injection -- deferred), negative value (impossible).
-    assert len(events) == 2
-    pen, manual = events
+    # 7 fixture records -> 3 ingested: a device-read bolus, the basal-type
+    # Tresiba (now a BASAL_INJECTION, issue #728), and the manual log. Skipped:
+    # prime (never entered the body), soft-deleted, incomplete (unconfirmed
+    # value), negative value (impossible).
+    assert len(events) == 3
+    bolus_events = [e for e in events if e.event_type is PumpEventType.BOLUS]
+    assert len(bolus_events) == 2
+    pen, manual = bolus_events  # fixture order preserved
 
-    assert pen.event_type is PumpEventType.BOLUS
     assert pen.units == 3.0
     assert pen.ns_id == "44444444-0000-0000-0000-000000000001"
     # Pen `timestamp` is genuine UTC (live-verified) -- no local-offset footgun.
@@ -136,6 +137,43 @@ def test_map_insulins_pen_doses_and_safety_skips():
     assert manual.units == 6.0
     assert manual.metadata_json["device_delivered"] is False
     assert "pen_device" not in manual.metadata_json
+
+
+def test_map_insulins_basal_injection_and_separate_bound():
+    # A long-acting (basal) pen dose maps to BASAL_INJECTION -- the injected
+    # amount, NOT a U/h rate -- and uses the larger 160 U bound (issue #728).
+    base = next(r for r in _load("insulins.json") if r.get("insulinType") == "basal")
+    [evt] = mapper.map_insulins([base])
+    assert evt.event_type is PumpEventType.BASAL_INJECTION
+    assert evt.units == 18.0
+    assert evt.ns_id == "44444444-0000-0000-0000-000000000005"
+    assert evt.metadata_json["medication"] == "Tresiba®"
+    assert evt.metadata_json["device_delivered"] is True
+
+    # 160 U (Tresiba U-200 max single injection) is the edge; above is corrupt.
+    assert (
+        mapper.map_insulins([{**base, "value": 160.0, "currentValue": 160.0}])[0].units
+        == 160.0
+    )
+    assert mapper.map_insulins([{**base, "value": 161.0, "currentValue": 161.0}]) == []
+    # The bound is type-specific: 90 U is a valid basal injection but would be
+    # rejected as a bolus (60 U bound) -- proving the two bounds are separate.
+    assert (
+        mapper.map_insulins([{**base, "value": 90.0, "currentValue": 90.0}])[0].units
+        == 90.0
+    )
+    assert (
+        mapper.map_insulins(
+            [{**base, "insulinType": "bolus", "value": 90.0, "currentValue": 90.0}]
+        )
+        == []
+    )
+
+
+def test_map_insulins_skips_unknown_insulin_type():
+    # Neither bolus nor basal -> skipped, not guessed.
+    base = next(r for r in _load("insulins.json") if r.get("insulinType") == "basal")
+    assert mapper.map_insulins([{**base, "insulinType": "intermediate"}]) == []
 
 
 def test_map_insulins_skips_accepted_prime():
@@ -237,8 +275,8 @@ def test_map_glooko_combines_all_series():
         insulins=_load("insulins.json"),
     )
     assert len(rec.glucose) == 5
-    # basals + boluses + events + pen insulins
-    assert len(rec.pump_events) == 2 + 2 + 4 + 2
+    # basals + boluses + events + pen insulins (2 bolus + 1 basal_injection)
+    assert len(rec.pump_events) == 2 + 2 + 4 + 3
 
 
 def test_map_pump_ts_refuses_missing_offset():

--- a/apps/api/tests/test_iob_projection.py
+++ b/apps/api/tests/test_iob_projection.py
@@ -750,10 +750,12 @@ class TestNonPumpDoseProjection:
         response = await _fetch_projection(email, password)
         assert response.status_code == 200
         projected = response.json()["projected_iob"]
-        # The fresh 4 U bolus is most of the IoB; the 20 U basal injection is
-        # excluded, so the total stays well under 10 (it would exceed 20 if the
-        # basal injection had leaked into the rapid-acting decay model).
-        assert 0 < projected < 10
+        # Projected IoB is exactly the 4 U bolus decaying (parabolic, DIA=4h):
+        # 4.0 * remaining(0.5h) = 4.0 * 0.984375 = 3.9375. The 20 U basal
+        # injection contributes nothing -- if it had leaked into the rapid-acting
+        # model the total would balloon past 20, so pinning the bolus-only value
+        # guards both the exclusion and the bolus contribution itself.
+        assert projected == pytest.approx(3.9375, rel=0.02)
 
     async def test_pen_dose_before_pump_anchor_counts(self, db_session):
         """THE BUG: a pen dose at-or-before the anchor must not vanish.

--- a/apps/api/tests/test_iob_projection.py
+++ b/apps/api/tests/test_iob_projection.py
@@ -280,6 +280,8 @@ class TestDoseEventTypePin:
             PumpEventType.BOLUS,
             PumpEventType.CORRECTION,
         }
+        # BASAL_INJECTION exists (issue #728) but must stay out of the allowlist.
+        assert PumpEventType.BASAL_INJECTION not in _DOSE_EVENT_TYPES
 
 
 class TestAnchorVisibilityClassification:
@@ -715,6 +717,43 @@ class TestNonPumpDoseProjection:
 
     # Decay reference (parabolic, DIA=4h): remaining(0.5h) = 0.984375,
     # remaining(1h) = 0.9375, remaining(2h) = 0.75.
+
+    async def test_basal_injection_does_not_enter_projected_iob(self, db_session):
+        """Behavioral pin: a long-acting BASAL_INJECTION must NOT contribute to
+        projected IoB (issue #728) -- the invariant the new event type relies on.
+        A 4 U bolus counts; a co-timed 20 U basal injection adds nothing, so the
+        projection stays in bolus range and never balloons toward ~24 U."""
+        user, email, password = await _create_user(db_session, "iob_basal_inj")
+        now = datetime.now(UTC)
+        bolus = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=now - timedelta(minutes=30),
+            units=4.0,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("bolus"),
+        )
+        basal_injection = PumpEvent(
+            user_id=user.id,
+            event_type=PumpEventType.BASAL_INJECTION,
+            event_timestamp=now - timedelta(minutes=30),
+            units=20.0,
+            received_at=now,
+            source="glooko",
+            ns_id=_unique_ns_id("basal-inj"),
+            metadata_json={"glooko_stream": "insulins", "device_delivered": True},
+        )
+        db_session.add_all([bolus, basal_injection])
+        await db_session.commit()
+
+        response = await _fetch_projection(email, password)
+        assert response.status_code == 200
+        projected = response.json()["projected_iob"]
+        # The fresh 4 U bolus is most of the IoB; the 20 U basal injection is
+        # excluded, so the total stays well under 10 (it would exceed 20 if the
+        # basal injection had leaked into the rapid-acting decay model).
+        assert 0 < projected < 10
 
     async def test_pen_dose_before_pump_anchor_counts(self, db_session):
         """THE BUG: a pen dose at-or-before the anchor must not vanish.


### PR DESCRIPTION
## 📋 Summary

Gives MDI users their missing half: long-acting (basal) pen injections — Lantus, Tresiba, Levemir. The Glooko `insulins` stream already carries these (`insulinType == "basal"`); #726 deliberately skipped them pending the representation decision you settled in the issue. This implements that decision.

A long-acting injection fits neither existing type: `BASAL` means a pump **rate** (U/h), and `BOLUS` would pollute rapid-acting IoB/TDD. So this adds a discrete `BASAL_INJECTION` event whose `units` is the injected amount, excluded from rapid-acting IoB.

## 🔗 Related Issues

Fixes #728 (per your green-light + spec)

## 🏷️ Type of Change

- [x] ✨ New feature (non-breaking; new enum value is invisible-by-default to type-matching queries)

## 🔨 Changes Made

- **`models/pump_data.py`**: add `PumpEventType.BASAL_INJECTION = "basal_injection"` (units = injected U, NOT a rate; comment contrasts it with `BASAL`).
- **`migrations/versions/068_basal_injection_event_type.py`**: `ALTER TYPE pumpeventtype ADD VALUE IF NOT EXISTS 'basal_injection'` outside a transaction (`op.execute("COMMIT")`), mirroring the repo's existing enum-add migrations (029/036/052). No-op downgrade (Postgres can't drop an enum value). Single Alembic head preserved (passes #739's guard).
- **`services/integrations/glooko/mapper.py`**: `map_insulins` now branches — `bolus` → `BOLUS` (60 U bound), `basal` → `BASAL_INJECTION` bounded to (0, **160 U**] = `_MAX_BASAL_INJECTION_U` (Tresiba U-200 FlexTouch max single injection), any other `insulinType` skipped (not guessed). `_dose_or_none` gained a `max_units` param; all prior safety skips (soft-deleted, primes, `incomplete`, `currentValue` preference, units-of-measure check) unchanged.

## 🧪 Test Plan

- [x] **IoB exclusion invariant** (the one you flagged): `BASAL_INJECTION not in _DOSE_EVENT_TYPES` (constant pin) **plus** a behavioral test that a 20 U basal injection alongside a 4 U bolus never inflates projected IoB. Confirmed the allowlist is explicit (`BOLUS, CORRECTION`) since #730, so exclusion is by construction.
- [x] Mapper: basal-type record → `BASAL_INJECTION` (units, metadata, ns_id); separate-bound proof (90 U valid as basal, rejected as bolus; 160 U edge ok, 161 rejected); unknown `insulinType` skipped.
- [x] Targeted suites (mapper, IoB, glooko sync/endpoints/client): 155 passed. Full backend suite: **2564 passed, 14 skipped, 0 failed**.
- [x] `ruff check` + `ruff format --check` clean; migration round-trip (`upgrade`/`downgrade`/`upgrade`) clean.

## ✅ Checklist

- [x] Self-review completed
- [x] Style guidelines (ruff clean)
- [x] No hardcoded secrets
- [x] No new warnings

## Notes for reviewer

- Stayed in scope per your point 5: **no display/TDD wiring** — the new value is invisible-by-default to type-matching queries (fails safe), so I left lighting up consumers (bolus-review table, TDD, AI context) to you as you preferred.
- Handled your migration gotcha: the value is added but not *used* in the same migration, and the add runs outside a transaction.
- The existing `TestDoseEventTypePin` guard (which already named `BASAL_INJECTION`/#728 in its docstring) now actively protects the invariant rather than just anticipating it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for long-acting basal injection insulin events, mapping them to a dedicated event type with separate safety limits from bolus dosing.
  * Basal injection events are excluded from insulin-on-board projections to prevent dose impact inflation.
* **Bug Fixes**
  * Improved insulin event mapping to correctly select the event type based on incoming insulin source data, skipping unknown types.
* **Tests**
  * Updated and added mapper and IoB projection tests to cover basal injection ingestion, bounds, and skip behavior.
* **Chores**
  * Introduced a database migration to register the new event type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->