### PR TITLE
feat(api): ground meal-photo carb estimates against history + USDA/OFF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ scripts/security/*.resolved.yaml
 # Ad-hoc debug snapshots at repo root (may contain PII captured from a live session)
 /*-snapshot.md
 /*-state.md
+
+# Playwright MCP session artifacts (local tooling, never committed)
+.playwright-mcp/

--- a/apps/api/migrations/versions/069_food_record_grounding.py
+++ b/apps/api/migrations/versions/069_food_record_grounding.py
@@ -1,0 +1,53 @@
+"""Add grounding-attribution columns to food_records (Story 50.E1).
+
+Grounding sharpens the *descriptive* carb estimate by reconciling it against the
+user's own logged history (RAG, USER_PROVIDED) and published nutrition facts
+(USDA FoodData Central / Open Food Facts, RESEARCHED/AUTHORITATIVE). These three
+nullable columns record *which* source grounded a given estimate so the API can
+cite provenance. They are attribution only -- the carb values themselves stay in
+``carbs_low`` / ``carbs_high`` (the immutable vision estimate) and ``corrected_*``
+(the user's truth); nothing here couples a record into IoB / treatment_safety /
+carb-ratio math.
+
+This is the deferred 50.B amendment (Open Food Facts requires attribution, so a
+provenance column was always going to be needed once grounding landed).
+
+Revision ID: 069_food_record_grounding
+Revises: 068_basal_injection_event_type
+Create Date: 2026-06-15
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "069_food_record_grounding"
+down_revision = "068_basal_injection_event_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Human-readable source name shown in the citation (e.g. "USDA FoodData
+    # Central", "Open Food Facts", "Your meal history").
+    op.add_column(
+        "food_records",
+        sa.Column("grounding_source", sa.String(length=120), nullable=True),
+    )
+    # Citation link (USDA food page / OFF product page). NULL for own-history.
+    op.add_column(
+        "food_records",
+        sa.Column("grounding_source_url", sa.Text(), nullable=True),
+    )
+    # Trust-tier marker for the grounding source, mirroring the knowledge_chunks
+    # tiers: USER_PROVIDED (own history) / RESEARCHED / AUTHORITATIVE (published).
+    # A plain string (not a DB enum) matches knowledge_chunks.trust_tier.
+    op.add_column(
+        "food_records",
+        sa.Column("grounding_trust_tier", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("food_records", "grounding_trust_tier")
+    op.drop_column("food_records", "grounding_source_url")
+    op.drop_column("food_records", "grounding_source")

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -160,6 +160,22 @@ class Settings(BaseSettings):
     # timeout because a CLI vision provider can take tens of seconds.
     vision_request_timeout_seconds: float = Field(default=120.0, gt=0)
 
+    # Nutrition grounding (Story 50.E1). Estimates are grounded against the
+    # user's own logged history (RAG) and published nutrition facts. The external
+    # sources below are cacheable/redistributable (USDA = CC0/public domain; Open
+    # Food Facts = ODbL) and fail open: a lookup error falls back to vision-only.
+    # USDA FoodData Central needs a free data.gov API key, per-deployment (BYO or
+    # bundled). Empty key -> USDA grounding is skipped (no error). 1k req/hr per
+    # IP is plenty for a self-hoster.
+    usda_fdc_api_key: str = ""
+    usda_fdc_base_url: str = "https://api.nal.usda.gov/fdc/v1"
+    # Open Food Facts needs no key (ODbL). Disable to opt out entirely.
+    open_food_facts_enabled: bool = True
+    open_food_facts_base_url: str = "https://world.openfoodfacts.org"
+    # Hard per-call timeout for an external nutrition lookup; kept short so a slow
+    # source never stalls the estimate path (it falls back to vision-only).
+    nutrition_grounding_timeout_seconds: float = Field(default=6.0, gt=0)
+
     # Device & API key limits (Story 28.7)
     max_devices_per_user: int = Field(default=10, ge=1)
     debug_device_limit: int = Field(default=50, ge=1)

--- a/apps/api/src/models/food_record.py
+++ b/apps/api/src/models/food_record.py
@@ -45,7 +45,11 @@ class FoodRecordSource(str, enum.Enum):
 
     AI_ESTIMATE = "ai_estimate"  # Raw vision-model estimate (default).
     USER_CORRECTED = "user_corrected"  # User fixed the estimate.
-    EXTERNAL_GROUNDED = "external_grounded"  # Grounded against a published source.
+    # Reserved. Grounding (Story 50.E1) is *attribution only* -- it records the
+    # source in the grounding_* columns but never changes the persisted carb
+    # values, so `source` correctly stays AI_ESTIMATE/USER_CORRECTED. This member
+    # is kept for a hypothetical future where grounding overwrites the estimate.
+    EXTERNAL_GROUNDED = "external_grounded"
 
 
 class FoodRecord(Base):
@@ -151,6 +155,22 @@ class FoodRecord(Base):
         nullable=True,
         index=True,
     )
+
+    # --- Grounding attribution (Story 50.E1) ---
+    # Which source grounded this estimate, recorded for citation. Attribution
+    # only: the carb values stay in ``carbs_low`` / ``carbs_high`` (vision) and
+    # ``corrected_*`` (user truth). NULL = pure vision (ungrounded). These are
+    # never read by IoB / treatment_safety / carb-ratio math.
+    grounding_source: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    grounding_source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Trust-tier marker mirroring knowledge_chunks.trust_tier: USER_PROVIDED
+    # (own history) / RESEARCHED / AUTHORITATIVE (published nutrition facts).
+    grounding_trust_tier: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # NOTE: the estimation pipeline (food_vision) attaches a transient, non-mapped
+    # ``grounding`` attribute (a schemas.food_record.GroundingDetail) to a freshly
+    # created instance so the create response can carry the grounded range + note +
+    # disclaimer. It is never persisted -- only the flat grounding_* columns above
+    # are -- and is absent on instances loaded from the DB.
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -15,6 +15,48 @@ from src.models.food_record import FoodRecordSource
 from src.vision.carb_contract import CARB_GRAMS_MAX, CARB_GRAMS_MIN
 
 
+class GroundingDetail(BaseModel):
+    """Grounding detail returned alongside a fresh estimate (Story 50.E1).
+
+    Describes *which* source grounded the estimate and the grounded carb range it
+    suggests. This is a descriptive, cite-able reference -- never a dose. The
+    persisted record keeps its own vision estimate in ``carbs_low`` / ``carbs_high``;
+    this object carries the supplementary grounded figure + citation for the UI.
+
+    It is computed at estimate time (the create path) and is not persisted beyond
+    the attribution fields (``grounding_source`` / ``grounding_source_url`` /
+    ``grounding_trust_tier``), so reads of an existing record carry those flat
+    fields but not this object.
+    """
+
+    source: str
+    source_url: str | None = None
+    trust_tier: str
+    # Grounded carb range from the source (own-history prior value, or the
+    # published per-serving/per-100g figure). May be absent if the source only
+    # confirms identity without a usable number.
+    carbs_low: float | None = Field(default=None, ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
+    carbs_high: float | None = Field(default=None, ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
+    # The basis of the grounded figure (e.g. "per 100 g", "your last log").
+    serving: str | None = None
+    # Human-readable note ("You've logged this before (~45g)").
+    note: str | None = None
+    # Source licence / non-medical disclaimer to surface (e.g. Open Food Facts).
+    disclaimer: str | None = None
+
+    @model_validator(mode="after")
+    def validate_carb_ordering(self) -> "GroundingDetail":
+        """Carb low must not exceed high when both are present (reject inversion)."""
+        if (
+            self.carbs_low is not None
+            and self.carbs_high is not None
+            and self.carbs_low > self.carbs_high
+        ):
+            msg = "carbs_low must not exceed carbs_high"
+            raise ValueError(msg)
+        return self
+
+
 class FoodRecordResponse(BaseModel):
     """A persisted food record returned to the client.
 
@@ -45,6 +87,13 @@ class FoodRecordResponse(BaseModel):
     common_food_id: uuid.UUID | None = None
     ai_model: str | None = None
     ai_provider: str | None = None
+    # Grounding provenance (Story 50.E1). The flat fields are persisted on the
+    # record and present on every read; ``grounding`` is the richer create-time
+    # detail (grounded range + note + disclaimer) and is absent on later reads.
+    grounding_source: str | None = None
+    grounding_source_url: str | None = None
+    grounding_trust_tier: str | None = None
+    grounding: GroundingDetail | None = None
     created_at: datetime
 
     @model_validator(mode="after")

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -23,11 +23,13 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.config import settings
 from src.logging_config import get_logger
 from src.models.common_food import CommonFood, normalize_common_food_name
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.schemas.common_food import CommonFoodUpdateRequest
 from src.schemas.food_record import FoodRecordCorrectionRequest
+from src.services import meal_rag
 from src.vision.carb_contract import CarbBoundsError, validate_carb_range
 
 logger = get_logger(__name__)
@@ -72,6 +74,15 @@ async def correct_food_record(
 
     await db.commit()
     await db.refresh(record)
+
+    # Re-index own-history RAG so a future photo recalls the user's corrected
+    # value (the truth) rather than the original AI estimate. Best-effort -- a
+    # re-index failure must not fail the correction response.
+    if settings.meal_intelligence_enabled:
+        try:
+            await meal_rag.index_food_record(record)
+        except Exception:
+            logger.warning("RAG re-indexing failed for corrected record", exc_info=True)
     return record
 
 
@@ -166,6 +177,17 @@ async def promote_to_common_food(
     record.common_food_id = common_food.id
     await db.commit()
     await db.refresh(common_food)
+    await db.refresh(record)
+
+    # Index the named baseline (and re-index the now-linked record) into
+    # own-history RAG so a future photo of this food recalls the user's curated
+    # baseline. Best-effort -- an indexing failure must not fail the promotion.
+    if settings.meal_intelligence_enabled:
+        try:
+            await meal_rag.index_common_food(common_food)
+            await meal_rag.index_food_record(record)
+        except Exception:
+            logger.warning("RAG indexing failed for promotion", exc_info=True)
     return common_food
 
 

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -35,7 +35,8 @@ from src.logging_config import get_logger
 from src.models.ai_provider import AIProviderConfig
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.models.user import User
-from src.services import food_image
+from src.schemas.food_record import GroundingDetail
+from src.services import food_image, meal_grounding, meal_rag
 from src.services.ai_client import DEFAULT_MODELS
 from src.vision.carb_contract import (
     SYSTEM_PROMPT,
@@ -237,6 +238,13 @@ async def create_food_record_from_image(
     if food_description:
         food_description = food_description[:_MAX_DESCRIPTION_CHARS]
 
+    # Ground the descriptive estimate against the user's own history (RAG) and
+    # published nutrition (USDA / OFF), best-effort. Computed before persisting so
+    # the own-history recall sees only prior records, not this one. Any failure
+    # falls back to a vision-only (ungrounded) estimate -- grounding never blocks
+    # or alters the core estimate, and never produces a dose.
+    grounding = await _ground_estimate(user, food_description)
+
     storage_path, size_bytes = food_image.store_image(user.id, processed)
     filename = Path(storage_path).name
 
@@ -254,6 +262,9 @@ async def create_food_record_from_image(
         ai_model=model,
         ai_provider=provider_label,
         source=FoodRecordSource.AI_ESTIMATE,
+        grounding_source=grounding.source if grounding else None,
+        grounding_source_url=grounding.source_url if grounding else None,
+        grounding_trust_tier=grounding.trust_tier if grounding else None,
     )
     db.add(record)
     try:
@@ -264,4 +275,32 @@ async def create_food_record_from_image(
         food_image.delete_stored_image(storage_path)
         raise
     await db.refresh(record)
+
+    # Index this record into own-history RAG so a future photo of the same food
+    # recalls it. Best-effort and after commit -- it must never fail the upload,
+    # so guard the call site too (index_food_record is already internally
+    # best-effort; this also covers anything raised before its own try).
+    if settings.meal_intelligence_enabled:
+        try:
+            await meal_rag.index_food_record(record)
+        except Exception:
+            logger.warning("RAG indexing failed for food record", exc_info=True)
+
+    # Attach the grounding detail (grounded range + citation + disclaimer) for the
+    # response. Transient -- not a persisted column; reads of the record later
+    # carry only the flat grounding_* attribution fields.
+    record.grounding = grounding
     return record
+
+
+async def _ground_estimate(
+    user: User, food_description: str | None
+) -> GroundingDetail | None:
+    """Compute grounding for an estimate; never raise (fall back to vision-only)."""
+    if not settings.meal_intelligence_enabled:
+        return None
+    try:
+        return await meal_grounding.ground_estimate(user.id, food_description)
+    except Exception:
+        logger.warning("Estimate grounding failed; using vision-only", exc_info=True)
+        return None

--- a/apps/api/src/services/knowledge_retrieval.py
+++ b/apps/api/src/services/knowledge_retrieval.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.logging_config import get_logger
 from src.models.knowledge_chunk import KnowledgeChunk
 from src.services.embedding import embed_text
+from src.services.meal_rag import FOOD_GROUNDING_SOURCE_TYPES
 
 logger = get_logger(__name__)
 
@@ -74,6 +75,12 @@ async def retrieve_knowledge(
                     KnowledgeChunk.injection_risk.is_(False),
                     KnowledgeChunk.trust_tier == KnowledgeChunk.TIER_AUTHORITATIVE,
                 ),
+                # Keep meal-grounding chunks (own-history + USDA/OFF cache, Story
+                # 50.E1) out of clinical retrieval -- they are a separate
+                # mechanism with their own retrieval path, and must never leak
+                # into a clinical knowledge prompt. (sorted() -> deterministic SQL
+                # text for statement-cache stability.)
+                KnowledgeChunk.source_type.not_in(sorted(FOOD_GROUNDING_SOURCE_TYPES)),
                 # Must have an embedding
                 KnowledgeChunk.embedding.is_not(None),
                 # Only sufficiently relevant chunks

--- a/apps/api/src/services/meal_grounding.py
+++ b/apps/api/src/services/meal_grounding.py
@@ -1,0 +1,104 @@
+"""Grounding orchestrator: reconcile an estimate against history + published facts.
+
+Story 50.E1, AC4. Given a vision-identified food, this picks the single best
+grounding source in trust order and returns a descriptive citation. Precedence:
+
+  1. own-history **corrected** value  (USER_PROVIDED -- the user's own truth)
+  2. USDA FoodData Central             (AUTHORITATIVE -- official, CC0)
+  3. Open Food Facts                   (RESEARCHED   -- crowd-sourced, ODbL)
+  4. own-history **uncorrected** value (USER_PROVIDED -- a prior estimate)
+  5. none -> pure vision
+
+The two mechanisms stay architecturally distinct (own-history RAG vs external
+research), separated by trust tier; this module only chooses between their
+already-computed results.
+
+Safety posture (NON-NEGOTIABLE): grounding sharpens the *descriptive* estimate
+only. It returns a carb range + citation, never a dose, and the result is never
+read by IoB / treatment_safety / carb-ratio math. The verify-before-dosing framing
+is preserved by the callers (the persistent qualifier on every estimate surface).
+"""
+
+import uuid
+
+from src.config import settings
+from src.logging_config import get_logger
+from src.models.knowledge_chunk import KnowledgeChunk
+from src.schemas.food_record import GroundingDetail
+from src.services import meal_rag, nutrition_sources
+
+logger = get_logger(__name__)
+
+
+def _recall_detail(recall: meal_rag.MealRecall) -> GroundingDetail:
+    low, high = recall.carbs_low, recall.carbs_high
+    span = f"~{low:g}g" if low == high else f"~{low:g}-{high:g}g"
+    basis = "your corrected value" if recall.is_corrected else "your earlier estimate"
+    return GroundingDetail(
+        source="Your meal history",
+        source_url=None,
+        trust_tier=KnowledgeChunk.TIER_USER_PROVIDED,
+        carbs_low=low,
+        carbs_high=high,
+        serving="your last log",
+        note=f"You've logged this before ({span}, {basis}).",
+        disclaimer=None,
+    )
+
+
+def _fact_detail(fact: nutrition_sources.NutritionFact) -> GroundingDetail:
+    return GroundingDetail(
+        source=fact.source_name,
+        source_url=fact.source_url,
+        trust_tier=fact.trust_tier,
+        carbs_low=fact.carbs_grams,
+        carbs_high=fact.carbs_grams,
+        serving=fact.serving,
+        note=f"{fact.name}: ~{fact.carbs_grams:g}g carbohydrate {fact.serving}.",
+        disclaimer=fact.disclaimer,
+    )
+
+
+async def ground_estimate(
+    user_id: uuid.UUID,
+    food_description: str | None,
+) -> GroundingDetail | None:
+    """Return the best grounding for a vision estimate, or None (pure vision).
+
+    Decoupled from any caller transaction: the own-history recall and the external
+    lookups each manage their own DB sessions and each fails open to None
+    internally (``recall_similar_meal`` and ``lookup_published_nutrition`` never
+    raise), so this orchestrator stays free of redundant try/except layers. The
+    single hard fail-open boundary for any truly unexpected error is the caller
+    (``food_vision._ground_estimate``).
+    """
+    # Defence in depth: the only caller is already flag-gated, but enforce the
+    # feature flag at this boundary too so a future caller can't run grounding
+    # (embedding + external fetch) while meal intelligence is off.
+    if not settings.meal_intelligence_enabled:
+        return None
+
+    description = (food_description or "").strip()
+    if not description:
+        return None
+
+    recall = await meal_rag.recall_similar_meal(user_id, description)
+
+    # 1. A corrected own-history match is the user's own truth -- top precedence,
+    # and lets us skip the external calls entirely.
+    if recall is not None and recall.is_corrected:
+        return _recall_detail(recall)
+
+    # 2/3. Published facts (USDA preferred over OFF). Each fails open to None.
+    usda, off = await nutrition_sources.lookup_published_nutrition(description)
+    if usda is not None:
+        return _fact_detail(usda)
+    if off is not None:
+        return _fact_detail(off)
+
+    # 4. An uncorrected prior log still grounds when nothing published matched.
+    if recall is not None:
+        return _recall_detail(recall)
+
+    # 5. Pure vision.
+    return None

--- a/apps/api/src/services/meal_rag.py
+++ b/apps/api/src/services/meal_rag.py
@@ -1,0 +1,307 @@
+"""Own-history meal RAG: index logged foods and recall similar prior ones.
+
+Story 50.E1, grounding mechanism (a): the user's own food history. A logged food
+record (and its promoted common-food baseline) is indexed into ``knowledge_chunks``
+at the ``USER_PROVIDED`` trust tier, owner-scoped. At estimate time the
+vision-identified food is embedded and the user's similar prior foods are
+retrieved by vector similarity -- "you've logged this before (~N g)" -- preferring
+the user's corrected value.
+
+This is *similarity* recall (vector), deliberately distinct from:
+  * Story 50.F1's recent-meals injection, which is *temporal* (last 48 h), and
+  * Story 50.E1's external research (USDA / Open Food Facts), which is a
+    different trust tier (RESEARCHED / AUTHORITATIVE). The trust-tier model keeps
+    the two grounding mechanisms architecturally separate (AC4).
+
+Safety posture (NON-NEGOTIABLE): recall sharpens a *descriptive* estimate only.
+Nothing here returns a dose, and the indexed chunks are never read by IoB /
+treatment_safety / carb-ratio math. Indexing and retrieval are strictly
+owner-scoped (``user_id`` equality), never shared across users.
+"""
+
+import asyncio
+import hashlib
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from src.database import get_session_maker
+from src.logging_config import get_logger
+from src.models.common_food import CommonFood
+from src.models.food_record import FoodRecord
+from src.models.knowledge_chunk import KnowledgeChunk
+from src.services.embedding import embed_text
+
+logger = get_logger(__name__)
+
+# Source-type vocabulary for every food-grounding chunk. Kept here as the single
+# home so the clinical-knowledge retriever can exclude them (food grounding must
+# not leak into clinical RAG prompts) and the external-source service can tag its
+# cache chunks consistently.
+SOURCE_TYPE_FOOD_RECORD = "user_food_record"
+SOURCE_TYPE_COMMON_FOOD = "user_common_food"
+SOURCE_TYPE_USDA = "usda_fdc"
+SOURCE_TYPE_OPEN_FOOD_FACTS = "open_food_facts"
+
+OWN_HISTORY_SOURCE_TYPES = frozenset({SOURCE_TYPE_FOOD_RECORD, SOURCE_TYPE_COMMON_FOOD})
+EXTERNAL_SOURCE_TYPES = frozenset({SOURCE_TYPE_USDA, SOURCE_TYPE_OPEN_FOOD_FACTS})
+# Every source_type used by the meal-grounding feature. Clinical retrieval
+# excludes these so nutrition grounding never pollutes clinical knowledge
+# prompts (the mechanisms stay separate -- AC4).
+FOOD_GROUNDING_SOURCE_TYPES = OWN_HISTORY_SOURCE_TYPES | EXTERNAL_SOURCE_TYPES
+
+# Cosine-distance ceiling for "this is the same food I logged before". Tighter
+# than the clinical retriever's 0.6 (which casts a wide net for related
+# material): a re-photographed known food embeds very close to its prior log, so
+# we only treat a near match as own-history grounding.
+RECALL_MAX_DISTANCE = 0.35
+
+# Cap the embedded text so a long description can't blow the embedding model's
+# input budget; the leading text carries the food identity.
+_MAX_EMBED_CHARS = 512
+
+
+@dataclass(frozen=True)
+class MealRecall:
+    """A prior logged food that closely matches the current estimate."""
+
+    name: str
+    carbs_low: float
+    carbs_high: float
+    is_corrected: bool
+    food_record_id: str | None
+    common_food_id: str | None
+    distance: float
+
+
+async def _embed(text: str) -> list[float] | None:
+    """Embed text off the event loop; return None on any failure (best-effort).
+
+    The embedding model is heavy and optional to the core estimate -- a failure
+    here must degrade grounding gracefully, never break the upload.
+    """
+    cleaned = (text or "").strip()[:_MAX_EMBED_CHARS]
+    if not cleaned:
+        return None
+    try:
+        return await asyncio.to_thread(embed_text, cleaned)
+    except Exception:
+        logger.warning("Meal-RAG embedding failed", exc_info=True)
+        return None
+
+
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+async def recall_similar_meal(
+    user_id: uuid.UUID,
+    food_description: str,
+) -> MealRecall | None:
+    """Return the user's closest prior logged food, or None.
+
+    Owner-scoped vector search over the user's own food-history chunks only. The
+    carb range comes from the chunk metadata (already the user's corrected value
+    when one exists -- see ``index_food_record``).
+
+    Runs on its own short-lived session, decoupled from any caller transaction:
+    embedding offloads to a worker thread, and reusing the request session across
+    that boundary inside the ASGI server can break SQLAlchemy's async greenlet
+    bridge. A dedicated session sidesteps that and keeps recall read-only.
+    """
+    embedding = await _embed(food_description)
+    if embedding is None:
+        return None
+
+    distance = KnowledgeChunk.embedding.cosine_distance(embedding)
+    try:
+        async with get_session_maker()() as db:
+            result = await db.execute(
+                select(KnowledgeChunk, distance.label("distance"))
+                .where(
+                    # Strictly owner-scoped: never another user's history, and
+                    # never the shared (NULL) clinical/external chunks.
+                    KnowledgeChunk.user_id == user_id,
+                    KnowledgeChunk.source_type.in_(OWN_HISTORY_SOURCE_TYPES),
+                    KnowledgeChunk.valid_to.is_(None),
+                    KnowledgeChunk.embedding.is_not(None),
+                    # Only chunks carrying a usable carb range -- so the closest
+                    # match with metadata is chosen, not a closer-but-unusable row.
+                    KnowledgeChunk.metadata_json["carbs_low"].astext.isnot(None),
+                    distance < RECALL_MAX_DISTANCE,
+                )
+                .order_by(distance)
+                .limit(1)
+            )
+            row = result.first()
+    except Exception:
+        logger.warning(
+            "Meal-RAG recall query failed", user_id=str(user_id), exc_info=True
+        )
+        return None
+
+    if row is None:
+        return None
+
+    chunk, dist = row
+    meta = chunk.metadata_json or {}
+    low = _coerce_float(meta.get("carbs_low"))
+    high = _coerce_float(meta.get("carbs_high"))
+    if low is None or high is None:
+        return None
+
+    return MealRecall(
+        name=chunk.source_name or "a previously logged food",
+        carbs_low=low,
+        carbs_high=high,
+        is_corrected=bool(meta.get("is_corrected")),
+        food_record_id=meta.get("food_record_id"),
+        common_food_id=meta.get("common_food_id"),
+        distance=float(dist),
+    )
+
+
+async def _store_food_chunk(
+    *,
+    user_id: uuid.UUID,
+    source_type: str,
+    ref_key: str,
+    ref_id: uuid.UUID,
+    name: str,
+    embed_source: str,
+    metadata: dict,
+) -> None:
+    """Index (or re-index) a single food into a USER_PROVIDED chunk.
+
+    Idempotent upsert keyed on the chunk's deterministic ``content_hash``
+    (``sha256(source_type:ref_id)``), which is covered by the partial
+    UNIQUE(content_hash, user_id) index (migration 050). A re-index (e.g. after a
+    correction) updates the existing row in place via ``ON CONFLICT DO UPDATE`` --
+    race-safe and without the delete-then-insert window. Runs on its own session
+    so it never touches the caller's transaction -- indexing is a best-effort side
+    effect that must not commit (or break) the caller's work.
+    """
+    embedding = await _embed(embed_source)
+    if embedding is None:
+        return
+
+    now = datetime.now(UTC)
+    content = name.strip()[:_MAX_EMBED_CHARS] or "logged food"
+    content_hash = hashlib.sha256(f"{source_type}:{ref_id}".encode()).hexdigest()
+    values = {
+        "user_id": user_id,
+        "trust_tier": KnowledgeChunk.TIER_USER_PROVIDED,
+        "source_type": source_type,
+        "source_name": content[:200],
+        "content": content,
+        "embedding": embedding,
+        "content_hash": content_hash,
+        "retrieved_at": now,
+        "metadata_json": {ref_key: str(ref_id), **metadata},
+    }
+    stmt = pg_insert(KnowledgeChunk).values(**values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["content_hash", "user_id"],
+        index_where=KnowledgeChunk.content_hash.isnot(None),
+        set_={
+            "source_name": stmt.excluded.source_name,
+            "content": stmt.excluded.content,
+            "embedding": stmt.excluded.embedding,
+            "retrieved_at": stmt.excluded.retrieved_at,
+            "metadata_json": stmt.excluded.metadata_json,
+            "updated_at": now,
+            "update_source": "meal_rag_reindex",
+        },
+    )
+    async with get_session_maker()() as db:
+        await db.execute(stmt)
+        await db.commit()
+
+
+def _record_effective_carbs(record: FoodRecord) -> tuple[float, float, bool]:
+    """Prefer the user's corrected carbs (their truth) over the AI estimate."""
+    if (
+        record.corrected_carbs_low is not None
+        and record.corrected_carbs_high is not None
+    ):
+        return record.corrected_carbs_low, record.corrected_carbs_high, True
+    return record.carbs_low, record.carbs_high, False
+
+
+async def index_food_record(record: FoodRecord) -> None:
+    """Index a food record into own-history RAG (best-effort, owner-scoped).
+
+    Embeds the food description so a re-photograph of the same food recalls it.
+    A record with no description is skipped (nothing to match on). Reads the
+    record's already-loaded fields, then persists on its own session.
+    """
+    description = (record.food_description or "").strip()
+    if not description:
+        return
+    low, high, corrected = _record_effective_carbs(record)
+    user_id = record.user_id
+    record_id = record.id
+    common_food_id = str(record.common_food_id) if record.common_food_id else None
+    try:
+        await _store_food_chunk(
+            user_id=user_id,
+            source_type=SOURCE_TYPE_FOOD_RECORD,
+            ref_key="food_record_id",
+            ref_id=record_id,
+            name=description,
+            embed_source=description,
+            metadata={
+                "carbs_low": low,
+                "carbs_high": high,
+                "is_corrected": corrected,
+                "common_food_id": common_food_id,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "Failed to index food record for recall",
+            food_record_id=str(record_id),
+            exc_info=True,
+        )
+
+
+async def index_common_food(common_food: CommonFood) -> None:
+    """Index a common-food baseline into own-history RAG (best-effort).
+
+    The named baseline is the user's curated truth for a frequently-eaten food;
+    indexing it by name lets a future photo of that food recall the baseline.
+    """
+    user_id = common_food.user_id
+    common_food_id = common_food.id
+    name = common_food.name
+    low = common_food.carbs_low
+    high = common_food.carbs_high
+    try:
+        await _store_food_chunk(
+            user_id=user_id,
+            source_type=SOURCE_TYPE_COMMON_FOOD,
+            ref_key="common_food_id",
+            ref_id=common_food_id,
+            name=name,
+            embed_source=name,
+            metadata={
+                "carbs_low": low,
+                "carbs_high": high,
+                # A common food is the user's curated baseline -- treat it as the
+                # corrected/preferred value for precedence.
+                "is_corrected": True,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "Failed to index common food for recall",
+            common_food_id=str(common_food_id),
+            exc_info=True,
+        )

--- a/apps/api/src/services/meal_rag.py
+++ b/apps/api/src/services/meal_rag.py
@@ -132,9 +132,11 @@ async def recall_similar_meal(
                     KnowledgeChunk.source_type.in_(OWN_HISTORY_SOURCE_TYPES),
                     KnowledgeChunk.valid_to.is_(None),
                     KnowledgeChunk.embedding.is_not(None),
-                    # Only chunks carrying a usable carb range -- so the closest
-                    # match with metadata is chosen, not a closer-but-unusable row.
+                    # Only chunks carrying a usable carb range (BOTH bounds) -- so
+                    # the closest match with complete metadata is chosen, not a
+                    # closer-but-unusable row that would then return None.
                     KnowledgeChunk.metadata_json["carbs_low"].astext.isnot(None),
+                    KnowledgeChunk.metadata_json["carbs_high"].astext.isnot(None),
                     distance < RECALL_MAX_DISTANCE,
                 )
                 .order_by(distance)

--- a/apps/api/src/services/nutrition_sources.py
+++ b/apps/api/src/services/nutrition_sources.py
@@ -31,6 +31,7 @@ from urllib.parse import urlparse
 
 import httpx
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
@@ -179,7 +180,10 @@ async def _cache_put(
     """Store a fetched fact as a shared, cite-able cache chunk (best-effort).
 
     The chunk is not embedded: it is keyed by ``content_hash`` for cache reuse and
-    is excluded from clinical retrieval, so a vector is unnecessary.
+    is excluded from clinical retrieval, so a vector is unnecessary. Idempotent
+    upsert on the partial UNIQUE(content_hash, user_id) index (migration 050), so
+    two concurrent first-time lookups for the same query update rather than one
+    silently losing the write on an IntegrityError.
     """
     now = datetime.now(UTC)
     # A published nutrition name should never contain dosing/advice phrasing; if
@@ -189,29 +193,43 @@ async def _cache_put(
     content = (
         f"{fact.name}: ~{fact.carbs_grams:g} g carbohydrate {fact.serving} "
         f"({fact.source_name})"
+    )[:1000]
+    metadata = {
+        "query": normalized_query,
+        "name": fact.name,
+        "carbs_grams": fact.carbs_grams,
+        "serving": fact.serving,
+        "disclaimer": fact.disclaimer,
+    }
+    stmt = pg_insert(KnowledgeChunk).values(
+        user_id=None,
+        trust_tier=fact.trust_tier,
+        source_type=source_type,
+        source_url=fact.source_url,
+        source_name=fact.source_name,
+        content=content,
+        embedding=None,
+        content_hash=_cache_key(source_type, normalized_query),
+        retrieved_at=now,
+        injection_risk=injection_risk,
+        metadata_json=metadata,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["content_hash", "user_id"],
+        index_where=KnowledgeChunk.content_hash.isnot(None),
+        set_={
+            "trust_tier": stmt.excluded.trust_tier,
+            "source_url": stmt.excluded.source_url,
+            "source_name": stmt.excluded.source_name,
+            "content": stmt.excluded.content,
+            "retrieved_at": stmt.excluded.retrieved_at,
+            "injection_risk": stmt.excluded.injection_risk,
+            "metadata_json": stmt.excluded.metadata_json,
+            "updated_at": now,
+        },
     )
     try:
-        db.add(
-            KnowledgeChunk(
-                user_id=None,
-                trust_tier=fact.trust_tier,
-                source_type=source_type,
-                source_url=fact.source_url,
-                source_name=fact.source_name,
-                content=content[:1000],
-                embedding=None,
-                content_hash=_cache_key(source_type, normalized_query),
-                retrieved_at=now,
-                injection_risk=injection_risk,
-                metadata_json={
-                    "query": normalized_query,
-                    "name": fact.name,
-                    "carbs_grams": fact.carbs_grams,
-                    "serving": fact.serving,
-                    "disclaimer": fact.disclaimer,
-                },
-            )
-        )
+        await db.execute(stmt)
         await db.commit()
     except Exception:
         await db.rollback()

--- a/apps/api/src/services/nutrition_sources.py
+++ b/apps/api/src/services/nutrition_sources.py
@@ -1,0 +1,419 @@
+"""External published-nutrition grounding: USDA FoodData Central + Open Food Facts.
+
+Story 50.E1, grounding mechanism (b): published nutrition *facts*. Generic foods
+are grounded against **USDA FoodData Central** (CC0/public domain) and packaged
+products against **Open Food Facts** (ODbL, no key). Both licences permit caching
+and redistribution -- unlike commercial aggregators (Nutritionix, Edamam, ...) --
+so a result is stored as a ``knowledge_chunks`` row (the cache + citation store)
+at the ``AUTHORITATIVE`` (USDA) / ``RESEARCHED`` (OFF) trust tier, keeping it
+architecturally separate from own-history (``USER_PROVIDED``) grounding (AC4).
+
+These cache chunks are **shared** (``user_id IS NULL``) because the facts are
+public and identical for everyone -- but they are deliberately tagged with a
+food-grounding ``source_type`` that the clinical-knowledge retriever excludes, so
+they never leak into a clinical RAG prompt.
+
+Security: the base URLs are fixed operator config (never user input); only the
+search term is user-influenced and it travels as an encoded query *parameter*,
+never the path. Each call validates the host against an allow-list (defence in
+depth vs a misconfigured base URL pointing at an internal service), refuses
+redirects, is hard time-boxed, and caps the response body. The data.gov API key
+is sent as a request parameter and is never logged. Any failure returns None so
+the estimate falls back to vision-only.
+"""
+
+import asyncio
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.database import get_session_maker
+from src.logging_config import get_logger
+from src.models.knowledge_chunk import KnowledgeChunk
+from src.services.meal_rag import SOURCE_TYPE_OPEN_FOOD_FACTS, SOURCE_TYPE_USDA
+from src.vision.carb_contract import find_dosing_violations
+
+logger = get_logger(__name__)
+
+# Hosts we are willing to talk to. The base URL is operator config, so this is a
+# defence-in-depth guard against a misconfiguration (or an injected env var)
+# pointing the lookup at an internal/metadata endpoint.
+_ALLOWED_HOSTS = frozenset(
+    {
+        "api.nal.usda.gov",
+        "world.openfoodfacts.org",
+        # Country sub-domains share the same search API + ODbL terms.
+        "us.openfoodfacts.org",
+    }
+)
+
+# Carbs per 100 g can never exceed 100 g; a value outside this band signals bad
+# source data (wrong basis / parse error), so we drop it rather than ground on it.
+_MAX_CARBS_PER_100G = 100.0
+
+_MAX_RESPONSE_BYTES = 512_000
+
+# USDA nutrient number for "Carbohydrate, by difference".
+_USDA_CARB_NUTRIENT_NUMBER = "205"
+
+# Restrict USDA to generic data types whose nutrient values are reported per
+# 100 g (Branded items are per-serving and would break the per-100 g basis).
+_USDA_GENERIC_DATATYPES = "Foundation,SR Legacy,Survey (FNDDS)"
+
+_OFF_DISCLAIMER = (
+    "Nutrition data from Open Food Facts (ODbL), contributed by volunteers and "
+    "not medically verified -- a descriptive reference only, verify before dosing."
+)
+
+_SERVING_PER_100G = "per 100 g"
+
+
+@dataclass(frozen=True)
+class NutritionFact:
+    """A grounded nutrition fact from a published source."""
+
+    source_name: str
+    source_url: str | None
+    trust_tier: str  # KnowledgeChunk.TIER_AUTHORITATIVE | TIER_RESEARCHED
+    name: str
+    carbs_grams: float
+    serving: str
+    disclaimer: str | None
+
+
+def _normalize_query(query: str) -> str:
+    return " ".join((query or "").lower().split())[:200]
+
+
+def _cache_key(source_type: str, normalized_query: str) -> str:
+    # Keyed on (source_type, normalized query) only -- it intentionally omits the
+    # request shape (USDA dataType, OFF fields). If the *basis* of a result ever
+    # changes (e.g. dropping the per-100 g dataType restriction), bump the
+    # source_type constant so stale-basis cache rows are not reused.
+    return hashlib.sha256(f"{source_type}:{normalized_query}".encode()).hexdigest()
+
+
+def _host_allowed(base_url: str) -> bool:
+    parsed = urlparse(base_url)
+    return parsed.scheme == "https" and (parsed.hostname or "") in _ALLOWED_HOSTS
+
+
+def _safe_off_citation_url(raw: object, code: object) -> str | None:
+    """Return a trustworthy OFF citation URL, or the server-built fallback.
+
+    The ``url`` field on an Open Food Facts product is volunteer-contributed, so
+    it must not be cited verbatim -- a ``javascript:`` or off-domain link would be
+    rendered to the user as "the source". Accept it only when it is an https
+    openfoodfacts.org URL; otherwise fall back to the URL we construct ourselves
+    from the product barcode.
+    """
+    if isinstance(raw, str):
+        parsed = urlparse(raw)
+        host = parsed.hostname or ""
+        if parsed.scheme == "https" and (
+            host == "openfoodfacts.org" or host.endswith(".openfoodfacts.org")
+        ):
+            return raw
+    if code:
+        return f"{settings.open_food_facts_base_url.rstrip('/')}/product/{code}"
+    return None
+
+
+def _valid_carbs(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    carbs = float(value)
+    if not (0.0 <= carbs <= _MAX_CARBS_PER_100G):
+        return None
+    return carbs
+
+
+async def _cache_get(
+    db: AsyncSession, source_type: str, normalized_query: str
+) -> NutritionFact | None:
+    """Return a cached, still-valid fact for this query, or None."""
+    content_hash = _cache_key(source_type, normalized_query)
+    try:
+        chunk = await db.scalar(
+            select(KnowledgeChunk).where(
+                KnowledgeChunk.source_type == source_type,
+                KnowledgeChunk.user_id.is_(None),
+                KnowledgeChunk.content_hash == content_hash,
+                KnowledgeChunk.valid_to.is_(None),
+            )
+        )
+    except Exception:
+        logger.warning("Nutrition cache lookup failed", source=source_type)
+        return None
+    if chunk is None:
+        return None
+    meta = chunk.metadata_json or {}
+    carbs = _valid_carbs(meta.get("carbs_grams"))
+    if carbs is None:
+        return None
+    return NutritionFact(
+        source_name=chunk.source_name or source_type,
+        source_url=chunk.source_url,
+        trust_tier=chunk.trust_tier,
+        name=meta.get("name") or chunk.source_name or normalized_query,
+        carbs_grams=carbs,
+        serving=meta.get("serving") or _SERVING_PER_100G,
+        disclaimer=meta.get("disclaimer"),
+    )
+
+
+async def _cache_put(
+    db: AsyncSession,
+    *,
+    source_type: str,
+    normalized_query: str,
+    fact: NutritionFact,
+) -> None:
+    """Store a fetched fact as a shared, cite-able cache chunk (best-effort).
+
+    The chunk is not embedded: it is keyed by ``content_hash`` for cache reuse and
+    is excluded from clinical retrieval, so a vector is unnecessary.
+    """
+    now = datetime.now(UTC)
+    # A published nutrition name should never contain dosing/advice phrasing; if
+    # it somehow does, flag it (defence in depth -- these chunks are not fed to a
+    # model today, but a future reader should not trust the name blindly).
+    injection_risk = bool(find_dosing_violations(fact.name))
+    content = (
+        f"{fact.name}: ~{fact.carbs_grams:g} g carbohydrate {fact.serving} "
+        f"({fact.source_name})"
+    )
+    try:
+        db.add(
+            KnowledgeChunk(
+                user_id=None,
+                trust_tier=fact.trust_tier,
+                source_type=source_type,
+                source_url=fact.source_url,
+                source_name=fact.source_name,
+                content=content[:1000],
+                embedding=None,
+                content_hash=_cache_key(source_type, normalized_query),
+                retrieved_at=now,
+                injection_risk=injection_risk,
+                metadata_json={
+                    "query": normalized_query,
+                    "name": fact.name,
+                    "carbs_grams": fact.carbs_grams,
+                    "serving": fact.serving,
+                    "disclaimer": fact.disclaimer,
+                },
+            )
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        logger.warning("Failed to cache nutrition fact", source=source_type)
+
+
+async def _get_json(base_url: str, path: str, params: dict) -> dict | None:
+    """Fetch JSON from an allow-listed host, time-boxed and redirect-free.
+
+    Returns the parsed object, or None on any error (the caller falls back to
+    vision-only). Never logs the URL or params (the data.gov key rides in params).
+    """
+    if not _host_allowed(base_url):
+        logger.warning("Nutrition base URL host not allow-listed", source=path)
+        return None
+    url = f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+    try:
+        # Stream so an oversized body is aborted mid-transfer, not buffered whole
+        # into memory and only then rejected.
+        async with (
+            httpx.AsyncClient(
+                timeout=settings.nutrition_grounding_timeout_seconds,
+                follow_redirects=False,
+                headers={"User-Agent": "GlycemicGPT/1.0 (+nutrition-grounding)"},
+            ) as client,
+            client.stream("GET", url, params=params) as resp,
+        ):
+            if resp.status_code != 200:
+                logger.warning("Nutrition source non-200", status=resp.status_code)
+                return None
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.aiter_bytes():
+                total += len(chunk)
+                if total > _MAX_RESPONSE_BYTES:
+                    logger.warning("Nutrition response too large")
+                    return None
+                chunks.append(chunk)
+        data = json.loads(b"".join(chunks))
+    except Exception:
+        # Never surface the exception text -- it can echo the URL incl. the key.
+        logger.warning("Nutrition source request failed")
+        return None
+    return data if isinstance(data, dict) else None
+
+
+async def lookup_usda(query: str) -> NutritionFact | None:
+    """Ground a generic food against USDA FoodData Central (CC0).
+
+    Skipped (returns None) when no data.gov key is configured. Cached results are
+    reused before any HTTP call. Cache reads/writes run on a dedicated session so
+    grounding never commits the caller's request transaction.
+    """
+    normalized = _normalize_query(query)
+    if not normalized or not settings.usda_fdc_api_key:
+        return None
+
+    async with get_session_maker()() as db:
+        cached = await _cache_get(db, SOURCE_TYPE_USDA, normalized)
+    if cached is not None:
+        return cached
+
+    data = await _get_json(
+        settings.usda_fdc_base_url,
+        "foods/search",
+        {
+            "api_key": settings.usda_fdc_api_key,
+            "query": query,
+            "pageSize": 1,
+            "dataType": _USDA_GENERIC_DATATYPES,
+        },
+    )
+    if data is None:
+        return None
+    foods = data.get("foods")
+    if not isinstance(foods, list) or not foods:
+        return None
+    food = foods[0]
+    if not isinstance(food, dict):
+        return None
+
+    carbs = None
+    for nutrient in food.get("foodNutrients") or []:
+        if not isinstance(nutrient, dict):
+            continue
+        number = str(nutrient.get("nutrientNumber") or "")
+        name = str(nutrient.get("nutrientName") or "").lower()
+        # Match "Carbohydrate, by difference" specifically -- not e.g.
+        # "Carbohydrate, other" -- so the per-100 g total carb is used.
+        if (
+            number == _USDA_CARB_NUTRIENT_NUMBER
+            or name == "carbohydrate, by difference"
+        ):
+            carbs = _valid_carbs(nutrient.get("value"))
+            break
+    if carbs is None:
+        return None
+
+    fdc_id = food.get("fdcId")
+    fact = NutritionFact(
+        source_name="USDA FoodData Central",
+        source_url=(
+            f"https://fdc.nal.usda.gov/fdc-app.html#/food-details/{fdc_id}/nutrients"
+            if fdc_id
+            else None
+        ),
+        trust_tier=KnowledgeChunk.TIER_AUTHORITATIVE,
+        name=str(food.get("description") or query)[:120],
+        carbs_grams=carbs,
+        serving=_SERVING_PER_100G,
+        disclaimer=None,
+    )
+    async with get_session_maker()() as db:
+        await _cache_put(
+            db, source_type=SOURCE_TYPE_USDA, normalized_query=normalized, fact=fact
+        )
+    return fact
+
+
+async def lookup_open_food_facts(query: str) -> NutritionFact | None:
+    """Ground a packaged product against Open Food Facts (ODbL, no key).
+
+    OFF's real strength is barcode lookup; a name/text search is used here. (A
+    barcode-scan input is a noted future enhancer, out of scope for 50.E1.)
+    Attribution + the non-medical disclaimer ride on the returned fact. Cache
+    reads/writes run on a dedicated session (decoupled from the caller).
+    """
+    normalized = _normalize_query(query)
+    if not normalized or not settings.open_food_facts_enabled:
+        return None
+
+    async with get_session_maker()() as db:
+        cached = await _cache_get(db, SOURCE_TYPE_OPEN_FOOD_FACTS, normalized)
+    if cached is not None:
+        return cached
+
+    data = await _get_json(
+        settings.open_food_facts_base_url,
+        "cgi/search.pl",
+        {
+            "search_terms": query,
+            "search_simple": 1,
+            "action": "process",
+            "json": 1,
+            "page_size": 1,
+            "fields": "product_name,carbohydrates_100g,code,url",
+        },
+    )
+    if data is None:
+        return None
+    products = data.get("products")
+    if not isinstance(products, list) or not products:
+        return None
+    product = products[0]
+    if not isinstance(product, dict):
+        return None
+
+    carbs = _valid_carbs(product.get("carbohydrates_100g"))
+    if carbs is None:
+        return None
+
+    name = str(product.get("product_name") or query).strip()[:120]
+    if not name:
+        name = query[:120]
+    source_url = _safe_off_citation_url(product.get("url"), product.get("code"))
+    fact = NutritionFact(
+        source_name="Open Food Facts",
+        source_url=source_url,
+        trust_tier=KnowledgeChunk.TIER_RESEARCHED,
+        name=name,
+        carbs_grams=carbs,
+        serving=_SERVING_PER_100G,
+        disclaimer=_OFF_DISCLAIMER,
+    )
+    async with get_session_maker()() as db:
+        await _cache_put(
+            db,
+            source_type=SOURCE_TYPE_OPEN_FOOD_FACTS,
+            normalized_query=normalized,
+            fact=fact,
+        )
+    return fact
+
+
+async def lookup_published_nutrition(
+    query: str,
+) -> tuple[NutritionFact | None, NutritionFact | None]:
+    """Run the USDA and OFF lookups concurrently, each failing open to None.
+
+    Each lookup uses its own session (see above), so running them concurrently is
+    safe -- they never share a connection.
+    """
+
+    async def _safe(coro):
+        try:
+            return await coro
+        except Exception:
+            logger.warning("Nutrition lookup raised", exc_info=True)
+            return None
+
+    usda, off = await asyncio.gather(
+        _safe(lookup_usda(query)),
+        _safe(lookup_open_food_facts(query)),
+    )
+    return usda, off

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -4,6 +4,7 @@ Properly configures async testing with SQLAlchemy to avoid event loop issues.
 """
 
 import asyncio
+import hashlib
 import os
 from collections.abc import AsyncGenerator
 
@@ -21,6 +22,10 @@ from src.config import settings
 settings.testing = True
 # Provide a sufficiently long secret_key for tests (generated at runtime)
 settings.secret_key = "t" * 32  # noqa: S105  -- test-only, not a real secret
+# Keep external nutrition-grounding lookups (Story 50.E1) off the network by
+# default; the grounding tests enable/patch them explicitly where needed.
+settings.open_food_facts_enabled = False
+settings.usda_fdc_api_key = ""
 
 from src.database import get_engine, get_session_maker, reset_database
 from src.main import app
@@ -60,6 +65,37 @@ async def db_session(db_engine) -> AsyncGenerator[AsyncSession, None]:
     async with session_maker() as session:
         yield session
         await session.rollback()
+
+
+@pytest.fixture(autouse=True)
+def _fake_embedding_model(monkeypatch):
+    """Replace the heavy fastembed model with a deterministic stub.
+
+    The embedding model is ~500 MB and downloads on first use; keeping it out of
+    the test run avoids a network dependency in CI. The stub is deterministic --
+    identical text yields an identical unit vector (cosine distance 0) and
+    different text yields a near-orthogonal one -- so own-history meal recall
+    (Story 50.E1) is testable without the real model. Tests that patch
+    ``embed_text`` directly are unaffected: they replace the imported symbol,
+    not this model factory.
+    """
+    import numpy as np
+
+    from src.services import embedding
+
+    class _FakeEmbeddingModel:
+        def embed(self, texts):
+            for text in texts:
+                seed = int.from_bytes(
+                    hashlib.sha256(text.encode("utf-8")).digest()[:8], "big"
+                )
+                vec = np.random.default_rng(seed).standard_normal(
+                    embedding.EMBEDDING_DIM
+                )
+                norm = np.linalg.norm(vec)
+                yield vec / norm if norm else vec
+
+    monkeypatch.setattr(embedding, "_get_model", lambda: _FakeEmbeddingModel())
 
 
 @pytest_asyncio.fixture

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -1,0 +1,751 @@
+"""Story 50.E1: grounding -- own-history RAG recall + USDA/OFF + precedence.
+
+Covers the two grounding mechanisms kept architecturally distinct by trust tier:
+own-history recall (USER_PROVIDED) and external published facts (USDA
+AUTHORITATIVE / Open Food Facts RESEARCHED); the precedence reconciliation; the
+SSRF/key-handling guards on the external fetch; the clinical-retrieval exclusion;
+and the cornerstone safety invariant (grounding never couples into dosing math).
+
+Embeddings are stubbed deterministically by the autouse ``_fake_embedding_model``
+conftest fixture: identical text -> identical vector (cosine distance 0), so
+own-history recall is exercised without the real model. External HTTP is mocked.
+"""
+
+import json
+import uuid
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from src.config import settings
+from src.database import get_session_maker
+from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProviderType
+from src.models.common_food import CommonFood, normalize_common_food_name
+from src.models.food_record import FoodRecord, FoodRecordSource
+from src.models.knowledge_chunk import KnowledgeChunk
+from src.models.user import User, UserRole
+from src.services import food_vision, meal_grounding, meal_rag, nutrition_sources
+from src.vision.carb_contract import find_dosing_violations
+
+# (asyncio_mode = "auto" in pyproject -- async tests need no explicit mark.)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _uniq(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+async def _new_user(db) -> User:
+    user = User(
+        email=f"grounding_{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        role=UserRole.DIABETIC,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _new_record(
+    db,
+    user: User,
+    description: str,
+    *,
+    low: float = 40,
+    high: float = 55,
+    corrected: tuple[float, float] | None = None,
+) -> FoodRecord:
+    record = FoodRecord(
+        user_id=user.id,
+        filename="x.png",
+        file_type="png",
+        file_size_bytes=10,
+        storage_path=f"/uploads/food/{user.id}/x.png",
+        food_description=description,
+        carbs_low=low,
+        carbs_high=high,
+        confidence="medium",
+        source=FoodRecordSource.AI_ESTIMATE,
+    )
+    if corrected is not None:
+        record.corrected_carbs_low, record.corrected_carbs_high = corrected
+        record.source = FoodRecordSource.USER_CORRECTED
+    db.add(record)
+    await db.commit()
+    await db.refresh(record)
+    return record
+
+
+async def _user_with_provider(db) -> User:
+    user = await _new_user(db)
+    db.add(
+        AIProviderConfig(
+            user_id=user.id,
+            provider_type=AIProviderType.CLAUDE_API,
+            model_name="claude-sonnet-4-5-20250929",
+            status=AIProviderStatus.CONNECTED,
+        )
+    )
+    await db.commit()
+    return user
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (16, 16), (90, 30, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _estimate_json(desc: str, low: float = 40, high: float = 55) -> str:
+    return json.dumps(
+        {
+            "food_description": desc,
+            "carbs_grams_low": low,
+            "carbs_grams_high": high,
+            "confidence": "medium",
+        }
+    )
+
+
+def _mock_httpx(payload: dict, status: int = 200, *, body: bytes | None = None):
+    """Patch httpx.AsyncClient.stream so the lookup gets ``payload``.
+
+    ``_get_json`` streams the response, so we mock ``client.stream(...)`` as an
+    async context manager yielding a response with ``aiter_bytes()``. Returns the
+    patch context and the client mock; assert on ``client.stream.call_count`` /
+    ``call_args``.
+    """
+    raw = body if body is not None else json.dumps(payload).encode()
+
+    async def _aiter_bytes():
+        yield raw
+
+    resp = MagicMock()
+    resp.status_code = status
+    resp.aiter_bytes = _aiter_bytes
+
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=resp)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+    client = AsyncMock()
+    client.stream = MagicMock(return_value=stream_cm)  # stream() is sync -> CM
+    ctx = patch("httpx.AsyncClient")
+    return ctx, client
+
+
+# --------------------------------------------------------------------------- #
+# Own-history RAG recall (AC1)
+# --------------------------------------------------------------------------- #
+class TestOwnHistoryRecall:
+    async def test_index_then_recall_same_food(self):
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            desc = _uniq("a bowl of oatmeal with berries")
+            record = await _new_record(db, user, desc, low=30, high=40)
+
+        await meal_rag.index_food_record(record)
+
+        recall = await meal_rag.recall_similar_meal(user.id, desc)
+        assert recall is not None
+        assert recall.carbs_low == 30 and recall.carbs_high == 40
+        assert recall.is_corrected is False
+        assert recall.food_record_id == str(record.id)
+        assert recall.distance == pytest.approx(0.0, abs=1e-6)
+
+    async def test_recall_prefers_corrected_value(self):
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            desc = _uniq("grilled chicken and rice")
+            record = await _new_record(
+                db, user, desc, low=50, high=70, corrected=(80, 90)
+            )
+
+        await meal_rag.index_food_record(record)
+
+        recall = await meal_rag.recall_similar_meal(user.id, desc)
+        assert recall is not None
+        # The corrected value -- the user's truth -- is what gets recalled.
+        assert recall.is_corrected is True
+        assert recall.carbs_low == 80 and recall.carbs_high == 90
+
+    async def test_different_food_does_not_match(self):
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            record = await _new_record(db, user, _uniq("oatmeal"), low=30, high=40)
+
+        await meal_rag.index_food_record(record)
+
+        recall = await meal_rag.recall_similar_meal(user.id, _uniq("ribeye steak"))
+        assert recall is None
+
+    async def test_recall_is_owner_scoped(self):
+        desc = _uniq("shared dish name")
+        async with get_session_maker()() as db:
+            owner = await _new_user(db)
+            other = await _new_user(db)
+            record = await _new_record(db, owner, desc, low=20, high=25)
+
+        await meal_rag.index_food_record(record)
+
+        # The other user must never recall someone else's history.
+        assert await meal_rag.recall_similar_meal(other.id, desc) is None
+        assert await meal_rag.recall_similar_meal(owner.id, desc) is not None
+
+    async def test_reindex_replaces_prior_chunk(self):
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            desc = _uniq("pasta plate")
+            record = await _new_record(db, user, desc, low=40, high=55)
+
+        await meal_rag.index_food_record(record)
+
+        # Correct the record and re-index: recall must now reflect the new value
+        # and there must be exactly one live chunk for the record.
+        async with get_session_maker()() as db:
+            record = await db.get(FoodRecord, record.id)
+            record.corrected_carbs_low = 60
+            record.corrected_carbs_high = 70
+            record.source = FoodRecordSource.USER_CORRECTED
+            await db.commit()
+            await db.refresh(record)
+        await meal_rag.index_food_record(record)
+
+        recall = await meal_rag.recall_similar_meal(user.id, desc)
+        assert recall.carbs_low == 60 and recall.carbs_high == 70
+
+        async with get_session_maker()() as db:
+            from sqlalchemy import func, select
+
+            live = await db.scalar(
+                select(func.count())
+                .select_from(KnowledgeChunk)
+                .where(
+                    KnowledgeChunk.user_id == user.id,
+                    KnowledgeChunk.source_type == meal_rag.SOURCE_TYPE_FOOD_RECORD,
+                    KnowledgeChunk.metadata_json["food_record_id"].astext
+                    == str(record.id),
+                    KnowledgeChunk.valid_to.is_(None),
+                )
+            )
+        assert live == 1
+
+    async def test_common_food_indexed_as_corrected_baseline(self):
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            name = _uniq("My usual smoothie")
+            cf = CommonFood(
+                user_id=user.id,
+                name=name,
+                normalized_name=normalize_common_food_name(name),
+                carbs_low=35,
+                carbs_high=45,
+            )
+            db.add(cf)
+            await db.commit()
+            await db.refresh(cf)
+
+        await meal_rag.index_common_food(cf)
+
+        recall = await meal_rag.recall_similar_meal(user.id, name)
+        assert recall is not None
+        assert recall.common_food_id == str(cf.id)
+        assert recall.is_corrected is True  # a curated baseline is the truth
+
+
+# --------------------------------------------------------------------------- #
+# External sources: USDA + Open Food Facts (AC2/AC3)
+# --------------------------------------------------------------------------- #
+class TestUsda:
+    _PAYLOAD = {
+        "foods": [
+            {
+                "description": "Oatmeal, cooked",
+                "fdcId": 123456,
+                "foodNutrients": [
+                    {"nutrientNumber": "203", "nutrientName": "Protein", "value": 2.0},
+                    {
+                        "nutrientNumber": "205",
+                        "nutrientName": "Carbohydrate, by difference",
+                        "value": 12.0,
+                        "unitName": "G",
+                    },
+                ],
+            }
+        ]
+    }
+
+    async def test_lookup_parses_and_caches(self, monkeypatch):
+        monkeypatch.setattr(settings, "usda_fdc_api_key", "TESTKEY")
+        query = _uniq("oatmeal")
+        ctx, client = _mock_httpx(self._PAYLOAD)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            first = await nutrition_sources.lookup_usda(query)
+            second = await nutrition_sources.lookup_usda(query)
+
+        assert first is not None
+        assert first.source_name == "USDA FoodData Central"
+        assert first.trust_tier == KnowledgeChunk.TIER_AUTHORITATIVE
+        assert first.carbs_grams == 12.0
+        assert first.serving == "per 100 g"
+        assert "fdc-app" in (first.source_url or "")
+        # Second call is served from the cache -- no second HTTP request.
+        assert client.stream.call_count == 1
+        assert second is not None and second.carbs_grams == 12.0
+
+    async def test_skipped_without_api_key(self, monkeypatch):
+        monkeypatch.setattr(settings, "usda_fdc_api_key", "")
+        ctx, client = _mock_httpx(self._PAYLOAD)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            result = await nutrition_sources.lookup_usda(_uniq("anything"))
+        assert result is None
+        assert client.stream.call_count == 0  # no key -> no network at all
+
+    async def test_implausible_carbs_rejected(self, monkeypatch):
+        monkeypatch.setattr(settings, "usda_fdc_api_key", "TESTKEY")
+        payload = {
+            "foods": [
+                {
+                    "description": "Bad row",
+                    "fdcId": 1,
+                    "foodNutrients": [
+                        {"nutrientNumber": "205", "value": 250.0}  # >100 g/100 g
+                    ],
+                }
+            ]
+        }
+        ctx, client = _mock_httpx(payload)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            result = await nutrition_sources.lookup_usda(_uniq("bad"))
+        assert result is None
+
+
+class TestOpenFoodFacts:
+    def _payload(self):
+        return {
+            "products": [
+                {
+                    "product_name": "Brand Cereal",
+                    "carbohydrates_100g": 70.0,
+                    "code": "999",
+                    "url": "https://world.openfoodfacts.org/product/999",
+                }
+            ]
+        }
+
+    async def test_lookup_attribution_and_disclaimer(self, monkeypatch):
+        monkeypatch.setattr(settings, "open_food_facts_enabled", True)
+        ctx, client = _mock_httpx(self._payload())
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await nutrition_sources.lookup_open_food_facts(_uniq("cereal"))
+        assert fact is not None
+        assert fact.source_name == "Open Food Facts"
+        assert fact.trust_tier == KnowledgeChunk.TIER_RESEARCHED
+        assert fact.carbs_grams == 70.0
+        assert fact.source_url == "https://world.openfoodfacts.org/product/999"
+        assert fact.disclaimer and "Open Food Facts" in fact.disclaimer
+
+    async def test_disabled_returns_none(self, monkeypatch):
+        monkeypatch.setattr(settings, "open_food_facts_enabled", False)
+        ctx, client = _mock_httpx(self._payload())
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            assert await nutrition_sources.lookup_open_food_facts(_uniq("x")) is None
+        assert client.stream.call_count == 0
+
+    async def test_malicious_product_url_rejected(self, monkeypatch):
+        # A volunteer-contributed off-domain / javascript: URL must not be cited
+        # verbatim; we fall back to the server-built /product/<code> URL.
+        monkeypatch.setattr(settings, "open_food_facts_enabled", True)
+        payload = {
+            "products": [
+                {
+                    "product_name": "Sketchy Item",
+                    "carbohydrates_100g": 20.0,
+                    "code": "555",
+                    "url": "javascript:alert(1)",
+                }
+            ]
+        }
+        ctx, client = _mock_httpx(payload)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await nutrition_sources.lookup_open_food_facts(_uniq("sketchy"))
+        assert fact is not None
+        assert fact.source_url == "https://world.openfoodfacts.org/product/555"
+
+    def test_off_url_validator(self):
+        ok = nutrition_sources._safe_off_citation_url(
+            "https://world.openfoodfacts.org/product/1", "1"
+        )
+        assert ok == "https://world.openfoodfacts.org/product/1"
+        # Off-domain / non-https / dangerous schemes fall back to the built URL.
+        for bad in (
+            "http://world.openfoodfacts.org/x",
+            "https://evil.com/x",
+            "javascript:x",
+        ):
+            assert (
+                nutrition_sources._safe_off_citation_url(bad, "9")
+                == "https://world.openfoodfacts.org/product/9"
+            )
+        # No usable url and no code -> None.
+        assert nutrition_sources._safe_off_citation_url("javascript:x", None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Security: SSRF / host allow-list on the external fetch
+# --------------------------------------------------------------------------- #
+class TestExternalFetchSecurity:
+    def test_host_allowlist(self):
+        assert nutrition_sources._host_allowed("https://api.nal.usda.gov")
+        assert nutrition_sources._host_allowed("https://world.openfoodfacts.org")
+        # Internal / metadata / plaintext targets are rejected.
+        assert not nutrition_sources._host_allowed("http://api.nal.usda.gov")
+        assert not nutrition_sources._host_allowed("https://169.254.169.254")
+        assert not nutrition_sources._host_allowed("https://localhost")
+        assert not nutrition_sources._host_allowed("https://evil.example.com")
+
+    async def test_disallowed_base_url_makes_no_request(self, monkeypatch):
+        monkeypatch.setattr(settings, "usda_fdc_api_key", "TESTKEY")
+        monkeypatch.setattr(settings, "usda_fdc_base_url", "http://169.254.169.254")
+        ctx, client = _mock_httpx({"foods": []})
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            result = await nutrition_sources.lookup_usda(_uniq("x"))
+        assert result is None
+        # Guard short-circuits before any HTTP client is constructed.
+        assert client.stream.call_count == 0
+
+    async def test_request_uses_redirect_free_param_query(self, monkeypatch):
+        # The search term travels as an encoded query *param*, never the path,
+        # and redirects are not followed (no redirect-based SSRF).
+        monkeypatch.setattr(settings, "usda_fdc_api_key", "TESTKEY")
+        query = _uniq("oatmeal")  # unique -> guaranteed cache miss -> real fetch
+        ctx, client = _mock_httpx(TestUsda._PAYLOAD)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            await nutrition_sources.lookup_usda(query)
+        # AsyncClient configured with follow_redirects=False.
+        _, kwargs = ac.call_args
+        assert kwargs.get("follow_redirects") is False
+        # The query rode in params, not interpolated into the URL path.
+        _, get_kwargs = client.stream.call_args
+        assert get_kwargs["params"]["query"] == query
+
+    async def test_non_200_returns_none(self, monkeypatch):
+        monkeypatch.setattr(settings, "usda_fdc_api_key", "TESTKEY")
+        ctx, client = _mock_httpx({"foods": []}, status=500)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            assert await nutrition_sources.lookup_usda(_uniq("x")) is None
+
+    async def test_oversized_body_rejected(self, monkeypatch):
+        monkeypatch.setattr(settings, "usda_fdc_api_key", "TESTKEY")
+        monkeypatch.setattr(nutrition_sources, "_MAX_RESPONSE_BYTES", 16)
+        ctx, client = _mock_httpx({}, body=b"x" * 64)  # 64 bytes > 16-byte cap
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            assert await nutrition_sources.lookup_usda(_uniq("x")) is None
+
+
+# --------------------------------------------------------------------------- #
+# Precedence reconciliation (AC4)
+# --------------------------------------------------------------------------- #
+class TestPrecedence:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch):
+        monkeypatch.setattr(settings, "meal_intelligence_enabled", True)
+
+    def _recall(self, *, corrected: bool):
+        return meal_rag.MealRecall(
+            name="leftover stew",
+            carbs_low=33,
+            carbs_high=33,
+            is_corrected=corrected,
+            food_record_id="r1",
+            common_food_id=None,
+            distance=0.05,
+        )
+
+    def _fact(self, source, tier, carbs, disclaimer=None):
+        return nutrition_sources.NutritionFact(
+            source_name=source,
+            source_url="https://example.org/x",
+            trust_tier=tier,
+            name=source,
+            carbs_grams=carbs,
+            serving="per 100 g",
+            disclaimer=disclaimer,
+        )
+
+    async def test_corrected_history_wins_and_skips_external(self):
+        with (
+            patch.object(
+                meal_rag,
+                "recall_similar_meal",
+                AsyncMock(return_value=self._recall(corrected=True)),
+            ),
+            patch.object(
+                nutrition_sources, "lookup_published_nutrition", AsyncMock()
+            ) as lookup,
+        ):
+            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "stew")
+        assert detail is not None
+        assert detail.source == "Your meal history"
+        assert detail.trust_tier == KnowledgeChunk.TIER_USER_PROVIDED
+        assert detail.carbs_low == 33
+        # Corrected history short-circuits -- the external lookup never runs.
+        lookup.assert_not_awaited()
+
+    async def test_usda_preferred_over_off(self):
+        usda = self._fact(
+            "USDA FoodData Central", KnowledgeChunk.TIER_AUTHORITATIVE, 12
+        )
+        off = self._fact("Open Food Facts", KnowledgeChunk.TIER_RESEARCHED, 70)
+        with (
+            patch.object(meal_rag, "recall_similar_meal", AsyncMock(return_value=None)),
+            patch.object(
+                nutrition_sources,
+                "lookup_published_nutrition",
+                AsyncMock(return_value=(usda, off)),
+            ),
+        ):
+            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "oatmeal")
+        assert detail.source == "USDA FoodData Central"
+        assert detail.carbs_low == 12
+
+    async def test_off_used_when_no_usda(self):
+        off = self._fact(
+            "Open Food Facts",
+            KnowledgeChunk.TIER_RESEARCHED,
+            70,
+            disclaimer="Open Food Facts (ODbL) -- verify before dosing.",
+        )
+        with (
+            patch.object(meal_rag, "recall_similar_meal", AsyncMock(return_value=None)),
+            patch.object(
+                nutrition_sources,
+                "lookup_published_nutrition",
+                AsyncMock(return_value=(None, off)),
+            ),
+        ):
+            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "cereal")
+        assert detail.source == "Open Food Facts"
+        assert detail.disclaimer  # OFF disclaimer carried through
+
+    async def test_uncorrected_history_below_published(self):
+        # When nothing published matches, an uncorrected prior log still grounds.
+        with (
+            patch.object(
+                meal_rag,
+                "recall_similar_meal",
+                AsyncMock(return_value=self._recall(corrected=False)),
+            ),
+            patch.object(
+                nutrition_sources,
+                "lookup_published_nutrition",
+                AsyncMock(return_value=(None, None)),
+            ),
+        ):
+            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "stew")
+        assert detail.source == "Your meal history"
+
+    async def test_pure_vision_when_nothing_grounds(self):
+        with (
+            patch.object(meal_rag, "recall_similar_meal", AsyncMock(return_value=None)),
+            patch.object(
+                nutrition_sources,
+                "lookup_published_nutrition",
+                AsyncMock(return_value=(None, None)),
+            ),
+        ):
+            assert await meal_grounding.ground_estimate(uuid.uuid4(), "x") is None
+
+    async def test_empty_description_is_ungrounded(self):
+        assert await meal_grounding.ground_estimate(uuid.uuid4(), "") is None
+        assert await meal_grounding.ground_estimate(uuid.uuid4(), None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Clinical-retrieval separation (AC4): food chunks never leak into clinical RAG
+# --------------------------------------------------------------------------- #
+class TestRetrievalSeparation:
+    async def test_food_chunks_excluded_from_clinical_retrieval(self):
+        from src.services.embedding import embed_text
+        from src.services.knowledge_retrieval import retrieve_knowledge
+
+        query = _uniq("how do I handle a high reading")
+        emb = embed_text(query)  # deterministic stub
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            # A clinical chunk (should be retrieved) and a food-grounding chunk
+            # (must be excluded) with the SAME embedding so only the source_type
+            # filter can separate them.
+            db.add(
+                KnowledgeChunk(
+                    user_id=user.id,
+                    trust_tier=KnowledgeChunk.TIER_USER_PROVIDED,
+                    source_type="user_document",
+                    source_name="Clinical note",
+                    content="clinical content",
+                    embedding=emb,
+                )
+            )
+            db.add(
+                KnowledgeChunk(
+                    user_id=user.id,
+                    trust_tier=KnowledgeChunk.TIER_USER_PROVIDED,
+                    source_type=meal_rag.SOURCE_TYPE_FOOD_RECORD,
+                    source_name="oatmeal",
+                    content="oatmeal",
+                    embedding=emb,
+                )
+            )
+            await db.commit()
+
+            chunks = await retrieve_knowledge(db, user.id, query)
+        source_types = {c.source_type for c in chunks}
+        assert "user_document" in source_types
+        assert meal_rag.SOURCE_TYPE_FOOD_RECORD not in source_types
+
+
+# --------------------------------------------------------------------------- #
+# Safety: grounding sharpens the descriptive estimate, never a dose (AC5)
+# --------------------------------------------------------------------------- #
+class TestNoTherapyCoupling:
+    def test_dosing_math_modules_do_not_reference_grounding(self):
+        """Static guard: therapy-math modules never import the grounding code."""
+        api_root = Path(__file__).resolve().parents[1]
+        therapy_sources = [
+            api_root / "src" / "services" / "iob_projection.py",
+            api_root / "src" / "core" / "treatment_safety" / "validator.py",
+            api_root / "src" / "core" / "treatment_safety" / "models.py",
+            api_root / "src" / "core" / "treatment_safety" / "constants.py",
+        ]
+        for path in therapy_sources:
+            text = path.read_text()
+            for needle in (
+                "meal_rag",
+                "meal_grounding",
+                "nutrition_sources",
+                "grounding",
+            ):
+                assert needle not in text, f"{path} references {needle}"
+
+    async def test_grounding_output_carries_no_dosing_language(self, monkeypatch):
+        monkeypatch.setattr(settings, "meal_intelligence_enabled", True)
+        # Every rendered grounding string must be free of dosing/advice phrasing.
+        recall = meal_rag.MealRecall(
+            name="oatmeal",
+            carbs_low=30,
+            carbs_high=40,
+            is_corrected=True,
+            food_record_id="r",
+            common_food_id=None,
+            distance=0.0,
+        )
+        with (
+            patch.object(
+                meal_rag, "recall_similar_meal", AsyncMock(return_value=recall)
+            ),
+        ):
+            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "oatmeal")
+        for field in (detail.source, detail.note, detail.serving):
+            assert not find_dosing_violations(field or "")
+
+    def test_food_record_grounding_columns_not_read_by_therapy(self):
+        # The new attribution columns must not leak into treatment-safety models.
+        api_root = Path(__file__).resolve().parents[1]
+        validator = (
+            api_root / "src" / "core" / "treatment_safety" / "validator.py"
+        ).read_text()
+        assert "grounding_source" not in validator
+
+
+# --------------------------------------------------------------------------- #
+# Estimation pipeline: grounding wired end-to-end (AC1 + AC4 + AC5)
+# --------------------------------------------------------------------------- #
+class TestEstimatePipelineGrounding:
+    @pytest.fixture(autouse=True)
+    def _enable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "upload_dir", str(tmp_path / "uploads"))
+        monkeypatch.setattr(settings, "meal_intelligence_enabled", True)
+
+    async def test_estimate_grounds_against_own_corrected_history(self):
+        from src.services import common_food as common_food_service
+
+        desc = _uniq("homemade lasagna")
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            # A prior logged + corrected record seeds own-history grounding.
+            prior = await _new_record(db, user, desc, low=40, high=55)
+            from src.schemas.food_record import FoodRecordCorrectionRequest
+
+            await common_food_service.correct_food_record(
+                db,
+                prior,
+                FoodRecordCorrectionRequest(
+                    corrected_carbs_low=70, corrected_carbs_high=80
+                ),
+            )
+
+        # A new photo the model identifies as the same food.
+        async with get_session_maker()() as db:
+            user = await db.get(User, user.id)
+            with patch.object(
+                food_vision,
+                "_call_vision",
+                AsyncMock(return_value=_estimate_json(desc, 45, 60)),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        # The persisted carbs stay the fresh vision estimate...
+        assert record.carbs_low == 45 and record.carbs_high == 60
+        # ...but it is grounded against the user's own corrected history.
+        assert record.grounding_source == "Your meal history"
+        assert record.grounding_trust_tier == KnowledgeChunk.TIER_USER_PROVIDED
+        assert record.grounding is not None
+        assert record.grounding.carbs_low == 70 and record.grounding.carbs_high == 80
+        assert "logged this before" in (record.grounding.note or "")
+        # Safety: nothing in the grounding output is dosing guidance.
+        assert not find_dosing_violations(record.grounding.note or "")
+
+    async def test_estimate_falls_back_to_vision_only_on_grounding_failure(self):
+        desc = _uniq("mystery casserole")
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            user = await db.get(User, user.id)
+            with (
+                patch.object(
+                    food_vision,
+                    "_call_vision",
+                    AsyncMock(return_value=_estimate_json(desc, 30, 45)),
+                ),
+                patch.object(
+                    meal_grounding,
+                    "ground_estimate",
+                    AsyncMock(side_effect=RuntimeError("source down")),
+                ),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        # Estimate still persists; grounding degraded cleanly to vision-only.
+        assert record.carbs_low == 30 and record.carbs_high == 45
+        assert record.grounding_source is None
+        assert record.grounding_trust_tier is None
+        assert record.grounding is None

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -328,6 +328,43 @@ class TestUsda:
             result = await nutrition_sources.lookup_usda(_uniq("bad"))
         assert result is None
 
+    async def test_cache_put_is_idempotent(self):
+        # Two writes for the same (source_type, query) -- e.g. concurrent
+        # first-time lookups -- must not raise on the unique index; the second
+        # upserts the latest value.
+        query = _uniq("idempotent food")
+        fact1 = nutrition_sources.NutritionFact(
+            source_name="USDA FoodData Central",
+            source_url="https://fdc.nal.usda.gov/x",
+            trust_tier=KnowledgeChunk.TIER_AUTHORITATIVE,
+            name="thing",
+            carbs_grams=12.0,
+            serving="per 100 g",
+            disclaimer=None,
+        )
+        fact2 = nutrition_sources.NutritionFact(
+            **{**fact1.__dict__, "carbs_grams": 20.0}
+        )
+        async with get_session_maker()() as db:
+            await nutrition_sources._cache_put(
+                db,
+                source_type=meal_rag.SOURCE_TYPE_USDA,
+                normalized_query=query,
+                fact=fact1,
+            )
+            await nutrition_sources._cache_put(
+                db,
+                source_type=meal_rag.SOURCE_TYPE_USDA,
+                normalized_query=query,
+                fact=fact2,
+            )
+            cached = await nutrition_sources._cache_get(
+                db, meal_rag.SOURCE_TYPE_USDA, query
+            )
+        assert (
+            cached is not None and cached.carbs_grams == 20.0
+        )  # updated, not rejected
+
 
 class TestOpenFoodFacts:
     def _payload(self):
@@ -727,7 +764,6 @@ class TestEstimatePipelineGrounding:
         desc = _uniq("mystery casserole")
         async with get_session_maker()() as db:
             user = await _user_with_provider(db)
-            user = await db.get(User, user.id)
             with (
                 patch.object(
                     food_vision,


### PR DESCRIPTION
## Summary
(Meal Intelligence). Makes the meal-photo carb estimate "smarter as it grows" by grounding it against two distinct sources, kept architecturally separate by trust tier:

- **Own history (RAG, `USER_PROVIDED`)** — food records and common foods are indexed into `knowledge_chunks` (owner-scoped); re-photographing a known food recalls the saved record ("you've logged this before") and prefers the user's corrected value.
- **Published nutrition (research, `AUTHORITATIVE`/`RESEARCHED`)** — generic foods against **USDA FoodData Central** (CC0) and packaged products against **Open Food Facts** (ODbL, no key). Both licences permit caching/redistribution, so results are stored + cited; OFF attribution and its non-medical disclaimer are surfaced.

Estimates return which source grounded them (own history vs USDA vs OFF vs pure vision) and fall back gracefully to a vision-only estimate when a lookup fails. Everything is flag-gated under `meal_intelligence_enabled`.

## Grounding precedence (AC4)

own-history corrected value > USDA > Open Food Facts > own-history uncorrected > pure vision. A corrected own-history match short-circuits and skips the external calls.

## What changed

- **Migration `069_food_record_grounding`** — nullable `grounding_source` / `grounding_source_url` / `grounding_trust_tier` attribution columns on `food_records` (the deferred 50.B amendment). Attribution only: the carb values stay in `carbs_low`/`carbs_high` (vision) and `corrected_*` (user truth).
- **`meal_rag.py`** — own-history indexing + vector recall (cosine similarity, tighter threshold than clinical retrieval), idempotent upsert keyed on the partial unique `content_hash` index. Re-indexed on correction and common-food promotion.
- **`nutrition_sources.py`** — USDA + OFF lookups with a host allow-list, no-redirect, streamed body cap, hard timeout, and the data.gov key never logged; results cached + cited as shared chunks. The volunteer-contributed OFF product URL is validated before it is cited.
- **`meal_grounding.py`** — precedence orchestrator returning a descriptive citation (range + serving + note + disclaimer).
- **`knowledge_retrieval.py`** — food-grounding chunks excluded from clinical RAG retrieval so the two mechanisms never cross.
- Wired into the estimation pipeline (`food_vision.py`); the API returns the grounding source + grounded range on create.

## Safety (AC5)

Grounding sharpens the **descriptive** estimate only — no dosing output, nothing couples into IoB / `treatment_safety` / carb-ratio math, and the verify-before-dosing framing is preserved. A no-coupling invariant test mirrors the B/C/F guards.

## Notes / scope

- The data.gov key is per-deployment (BYO or bundled); empty key → USDA grounding is skipped silently. 1k req/hr/IP suits a self-hoster.
- Restaurant grounding is **50.E2** (different sources/licensing). Barcode scanning is noted as a future OFF enhancer, out of scope here.
- Surfacing the citation in the mobile UI is a thin follow-on; the API already returns it.

## Testing / gates

- `tests/test_meal_grounding.py` (recall, USDA/OFF parse + cache + SSRF guards + key handling, precedence, clinical-retrieval separation, no-coupling invariant, end-to-end pipeline grounding + vision-only fallback) plus `test_food_records.py`; full backend suite green (one unrelated pre-existing nightscout flake).
- `ruff check` + `ruff format` clean; adversarial + senior reviews and CodeRabbit CLI addressed; security review of the staged diff clean; Sentry validation gate run (own-history, USDA, OFF, vision-only paths exercised) with no new unresolved issues attributable to the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added “nutrition grounding” attribution on food records, including provenance (source, trust tier, and grounded carb range details).
  * Implemented grounding estimation for vision-based entries, with graceful fallback when grounding isn’t available.
  * Added own-history meal RAG indexing and recall, plus best-effort re-indexing after corrections and common-food promotion.

* **New Configuration**
  * Added settings to enable/disable nutrition grounding and external sourcing, including API keys/base URLs and a per-call timeout.

* **Data & Schema**
  * Added a migration to persist grounding attribution fields.

* **Tests**
  * Added end-to-end coverage for grounding, retrieval separation, caching, and external-source security.

* **Chores**
  * Updated `.gitignore` to exclude Playwright MCP session artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->