### PR TITLE
feat(api): auto-generate daily briefs on a schedule

### DIFF
--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -130,6 +130,10 @@ class Settings(BaseSettings):
     escalation_check_interval_minutes: int = 1  # Check every 1 minute
     escalation_check_enabled: bool = True  # Enable/disable automatic escalation
 
+    # Daily brief auto-generation (issue #741)
+    brief_check_interval_minutes: int = 5  # Tick cadence; gates on per-user local time
+    brief_scheduler_enabled: bool = True  # Enable/disable automatic daily briefs
+
     # Data Retention (Story 9.3)
     data_retention_enabled: bool = True
     data_retention_check_interval_hours: int = 24  # Run daily

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -131,7 +131,9 @@ class Settings(BaseSettings):
     escalation_check_enabled: bool = True  # Enable/disable automatic escalation
 
     # Daily brief auto-generation (issue #741)
-    brief_check_interval_minutes: int = 5  # Tick cadence; gates on per-user local time
+    # Bounded like the sync-tick intervals: the value feeds IntervalTrigger, which
+    # starves/crashes on zero/negative/absurd values.
+    brief_check_interval_minutes: int = Field(default=5, ge=1, le=60)
     brief_scheduler_enabled: bool = True  # Enable/disable automatic daily briefs
 
     # Data Retention (Story 9.3)

--- a/apps/api/src/services/brief_notifier.py
+++ b/apps/api/src/services/brief_notifier.py
@@ -11,7 +11,9 @@ import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.logging_config import get_logger
+from src.models.brief_delivery_config import DeliveryChannel
 from src.models.daily_brief import DailyBrief
