### PR TITLE
feat(api): surface long-acting basal injections in TDD, AI context, and insulin views

### DIFF
--- a/apps/api/src/models/pump_data.py
+++ b/apps/api/src/models/pump_data.py
@@ -94,6 +94,18 @@ ControlIQMode = PumpActivityMode
 # command a pump to deliver 60 U.
 MAX_INSULIN_DOSE_UNITS: Final[float] = 60.0
 
+# Canonical sanity bound on a single long-acting (basal) pen INJECTION (U).
+# Larger than `MAX_INSULIN_DOSE_UNITS` because once-daily basal doses are
+# bigger: 160 U is the max single injection of the Tresiba U-200 FlexTouch (the
+# highest-capacity supported pen); anything above is a corrupt or unit-confused
+# record. This bounds the discrete injected amount carried on a BASAL_INJECTION
+# event -- NOT a U/h rate. Like `MAX_INSULIN_DOSE_UNITS`, consumers import it
+# instead of hard-coding 160: the Glooko + Nightscout ingestion mappers and the
+# display/stats read filters in `routers.integrations` -- so a legitimate large
+# basal injection accepted at ingest is not silently dropped or hidden behind
+# the lower bolus bound downstream.
+MAX_BASAL_INJECTION_UNITS: Final[float] = 160.0
+
 
 class PumpEvent(Base):
     """Stores pump events from Tandem t:connect.

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -27,7 +27,7 @@ from fastapi import (
 from fastapi.responses import FileResponse, PlainTextResponse
 from pydexcom import Dexcom
 from pydexcom import errors as dexcom_errors
-from sqlalchemy import and_, case, delete, func, select, text
+from sqlalchemy import and_, case, delete, func, or_, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from tconnectsync.api.common import ApiException
@@ -79,6 +79,7 @@ from src.models.medtronic_connect_state import (
     MedtronicConnectState,
 )
 from src.models.pump_data import (
+    MAX_BASAL_INJECTION_UNITS,
     MAX_INSULIN_DOSE_UNITS,
     PumpEvent,
     PumpEventType,
@@ -3879,6 +3880,11 @@ _AGP_MAX_ROWS = 50_000
 # doses since #726; bounding the display at 25U silently hid them while IoB and
 # safety totals still counted them. The bound excludes only corrupt rows.
 _MAX_BOLUS_UNITS = MAX_INSULIN_DOSE_UNITS
+# Sanity bound for a single long-acting (basal) pen injection (units). Larger
+# than the bolus bound -- once-daily basal doses run higher (see
+# MAX_BASAL_INJECTION_UNITS). Used as the read-filter ceiling so a legitimate
+# basal injection is not clipped by the lower bolus bound.
+_MAX_BASAL_INJECTION = MAX_BASAL_INJECTION_UNITS
 # Maximum basal rate (Tandem X2/Mobi max = 15 U/hr)
 _MAX_BASAL_RATE = 15.0
 # Maximum gap between basal records before capping (handles disconnections).
@@ -4333,6 +4339,41 @@ async def get_insulin_summary(
     )
     basal_units = float(basal_result.scalar() or 0.0)
 
+    # Long-acting (basal) pen injections (MDI -- e.g. Lantus, Tresiba). Discrete
+    # injected amounts (units), NOT a rate, so they sum directly (no LEAD time
+    # integration). Same (event_timestamp, units) dedupe as boluses collapses
+    # cross-source duplicates (e.g. the same dose reported by both Glooko and
+    # Nightscout). Bounded to the basal-injection limit, not the lower bolus
+    # bound, so a legitimate large basal dose is not clipped.
+    basal_injection_query = text(  # nosemgrep: avoid-sqlalchemy-text
+        f"""
+        WITH injections AS (
+            SELECT event_timestamp, units
+            FROM {_bolus_table}
+            WHERE user_id = :user_id
+              AND event_timestamp >= :cutoff AND event_timestamp <= :now
+              AND event_type = :basal_injection_type
+              AND units IS NOT NULL AND units > 0 AND units <= :max_injection
+            GROUP BY event_timestamp, units
+        )
+        SELECT COALESCE(SUM(units), 0) AS total_units, COUNT(*) AS injection_count
+        FROM injections
+    """
+    )
+    basal_injection_result = await db.execute(
+        basal_injection_query,
+        {
+            "user_id": str(current_user.id),
+            "cutoff": cutoff,
+            "now": now,
+            "basal_injection_type": PumpEventType.BASAL_INJECTION.value,
+            "max_injection": float(_MAX_BASAL_INJECTION),
+        },
+    )
+    basal_injection_row = basal_injection_result.one()
+    basal_injection_units = float(basal_injection_row.total_units or 0.0)
+    basal_injection_count = int(basal_injection_row.injection_count or 0)
+
     bolus_units = 0.0
     correction_units = 0.0
     bolus_count = 0
@@ -4347,11 +4388,13 @@ async def get_insulin_summary(
             bolus_units += units
             bolus_count += int(row.delivery_count)
 
-    tdd_total = basal_units + bolus_units + correction_units
+    tdd_total = basal_units + basal_injection_units + bolus_units + correction_units
     # Compute percentages from raw totals before rounding to avoid
-    # compounding rounding error.
+    # compounding rounding error. A long-acting injection is basal therapy for
+    # an MDI user, so it counts toward the basal share (it is surfaced
+    # separately via `basal_injection_units` for the distinct line item).
     if tdd_total > 0:
-        basal_pct = round((basal_units / tdd_total) * 100, 1)
+        basal_pct = round(((basal_units + basal_injection_units) / tdd_total) * 100, 1)
         bolus_pct = round(100 - basal_pct, 1)
     else:
         basal_pct = 0.0
@@ -4386,6 +4429,9 @@ async def get_insulin_summary(
             OR
             (event_type = :basal_type
              AND units <= :max_rate)
+            OR
+            (event_type = :basal_injection_type
+             AND units <= :max_injection)
           )
         """
     )
@@ -4398,8 +4444,10 @@ async def get_insulin_summary(
             "bolus_type": _bolus_val,
             "correction_type": _correction_val,
             "basal_type": _basal_val,
+            "basal_injection_type": PumpEventType.BASAL_INJECTION.value,
             "max_bolus": float(_MAX_BOLUS_UNITS),
             "max_rate": float(_MAX_BASAL_RATE),
+            "max_injection": float(_MAX_BASAL_INJECTION),
         },
     )
     earliest_row = earliest_result.first()