+from src.services.brief_delivery_config import get_or_create_config
 from src.services.telegram_bot import (
     TelegramBotError,
     get_telegram_link,
@@ -102,6 +104,16 @@ async def notify_user_of_brief(
     Returns:
         True if the message was sent successfully, False otherwise.
     """
+    # Respect the user's delivery channel: web_only means no Telegram push
+    # (the brief is still persisted and shown in the dashboard).
+    cfg = await get_or_create_config(user_id, db)
+    if cfg.channel == DeliveryChannel.WEB_ONLY:
+        logger.debug(
+            "Brief channel is web_only, skipping Telegram notification",
+            user_id=str(user_id),
+        )
+        return False
+
     link = await get_telegram_link(db, user_id)
     if link is None or not link.is_verified:
         logger.debug(

--- a/apps/api/src/services/daily_brief.py
+++ b/apps/api/src/services/daily_brief.py
@@ -3,13 +3,18 @@
 Aggregates glucose and pump data, generates AI-powered analysis briefs.
 """
 
-from datetime import UTC, datetime, timedelta
+import asyncio
+import uuid
+from datetime import UTC, datetime, time, timedelta
+from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.database import get_session_maker
 from src.logging_config import get_logger
+from src.models.brief_delivery_config import BriefDeliveryConfig
 from src.models.daily_brief import DailyBrief
 from src.models.glucose import GlucoseReading
 from src.models.pump_data import PumpEvent, PumpEventType
@@ -498,3 +503,165 @@ async def get_brief_by_id(
         )
 
     return brief
+
+
+# ── Scheduled auto-generation (issue #741) ──────────────────────────────────
+# Per-user in-process lock: the local-day existence check below is the real
+# idempotency guard; this just prevents a slow generation from overlapping the
+# next tick for the same user. A multi-replica deployment would instead need a
+# DB-level uniqueness constraint on (user, local day) -- single scheduler today.
+_brief_locks: dict[uuid.UUID, asyncio.Lock] = {}
+
+
+def _lock_for(user_id: uuid.UUID) -> asyncio.Lock:
+    lock = _brief_locks.get(user_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _brief_locks[user_id] = lock
+    return lock
+
+
+def _release_lock(user_id: uuid.UUID, lock: asyncio.Lock) -> None:
+    if not getattr(lock, "_waiters", None):
+        _brief_locks.pop(user_id, None)
+
+
+def _local_day_start_utc(now_utc: datetime, tz_name: str) -> tuple[datetime, datetime]:
+    """Return (now in the user's tz, UTC instant of the user's local midnight today)."""
+    tz = ZoneInfo(tz_name)
+    now_local = now_utc.astimezone(tz)
+    local_midnight = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    return now_local, local_midnight.astimezone(UTC)
+
+
+def _brief_due(
+    *,
+    enabled: bool,
+    delivery_time: time,
+    now_local: datetime,
+    brief_exists_today: bool,
+) -> bool:
+    """Generate iff enabled, the local clock has reached delivery_time, and no
+    brief exists for the local day yet. The last condition gives both idempotency
+    and same-day catch-up (a restart after delivery_time still fires that day)."""
+    return enabled and not brief_exists_today and now_local.time() >= delivery_time
+
+
+async def _has_brief_for_local_day(
+    db: AsyncSession, user_id: uuid.UUID, local_midnight_utc: datetime
+) -> bool:
+    """Whether a brief was already generated on the user's current local day."""
+    result = await db.execute(
+        select(DailyBrief.id)
+        .where(
+            DailyBrief.user_id == user_id,
+            DailyBrief.created_at >= local_midnight_utc,
+        )
+        .limit(1)
+    )
+    return result.first() is not None
+
+
+async def generate_briefs_all_users(now: datetime | None = None) -> None:
+    """Scheduled tick: auto-generate a daily brief for each enabled user whose
+    local delivery_time has passed and who has no brief for their local day yet.
+
+    Per-user failures (insufficient data, no AI provider, anything else) are
+    swallowed so one user never aborts the run.
+    """
+    now_utc = now or datetime.now(UTC)
+    logger.info("Starting scheduled brief generation")
+
+    async with get_session_maker()() as db:
+        configs = (
+            (
+                await db.execute(
+                    select(BriefDeliveryConfig).where(
+                        BriefDeliveryConfig.enabled.is_(True)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    generated = skipped = errors = 0
+    for cfg in configs:
+        lock = _lock_for(cfg.user_id)
+        async with lock:
+            try:
+                try:
+                    now_local, local_midnight_utc = _local_day_start_utc(
+                        now_utc, cfg.timezone
+                    )
+                except Exception:
+                    logger.warning(
+                        "Bad brief timezone, skipping user",
+                        user_id=str(cfg.user_id),
+                        tz=cfg.timezone,
+                    )
+                    errors += 1
+                    continue
+
+                async with get_session_maker()() as user_db:
+                    brief_exists = await _has_brief_for_local_day(
+                        user_db, cfg.user_id, local_midnight_utc
+                    )
+                    if not _brief_due(
+                        enabled=cfg.enabled,
+                        delivery_time=cfg.delivery_time,
+                        now_local=now_local,
+                        brief_exists_today=brief_exists,
+                    ):
+                        skipped += 1
+                        continue
+
+                    user = (
+                        await user_db.execute(
+                            select(User).where(
+                                User.id == cfg.user_id, User.is_active.is_(True)
+                            )
+                        )
+                    ).scalar_one_or_none()
+                    if user is None:
+                        skipped += 1
+                        continue
+
+                    try:
+                        await generate_daily_brief(user, user_db, hours=24)
+                        generated += 1
+                    except HTTPException as e:
+                        # 400 insufficient data / 404 no AI provider -> graceful skip.
+                        logger.info(
+                            "Brief auto-generation skipped",
+                            user_id=str(cfg.user_id),
+                            detail=str(e.detail),
+                        )
+                        skipped += 1
+                    except Exception:
+                        logger.error(
+                            "Brief auto-generation failed",
+                            user_id=str(cfg.user_id),
+                            exc_info=True,
+                        )
+                        errors += 1
+            except Exception:
+                # Any other per-user failure (e.g. a transient DB error on the
+                # existence check or user load) must not abort the whole tick.
+                logger.error(
+                    "Brief generation tick error for user",
+                    user_id=str(cfg.user_id),
+                    exc_info=True,
+                )
+                errors += 1
+            finally:
+                _release_lock(cfg.user_id, lock)
+
+        await asyncio.sleep(0.2)
+
+    logger.info(
+        "Scheduled brief generation completed",
+        generated=generated,
+        skipped=skipped,
+        errors=errors,
+    )

--- a/apps/api/src/services/scheduler.py
+++ b/apps/api/src/services/scheduler.py
@@ -30,6 +30,7 @@ from src.models.medtronic_connect_state import (
     MedtronicConnectState,
 )
 from src.models.tandem_sync_state import TandemSyncState
+from src.services.daily_brief import generate_briefs_all_users
 from src.services.dexcom_sync import DexcomSyncError, sync_dexcom_for_user
 from src.services.integrations.glooko.sync import (
     GlookoSyncRunError,
@@ -892,6 +893,21 @@ def start_scheduler() -> AsyncIOScheduler:
         logger.info(
             "Scheduled escalation check job",
             interval_minutes=settings.escalation_check_interval_minutes,
+        )
+
+    # Add daily brief auto-generation job if enabled (issue #741)
+    if settings.brief_scheduler_enabled:
+        scheduler.add_job(
+            generate_briefs_all_users,
+            trigger=IntervalTrigger(minutes=settings.brief_check_interval_minutes),
+            id="daily_brief",
+            name="Daily Brief Generation",
+            replace_existing=True,
+            max_instances=1,
+        )
+        logger.info(
+            "Scheduled daily brief job",
+            interval_minutes=settings.brief_check_interval_minutes,
         )
 
     # Add data retention enforcement job if enabled (Story 9.3)

--- a/apps/api/src/services/scheduler.py
+++ b/apps/api/src/services/scheduler.py
@@ -904,6 +904,7 @@ def start_scheduler() -> AsyncIOScheduler:
             name="Daily Brief Generation",
             replace_existing=True,
             max_instances=1,
+            coalesce=True,
         )
         logger.info(
             "Scheduled daily brief job",

--- a/apps/api/tests/test_brief_notifier.py
+++ b/apps/api/tests/test_brief_notifier.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.models.brief_delivery_config import DeliveryChannel
 from src.models.daily_brief import DailyBrief
 from src.services.brief_notifier import (
     _tir_emoji,
@@ -209,6 +210,33 @@ class TestFormatBriefMessage:
 # ---------------------------------------------------------------------------
 class TestNotifyUserOfBrief:
     """Tests for notify_user_of_brief delivery function."""
+
+    @pytest.fixture(autouse=True)
+    def channel_config(self):
+        """notify_user_of_brief now consults the delivery channel first. Patch it
+        to a non-web_only channel by default so the send-path tests proceed; a
+        test can flip ``channel_config.channel`` to assert the web_only skip."""
+        cfg = MagicMock()
+        cfg.channel = DeliveryChannel.BOTH
+        with patch(
+            "src.services.brief_notifier.get_or_create_config",
+            new=AsyncMock(return_value=cfg),
+        ):
+            yield cfg
+
+    @pytest.mark.asyncio
+    @patch("src.services.brief_notifier.send_message", new_callable=AsyncMock)
+    @patch("src.services.brief_notifier.get_telegram_link", new_callable=AsyncMock)
+    async def test_web_only_channel_skips_telegram(
+        self, mock_get_link, mock_send, channel_config
+    ):
+        channel_config.channel = DeliveryChannel.WEB_ONLY
+
+        result = await notify_user_of_brief(AsyncMock(), uuid.uuid4(), make_brief())
+
+        assert result is False
+        mock_get_link.assert_not_called()
+        mock_send.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("src.services.brief_notifier.send_message", new_callable=AsyncMock)

--- a/apps/api/tests/test_brief_scheduler.py
+++ b/apps/api/tests/test_brief_scheduler.py
@@ -1,0 +1,215 @@
+"""Tests for the automatic daily-brief scheduler (issue #741).
+
+Pure-gate unit tests (timezone / delivery_time / idempotency logic) plus a
+DB-backed test of the `generate_briefs_all_users` tick against the dev DB,
+mirroring `test_nightscout_scheduler.py`'s `scheduler_ctx` pattern. The heavy
+`generate_daily_brief` (AI call) is patched.
+"""
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, time, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy import delete
+
+from src.database import get_session_maker
+from src.models.brief_delivery_config import BriefDeliveryConfig, DeliveryChannel
+from src.models.daily_brief import DailyBrief
+from src.models.user import User
+from src.services.daily_brief import (
+    _brief_due,
+    _local_day_start_utc,
+    generate_briefs_all_users,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure gate: timezone + delivery_time + idempotency
+# ---------------------------------------------------------------------------
+class TestBriefGate:
+    def test_local_day_start_utc_honors_timezone(self):
+        # 06:30 UTC is 08:30 in Berlin (CEST, UTC+2); local midnight is the prior
+        # 22:00 UTC.
+        now_utc = datetime(2026, 6, 15, 6, 30, tzinfo=UTC)
+        now_local, local_midnight_utc = _local_day_start_utc(now_utc, "Europe/Berlin")
+        assert now_local.hour == 8 and now_local.minute == 30
+        assert now_local.date() == datetime(2026, 6, 15).date()
+        assert local_midnight_utc == datetime(2026, 6, 14, 22, 0, tzinfo=UTC)
+
+    def test_due_after_delivery_time_with_no_brief(self):
+        now_local, _ = _local_day_start_utc(
+            datetime(2026, 6, 15, 6, 30, tzinfo=UTC), "Europe/Berlin"
+        )  # 08:30 local
+        assert _brief_due(
+            enabled=True,
+            delivery_time=time(7, 0),
+            now_local=now_local,
+            brief_exists_today=False,
+        )
+
+    def test_timezone_decides_the_boundary(self):
+        # Same instant: past 07:00 in Berlin (08:30) but not in UTC (06:30).
+        now_utc = datetime(2026, 6, 15, 6, 30, tzinfo=UTC)
+        berlin_local, _ = _local_day_start_utc(now_utc, "Europe/Berlin")
+        utc_local, _ = _local_day_start_utc(now_utc, "UTC")
+        kw = {"enabled": True, "delivery_time": time(7, 0), "brief_exists_today": False}
+        assert _brief_due(now_local=berlin_local, **kw) is True
+        assert _brief_due(now_local=utc_local, **kw) is False
+
+    def test_before_delivery_time_skips(self):
+        now_local, _ = _local_day_start_utc(
+            datetime(2026, 6, 15, 3, 0, tzinfo=UTC), "Europe/Berlin"
+        )  # 05:00 local
+        assert not _brief_due(
+            enabled=True,
+            delivery_time=time(7, 0),
+            now_local=now_local,
+            brief_exists_today=False,
+        )
+
+    def test_existing_brief_today_skips(self):
+        now_local, _ = _local_day_start_utc(
+            datetime(2026, 6, 15, 10, 0, tzinfo=UTC), "UTC"
+        )
+        assert not _brief_due(
+            enabled=True,
+            delivery_time=time(7, 0),
+            now_local=now_local,
+            brief_exists_today=True,
+        )
+
+    def test_disabled_skips(self):
+        now_local, _ = _local_day_start_utc(
+            datetime(2026, 6, 15, 10, 0, tzinfo=UTC), "UTC"
+        )
+        assert not _brief_due(
+            enabled=False,
+            delivery_time=time(7, 0),
+            now_local=now_local,
+            brief_exists_today=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tick against the dev DB (generate_daily_brief patched)
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture
+async def brief_ctx() -> AsyncGenerator[uuid.UUID, None]:
+    """A user with a brief-delivery config; cleaned up via a fresh session."""
+    session_maker = get_session_maker()
+    session = session_maker()
+    user = User(
+        email=f"brief_{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="not-a-real-hash",
+    )
+    session.add(user)
+    await session.flush()
+    user_id = user.id
+    await session.commit()
+    await session.close()
+    try:
+        yield user_id
+    finally:
+        async with session_maker() as cleanup:
+            await cleanup.execute(
+                delete(DailyBrief).where(DailyBrief.user_id == user_id)
+            )
+            await cleanup.execute(
+                delete(BriefDeliveryConfig).where(
+                    BriefDeliveryConfig.user_id == user_id
+                )
+            )
+            await cleanup.execute(delete(User).where(User.id == user_id))
+            await cleanup.commit()
+
+
+async def _add_config(user_id: uuid.UUID, *, enabled: bool = True) -> None:
+    async with get_session_maker()() as db:
+        db.add(
+            BriefDeliveryConfig(
+                user_id=user_id,
+                enabled=enabled,
+                delivery_time=time(0, 0),  # always past -> due whenever it runs
+                timezone="UTC",
+                channel=DeliveryChannel.WEB_ONLY,
+            )
+        )
+        await db.commit()
+
+
+async def test_tick_generates_for_enabled_due_user(brief_ctx):
+    await _add_config(brief_ctx, enabled=True)
+    calls: list[uuid.UUID] = []
+
+    async def _fake_generate(user, db, hours=24):
+        calls.append(user.id)
+        return MagicMock()
+
+    with patch("src.services.daily_brief.generate_daily_brief", new=_fake_generate):
+        await generate_briefs_all_users(now=datetime.now(UTC))
+
+    assert brief_ctx in calls
+
+
+async def test_tick_skips_disabled_user(brief_ctx):
+    await _add_config(brief_ctx, enabled=False)
+    calls: list[uuid.UUID] = []
+
+    async def _fake_generate(user, db, hours=24):
+        calls.append(user.id)
+        return MagicMock()
+
+    with patch("src.services.daily_brief.generate_daily_brief", new=_fake_generate):
+        await generate_briefs_all_users(now=datetime.now(UTC))
+
+    assert brief_ctx not in calls
+
+
+async def test_tick_swallows_generation_error(brief_ctx):
+    await _add_config(brief_ctx, enabled=True)
+
+    async def _raise(user, db, hours=24):
+        raise HTTPException(status_code=400, detail="Insufficient glucose data")
+
+    with patch("src.services.daily_brief.generate_daily_brief", new=_raise):
+        # Must NOT raise even though generation fails for this user.
+        await generate_briefs_all_users(now=datetime.now(UTC))
+
+
+async def test_tick_idempotent_when_brief_exists_today(brief_ctx):
+    await _add_config(brief_ctx, enabled=True)
+    now = datetime.now(UTC)
+    async with get_session_maker()() as db:
+        db.add(
+            DailyBrief(
+                user_id=brief_ctx,
+                period_start=now - timedelta(hours=24),
+                period_end=now,
+                time_in_range_pct=80.0,
+                average_glucose=120.0,
+                low_count=0,
+                high_count=0,
+                readings_count=288,
+                correction_count=0,
+                ai_summary="seeded",
+                ai_model="test",
+                ai_provider="test",
+                input_tokens=0,
+                output_tokens=0,
+            )
+        )
+        await db.commit()
+
+    calls: list[uuid.UUID] = []
+
+    async def _fake_generate(user, db, hours=24):
+        calls.append(user.id)
+        return MagicMock()
+
+    with patch("src.services.daily_brief.generate_daily_brief", new=_fake_generate):
+        await generate_briefs_all_users(now=now)
+
+    assert brief_ctx not in calls

--- a/docs/troubleshooting/alerts-or-briefs-not-firing.md
+++ b/docs/troubleshooting/alerts-or-briefs-not-firing.md
@@ -65,7 +65,7 @@ In addition to Step 2 (AI provider), check:
 
 - **Was there enough data?** A morning brief on day 1 of using GlycemicGPT will be empty -- the AI can't summarize what isn't there. Wait a few days.
 - **Did the brief generation actually run?** Look at API logs around the configured time: `docker compose logs --tail=100 api | grep -i brief`. You should see a "generating brief" entry near the time you scheduled it.
-- **Is the schedule correct?** "Morning" in **Settings → Briefs** is *server time*, not your local time -- if your platform is on a server in a different region, the time will be off.
+- **Is the schedule correct?** The brief is generated at the **delivery time in the time zone you set** in **Settings → Briefs** (not server time). The scheduler checks every few minutes and generates the day's brief once the configured time has passed *in that zone*; if it hasn't fired, confirm the time has already passed today in your configured zone (and that the time zone itself is correct).
 
 ## Still stuck?
 


### PR DESCRIPTION
## 📋 Summary

Daily briefs were only ever created by the manual `POST /briefs/generate` endpoint — nothing read the per-user `brief_delivery_configs`, so the documented automatic morning brief never fired. (Confirmed on a live instance: zero briefs despite an enabled config; a manual generate worked fine.) This adds the missing scheduled job, per your spec on the issue.

## 🔗 Related Issues

Fixes #741

## 🏷️ Type of Change

- [x] ✨ New feature (non-breaking; behind `brief_scheduler_enabled`, default on)

## 🔨 Changes Made

- **`scheduler.py` + `daily_brief.py`**: a 5-minute tick `generate_briefs_all_users` mirroring `check_alerts_all_users`. For each user with an enabled config, generate **one brief per local day** at/after their `delivery_time`, honoring the row's `timezone` (`zoneinfo`). Reuses `generate_daily_brief(user, db, hours=24)`.
- **Idempotency + catch-up from one guard** (per your direction): generate iff no brief exists for the user's current local day (`created_at >= local-midnight-in-tz`). No new column, no migration. A restart after `delivery_time` still delivers that day; once the local day rolls over with a brief present, it stops.
- **Per-user isolation**: an in-process per-user lock (mirrors Glooko's `_lock_for`); per-user errors (insufficient data → `HTTPException(400)`, no AI provider → `404`, or any transient DB error) are swallowed so one user never aborts the tick. Code comments that a multi-replica deployment would need a DB uniqueness constraint instead.
- **`config.py`**: `brief_scheduler_enabled: bool = True`, `brief_check_interval_minutes: int = 5`.
- **`brief_notifier.py`**: `notify_user_of_brief` now skips the Telegram send when `channel == WEB_ONLY`, so both the scheduler and the manual endpoint respect the configured channel.
- **`docs/troubleshooting/alerts-or-briefs-not-firing.md`**: the "briefs fire at *server time*" note is now wrong — updated to the configured delivery time in the configured timezone.

## 🧪 Test Plan

- [x] New `tests/test_brief_scheduler.py`: pure-gate unit tests (before/after `delivery_time`, brief-exists-today, disabled, **timezone boundary** — 06:30 UTC is past 07:00 in Europe/Berlin but not in UTC, local-midnight→UTC conversion) + DB-backed tick tests (enabled-only selection, disabled skip, **graceful skip when generation raises `HTTPException`**, idempotent when a brief already exists today).
- [x] `tests/test_brief_notifier.py`: updated to patch the new channel lookup; added a `web_only`→no-Telegram test.
- [x] Targeted suite (`test_brief_scheduler`, `test_daily_brief`, `test_brief_delivery_config`, `test_brief_notifier`): **97 passed**. Full backend suite green (the one unrelated failure is the pre-existing `test_nightscout_scheduler` wall-clock-budget test, which fails on `develop` too under load).
- [x] `ruff check` + `ruff format --check` clean. No migration ⇒ single Alembic head intact.

## ✅ Checklist
- [x] Self-review; style guidelines; no secrets; no new warnings
- [x] Docs updated

## Reviewer notes
- **Behavior change to flag:** a `web_only` user who *also* has a verified Telegram link will no longer get a Telegram message on **manual** generate (previously they did). Correct per the setting, but it touches the existing manual path — wanted it explicit.
- **Open-question resolutions** (from the issue): idempotency key = `created_at`-in-tz (also dedupes a same-day manual generate); tick + gate live in `daily_brief.py`; `hours=24`; eligible = enabled config AND `User.is_active`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily briefs can now auto-generate on an interval (default every 5 minutes), using your selected timezone and local delivery time.
  * Added a setting to enable/disable the automatic scheduler.
  * Delivery channel settings are respected: web-only users won’t trigger Telegram delivery.
* **Documentation**
  * Updated “brief never appeared” troubleshooting to reflect timezone-based, delivery-time generation.
* **Tests**
  * Added coverage for timezone/day-boundary gating, idempotency when a brief already exists, per-user error handling, scheduler enable/disable, and web-only skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->