@@ -4413,12 +4461,15 @@ async def get_insulin_summary(
     d = max(effective_period_days, 1.0 / 24)
     tdd = round(tdd_total / d, 1)
     basal_avg = round(basal_units / d, 1)
+    basal_injection_avg = round(basal_injection_units / d, 1)
     bolus_avg = round((bolus_units + correction_units) / d, 1)
     correction_avg = round(correction_units / d, 1)
 
     return InsulinSummaryResponse(
         tdd=tdd,
         basal_units=basal_avg,
+        basal_injection_units=basal_injection_avg,
+        basal_injection_count=basal_injection_count,
         bolus_units=bolus_avg,
         correction_units=correction_avg,
         basal_pct=basal_pct,
@@ -4486,18 +4537,27 @@ async def get_bolus_review(
     # level is its own piece of work (write-time content-hash dedupe);
     # for the table view, displaying both rows with their distinct
     # source labels is an acceptable interim. See issue #574.
+    # Boluses/corrections share the 60U bound; long-acting (basal) pen
+    # injections run higher, so they carry the 160U bound. Per-type bounds keep
+    # a legitimate 90U basal injection visible while still rejecting a corrupt
+    # 90U "bolus".
     bolus_filter = [
         PumpEvent.user_id == current_user.id,
         PumpEvent.event_timestamp >= cutoff,
         PumpEvent.event_timestamp <= now,
         PumpEvent.units.is_not(None),
         PumpEvent.units >= 0,
-        PumpEvent.units <= _MAX_BOLUS_UNITS,
-        PumpEvent.event_type.in_(
-            [
-                PumpEventType.BOLUS,
-                PumpEventType.CORRECTION,
-            ]
+        or_(
+            and_(
+                PumpEvent.event_type.in_(
+                    [PumpEventType.BOLUS, PumpEventType.CORRECTION]
+                ),
+                PumpEvent.units <= _MAX_BOLUS_UNITS,
+            ),
+            and_(
+                PumpEvent.event_type == PumpEventType.BASAL_INJECTION,
+                PumpEvent.units <= _MAX_BASAL_INJECTION,
+            ),
         ),
     ]
 
@@ -4519,6 +4579,7 @@ async def get_bolus_review(
         boluses=[
             BolusReviewItem(
                 event_timestamp=e.event_timestamp,
+                event_type=e.event_type.value,
                 units=e.units or 0.0,
                 is_automated=e.is_automated,
                 control_iq_reason=e.control_iq_reason,

--- a/apps/api/src/schemas/daily_brief.py
+++ b/apps/api/src/schemas/daily_brief.py
@@ -28,6 +28,13 @@ class InsulinBreakdown(BaseModel):
         default=0.0,
         description="Estimated basal delivery (rate x time integration)",
     )
+    basal_injection_units: float = Field(
+        default=0.0,
+        description="Long-acting (basal) pen injections -- MDI, e.g. Lantus/Tresiba (units)",
+    )
+    basal_injection_count: int = Field(
+        default=0, description="Number of long-acting basal injections"
+    )
     total_units: float = Field(
         default=0.0, description="Total insulin delivered (all types)"
     )

--- a/apps/api/src/schemas/pump.py
+++ b/apps/api/src/schemas/pump.py
@@ -9,7 +9,10 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from src.models.pump_data import MAX_INSULIN_DOSE_UNITS, PumpEventType
+from src.models.pump_data import (
+    MAX_BASAL_INJECTION_UNITS,
+    PumpEventType,
+)
 
 
 class PumpEventResponse(BaseModel):
@@ -442,7 +445,19 @@ class InsulinSummaryResponse(BaseModel):
 
     tdd: float = Field(..., ge=0, description="Average total daily dose (units/day)")
     basal_units: float = Field(
-        ..., ge=0, description="Average daily basal insulin (units/day)"
+        ..., ge=0, description="Average daily basal insulin -- pump rate (units/day)"
+    )
+    basal_injection_units: float = Field(
+        default=0.0,
+        ge=0,
+        description=(
+            "Average daily long-acting (basal) pen injections -- MDI, e.g. "
+            "Lantus/Tresiba (units/day). Counted within basal_pct; surfaced "
+            "separately as a distinct line. Add to basal_units for the basal total."
+        ),
+    )
+    basal_injection_count: int = Field(
+        default=0, ge=0, description="Total long-acting basal injections in period"
     )
     bolus_units: float = Field(
         ..., ge=0, description="Average daily bolus + correction insulin (units/day)"
@@ -464,16 +479,26 @@ class InsulinSummaryResponse(BaseModel):
 
 
 class BolusReviewItem(BaseModel):
-    """A single bolus event for the review table."""
+    """A single insulin event for the review table.
+
+    Carries boluses, corrections, and long-acting (basal) pen injections; the
+    row type is `event_type` so the UI can render each distinctly. Per-type
+    safety bounds are enforced upstream in the read query (boluses/corrections
+    <= 60U, basal injections <= 160U); the field cap here is the widest of those.
+    """
 
     model_config = ConfigDict(from_attributes=True)
 
     event_timestamp: datetime
+    event_type: str = Field(
+        default=PumpEventType.BOLUS.value,
+        description="Event type: bolus | correction | basal_injection",
+    )
     units: float = Field(
         ...,
         ge=0,
-        le=MAX_INSULIN_DOSE_UNITS,
-        description="Bolus units (hard safety cap = platform max single dose, 60U)",
+        le=MAX_BASAL_INJECTION_UNITS,
+        description="Insulin units (hard safety cap = max basal injection, 160U)",
     )
     is_automated: bool = False
     control_iq_reason: str | None = None

--- a/apps/api/src/services/daily_brief.py
+++ b/apps/api/src/services/daily_brief.py
@@ -284,12 +284,13 @@ async def calculate_metrics(
     # units -- NOT a rate -- so they sum directly (no time integration). Counts
     # toward basal for the therapy picture but kept as its own line. Bounded to
     # the basal-injection limit (corrupt-record guard) -- the lower bolus bound
-    # would clip a legitimate large basal dose. Like the bolus/correction sums
-    # above, this path intentionally does NOT cross-source dedupe (that lives in
-    # the display `/insulin/summary` query); the daily brief mirrors its
-    # neighbours here rather than diverging.
-    basal_inj_result = await db.execute(
-        select(func.count(), func.coalesce(func.sum(PumpEvent.units), 0.0)).where(
+    # would clip a legitimate large basal dose. Deduplicated by
+    # (event_timestamp, units) -- matching the `/insulin/summary` query -- so the
+    # same dose imported from both Glooko and Nightscout isn't double-counted in
+    # the total fed to the AI brief.
+    basal_inj_subq = (
+        select(PumpEvent.event_timestamp, PumpEvent.units)
+        .where(
             PumpEvent.user_id == user_id,
             PumpEvent.event_timestamp >= period_start,
             PumpEvent.event_timestamp < period_end,
@@ -297,6 +298,14 @@ async def calculate_metrics(
             PumpEvent.units.is_not(None),
             PumpEvent.units > 0,
             PumpEvent.units <= MAX_BASAL_INJECTION_UNITS,
+        )
+        .group_by(PumpEvent.event_timestamp, PumpEvent.units)
+        .subquery()
+    )
+    basal_inj_result = await db.execute(
+        select(
+            func.count(basal_inj_subq.c.units),
+            func.coalesce(func.sum(basal_inj_subq.c.units), 0.0),
         )
     )
     basal_inj_row = basal_inj_result.one()

--- a/apps/api/src/services/daily_brief.py
+++ b/apps/api/src/services/daily_brief.py
@@ -12,7 +12,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.logging_config import get_logger
 from src.models.daily_brief import DailyBrief
 from src.models.glucose import GlucoseReading
-from src.models.pump_data import PumpEvent, PumpEventType
+from src.models.pump_data import (
+    MAX_BASAL_INJECTION_UNITS,
+    PumpEvent,
+    PumpEventType,
+)
 from src.models.user import User
 from src.schemas.ai_response import AIMessage
 from src.schemas.daily_brief import DailyBriefMetrics, InsulinBreakdown
@@ -96,6 +100,11 @@ def _build_analysis_prompt(
             f"  - Auto-corrections (Control-IQ): {bd.auto_correction_count} ({bd.auto_correction_units:.1f}u)"
         )
         lines.append(f"  - Basal delivery (estimated): {bd.basal_units:.1f}u")
+        if bd.basal_injection_count:
+            lines.append(
+                f"  - Long-acting injections: {bd.basal_injection_count} "
+                f"({bd.basal_injection_units:.1f}u)"
+            )
     elif metrics.total_insulin is not None:
         lines.append(f"- Total insulin delivered: {metrics.total_insulin:.1f} units")
 
@@ -271,8 +280,31 @@ async def calculate_metrics(
         duration_hours = min(duration_hours, 1.0)
         basal_units += rate * duration_hours
 
+    # Long-acting (basal) pen injections (MDI). Discrete injected amounts in
+    # units -- NOT a rate -- so they sum directly (no time integration). Counts
+    # toward basal for the therapy picture but kept as its own line. Bounded to
+    # the basal-injection limit (corrupt-record guard) -- the lower bolus bound
+    # would clip a legitimate large basal dose. Like the bolus/correction sums
+    # above, this path intentionally does NOT cross-source dedupe (that lives in
+    # the display `/insulin/summary` query); the daily brief mirrors its
+    # neighbours here rather than diverging.
+    basal_inj_result = await db.execute(
+        select(func.count(), func.coalesce(func.sum(PumpEvent.units), 0.0)).where(
+            PumpEvent.user_id == user_id,
+            PumpEvent.event_timestamp >= period_start,
+            PumpEvent.event_timestamp < period_end,
+            PumpEvent.event_type == PumpEventType.BASAL_INJECTION,
+            PumpEvent.units.is_not(None),
+            PumpEvent.units > 0,
+            PumpEvent.units <= MAX_BASAL_INJECTION_UNITS,
+        )
+    )
+    basal_inj_row = basal_inj_result.one()
+    basal_injection_count = basal_inj_row[0] or 0
+    basal_injection_units = float(basal_inj_row[1] or 0)
+
     total_bolus_corr = bolus_units + manual_corr_units + auto_corr_units
-    total_insulin = total_bolus_corr + basal_units
+    total_insulin = total_bolus_corr + basal_units + basal_injection_units
 
     breakdown = InsulinBreakdown(
         bolus_units=round(bolus_units, 1),
@@ -282,6 +314,8 @@ async def calculate_metrics(
         auto_correction_units=round(auto_corr_units, 1),
         auto_correction_count=auto_corr_count,
         basal_units=round(basal_units, 1),
+        basal_injection_units=round(basal_injection_units, 1),
+        basal_injection_count=basal_injection_count,
         total_units=round(total_insulin, 1),
     )
 

--- a/apps/api/src/services/diabetes_context.py
+++ b/apps/api/src/services/diabetes_context.py
@@ -25,6 +25,10 @@ logger = get_logger(__name__)
 GLUCOSE_CONTEXT_HOURS = 6
 PUMP_CONTEXT_HOURS = 6
 CONTROL_IQ_SUMMARY_HOURS = 24
+# Long-acting (basal) injections are typically once or twice daily, so the
+# short pump-activity window misses them most of the day. Look back far enough
+# to surface the active basal dose + timing for overnight-pattern analysis.
+BASAL_INJECTION_CONTEXT_HOURS = 30
 
 # Maximum readings to fetch for glucose context
 GLUCOSE_MAX_READINGS = 72  # ~6 hours of 5-min CGM readings
@@ -153,11 +157,32 @@ async def build_pump_section(
     user_id: uuid.UUID,
 ) -> str | None:
     """Build pump activity section from recent pump events."""
-    from src.models.pump_data import PumpEventType
+    from src.models.pump_data import PumpEvent, PumpEventType
     from src.services.tandem_sync import get_pump_events
 
     events = await get_pump_events(db, user_id, hours=PUMP_CONTEXT_HOURS, limit=500)
-    if not events:
+
+    # Long-acting (basal) injection lookback -- a once/twice-daily MDI dose
+    # falls outside the short pump-activity window most of the time, but the AI
+    # needs the active basal dose + timing for overnight-pattern analysis.
+    # Fetched over a wider window, independent of the 6h activity events above.
+    basal_inj_cutoff = datetime.now(UTC) - timedelta(
+        hours=BASAL_INJECTION_CONTEXT_HOURS
+    )
+    basal_inj_result = await db.execute(
+        select(PumpEvent)
+        .where(
+            PumpEvent.user_id == user_id,
+            PumpEvent.event_type == PumpEventType.BASAL_INJECTION,
+            PumpEvent.event_timestamp >= basal_inj_cutoff,
+            PumpEvent.units.is_not(None),
+        )
+        .order_by(PumpEvent.event_timestamp.desc())
+        .limit(5)
+    )
+    basal_injections = list(basal_inj_result.scalars().all())
+
+    if not events and not basal_injections:
         return None
 
     manual_bolus_count = 0
@@ -189,22 +214,42 @@ async def build_pump_section(
         elif event.event_type == PumpEventType.SUSPEND:
             suspend_count += 1
 
-    lines = [
-        f"[Pump Activity - last {PUMP_CONTEXT_HOURS}h]",
-        f"- Manual boluses: {manual_bolus_count} ({manual_bolus_units:.1f}u total)",
-        f"- Auto-corrections (Control-IQ): {auto_correction_count} ({auto_correction_units:.1f}u total)",
-        f"- Basal adjustments: {basal_increase_count} increases, {basal_decrease_count} decreases",
-    ]
-    if suspend_count:
-        lines.append(f"- Suspends: {suspend_count}")
-    if last_auto_correction:
-        minutes_ago = int(
-            (datetime.now(UTC) - last_auto_correction.event_timestamp).total_seconds()
-            / 60
+    lines: list[str] = []
+    if events:
+        lines.extend(
+            [
+                f"[Pump Activity - last {PUMP_CONTEXT_HOURS}h]",
+                f"- Manual boluses: {manual_bolus_count} ({manual_bolus_units:.1f}u total)",
+                f"- Auto-corrections (Control-IQ): {auto_correction_count} ({auto_correction_units:.1f}u total)",
+                f"- Basal adjustments: {basal_increase_count} increases, {basal_decrease_count} decreases",
+            ]
         )
+        if suspend_count:
+            lines.append(f"- Suspends: {suspend_count}")
+        if last_auto_correction:
+            minutes_ago = int(
+                (
+                    datetime.now(UTC) - last_auto_correction.event_timestamp
+                ).total_seconds()
+                / 60
+            )
+            lines.append(
+                f"- Last auto-correction: {last_auto_correction.units or 0:.1f}u ({minutes_ago}min ago)"
+            )
+
+    if basal_injections:
+        now = datetime.now(UTC)
         lines.append(
-            f"- Last auto-correction: {last_auto_correction.units or 0:.1f}u ({minutes_ago}min ago)"
+            f"[Long-acting (basal) injections - last {BASAL_INJECTION_CONTEXT_HOURS}h]"
         )
+        for inj in basal_injections:
+            hours_ago = (now - inj.event_timestamp).total_seconds() / 3600
+            # Glooko writes `medication`; Nightscout writes `insulin_type`.
+            meta = inj.metadata_json or {}
+            med = meta.get("medication") or meta.get("insulin_type")
+            med_label = f"{med} " if med else ""
+            lines.append(f"- {med_label}{inj.units or 0:.1f}u ({hours_ago:.0f}h ago)")
+
     return "\n".join(lines)
 
 

--- a/apps/api/src/services/integrations/glooko/mapper.py
+++ b/apps/api/src/services/integrations/glooko/mapper.py
@@ -23,7 +23,11 @@ import math
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 
-from src.models.pump_data import MAX_INSULIN_DOSE_UNITS, PumpEventType
+from src.models.pump_data import (
+    MAX_BASAL_INJECTION_UNITS,
+    MAX_INSULIN_DOSE_UNITS,
+    PumpEventType,
+)
 
 SOURCE = "glooko"
 
@@ -51,12 +55,12 @@ _MAX_BASAL_RATE_UH = 35.0
 # helpers reading in single-letter units.
 _MAX_BOLUS_DOSE_U = MAX_INSULIN_DOSE_UNITS
 
-# Sanity bound on a single long-acting (basal) pen INJECTION (U). Larger than the
-# bolus bound because once-daily basal doses are bigger: 160 U is the max single
-# injection of the Tresiba U-200 FlexTouch (the highest-capacity supported pen);
-# anything above is a corrupt or unit-confused record. This bounds the discrete
+# Sanity bound on a single long-acting (basal) pen INJECTION (U). Aliased from
+# the canonical platform bound to keep the bounds-checking helpers reading in
+# single-letter units; see ``MAX_BASAL_INJECTION_UNITS`` for the rationale (160 U
+# = Tresiba U-200 FlexTouch max single injection). This bounds the discrete
 # injected amount, NOT a U/h rate (that is _MAX_BASAL_RATE_UH).
-_MAX_BASAL_INJECTION_U = 160.0
+_MAX_BASAL_INJECTION_U = MAX_BASAL_INJECTION_UNITS
 
 
 # Glooko pump-events ``type`` -> our PumpEventType. Pod/cartridge/prime lifecycle

--- a/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_pump_events_mapper.py
@@ -218,6 +218,28 @@ def _map_bolus(treatment: NightscoutTreatment, base: dict[str, Any]) -> dict[str
     return base
 
 
+def _map_basal_injection(
+    treatment: NightscoutTreatment, base: dict[str, Any]
+) -> dict[str, Any]:
+    """MDI long-acting (basal) pen injection -- e.g. Lantus, Tresiba (#728).
+
+    `units` is the injected amount (NOT a U/h rate); the long-acting
+    `insulinType` is preserved in metadata. Stays manual (`is_automated`
+    defaults False) -- a pen injection is never pump-automated. Deliberately
+    excluded from rapid-acting IoB downstream.
+    """
+    extras: dict[str, Any] = {}
+    if treatment.insulin_type:
+        extras["insulin_type"] = treatment.insulin_type
+    base.update(
+        {
+            "units": treatment.insulin,
+            "metadata_json": _build_metadata(treatment, extra=extras),
+        }
+    )
+    return base
+
+
 def _map_carb_entry(
     treatment: NightscoutTreatment, base: dict[str, Any]
 ) -> dict[str, Any]:
@@ -492,6 +514,7 @@ def map_treatment_to_pump_events(
     # is special-cased below because it produces TWO rows.
     routing = {
         "bolus": (PumpEventType.BOLUS, _map_bolus),
+        "basal_injection": (PumpEventType.BASAL_INJECTION, _map_basal_injection),
         "carb_entry": (PumpEventType.CARBS, _map_carb_entry),
         "temp_basal": (PumpEventType.BASAL, _map_temp_basal),
         "temp_basal_suspend": (PumpEventType.SUSPEND, _map_temp_basal_suspend),

--- a/apps/api/src/services/integrations/nightscout/models.py
+++ b/apps/api/src/services/integrations/nightscout/models.py
@@ -344,6 +344,7 @@ class NightscoutEntry(BaseModel):
 # enum captures what the translator actually does with the record.
 SemanticKind = Literal[
     "bolus",
+    "basal_injection",  # MDI long-acting (basal) pen injection -- discrete dose
     "carb_entry",
     "meal_bolus_pair",  # carbs + insulin -- split into bolus + carb_entry rows
     "temp_basal",
@@ -374,6 +375,34 @@ _DEVICE_EVENT_EVENTTYPES = frozenset(
         "sensor stop",
         "insulin change",
         "pump battery change",
+    }
+)
+
+
+# `insulinType` strings that identify a long-acting (basal) injection. The
+# field carries either a category ("basal") or a product name depending on the
+# uploader, so we match both an explicit "basal" category and known long-acting
+# generics/brands. Rapid-acting products (Humalog, NovoRapid, Fiasp, ...) and
+# the ambiguous "intermediate" (NPH) are deliberately excluded: misclassifying
+# rapid insulin as long-acting would drop it from rapid-acting IoB and
+# under-count active insulin -- a safety risk in the unsafe direction. Matched
+# as substrings so qualified product names (e.g. "insulin glargine u-300") still
+# resolve. NOT keyed on AAPS `isBasalInsulin`: that flag marks pump basal insulin
+# (rate-equivalent micro-delivery), is False on SMBs, and never denotes an MDI
+# pen injection.
+_LONG_ACTING_INSULIN_INDICATORS = frozenset(
+    {
+        "basal",
+        "glargine",
+        "lantus",
+        "toujeo",
+        "basaglar",
+        "semglee",
+        "rezvoglar",
+        "detemir",
+        "levemir",
+        "degludec",
+        "tresiba",
     }
 )
 
@@ -596,6 +625,29 @@ class NightscoutTreatment(BaseModel):
         but that requires uploader detection upstream of this property.
         """
         return self.normalized_event_type == "external insulin"
+
+    @property
+    def is_basal_injection(self) -> bool:
+        """A long-acting (basal) pen INJECTION -- e.g. Lantus, Tresiba (#728).
+
+        MDI users' once-daily basal dose arrives as an insulin treatment whose
+        `insulinType` names a long-acting product or the "basal" category. It is
+        a discrete injected amount (units), NOT a pump rate, so it is routed to
+        BASAL_INJECTION and kept out of rapid-acting IoB rather than falling
+        through to the `has_insulin -> bolus` default (which would pollute the
+        rapid-acting IoB/TDD it does not belong to).
+
+        Conservative by design: only an explicit long-acting `insulinType`
+        triggers this. A bare "External Insulin" or a rapid/unspecified
+        `insulinType` stays a BOLUS, because misclassifying rapid insulin as
+        basal would drop it from active-insulin math.
+        """
+        if not self.has_insulin:
+            return False
+        insulin_type = (self.insulin_type or "").strip().lower()
+        if not insulin_type:
+            return False
+        return any(ind in insulin_type for ind in _LONG_ACTING_INSULIN_INDICATORS)
 
     @property
     def _is_zero_rate_temp(self) -> bool:
@@ -825,6 +877,16 @@ class NightscoutTreatment(BaseModel):
         # --- Field-presence routing (last resort, handles empty eventType
         # from xDrip+ and unrecognized eventTypes from any uploader) ---
 
+        # Long-acting (basal) pen injection -- a discrete dose kept out of rapid
+        # IoB. Checked BEFORE both the meal pair and the generic has_insulin
+        # fallback: a long-acting dose must never be split out / ingested as a
+        # rapid bolus (that would pollute rapid-acting IoB/TDD). A carbs field on
+        # such a record is pathological (you don't log a meal on a once-daily
+        # basal shot); the long-acting classification wins and the incidental
+        # carbs are not split out. SMB/automated rapid insulin is unaffected --
+        # it never carries a long-acting `insulinType` (see is_basal_injection).
+        if self.is_basal_injection:
+            return "basal_injection"
         if self.has_carbs and self.has_insulin:
             return "meal_bolus_pair"
         if self.has_insulin:

--- a/apps/api/tests/test_aggregate_stats.py
+++ b/apps/api/tests/test_aggregate_stats.py
@@ -1762,7 +1762,7 @@ class TestBasalInjectionSurfacing:
                     PumpEvent(
                         user_id=uid,
                         event_type=PumpEventType.BOLUS,
-                        event_timestamp=ts - timedelta(seconds=1),
+                        event_timestamp=ts,
                         units=6.0,
                         is_automated=False,
                         received_at=ts,
@@ -1813,7 +1813,7 @@ class TestBasalInjectionSurfacing:
                     PumpEvent(
                         user_id=uid,
                         event_type=PumpEventType.BOLUS,
-                        event_timestamp=ts - timedelta(seconds=1),
+                        event_timestamp=ts,
                         units=90.0,
                         is_automated=False,
                         received_at=ts,

--- a/apps/api/tests/test_aggregate_stats.py
+++ b/apps/api/tests/test_aggregate_stats.py
@@ -1726,3 +1726,111 @@ class TestPenDoseDisplayBound:
         # bolus_units reflects the 30U dose (per-day divisor may scale it, but
         # it must be well above the old 25U ceiling and not include the 70U row).
         assert data["bolus_units"] >= 30.0
+
+
+@pytest.mark.asyncio
+class TestBasalInjectionSurfacing:
+    """Long-acting (basal) pen injections surface in TDD + the review table,
+    counted toward the basal share but shown distinctly (issue #728/#742).
+
+    They use the higher 160U bound (Tresiba U-200 max single injection), not
+    the 60U bolus bound.
+    """
+
+    async def test_basal_injection_counts_as_basal_in_summary(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie, user_id = await register_and_login(client)
+            async for db in get_db():
+                uid = uuid.UUID(user_id)
+                ts = _stable_test_ts(days=1)
+                # An MDI user: one 24U long-acting injection + a 6U bolus, no
+                # pump basal rate at all.
+                db.add(
+                    PumpEvent(
+                        user_id=uid,
+                        event_type=PumpEventType.BASAL_INJECTION,
+                        event_timestamp=ts,
+                        units=24.0,
+                        is_automated=False,
+                        received_at=ts,
+                        source="glooko",
+                    )
+                )
+                db.add(
+                    PumpEvent(
+                        user_id=uid,
+                        event_type=PumpEventType.BOLUS,
+                        event_timestamp=ts - timedelta(seconds=1),
+                        units=6.0,
+                        is_automated=False,
+                        received_at=ts,
+                        source="glooko",
+                    )
+                )
+                await db.commit()
+                break
+
+            resp = await client.get(
+                "/api/integrations/insulin/summary?days=1",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Surfaced as its own line item...
+        assert data["basal_injection_units"] >= 24.0
+        assert data["basal_injection_count"] == 1
+        # ...and counted toward the basal share (not 0% basal for an MDI user).
+        # 24 basal / (24 basal + 6 bolus) = 80%.
+        assert data["basal_pct"] == pytest.approx(80.0, abs=0.5)
+        assert data["bolus_pct"] == pytest.approx(20.0, abs=0.5)
+
+    async def test_basal_injection_in_review_with_type_and_higher_bound(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            cookie, user_id = await register_and_login(client)
+            async for db in get_db():
+                uid = uuid.UUID(user_id)
+                ts = _stable_test_ts(days=1)
+                # 90U basal injection: above the 60U bolus bound but within the
+                # 160U injection bound -> must appear, tagged as its type.
+                db.add(
+                    PumpEvent(
+                        user_id=uid,
+                        event_type=PumpEventType.BASAL_INJECTION,
+                        event_timestamp=ts,
+                        units=90.0,
+                        is_automated=False,
+                        received_at=ts,
+                        source="nightscout",
+                    )
+                )
+                # 90U *bolus*: corrupt for a rapid dose -> still excluded by the
+                # 60U bolus bound. Proves the bound is per-type.
+                db.add(
+                    PumpEvent(
+                        user_id=uid,
+                        event_type=PumpEventType.BOLUS,
+                        event_timestamp=ts - timedelta(seconds=1),
+                        units=90.0,
+                        is_automated=False,
+                        received_at=ts,
+                        source="nightscout",
+                    )
+                )
+                await db.commit()
+                break
+
+            resp = await client.get(
+                "/api/integrations/bolus/review?days=1&limit=10",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Only the basal injection survives; the 90U bolus is rejected.
+        assert data["total_count"] == 1
+        row = data["boluses"][0]
+        assert row["event_type"] == "basal_injection"
+        assert row["units"] == 90.0

--- a/apps/api/tests/test_daily_brief.py
+++ b/apps/api/tests/test_daily_brief.py
@@ -92,7 +92,8 @@ class TestCalculateMetrics:
         correction_result = MagicMock()
         correction_result.scalar.return_value = 0
 
-        # Mock insulin breakdown queries: bolus, manual_corr, auto_corr, seed_basal, basal
+        # Mock insulin breakdown queries: bolus, manual_corr, auto_corr,
+        # seed_basal, basal, basal_injection
         bolus_result = MagicMock()
         bolus_result.one.return_value = (2, 10.0)
         manual_corr_result = MagicMock()
@@ -103,6 +104,9 @@ class TestCalculateMetrics:
         seed_basal_result.first.return_value = None  # no pre-window basal
         basal_result = MagicMock()
         basal_result.all.return_value = []  # no basal events
+        # One long-acting (basal) injection of 20.0 U (issue #728)
+        basal_inj_result = MagicMock()
+        basal_inj_result.one.return_value = (1, 20.0)
 
         mock_db.execute.side_effect = [
             glucose_result,
@@ -112,6 +116,7 @@ class TestCalculateMetrics:
             auto_corr_result,
             seed_basal_result,
             basal_result,
+            basal_inj_result,
         ]
 
         user_id = uuid.uuid4()
@@ -125,12 +130,15 @@ class TestCalculateMetrics:
         assert metrics.average_glucose == 120.0
         assert metrics.low_count == 0
         assert metrics.high_count == 0
-        assert metrics.total_insulin == 17.5
+        # 10 bolus + 5 manual corr + 2.5 auto corr + 20 basal injection
+        assert metrics.total_insulin == 37.5
         assert metrics.insulin_breakdown is not None
         assert metrics.insulin_breakdown.bolus_units == 10.0
         assert metrics.insulin_breakdown.correction_units == 5.0
         assert metrics.insulin_breakdown.auto_correction_units == 2.5
         assert metrics.insulin_breakdown.basal_units == 0.0
+        assert metrics.insulin_breakdown.basal_injection_units == 20.0
+        assert metrics.insulin_breakdown.basal_injection_count == 1
 
     async def test_mixed_readings_with_lows_and_highs(self):
         """Test metrics with a mix of low, in-range, and high readings."""
@@ -154,6 +162,8 @@ class TestCalculateMetrics:
         seed_basal_result.first.return_value = None
         basal_result = MagicMock()
         basal_result.all.return_value = []
+        basal_inj_result = MagicMock()
+        basal_inj_result.one.return_value = (0, 0.0)
 
         mock_db.execute.side_effect = [
             glucose_result,
@@ -163,6 +173,7 @@ class TestCalculateMetrics:
             auto_corr_result,
             seed_basal_result,
             basal_result,
+            basal_inj_result,
         ]
 
         user_id = uuid.uuid4()
@@ -199,6 +210,8 @@ class TestCalculateMetrics:
         seed_basal_result.first.return_value = None
         basal_result = MagicMock()
         basal_result.all.return_value = []
+        basal_inj_result = MagicMock()
+        basal_inj_result.one.return_value = (0, 0.0)
 
         mock_db.execute.side_effect = [
             glucose_result,
@@ -208,6 +221,7 @@ class TestCalculateMetrics:
             auto_corr_result,
             seed_basal_result,
             basal_result,
+            basal_inj_result,
         ]
 
         user_id = uuid.uuid4()

--- a/apps/api/tests/test_diabetes_context.py
+++ b/apps/api/tests/test_diabetes_context.py
@@ -1,6 +1,8 @@
 """Story 35.1: Tests for shared diabetes context builders."""
 
 import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,6 +12,7 @@ from src.services.diabetes_context import (
     PumpProfileSummary,
     _sanitize_for_prompt,
     build_pump_profile_section,
+    build_pump_section,
     format_iob_for_prompt,
     format_pump_profile_for_prompt,
     get_pump_profile_summary,
@@ -284,3 +287,64 @@ class TestFormatIobForPrompt:
         assert result is not None
         assert "3.2 units" in result
         assert "2.5u" in result
+
+
+@pytest.mark.asyncio
+class TestBuildPumpSectionBasalInjection:
+    """A long-acting (basal) injection must surface in the AI pump section even
+    when it falls outside the short 6h pump-activity window (issue #728/#742),
+    so the model knows the active basal dose + timing for overnight analysis.
+    """
+
+    @staticmethod
+    def _mock_db_with_injections(injections: list) -> AsyncMock:
+        db = AsyncMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = injections
+        db.execute.return_value = result
+        return db
+
+    @patch("src.services.tandem_sync.get_pump_events")
+    async def test_basal_injection_lookback_renders(self, mock_get_events):
+        # No recent 6h pump activity, but a 24U basal injection 9h ago.
+        mock_get_events.return_value = []
+        now = datetime.now(UTC)
+        inj = SimpleNamespace(
+            event_timestamp=now - timedelta(hours=9),
+            units=24.0,
+            metadata_json={"medication": "Tresiba®"},
+        )
+        db = self._mock_db_with_injections([inj])
+
+        section = await build_pump_section(db, uuid.uuid4())
+
+        assert section is not None
+        assert "Long-acting (basal) injections" in section
+        assert "Tresiba®" in section
+        assert "24.0u" in section
+        assert "9h ago" in section
+
+    @patch("src.services.tandem_sync.get_pump_events")
+    async def test_insulin_type_used_when_no_medication(self, mock_get_events):
+        mock_get_events.return_value = []
+        now = datetime.now(UTC)
+        inj = SimpleNamespace(
+            event_timestamp=now - timedelta(hours=2),
+            units=18.0,
+            metadata_json={"insulin_type": "Lantus"},
+        )
+        db = self._mock_db_with_injections([inj])
+
+        section = await build_pump_section(db, uuid.uuid4())
+        assert section is not None
+        assert "Lantus" in section
+
+    @patch("src.services.tandem_sync.get_pump_events")
+    async def test_returns_none_when_no_activity_and_no_injections(
+        self, mock_get_events
+    ):
+        mock_get_events.return_value = []
+        db = self._mock_db_with_injections([])
+
+        section = await build_pump_section(db, uuid.uuid4())
+        assert section is None

--- a/apps/api/tests/test_nightscout_models.py
+++ b/apps/api/tests/test_nightscout_models.py
@@ -1157,6 +1157,83 @@ class TestAdversarialRegressions:
         assert t.semantic_kind == "bolus"
 
 
+class TestBasalInjectionClassification:
+    """MDI long-acting (basal) pen injection detection (issue #728).
+
+    A long-acting dose must route to `basal_injection` (kept out of rapid IoB),
+    NOT fall through to the `has_insulin -> bolus` default. The detection is
+    conservative: only an explicit long-acting `insulinType` triggers it, so
+    rapid/automated insulin is never misclassified (which would drop it from
+    active-insulin math -- unsafe).
+    """
+
+    def _t(self, **kwargs):
+        base = {"insulin": 18.0, "created_at": "2026-05-06T07:00:00Z"}
+        base.update(kwargs)
+        return NightscoutTreatment.model_validate(base)
+
+    def test_insulin_type_basal_category_is_basal_injection(self):
+        t = self._t(insulinType="basal")
+        assert t.is_basal_injection is True
+        assert t.semantic_kind == "basal_injection"
+
+    def test_long_acting_product_name_is_basal_injection(self):
+        # Product names (with qualifiers) resolve via substring match.
+        for name in ("Lantus", "Tresiba", "insulin glargine u-300", "Levemir"):
+            t = self._t(insulinType=name)
+            assert t.is_basal_injection is True, name
+            assert t.semantic_kind == "basal_injection", name
+
+    def test_external_insulin_with_basal_type_is_basal_injection(self):
+        t = self._t(eventType="External Insulin", insulinType="basal")
+        assert t.semantic_kind == "basal_injection"
+
+    def test_rapid_insulin_type_stays_bolus(self):
+        # Humalog/Fiasp are rapid-acting -- must NOT become basal_injection.
+        for name in ("Humalog", "Fiasp", "NovoRapid"):
+            t = self._t(insulinType=name)
+            assert t.is_basal_injection is False, name
+            assert t.semantic_kind == "bolus", name
+
+    def test_no_insulin_type_stays_bolus(self):
+        t = self._t()  # insulin present, no insulinType
+        assert t.is_basal_injection is False
+        assert t.semantic_kind == "bolus"
+
+    def test_intermediate_nph_not_reclassified(self):
+        # "intermediate" (NPH) is ambiguous -- deliberately left as bolus
+        # rather than risk dropping it from rapid IoB.
+        t = self._t(insulinType="intermediate")
+        assert t.is_basal_injection is False
+        assert t.semantic_kind == "bolus"
+
+    def test_aaps_smb_never_basal_injection(self):
+        # AAPS SMB is automated rapid insulin (type=SMB). isBasalInsulin must
+        # NOT pull it into basal_injection -- that would under-count active IoB.
+        t = self._t(
+            eventType="Correction Bolus",
+            insulin=0.3,
+            type="SMB",
+            isBasalInsulin=False,
+        )
+        assert t.is_basal_injection is False
+        assert t.is_smb is True
+        assert t.semantic_kind == "bolus"
+
+    def test_zero_insulin_basal_type_not_injection(self):
+        # No actual insulin delivered -> nothing to record.
+        t = self._t(insulin=0, insulinType="basal")
+        assert t.is_basal_injection is False
+
+    def test_carbs_plus_long_acting_routes_to_basal_injection_not_meal_pair(self):
+        # A (pathological) carbs + long-acting record must NOT split into a rapid
+        # meal bolus -- the long-acting classification wins so the dose stays out
+        # of rapid IoB.
+        t = self._t(insulinType="Tresiba", carbs=30)
+        assert t.is_basal_injection is True
+        assert t.semantic_kind == "basal_injection"
+
+
 # ---------------------------------------------------------------------------
 # Fixture invariants -- meta-finding from the adversarial review
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_nightscout_translator.py
+++ b/apps/api/tests/test_nightscout_translator.py
@@ -286,6 +286,50 @@ class TestTreatmentsPath:
         assert ev.metadata_json["source_uploader"] == "loop"
 
     @pytest.mark.asyncio
+    async def test_long_acting_injection_routes_to_basal_injection(
+        self, translator_ctx
+    ):
+        """MDI long-acting pen dose -> BASAL_INJECTION, NOT a rapid bolus (#728).
+
+        Before this, a long-acting dose fell through to the has_insulin -> bolus
+        default and polluted rapid-acting IoB/TDD.
+        """
+        session, user_id, conn_id = translator_ctx
+        pump_outcome, _ = await translate_treatments(
+            [
+                {
+                    "_id": "basalinj0000000000000001",
+                    "eventType": "External Insulin",
+                    "insulin": 24.0,
+                    "insulinType": "Tresiba",
+                    "enteredBy": "Trio",
+                    "created_at": "2026-05-06T07:00:00Z",
+                }
+            ],
+            session=session,
+            user_id=str(user_id),
+            connection_id=str(conn_id),
+        )
+        await session.flush()
+        assert pump_outcome.inserted == 1
+
+        rows = (
+            (
+                await session.execute(
+                    select(PumpEvent).where(PumpEvent.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        ev = rows[0]
+        assert ev.event_type == PumpEventType.BASAL_INJECTION
+        assert ev.units == 24.0
+        assert ev.is_automated is False  # a pen injection is never automated
+        assert ev.metadata_json["insulin_type"] == "Tresiba"
+
+    @pytest.mark.asyncio
     async def test_meal_bolus_pair_splits_into_two_linked_rows(self, translator_ctx):
         session, user_id, conn_id = translator_ctx
         await translate_treatments(

--- a/apps/api/tests/test_telegram_chat.py
+++ b/apps/api/tests/test_telegram_chat.py
@@ -254,6 +254,21 @@ class TestBuildIobSection:
         assert result is None
 
 
+def _db_no_basal_injections() -> AsyncMock:
+    """A db mock whose basal-injection lookback query returns no rows.
+
+    `build_pump_section` issues a direct `db.execute(...)` for the long-acting
+    (basal) injection lookback (issue #742) in addition to `get_pump_events`;
+    these tests cover the 6h pump-activity path, so the injection query yields
+    nothing and the activity assertions stay unchanged.
+    """
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    db.execute.return_value = result
+    return db
+
+
 class TestBuildPumpSection:
     """Tests for build_pump_section."""
 
@@ -261,7 +276,7 @@ class TestBuildPumpSection:
     @patch("src.services.tandem_sync.get_pump_events", new_callable=AsyncMock)
     async def test_no_events_returns_none(self, mock_get_events):
         mock_get_events.return_value = []
-        result = await build_pump_section(AsyncMock(), uuid.uuid4())
+        result = await build_pump_section(_db_no_basal_injections(), uuid.uuid4())
         assert result is None
 
     @pytest.mark.asyncio
@@ -271,7 +286,7 @@ class TestBuildPumpSection:
             make_pump_event("bolus", units=3.0, is_automated=False),
             make_pump_event("bolus", units=5.0, is_automated=False),
         ]
-        result = await build_pump_section(AsyncMock(), uuid.uuid4())
+        result = await build_pump_section(_db_no_basal_injections(), uuid.uuid4())
 
         assert "Manual boluses: 2" in result
         assert "8.0u total" in result
@@ -282,7 +297,7 @@ class TestBuildPumpSection:
         mock_get_events.return_value = [
             make_pump_event("correction", units=0.5, is_automated=True, minutes_ago=10),
         ]
-        result = await build_pump_section(AsyncMock(), uuid.uuid4())
+        result = await build_pump_section(_db_no_basal_injections(), uuid.uuid4())
 
         assert "Auto-corrections (Control-IQ): 1" in result
         assert "0.5u total" in result
@@ -296,7 +311,7 @@ class TestBuildPumpSection:
             make_pump_event("basal", is_automated=True, basal_adjustment_pct=-10.0),
             make_pump_event("basal", is_automated=True, basal_adjustment_pct=20.0),
         ]
-        result = await build_pump_section(AsyncMock(), uuid.uuid4())
+        result = await build_pump_section(_db_no_basal_injections(), uuid.uuid4())
 
         assert "2 increases" in result
         assert "1 decreases" in result
@@ -307,7 +322,7 @@ class TestBuildPumpSection:
         mock_get_events.return_value = [
             make_pump_event("suspend", units=None),
         ]
-        result = await build_pump_section(AsyncMock(), uuid.uuid4())
+        result = await build_pump_section(_db_no_basal_injections(), uuid.uuid4())
 
         assert "Suspends: 1" in result
 

--- a/apps/web/__tests__/components/dashboard/bolus-review-table.test.tsx
+++ b/apps/web/__tests__/components/dashboard/bolus-review-table.test.tsx
@@ -18,6 +18,7 @@ let mockHookReturn: {
   data: {
     boluses: Array<{
       event_timestamp: string;
+      event_type?: string;
       units: number;
       is_automated: boolean;
       control_iq_reason: string | null;
@@ -163,7 +164,7 @@ describe("BolusReviewTable", () => {
       mockHookReturn.error = "Server error";
       renderComponent();
       expect(
-        screen.getByRole("radiogroup", { name: /bolus review time period/i })
+        screen.getByRole("radiogroup", { name: /insulin review time period/i })
       ).toBeInTheDocument();
     });
   });
@@ -173,7 +174,7 @@ describe("BolusReviewTable", () => {
       mockHookReturn.data = null;
       renderComponent();
       expect(
-        screen.getByText("No bolus events recorded for this period.")
+        screen.getByText("No insulin events recorded for this period.")
       ).toBeInTheDocument();
     });
 
@@ -181,7 +182,7 @@ describe("BolusReviewTable", () => {
       mockHookReturn.data = makeData({ boluses: [], total_count: 0 });
       renderComponent();
       expect(
-        screen.getByText("No bolus events recorded for this period.")
+        screen.getByText("No insulin events recorded for this period.")
       ).toBeInTheDocument();
     });
   });
@@ -264,7 +265,29 @@ describe("BolusReviewTable", () => {
 
     it("shows heading text", () => {
       renderComponent();
-      expect(screen.getByText("Recent Boluses")).toBeInTheDocument();
+      expect(screen.getByText("Recent Insulin")).toBeInTheDocument();
+    });
+
+    it("renders a long-acting basal injection with its type badge and full units", () => {
+      mockHookReturn.data = makeData({
+        boluses: [
+          {
+            event_timestamp: "2026-03-01T07:00:00Z",
+            event_type: "basal_injection",
+            units: 90.0, // above the 50U bolus display cap -- must NOT show ">50"
+            is_automated: false,
+            control_iq_reason: null,
+            pump_activity_mode: null,
+            iob_at_event: null,
+            bg_at_event: null,
+          },
+        ],
+        total_count: 1,
+      });
+      renderComponent();
+      expect(screen.getByText("Basal injection")).toBeInTheDocument();
+      expect(screen.getByText("90.00 U")).toBeInTheDocument();
+      expect(screen.getByText("Long-acting (basal)")).toBeInTheDocument();
     });
 
     it("shows truncation notice when total > displayed", () => {

--- a/apps/web/__tests__/components/dashboard/insulin-summary-stats.test.tsx
+++ b/apps/web/__tests__/components/dashboard/insulin-summary-stats.test.tsx
@@ -18,6 +18,8 @@ let mockHookReturn: {
   data: {
     tdd: number;
     basal_units: number;
+    basal_injection_units?: number;
+    basal_injection_count?: number;
     bolus_units: number;
     correction_units: number;
     basal_pct: number;
@@ -184,6 +186,29 @@ describe("InsulinSummaryStats", () => {
       renderComponent();
       expect(screen.getByText("22.0 U")).toBeInTheDocument();
       expect(screen.getByText("52% of TDD")).toBeInTheDocument();
+    });
+
+    it("folds long-acting injection into the basal value with a distinct sub-line", () => {
+      // MDI user: no pump basal rate, all basal is a 24U injection.
+      mockHookReturn.data = makeData({
+        basal_units: 0,
+        basal_injection_units: 24.0,
+        basal_injection_count: 1,
+        bolus_units: 6.0,
+        correction_units: 0,
+        basal_pct: 80.0,
+        bolus_pct: 20.0,
+      });
+      renderComponent();
+      // Basal headline = pump basal (0) + injection (24) = 24.0 U
+      expect(screen.getByText("24.0 U")).toBeInTheDocument();
+      // ...with the distinct injection breakdown sub-line.
+      expect(screen.getByText("incl. 24.0 U injection")).toBeInTheDocument();
+    });
+
+    it("omits the injection sub-line when there are no injections", () => {
+      renderComponent();
+      expect(screen.queryByText(/incl\..*injection/)).not.toBeInTheDocument();
     });
 
     it("displays bolus units with percentage and split assessment", () => {

--- a/apps/web/src/components/dashboard/bolus-review-table.tsx
+++ b/apps/web/src/components/dashboard/bolus-review-table.tsx
@@ -57,13 +57,24 @@ function SkeletonRow() {
 }
 
 const MAX_BOLUS_DISPLAY = 50;
+// Long-acting (basal) injections run higher than boluses (Tresiba U-200 max
+// single injection = 160U), so they get a wider display ceiling.
+const MAX_BASAL_INJECTION_DISPLAY = 160;
 const BG_MIN = 20;
 const BG_MAX = 500;
 
-function formatUnits(value: number | null | undefined, decimals: number): string {
+function formatUnits(
+  value: number | null | undefined,
+  decimals: number,
+  maxDisplay: number = MAX_BOLUS_DISPLAY
+): string {
   if (value == null || !Number.isFinite(value) || value < 0) return "---";
-  if (value > MAX_BOLUS_DISPLAY) return `>${MAX_BOLUS_DISPLAY}`;
+  if (value > maxDisplay) return `>${maxDisplay}`;
   return `${value.toFixed(decimals)} U`;
+}
+
+function isBasalInjection(item: BolusReviewItem): boolean {
+  return item.event_type === "basal_injection";
 }
 
 function formatBg(value: number | null | undefined): string {
@@ -73,19 +84,30 @@ function formatBg(value: number | null | undefined): string {
 }
 
 function BolusRow({ bolus }: { bolus: BolusReviewItem }) {
+  const basalInjection = isBasalInjection(bolus);
+  const unitsMax = basalInjection ? MAX_BASAL_INJECTION_DISPLAY : MAX_BOLUS_DISPLAY;
+  const typeLabel = basalInjection
+    ? "basal injection"
+    : bolus.is_automated
+      ? "automated"
+      : "manual";
   return (
     <tr
       className="border-b border-slate-200/50 dark:border-slate-800/50 hover:bg-slate-100/30 dark:hover:bg-slate-800/30 transition-colors"
-      aria-label={`Bolus at ${formatDateTime(bolus.event_timestamp)}, ${formatUnits(bolus.units, 2)}, ${bolus.is_automated ? "automated" : "manual"}`}
+      aria-label={`Insulin at ${formatDateTime(bolus.event_timestamp)}, ${formatUnits(bolus.units, 2, unitsMax)}, ${typeLabel}`}
     >
       <td className="px-4 py-3 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
         {formatDateTime(bolus.event_timestamp)}
       </td>
       <td className="px-4 py-3 text-sm text-slate-900 dark:text-white font-medium whitespace-nowrap">
-        {formatUnits(bolus.units, 2)}
+        {formatUnits(bolus.units, 2, unitsMax)}
       </td>
       <td className="px-4 py-3 whitespace-nowrap">
-        {bolus.is_automated ? (
+        {basalInjection ? (
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-sky-500/20 text-sky-700 dark:text-sky-300">
+            Basal injection
+          </span>
+        ) : bolus.is_automated ? (
           <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-violet-500/20 text-violet-700 dark:text-violet-300">
             Auto
           </span>
@@ -96,15 +118,17 @@ function BolusRow({ bolus }: { bolus: BolusReviewItem }) {
         )}
       </td>
       <td className="px-4 py-3 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
-        {formatBg(bolus.bg_at_event)}
+        {basalInjection ? "---" : formatBg(bolus.bg_at_event)}
       </td>
       <td className="px-4 py-3 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
-        {formatUnits(bolus.iob_at_event, 1)}
+        {basalInjection ? "---" : formatUnits(bolus.iob_at_event, 1)}
       </td>
       <td className="px-4 py-3 text-sm text-slate-500 dark:text-slate-400 whitespace-nowrap max-w-[200px] truncate">
-        {bolus.is_automated
-          ? (bolus.control_iq_reason || "Automated correction")
-          : ""}
+        {basalInjection
+          ? "Long-acting (basal)"
+          : bolus.is_automated
+            ? bolus.control_iq_reason || "Automated correction"
+            : ""}
       </td>
     </tr>
   );
@@ -139,7 +163,7 @@ export function BolusReviewTable({ className }: BolusReviewTableProps) {
   const noData = !data || !data.boluses || data.boluses.length === 0;
 
   const periodSelector = (
-    <div className="flex gap-1" role="radiogroup" aria-label="Bolus review time period">
+    <div className="flex gap-1" role="radiogroup" aria-label="Insulin review time period">
       {PERIOD_OPTIONS.map((opt, i) => (
         <button
           key={opt.value}
@@ -176,7 +200,7 @@ export function BolusReviewTable({ className }: BolusReviewTableProps) {
             <ListOrdered className="h-5 w-5 text-violet-400" aria-hidden="true" />
           </div>
           <h2 id="bolus-review-heading" className="text-slate-900 dark:text-white font-semibold">
-            Recent Boluses
+            Recent Insulin
             <span className="text-slate-500 dark:text-slate-400 text-sm font-normal ml-2">
               {periodLabel}
             </span>
@@ -223,7 +247,7 @@ export function BolusReviewTable({ className }: BolusReviewTableProps) {
         </div>
       ) : noData ? (
         <p className="text-slate-500 dark:text-slate-400 text-sm text-center py-4">
-          No bolus events recorded for this period.
+          No insulin events recorded for this period.
         </p>
       ) : (
         <div className="overflow-x-auto max-h-96 overflow-y-auto">

--- a/apps/web/src/components/dashboard/insulin-summary-stats.tsx
+++ b/apps/web/src/components/dashboard/insulin-summary-stats.tsx
@@ -70,10 +70,20 @@ interface StatCardProps {
   value: string;
   subtitle: string;
   subtitleColor?: string;
+  // Optional second subtitle line (e.g. a distinct basal-injection breakdown).
+  subtitle2?: string;
   ariaLabel: string;
 }
 
-function StatCard({ icon, label, value, subtitle, subtitleColor = "text-slate-500", ariaLabel }: StatCardProps) {
+function StatCard({
+  icon,
+  label,
+  value,
+  subtitle,
+  subtitleColor = "text-slate-500",
+  subtitle2,
+  ariaLabel,
+}: StatCardProps) {
   return (
     <div className="space-y-1" role="group" aria-label={ariaLabel}>
       <div className="flex items-center gap-2">
@@ -82,6 +92,9 @@ function StatCard({ icon, label, value, subtitle, subtitleColor = "text-slate-50
       </div>
       <p className="text-2xl font-bold text-slate-900 dark:text-white">{value}</p>
       <p className={`text-xs ${subtitleColor}`}>{subtitle}</p>
+      {subtitle2 ? (
+        <p className="text-xs text-slate-500 dark:text-slate-500">{subtitle2}</p>
+      ) : null}
     </div>
   );
 }
@@ -203,10 +216,20 @@ export function InsulinSummaryStats({ className }: InsulinSummaryStatsProps) {
           <StatCard
             icon={<Droplets className="h-4 w-4 text-sky-400" aria-hidden="true" />}
             label="Basal"
-            value={`${safeFixed1(data.basal_units)} U`}
+            // Basal therapy = pump basal rate + any long-acting (MDI) injection.
+            value={`${safeFixed1((data.basal_units ?? 0) + (data.basal_injection_units ?? 0))} U`}
             subtitle={`${safeRound(data.basal_pct)}% of TDD`}
             subtitleColor={splitAssessment?.color ?? "text-slate-500"}
-            ariaLabel={`Basal: ${safeFixed1(data.basal_units)} units per day, ${safeRound(data.basal_pct)} percent of TDD`}
+            subtitle2={
+              (data.basal_injection_units ?? 0) > 0
+                ? `incl. ${safeFixed1(data.basal_injection_units ?? 0)} U injection`
+                : undefined
+            }
+            ariaLabel={`Basal: ${safeFixed1((data.basal_units ?? 0) + (data.basal_injection_units ?? 0))} units per day, ${safeRound(data.basal_pct)} percent of TDD${
+              (data.basal_injection_units ?? 0) > 0
+                ? `, including ${safeFixed1(data.basal_injection_units ?? 0)} units long-acting injection`
+                : ""
+            }`}
           />
 
           <StatCard

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3311,6 +3311,11 @@ export async function getGlucosePercentiles(
 export interface InsulinSummaryResponse {
   tdd: number;
   basal_units: number;
+  // Long-acting (basal) pen injections -- MDI, e.g. Lantus/Tresiba. Counted
+  // within basal_pct; add to basal_units for the basal total. Optional for
+  // backward compatibility with responses predating issue #742.
+  basal_injection_units?: number;
+  basal_injection_count?: number;
   bolus_units: number;
   correction_units: number;
   basal_pct: number;
@@ -3344,6 +3349,9 @@ export async function getInsulinSummary(
 
 export interface BolusReviewItem {
   event_timestamp: string;
+  // "bolus" | "correction" | "basal_injection". Optional for backward
+  // compatibility with responses predating issue #742 (treated as a bolus).
+  event_type?: string;
   units: number;
   is_automated: boolean;
   control_iq_reason: string | null;

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -35,6 +35,10 @@ A discrete dose of insulin you give yourself (or your pump delivers) for a meal 
 
 A continuous trickle of insulin your pump delivers throughout the day to maintain background insulin levels (in the absence of meals). Configured as a "basal rate" in units per hour, can vary by time of day.
 
+### Basal injection (long-acting)
+
+For people on multiple daily injections (MDI) rather than a pump, the background insulin is a once- or twice-daily injection of a long-acting insulin (e.g. Lantus, Tresiba, Levemir) instead of a pump basal rate. GlycemicGPT records these as a distinct **basal injection** -- the injected amount in units, counted toward your basal total and total daily dose, but kept out of the rapid-acting Insulin on Board calculation (long-acting insulin acts over ~24 hours).
+
 ### Carb ratio (I:C)
 
 How much insulin to dose per gram of carbohydrate. e.g., 1:10 means 1 unit of insulin per 10 grams of carbs. Set in your pump or calculated manually.

--- a/docs/daily-use/dashboard.md
+++ b/docs/daily-use/dashboard.md
@@ -88,7 +88,9 @@ If any of these are missing or stale, the data flow from your pump has likely st
 
 ## Bolus review
 
-A tabular view of recent insulin events -- when each bolus was delivered, how much, and whether it was a manual bolus or a Control-IQ correction.
+A tabular view of recent insulin events -- when each dose was delivered, how much, and its type: a manual bolus, a Control-IQ correction, or a long-acting (basal) injection.
+
+If you take long-acting injections (MDI -- e.g. Lantus, Tresiba, Levemir), they show here as a distinct **Basal injection** row, clearly separated from rapid-acting boluses. They are counted toward your basal total and total daily dose, but deliberately kept out of the rapid-acting Insulin on Board calculation -- long-acting insulin acts over ~24 hours and doesn't belong in the rapid-acting IoB curve. In the insulin summary, a long-acting injection is folded into your **Basal** figure (with the injected amount shown on its own line) since for an MDI user it is the basal therapy.
 
 ## Period selector
 


### PR DESCRIPTION
## Summary

Closes #742. Builds on the `BASAL_INJECTION` event type (#740) to make MDI long-acting (basal) pen injections visible everywhere they belong — source-agnostically — and fixes a Nightscout ingestion bug that was recording them as rapid boluses.

#740 added the event type and Glooko ingestion but left it invisible to consumers. Looking at this through the Nightscout lens surfaced that NS pen users were worse off than invisible: a long-acting dose with an `insulin` value fell through `semantic_kind` to the `has_insulin -> bolus` default and was stored as a rapid `BOLUS`, polluting rapid-acting IoB/TDD — the exact thing `BASAL_INJECTION` exists to prevent. So this PR is both a feature (surfacing) and a correctness/safety fix (NS ingestion).

## Approach

Surfacing keys off the event **type**, never the source — so every ingestion path that emits `BASAL_INJECTION` benefits at once (Glooko today, Nightscout here, manual later).

### Nightscout ingestion (correctness/safety)
- New `is_basal_injection` classification (`integrations/nightscout/models.py`): a dose whose `insulinType` names a long-acting product/category routes to `BASAL_INJECTION` via a new `_map_basal_injection` mapper, instead of the bolus fallback.
- Conservative by design: only an explicit long-acting `insulinType` triggers it. It deliberately does **not** key on AAPS `isBasalInsulin` (that marks pump-basal / SMB semantics and is `False` on SMBs) — misclassifying rapid insulin as long-acting would drop it from active-insulin math, the unsafe direction.
- Routed before the meal-pair / bolus paths so a long-acting dose is never split out as rapid.

### Surfacing (keyed on event type)
- **TDD x2**: the daily-brief breakdown and the `/insulin/summary` widget include basal injections, counted toward the basal share but surfaced as a distinct line item.
- **`/bolus/review`**: rows carry `event_type` and render basal injections as a distinct row type, with per-type safety bounds (160U injection vs 60U bolus).
- **AI context** (`diabetes_context.py`): a dedicated ~30h basal-injection lookback so the model sees the daily basal dose + timing for overnight-pattern analysis (the existing 6h pump-activity window misses a once-daily dose most of the day).

### Other
- Hoisted `MAX_BASAL_INJECTION_UNITS` (160U) to `models/pump_data.py` as the shared bound.
- Frontend: insulin-summary Basal card folds the injection into the basal total with an "incl. X U injection" sub-line; bolus-review renamed to "Recent Insulin" with a Basal injection badge and a wider display cap.
- `BASAL_INJECTION` remains excluded from rapid-acting IoB by construction (the `_DOSE_EVENT_TYPES` allowlist is untouched).

## Testing

- Backend: new tests for NS classification (incl. AAPS-SMB-not-basal, rapid-stays-bolus, carbs+long-acting precedence), NS translator mapping, the two TDD computations, the per-type review bound, and the AI-context lookback. Full affected suites green; `ruff check` + `ruff format` clean.
- Web: new tests for the basal sub-line, the basal-injection badge / 160U display, and the rename. Jest green; eslint clean.
- Visual verification on the live stack (insulin summary shows Basal folding in the injection with the sub-line; Recent Insulin shows the basal-injection rows at full units).
- Sentry validation run: no new unresolved issues attributable to the change.

## Docs

Updated `docs/daily-use/dashboard.md` and `docs/concepts/glossary.md` to describe basal injections in TDD / views and the rapid-IoB exclusion.

## Note for reviewers

Stayed within the "no rapid-IoB inclusion" invariant throughout. The one cross-file touchpoint with #741 (daily-brief scheduling, assigned separately) is additive and does not change `generate_daily_brief`'s signature — flagged on that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added long-acting (basal/MDI) pen injection support across insulin summaries and daily analytics, including surfaced injection units and injection counts.
  * Insulin and bolus review now treat basal injections as a distinct insulin event type with appropriate badges and table labeling, and they contribute to basal totals/TDD while remaining separate from “on board” logic.
* **Documentation**
  * Updated glossary and dashboard documentation to reflect how basal injections are displayed and counted.
* **Tests**
  * Updated and added backend and UI tests to validate basal-injection queries, API responses, and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->