### PR TITLE
feat: Milestone H — empirical confidence, identity gating & auditability (H1–H3)

### DIFF
--- a/apps/api/migrations/versions/070_food_record_identity.py
+++ b/apps/api/migrations/versions/070_food_record_identity.py
@@ -1,0 +1,59 @@
+"""Add food-identity confirmation columns to food_records (Story 50.H2).
+
+Food *misidentification* is the dominant, upstream error in LLM carb vision, and
+grounding (50.E1/E2) amplifies it: grounding a misidentified food to USDA /
+restaurant data certifies a confident-wrong answer with an authoritative
+citation. So identity becomes a confirmable thing the user owns, separate from
+the carb correction (50.C1), and external authoritative grounding only applies
+to a confirmed-or-corrected identity.
+
+Two columns, mirroring the preserve-the-original pattern used for carbs
+(``food_description`` keeps the AI-identified name, like ``carbs_low/high`` keep
+the AI estimate):
+
+* ``confirmed_food_name`` -- the user's confirmed-or-corrected identity. NULL
+  until the user acts. This is the identity used as the grounding key (and the
+  one 50.H3 records as "the identity grounding ran against").
+* ``identity_confirmed`` -- whether the identity has been confirmed. Gates
+  external grounding: while False the estimate stays vision-only.
+
+Attribution only -- nothing here is read by IoB / treatment_safety / carb-ratio
+math.
+
+Revision ID: 070_food_record_identity
+Revises: 069_food_record_grounding
+Create Date: 2026-06-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "070_food_record_identity"
+down_revision = "069_food_record_grounding"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # The user-confirmed / corrected food identity. NULL = not yet confirmed.
+    op.add_column(
+        "food_records",
+        sa.Column("confirmed_food_name", sa.Text(), nullable=True),
+    )
+    # Whether the identity has been confirmed. NOT NULL with a False server
+    # default so every existing row is correctly "unconfirmed" (and therefore
+    # ungrounded-by-external-sources) without a data backfill.
+    op.add_column(
+        "food_records",
+        sa.Column(
+            "identity_confirmed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("food_records", "identity_confirmed")
+    op.drop_column("food_records", "confirmed_food_name")

--- a/apps/api/migrations/versions/071_food_record_audit_provenance.py
+++ b/apps/api/migrations/versions/071_food_record_audit_provenance.py
@@ -1,0 +1,68 @@
+"""Add the food_record_audits provenance table (Story 50.H3).
+
+Makes a meal-photo estimate auditable after the fact: per food record, the raw
+per-sample vision outputs (50.H1), the empirical dispersion summary, and the
+precedence decision + identity used (50.H2). 1:1 with food_records, owner-scoped,
+and ON DELETE CASCADE on both the record and the user so deleting either (single
+delete or a retention purge) drops the audit trail automatically -- no raw image
+bytes are duplicated (the photo reference stays on the food record). The grounding
+attribution itself reuses the existing food_records.grounding_* columns (50.E1);
+this table adds only the new raw-sample + precedence provenance.
+
+Revision ID: 071_food_record_audit_provenance
+Revises: 070_food_record_identity
+Create Date: 2026-06-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "071_food_record_audit_provenance"
+down_revision = "070_food_record_identity"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "food_record_audits",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("food_record_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("samples_json", JSONB(), nullable=True),
+        sa.Column("dispersion_json", JSONB(), nullable=True),
+        sa.Column("precedence_json", JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["food_record_id"], ["food_records.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        # 1:1 with the food record.
+        sa.UniqueConstraint(
+            "food_record_id", name="uq_food_record_audits_food_record_id"
+        ),
+    )
+    op.create_index("ix_food_record_audits_user_id", "food_record_audits", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_food_record_audits_user_id", table_name="food_record_audits")
+    op.drop_table("food_record_audits")

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -159,6 +159,13 @@ class Settings(BaseSettings):
     # Timeout (seconds) for the sidecar vision call; longer than the text
     # timeout because a CLI vision provider can take tens of seconds.
     vision_request_timeout_seconds: float = Field(default=120.0, gt=0)
+    # Multi-sample estimation (Story 50.H1). One photo is sampled this many times
+    # in a single request; the confidence/range come from the observed spread,
+    # not the model's (discredited) self-reported confidence. Cost guardrail:
+    # ~N x vision tokens/estimate, so capped low (1 disables multi-sampling and
+    # yields a single, necessarily low-confidence draw). 50.H4's variance harness
+    # tunes the value against the accuracy-vs-cost curve.
+    meal_estimate_sample_count: int = Field(default=3, ge=1, le=7)
 
     # Nutrition grounding (Story 50.E1). Estimates are grounded against the
     # user's own logged history (RAG) and published nutrition facts. The external

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -23,6 +23,7 @@ from src.models.escalation_event import (
     NotificationStatus,
 )
 from src.models.food_record import FoodRecord, FoodRecordSource
+from src.models.food_record_audit import FoodRecordAudit
 from src.models.glooko_sync_state import GlookoSyncState
 from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.insulin_config import InsulinConfig
@@ -76,6 +77,7 @@ __all__ = [
     "EscalationEvent",
     "EscalationTier",
     "FoodRecord",
+    "FoodRecordAudit",
     "FoodRecordSource",
     "GlookoSyncState",
     "GlucoseReading",

--- a/apps/api/src/models/food_record.py
+++ b/apps/api/src/models/food_record.py
@@ -17,6 +17,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     DateTime,
     Enum,
@@ -154,6 +155,21 @@ class FoodRecord(Base):
         ForeignKey("common_foods.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
+    )
+
+    # --- Food-identity confirmation (Story 50.H2) ---
+    # The AI-identified name lives in ``food_description`` (preserved, like the
+    # original carb estimate). These record the user's confirmation/correction of
+    # *what the food is*, kept separate from the carb correction (50.C1). External
+    # authoritative grounding (USDA / OFF / restaurant) is applied ONLY when
+    # ``identity_confirmed`` is True, so a misidentified label is never certified
+    # with an authoritative citation. Never read by IoB / treatment_safety.
+    confirmed_food_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    identity_confirmed: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default="false",
+        nullable=False,
     )
 
     # --- Grounding attribution (Story 50.E1) ---

--- a/apps/api/src/models/food_record.py
+++ b/apps/api/src/models/food_record.py
@@ -161,9 +161,10 @@ class FoodRecord(Base):
     # The AI-identified name lives in ``food_description`` (preserved, like the
     # original carb estimate). These record the user's confirmation/correction of
     # *what the food is*, kept separate from the carb correction (50.C1). External
-    # authoritative grounding (USDA / OFF / restaurant) is applied ONLY when
-    # ``identity_confirmed`` is True, so a misidentified label is never certified
-    # with an authoritative citation. Never read by IoB / treatment_safety.
+    # authoritative grounding (USDA / Open Food Facts today; restaurant via 50.E2)
+    # is applied ONLY when ``identity_confirmed`` is True, so a misidentified label
+    # is never certified with an authoritative citation. Never read by
+    # IoB / treatment_safety.
     confirmed_food_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     identity_confirmed: Mapped[bool] = mapped_column(
         Boolean,

--- a/apps/api/src/models/food_record_audit.py
+++ b/apps/api/src/models/food_record_audit.py
@@ -1,0 +1,95 @@
+"""Audit & provenance trail for a meal-photo estimate (Story 50.H3).
+
+Traditional healthcare ML is auditable because it is deterministic; an LLM is
+not, but the *pipeline* around it can still be made answerable. This stores, per
+food record, what the model actually returned and how the estimate resolved, so
+"why did it say this" has an answer after the fact:
+
+  * the raw per-sample vision outputs from the multi-sample run (50.H1) -- each
+    sample's carb range, identified food, and the model's own self-reported
+    confidence (retained as INTERNAL-only audit/eval data, never surfaced as a
+    user-facing safety signal),
+  * the empirical dispersion summary that produced the shown confidence, and
+  * the precedence decision -- which grounding source won (or vision-only) and
+    the identity it was keyed on (50.H2).
+
+Owner-scoped and 1:1 with a ``food_records`` row. ``ON DELETE CASCADE`` on both
+the food record and the user means deleting either drops the audit trail with no
+extra code (AC5: deleting a record deletes its audit; retention/purge of records
+cascades here). No raw image bytes are duplicated -- the photo reference stays on
+the food record. Nothing here is read by IoB / treatment_safety / carb-ratio
+math; this is descriptive provenance only.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+
+class FoodRecordAudit(Base):
+    """The provenance trail for one food record's estimate (1:1, owner-scoped)."""
+
+    __tablename__ = "food_record_audits"
+
+    __table_args__ = (
+        # 1:1 with the food record (the unique constraint also serves lookups).
+        UniqueConstraint("food_record_id", name="uq_food_record_audits_food_record_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=func.gen_random_uuid(),
+    )
+
+    # 1:1 with the food record. CASCADE so deleting the record (single delete or
+    # retention purge) drops the audit row automatically.
+    food_record_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("food_records.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Denormalized owner for direct owner-scoped retrieval (IDOR defence) and so a
+    # user deletion cascades here independently of the food-record path.
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Lean raw per-sample outputs (50.H1): a list of
+    # {carbs_low, carbs_high, identity, self_reported_confidence, parse_ok}.
+    # self_reported_confidence is INTERNAL-only -- kept for eval/Sentry triage,
+    # not exposed as a user-facing safety signal.
+    samples_json: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
+    # The empirical dispersion summary that produced the shown confidence band
+    # (cv, samples requested/used, identity agreement, wide-spread).
+    dispersion_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # The precedence decision: which source won (or vision-only), its trust tier,
+    # the identity it was keyed on, and whether identity was confirmed.
+    precedence_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<FoodRecordAudit(id={self.id}, food_record_id={self.food_record_id})>"

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -32,13 +32,14 @@ from src.schemas.common_food import (
     SaveAsCommonFoodRequest,
 )
 from src.schemas.food_record import (
+    FoodRecordAuditResponse,
     FoodRecordCorrectionRequest,
     FoodRecordIdentityRequest,
     FoodRecordListResponse,
     FoodRecordResponse,
 )
 from src.services import common_food as common_food_service
-from src.services import food_image, food_vision
+from src.services import food_image, food_vision, meal_audit
 
 logger = get_logger(__name__)
 
@@ -194,6 +195,37 @@ async def get_food_record(
     require_meal_intelligence()
     record = await _get_owned_record(record_id, current_user.id, db)
     return FoodRecordResponse.model_validate(record)
+
+
+@router.get(
+    "/{record_id}/audit",
+    response_model=FoodRecordAuditResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Audit trail not found"},
+    },
+)
+async def get_food_record_audit(
+    record_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> FoodRecordAuditResponse:
+    """Get the "how was this estimated" provenance trail for a record (50.H3).
+
+    Owner-scoped (IDOR-safe): the record must belong to the caller, and the audit
+    fetch is itself scoped by user id. Descriptive only -- raw per-sample reads,
+    the empirical dispersion, and the precedence decision; never a dose.
+    """
+    require_meal_intelligence()
+    # 404 if the record isn't the caller's (ownership check) ...
+    await _get_owned_record(record_id, current_user.id, db)
+    # ... and the audit fetch is independently owner-scoped.
+    audit = await meal_audit.get_audit(db, record_id, current_user.id)
+    if audit is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Audit trail not found"
+        )
+    return FoodRecordAuditResponse.from_audit(audit)
 
 
 @router.delete(

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -270,9 +270,10 @@ async def confirm_food_identity(
     """Confirm or correct *what the food is* (Story 50.H2).
 
     Distinct from carb correction and never a dose. The confirmed identity opens
-    the grounding gate: only now is external authoritative nutrition (USDA / OFF /
-    restaurant) looked up, keyed on the confirmed name -- so a misidentified label
-    is never certified with an authoritative citation.
+    the grounding gate: only now is external authoritative nutrition (USDA / Open
+    Food Facts today; restaurant facts via 50.E2) looked up, keyed on the confirmed
+    name -- so a misidentified label is never certified with an authoritative
+    citation.
     """
     require_meal_intelligence()
     record = await _get_owned_record(record_id, current_user.id, db)
@@ -280,6 +281,8 @@ async def confirm_food_identity(
         record = await common_food_service.confirm_food_identity(
             db, record, identity.confirmed_food_name
         )
+    # Defence in depth: the schema already rejects a blank/oversized name (422),
+    # so this only fires for a non-HTTP caller -- mirrors the carb-correction path.
     except common_food_service.IdentityValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -33,6 +33,7 @@ from src.schemas.common_food import (
 )
 from src.schemas.food_record import (
     FoodRecordCorrectionRequest,
+    FoodRecordIdentityRequest,
     FoodRecordListResponse,
     FoodRecordResponse,
 )
@@ -245,6 +246,41 @@ async def correct_food_record(
     try:
         record = await common_food_service.correct_food_record(db, record, correction)
     except common_food_service.CarbValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    return FoodRecordResponse.model_validate(record)
+
+
+@router.post(
+    "/{record_id}/confirm-identity",
+    response_model=FoodRecordResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Food record not found"},
+        422: {"model": ErrorResponse, "description": "Identity name invalid"},
+    },
+)
+async def confirm_food_identity(
+    record_id: uuid.UUID,
+    identity: FoodRecordIdentityRequest,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> FoodRecordResponse:
+    """Confirm or correct *what the food is* (Story 50.H2).
+
+    Distinct from carb correction and never a dose. The confirmed identity opens
+    the grounding gate: only now is external authoritative nutrition (USDA / OFF /
+    restaurant) looked up, keyed on the confirmed name -- so a misidentified label
+    is never certified with an authoritative citation.
+    """
+    require_meal_intelligence()
+    record = await _get_owned_record(record_id, current_user.id, db)
+    try:
+        record = await common_food_service.confirm_food_identity(
+            db, record, identity.confirmed_food_name
+        )
+    except common_food_service.IdentityValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
         ) from exc

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -168,6 +168,58 @@ class FoodRecordListResponse(BaseModel):
     total: int
 
 
+class AuditSample(BaseModel):
+    """One raw vision sample, as surfaced in the audit trail (Story 50.H3).
+
+    Deliberately omits the model's self-reported confidence: that is retained in
+    storage for internal eval/triage only and is never surfaced as a user-facing
+    signal (the whole point of 50.H1).
+    """
+
+    carbs_low: float | None = None
+    carbs_high: float | None = None
+    identity: str | None = None
+    parse_ok: bool = False
+
+
+class FoodRecordAuditResponse(BaseModel):
+    """The "how was this estimated" provenance trail for a food record (50.H3).
+
+    Descriptive only -- raw per-sample reads, the empirical dispersion summary,
+    and the precedence decision. No dose, and nothing here feeds dosing math.
+    """
+
+    food_record_id: uuid.UUID
+    samples: list[AuditSample] = Field(default_factory=list)
+    dispersion: dict | None = None
+    precedence: dict | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_audit(cls, audit: object) -> "FoodRecordAuditResponse":
+        """Build from a ``FoodRecordAudit`` row, stripping internal-only fields."""
+        raw_samples = getattr(audit, "samples_json", None) or []
+        samples = [
+            AuditSample(
+                carbs_low=s.get("carbs_low"),
+                carbs_high=s.get("carbs_high"),
+                identity=s.get("identity"),
+                parse_ok=bool(s.get("parse_ok")),
+            )
+            for s in raw_samples
+            if isinstance(s, dict)
+        ]
+        return cls(
+            food_record_id=audit.food_record_id,
+            samples=samples,
+            dispersion=audit.dispersion_json,
+            precedence=audit.precedence_json,
+            created_at=audit.created_at,
+            updated_at=audit.updated_at,
+        )
+
+
 # Cap user-supplied nutrition so a correction can't store an unbounded JSON blob.
 # Bound both the field count and the serialized size: the key count alone does
 # not stop a single key holding a deeply-nested / multi-MB value.

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -8,12 +8,15 @@ dose/insulin field. Nothing here computes or returns dosing guidance.
 import json
 import uuid
 from datetime import datetime
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
 from src.models.food_record import FoodRecordSource
 from src.vision.carb_contract import CARB_GRAMS_MAX, CARB_GRAMS_MIN
+
+if TYPE_CHECKING:
+    from src.models.food_record_audit import FoodRecordAudit
 
 
 class GroundingDetail(BaseModel):
@@ -182,6 +185,23 @@ class AuditSample(BaseModel):
     parse_ok: bool = False
 
 
+class AuditDispersion(BaseModel):
+    """The empirical dispersion summary surfaced in the audit trail (50.H3).
+
+    A typed allow-list (like ``AuditSample``) so the no-leak guarantee for the
+    discredited self-reported confidence is enforced structurally, not by
+    convention -- a future field added to the stored blob can't slip through.
+    """
+
+    confidence: str | None = None
+    coefficient_of_variation: float | None = None
+    samples_requested: int | None = None
+    samples_used: int | None = None
+    identity_agreement: bool | None = None
+    distinct_identities: list[str] = Field(default_factory=list)
+    wide_spread: bool | None = None
+
+
 class FoodRecordAuditResponse(BaseModel):
     """The "how was this estimated" provenance trail for a food record (50.H3).
 
@@ -191,15 +211,17 @@ class FoodRecordAuditResponse(BaseModel):
 
     food_record_id: uuid.UUID
     samples: list[AuditSample] = Field(default_factory=list)
-    dispersion: dict | None = None
+    dispersion: AuditDispersion | None = None
+    # The precedence decision is intentionally schema-loose (a raw dict): its
+    # shape is still settling pre-50.E2. It is built entirely by our own code
+    # (services.meal_audit) and never contains per-sample/self-reported data.
     precedence: dict | None = None
     created_at: datetime
     updated_at: datetime
 
     @classmethod
-    def from_audit(cls, audit: object) -> "FoodRecordAuditResponse":
+    def from_audit(cls, audit: "FoodRecordAudit") -> "FoodRecordAuditResponse":
         """Build from a ``FoodRecordAudit`` row, stripping internal-only fields."""
-        raw_samples = getattr(audit, "samples_json", None) or []
         samples = [
             AuditSample(
                 carbs_low=s.get("carbs_low"),
@@ -207,13 +229,18 @@ class FoodRecordAuditResponse(BaseModel):
                 identity=s.get("identity"),
                 parse_ok=bool(s.get("parse_ok")),
             )
-            for s in raw_samples
+            for s in (audit.samples_json or [])
             if isinstance(s, dict)
         ]
+        dispersion = (
+            AuditDispersion.model_validate(audit.dispersion_json)
+            if isinstance(audit.dispersion_json, dict)
+            else None
+        )
         return cls(
             food_record_id=audit.food_record_id,
             samples=samples,
-            dispersion=audit.dispersion_json,
+            dispersion=dispersion,
             precedence=audit.precedence_json,
             created_at=audit.created_at,
             updated_at=audit.updated_at,

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -8,6 +8,7 @@ dose/insulin field. Nothing here computes or returns dosing guidance.
 import json
 import uuid
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -76,8 +77,13 @@ class EstimateDispersion(BaseModel):
     qualifier dominant regardless of this value.
     """
 
-    confidence: str  # empirical band: high | medium | low (dispersion-derived)
+    # Empirical, dispersion-derived band (constrained so a typo'd band can't pass
+    # this system boundary).
+    confidence: Literal["low", "medium", "high"]
     coefficient_of_variation: float | None = None
+    # The configured target sample count (settings.meal_estimate_sample_count),
+    # not necessarily the number of network calls made; ``samples_used`` is how
+    # many produced a usable, in-bounds estimate.
     samples_requested: int
     samples_used: int
     identity_agreement: bool

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -125,6 +125,14 @@ class FoodRecordResponse(BaseModel):
     common_food_id: uuid.UUID | None = None
     ai_model: str | None = None
     ai_provider: str | None = None
+    # Food-identity confirmation (Story 50.H2). ``food_description`` is the
+    # AI-identified name; ``confirmed_food_name`` is the user's confirmed/corrected
+    # identity (null until confirmed); external grounding only runs once
+    # ``identity_confirmed`` is true. ``suggested_identity`` is a transient
+    # create-time own-history pre-fill ("looks like your saved X"); absent later.
+    confirmed_food_name: str | None = None
+    identity_confirmed: bool = False
+    suggested_identity: str | None = None
     # Grounding provenance (Story 50.E1). The flat fields are persisted on the
     # record and present on every read; ``grounding`` is the richer create-time
     # detail (grounded range + note + disclaimer) and is absent on later reads.
@@ -207,4 +215,29 @@ class FoodRecordCorrectionRequest(BaseModel):
             msg = "corrected_carbs_low must not exceed corrected_carbs_high"
             raise ValueError(msg)
         validate_nutrition(self.corrected_nutrition)
+        return self
+
+
+# Cap a user-supplied identity at the schema boundary (the service caps again).
+_MAX_IDENTITY_NAME_CHARS = 200
+
+
+class FoodRecordIdentityRequest(BaseModel):
+    """A user confirmation/correction of *what the food is* (Story 50.H2).
+
+    Confirming identity is distinct from correcting carbs and never implies a
+    dose. The confirmed name opens the grounding gate: external authoritative
+    nutrition (USDA / OFF / restaurant) is only looked up once an identity has
+    been confirmed, so a misidentified label is never certified with a citation.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    confirmed_food_name: str = Field(min_length=1, max_length=_MAX_IDENTITY_NAME_CHARS)
+
+    @model_validator(mode="after")
+    def validate_identity(self) -> "FoodRecordIdentityRequest":
+        if not self.confirmed_food_name.strip():
+            msg = "confirmed_food_name must not be blank"
+            raise ValueError(msg)
         return self

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -218,7 +218,8 @@ class FoodRecordCorrectionRequest(BaseModel):
         return self
 
 
-# Cap a user-supplied identity at the schema boundary (the service caps again).
+# Cap a user-supplied identity at the schema boundary (the service caps again as
+# defence-in-depth; keep in sync with common_food._MAX_IDENTITY_CHARS).
 _MAX_IDENTITY_NAME_CHARS = 200
 
 
@@ -227,8 +228,9 @@ class FoodRecordIdentityRequest(BaseModel):
 
     Confirming identity is distinct from correcting carbs and never implies a
     dose. The confirmed name opens the grounding gate: external authoritative
-    nutrition (USDA / OFF / restaurant) is only looked up once an identity has
-    been confirmed, so a misidentified label is never certified with a citation.
+    nutrition (USDA / Open Food Facts today; restaurant facts via 50.E2) is only
+    looked up once an identity has been confirmed, so a misidentified label is
+    never certified with a citation.
     """
 
     model_config = {"extra": "forbid"}

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -57,12 +57,44 @@ class GroundingDetail(BaseModel):
         return self
 
 
+class EstimateDispersion(BaseModel):
+    """Multi-sample dispersion detail returned with a fresh estimate (Story 50.H1).
+
+    The same photo is sampled N times; ``confidence`` is derived from how much
+    those samples disagree (their coefficient of variation), NOT from the model's
+    self-reported confidence -- which research shows is uncorrelated with accuracy
+    and is therefore never surfaced as a safety signal. ``carbs_low`` / ``carbs_high``
+    on the record are the empirical band (the observed spread across samples).
+
+    This is computed at estimate time (the create path) and is transient: it is
+    not persisted by H1 (50.H3 adds durable audit retention), so reads of an
+    existing record do not carry it.
+
+    Safety: ``wide_spread`` and ``note`` exist to communicate uncertainty
+    viscerally, never to bless a number. Low dispersion is NOT "safe to dose" --
+    consistency is not correctness -- so callers keep the verify-before-dosing
+    qualifier dominant regardless of this value.
+    """
+
+    confidence: str  # empirical band: high | medium | low (dispersion-derived)
+    coefficient_of_variation: float | None = None
+    samples_requested: int
+    samples_used: int
+    identity_agreement: bool
+    distinct_identities: list[str] = Field(default_factory=list)
+    wide_spread: bool = False
+    note: str | None = None
+
+
 class FoodRecordResponse(BaseModel):
     """A persisted food record returned to the client.
 
     ``carbs_low`` / ``carbs_high`` are the original AI estimate. When the record
     has been corrected, ``corrected_carbs_*`` carry the user's values and
     ``source`` is ``user_corrected``; the original estimate is kept.
+
+    ``confidence`` is the **empirical** dispersion-derived band (Story 50.H1), not
+    the model's self-reported confidence (which is no longer surfaced).
     """
 
     model_config = {"from_attributes": True}
@@ -94,6 +126,9 @@ class FoodRecordResponse(BaseModel):
     grounding_source_url: str | None = None
     grounding_trust_tier: str | None = None
     grounding: GroundingDetail | None = None
+    # Multi-sample dispersion (Story 50.H1). Transient create-time detail
+    # (empirical confidence + observed spread); absent on later reads.
+    estimate_dispersion: EstimateDispersion | None = None
     created_at: datetime
 
     @model_validator(mode="after")

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -29,10 +29,15 @@ from src.models.common_food import CommonFood, normalize_common_food_name
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.schemas.common_food import CommonFoodUpdateRequest
 from src.schemas.food_record import FoodRecordCorrectionRequest
-from src.services import meal_rag
+from src.services import meal_grounding, meal_rag
 from src.vision.carb_contract import CarbBoundsError, validate_carb_range
 
 logger = get_logger(__name__)
+
+# Cap a user-supplied identity name before it's persisted / used as a grounding
+# query (it travels to USDA / OFF as a search term). Generous -- identities are
+# short food names, not prose.
+_MAX_IDENTITY_CHARS = 200
 
 
 class CommonFoodError(Exception):
@@ -41,6 +46,10 @@ class CommonFoodError(Exception):
 
 class CarbValidationError(CommonFoodError):
     """A user-supplied carb range fell outside the reject-not-clamp bounds."""
+
+
+class IdentityValidationError(CommonFoodError):
+    """A user-supplied food identity was empty/unusable."""
 
 
 class DuplicateCommonFoodError(CommonFoodError):
@@ -83,6 +92,55 @@ async def correct_food_record(
             await meal_rag.index_food_record(record)
         except Exception:
             logger.warning("RAG re-indexing failed for corrected record", exc_info=True)
+    return record
+
+
+async def confirm_food_identity(
+    db: AsyncSession,
+    record: FoodRecord,
+    confirmed_name: str,
+) -> FoodRecord:
+    """Confirm/correct *what the food is*, then ground against that identity.
+
+    Story 50.H2: the gate-opening action. The user-confirmed identity is
+    persisted (the AI-identified ``food_description`` is preserved, like the
+    original carb estimate), and only now -- on a user-owned identity -- is
+    external authoritative grounding (USDA / OFF / restaurant) allowed to run, so
+    a misidentified label is never silently certified with a citation. Confirming
+    is distinct from carb correction and never implies a dose. Re-confirming with
+    a different name re-grounds against it.
+    """
+    name = (confirmed_name or "").strip()[:_MAX_IDENTITY_CHARS]
+    if not name:
+        raise IdentityValidationError("A food name is required to confirm identity.")
+
+    record.confirmed_food_name = name
+    record.identity_confirmed = True
+
+    # Identity is confirmed -> grounding may now run, keyed on the confirmed name.
+    # Best-effort: a failure leaves the estimate vision-only (grounding never
+    # alters the carb values or produces a dose). meal_grounding re-checks the
+    # gate as defence in depth.
+    grounding = None
+    if settings.meal_intelligence_enabled:
+        try:
+            grounding = await meal_grounding.ground_estimate(
+                record.user_id, name, identity_confirmed=True
+            )
+        except Exception:
+            logger.warning(
+                "Grounding after identity confirmation failed", exc_info=True
+            )
+    record.grounding_source = grounding.source if grounding else None
+    record.grounding_source_url = grounding.source_url if grounding else None
+    record.grounding_trust_tier = grounding.trust_tier if grounding else None
+
+    await db.commit()
+    await db.refresh(record)
+
+    # Transient grounding detail for the response (the grounded range + citation +
+    # disclaimer); reads later carry only the flat grounding_* columns.
+    record.grounding = grounding
     return record
 
 

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -34,7 +34,7 @@ from src.models.common_food import CommonFood, normalize_common_food_name
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.schemas.common_food import CommonFoodUpdateRequest
 from src.schemas.food_record import FoodRecordCorrectionRequest
-from src.services import meal_grounding, meal_rag
+from src.services import meal_audit, meal_grounding, meal_rag
 from src.vision.carb_contract import CarbBoundsError, validate_carb_range
 
 logger = get_logger(__name__)
@@ -156,6 +156,19 @@ async def confirm_food_identity(
             logger.warning(
                 "RAG re-indexing failed after identity confirmation", exc_info=True
             )
+
+    # Append the grounding decision to the audit trail (Story 50.H3): which source
+    # won (or vision-only) and the identity it was keyed on. Best-effort.
+    try:
+        await meal_audit.record_grounding_decision(
+            record.id,
+            record.user_id,
+            grounding=grounding,
+            identity=name,
+            identity_confirmed=True,
+        )
+    except Exception:
+        logger.warning("Grounding audit update failed", exc_info=True)
 
     # Transient grounding detail for the response (the grounded range + citation +
     # disclaimer); reads later carry only the flat grounding_* columns.

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -6,15 +6,20 @@ estimation pipeline:
   * ``correct_food_record`` applies a user's carb/nutrition correction to a
     record -- writing the ``corrected_*`` seams, flipping provenance to
     ``USER_CORRECTED``, and preserving the original AI estimate.
+  * ``confirm_food_identity`` confirms/corrects *what the food is* (Story 50.H2),
+    then -- and only then -- runs external grounding (USDA / Open Food Facts)
+    against the confirmed identity. This is the one function here that performs an
+    outbound nutrition lookup.
   * ``promote_to_common_food`` saves a record's (corrected, else AI) values as a
     user-named, deduped baseline and links the record to it.
   * ``link_record_to_common_food`` / ``update_common_food`` handle explicit
     linking and baseline edits.
 
-Safety posture (NON-NEGOTIABLE): a correction fixes a *description of the food*,
-never a dose. Nothing here returns or computes insulin, and neither corrected
-records nor common foods are ever read by IoB / treatment_safety / carb-ratio
-math. All work is scoped to the authenticated owner by the caller.
+Safety posture (NON-NEGOTIABLE): a correction or an identity confirmation fixes a
+*description of the food*, never a dose. Nothing here returns or computes insulin,
+and neither corrected records, confirmed identities, nor common foods are ever
+read by IoB / treatment_safety / carb-ratio math. All work is scoped to the
+authenticated owner by the caller.
 """
 
 from datetime import UTC, datetime
@@ -35,8 +40,9 @@ from src.vision.carb_contract import CarbBoundsError, validate_carb_range
 logger = get_logger(__name__)
 
 # Cap a user-supplied identity name before it's persisted / used as a grounding
-# query (it travels to USDA / OFF as a search term). Generous -- identities are
-# short food names, not prose.
+# query (it travels to USDA / OFF as a search term). Defence-in-depth for callers
+# that reach the service without the schema validation (e.g. the create/confirm
+# internal path); keep in sync with schemas.food_record._MAX_IDENTITY_NAME_CHARS.
 _MAX_IDENTITY_CHARS = 200
 
 
@@ -105,8 +111,9 @@ async def confirm_food_identity(
     Story 50.H2: the gate-opening action. The user-confirmed identity is
     persisted (the AI-identified ``food_description`` is preserved, like the
     original carb estimate), and only now -- on a user-owned identity -- is
-    external authoritative grounding (USDA / OFF / restaurant) allowed to run, so
-    a misidentified label is never silently certified with a citation. Confirming
+    external authoritative grounding (USDA / Open Food Facts today; restaurant via
+    50.E2) allowed to run, so a misidentified label is never silently certified
+    with a citation. Confirming
     is distinct from carb correction and never implies a dose. Re-confirming with
     a different name re-grounds against it.
     """
@@ -137,6 +144,18 @@ async def confirm_food_identity(
 
     await db.commit()
     await db.refresh(record)
+
+    # Re-index own-history RAG against the confirmed identity (best-effort), so a
+    # future photo of this food recalls/suggests the user's confirmed truth rather
+    # than the stale AI label -- mirrors the carb-correction re-index above and
+    # closes the one-tap-confirm loop (``suggest_identity`` reads this store).
+    if settings.meal_intelligence_enabled:
+        try:
+            await meal_rag.index_food_record(record)
+        except Exception:
+            logger.warning(
+                "RAG re-indexing failed after identity confirmation", exc_info=True
+            )
 
     # Transient grounding detail for the response (the grounded range + citation +
     # disclaimer); reads later carry only the flat grounding_* columns.

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -157,18 +157,19 @@ async def confirm_food_identity(
                 "RAG re-indexing failed after identity confirmation", exc_info=True
             )
 
-    # Append the grounding decision to the audit trail (Story 50.H3): which source
-    # won (or vision-only) and the identity it was keyed on. Best-effort.
-    try:
-        await meal_audit.record_grounding_decision(
-            record.id,
-            record.user_id,
-            grounding=grounding,
-            identity=name,
-            identity_confirmed=True,
-        )
-    except Exception:
-        logger.warning("Grounding audit update failed", exc_info=True)
+        # Append the grounding decision to the audit trail (Story 50.H3): which
+        # source won (or vision-only) and the identity it was keyed on. Behind the
+        # same flag as the side-effects above; best-effort.
+        try:
+            await meal_audit.record_grounding_decision(
+                record.id,
+                record.user_id,
+                grounding=grounding,
+                identity=name,
+                identity_confirmed=True,
+            )
+        except Exception:
+            logger.warning("Grounding audit update failed", exc_info=True)
 
     # Transient grounding detail for the response (the grounded range + citation +
     # disclaimer); reads later carry only the flat grounding_* columns.

--- a/apps/api/src/services/data_purge.py
+++ b/apps/api/src/services/data_purge.py
@@ -153,6 +153,9 @@ async def purge_all_user_data(
         deleted_food_rows = result.all()
         food_photo_paths = [sp for (sp,) in deleted_food_rows if sp]
         deleted["food_records"] = len(deleted_food_rows)
+        # food_record_audits rows cascade from this delete (FK ON DELETE CASCADE,
+        # migration 071), so the audit trail is purged here with the records --
+        # no separate delete needed (Story 50.H3, AC5).
 
         # Common foods are deleted after food_records: the records are already
         # gone, so the food_records.common_food_id FK (ON DELETE SET NULL) has

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -23,6 +23,7 @@ and the persisted record is never read by IoB / treatment_safety / carb-ratio
 math.
 """
 
+import asyncio
 import base64
 from pathlib import Path
 
@@ -35,8 +36,8 @@ from src.logging_config import get_logger
 from src.models.ai_provider import AIProviderConfig
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.models.user import User
-from src.schemas.food_record import GroundingDetail
-from src.services import food_image, meal_grounding, meal_rag
+from src.schemas.food_record import EstimateDispersion, GroundingDetail
+from src.services import food_image, meal_estimate_aggregate, meal_grounding, meal_rag
 from src.services.ai_client import DEFAULT_MODELS
 from src.vision.carb_contract import (
     SYSTEM_PROMPT,
@@ -170,6 +171,46 @@ async def _call_vision(model: str, media_type: str, image_b64: str) -> str:
     return content
 
 
+async def _call_vision_samples(
+    model: str, media_type: str, image_b64: str, n: int
+) -> list[str]:
+    """Issue ``n`` concurrent vision samples of the same image (Story 50.H1).
+
+    Returns the raw text of every sample that succeeded. Per-sample failures are
+    tolerated -- multi-sampling exists to measure disagreement, so losing a sample
+    only narrows the evidence, it must not fail the request (AC6). If *no* sample
+    succeeds, the failure is re-raised so the caller surfaces the original, clear
+    error (``VisionUnavailableError`` when the provider has no vision route at
+    all -- deterministic across samples -- otherwise ``VisionServiceError``)
+    rather than a misleading "couldn't read the photo" parse error.
+    """
+    results = await asyncio.gather(
+        *(_call_vision(model, media_type, image_b64) for _ in range(max(n, 1))),
+        return_exceptions=True,
+    )
+    texts = [r for r in results if isinstance(r, str)]
+    if texts:
+        failures = len(results) - len(texts)
+        if failures:
+            logger.warning(
+                "Some vision samples failed; aggregating the rest",
+                requested=len(results),
+                succeeded=len(texts),
+            )
+        return texts
+
+    # No sample succeeded -- re-raise a representative error. Prefer a
+    # VisionUnavailableError (the actionable "your provider can't do vision"
+    # case) over a transient service error.
+    for r in results:
+        if isinstance(r, VisionUnavailableError):
+            raise r
+    for r in results:
+        if isinstance(r, BaseException):
+            raise r
+    raise VisionServiceError("AI vision service returned no usable output.")
+
+
 def _error_message(resp: httpx.Response) -> str | None:
     try:
         body = resp.json()
@@ -202,39 +243,52 @@ async def create_food_record_from_image(
     model, provider_label = await _resolve_model(user, db)
 
     image_b64 = base64.standard_b64encode(processed.data).decode("ascii")
-    raw_text = await _call_vision(model, processed.media_type, image_b64)
 
-    estimate = parse_estimate(raw_text)
-    if (
-        not estimate.parse_ok
-        or estimate.carbs_low is None
-        or estimate.carbs_high is None
-    ):
+    # Sample the same photo N times and aggregate the spread (Story 50.H1): the
+    # confidence and range come from how much the samples disagree with each
+    # other, not the model's self-reported confidence (which research shows is
+    # uncorrelated with accuracy). Per-sample failures are tolerated; the call
+    # only raises if *every* sample failed.
+    requested_n = settings.meal_estimate_sample_count
+    raw_texts = await _call_vision_samples(
+        model, processed.media_type, image_b64, requested_n
+    )
+    samples = [parse_estimate(text) for text in raw_texts]
+
+    # Per-sample dosing scrub BEFORE aggregation: a sample whose description
+    # smuggled in advice has that description nulled (its carb numbers stay
+    # usable), so the scrubbed text can never be chosen as the representative
+    # description. Count only -- never log the content.
+    scrubbed = 0
+    for sample in samples:
+        desc_violation = bool(
+            sample.food_description and find_dosing_violations(sample.food_description)
+        )
+        if sample.dosing_violations or desc_violation:
+            scrubbed += 1
+        if desc_violation:
+            sample.food_description = ""
+    if scrubbed:
+        logger.warning(
+            "Dosing phrasing detected in vision sample(s); scrubbed",
+            sample_count=scrubbed,
+        )
+
+    aggregate = meal_estimate_aggregate.aggregate_samples(
+        samples, samples_requested=requested_n
+    )
+    if aggregate is None:
         raise EstimateRejectedError(
             "Could not read a carbohydrate estimate from this photo."
         )
     try:
-        low, high = validate_carb_range(estimate.carbs_low, estimate.carbs_high)
+        low, high = validate_carb_range(aggregate.carbs_low, aggregate.carbs_high)
     except CarbBoundsError as exc:
         raise EstimateRejectedError(
             "The estimate was outside the supported range."
         ) from exc
 
-    # Defensive scrub: never persist any dosing/advice phrasing. We already drop
-    # the raw prose; null a food description that smuggled in advice and log it
-    # for monitoring (count only -- no content).
-    food_description: str | None = estimate.food_description or None
-    desc_violations = (
-        find_dosing_violations(food_description) if food_description else []
-    )
-    if estimate.dosing_violations or desc_violations:
-        logger.warning(
-            "Dosing phrasing detected in vision response; scrubbed",
-            violation_count=len(estimate.dosing_violations) + len(desc_violations),
-        )
-        if desc_violations:
-            food_description = None
-
+    food_description: str | None = aggregate.food_description or None
     if food_description:
         food_description = food_description[:_MAX_DESCRIPTION_CHARS]
 
@@ -257,8 +311,10 @@ async def create_food_record_from_image(
         food_description=food_description,
         carbs_low=low,
         carbs_high=high,
-        confidence=estimate.confidence,
-        nutrition_json=estimate.nutrition or None,
+        # Empirical, dispersion-derived band -- NOT the model's self-reported
+        # confidence (Story 50.H1), which is no longer surfaced to users.
+        confidence=aggregate.confidence,
+        nutrition_json=aggregate.nutrition or None,
         ai_model=model,
         ai_provider=provider_label,
         source=FoodRecordSource.AI_ESTIMATE,
@@ -290,7 +346,52 @@ async def create_food_record_from_image(
     # response. Transient -- not a persisted column; reads of the record later
     # carry only the flat grounding_* attribution fields.
     record.grounding = grounding
+    # Attach the multi-sample dispersion detail (empirical confidence + observed
+    # spread + visceral note) for the response. Transient -- 50.H3 adds durable
+    # audit retention of the raw samples; H1 keeps it create-time only.
+    record.estimate_dispersion = _build_dispersion_detail(aggregate)
     return record
+
+
+def _dispersion_note(
+    aggregate: meal_estimate_aggregate.AggregatedEstimate,
+) -> str:
+    """A plain-language note that communicates uncertainty viscerally.
+
+    Never blesses a number and never contains dosing language: a tight spread is
+    deliberately NOT described as trustworthy (consistency is not correctness),
+    and the persistent verify-before-dosing qualifier on every estimate surface
+    carries the safety framing regardless of what this says.
+    """
+    low, high = aggregate.carbs_low, aggregate.carbs_high
+    if not aggregate.identity_agreement:
+        return (
+            "The AI didn't consistently agree on what this food is, so this "
+            "estimate is uncertain -- confirm the food before relying on it."
+        )
+    if aggregate.wide_spread:
+        return (
+            f"Repeated looks at this photo disagreed (about {low:g} g to "
+            f"{high:g} g) -- treat this as a rough guess, not a measurement."
+        )
+    if aggregate.samples_ok <= 1:
+        return "Estimated from a single read of the photo, so confidence is low."
+    return f"Estimated from {aggregate.samples_ok} reads of the photo."
+
+
+def _build_dispersion_detail(
+    aggregate: meal_estimate_aggregate.AggregatedEstimate,
+) -> EstimateDispersion:
+    return EstimateDispersion(
+        confidence=aggregate.confidence,
+        coefficient_of_variation=aggregate.dispersion_cv,
+        samples_requested=aggregate.samples_requested,
+        samples_used=aggregate.samples_ok,
+        identity_agreement=aggregate.identity_agreement,
+        distinct_identities=aggregate.distinct_identities,
+        wide_spread=aggregate.wide_spread,
+        note=_dispersion_note(aggregate),
+    )
 
 
 async def _ground_estimate(

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -343,9 +343,11 @@ async def create_food_record_from_image(
         except Exception:
             logger.warning("RAG indexing failed for food record", exc_info=True)
 
-    # No grounding at create time (identity unconfirmed). Attach transient
-    # response detail: the multi-sample dispersion (Story 50.H1) and the suggested
-    # identity to confirm (Story 50.H2). Neither is a persisted column.
+    # No grounding at create time (identity unconfirmed) -- grounding actually
+    # happens later in ``common_food.confirm_food_identity`` once the user confirms
+    # the identity. Attach transient response detail: the multi-sample dispersion
+    # (Story 50.H1) and the suggested identity to confirm (Story 50.H2). Neither is
+    # a persisted column.
     record.grounding = None
     record.estimate_dispersion = _build_dispersion_detail(aggregate)
     record.suggested_identity = suggested_identity

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -353,6 +353,12 @@ async def create_food_record_from_image(
     return record
 
 
+# Fallback if a composed dispersion note ever trips the dosing scan (it cannot
+# today -- every branch is fixed prose + numbers -- but the guard keeps the
+# user-facing sink safe if a future edit interpolates model text into the note).
+_SAFE_DISPERSION_NOTE = "This is an estimate from a photo -- treat it as approximate."
+
+
 def _dispersion_note(
     aggregate: meal_estimate_aggregate.AggregatedEstimate,
 ) -> str:
@@ -369,19 +375,31 @@ def _dispersion_note(
             "The AI didn't consistently agree on what this food is, so this "
             "estimate is uncertain -- confirm the food before relying on it."
         )
-    if aggregate.wide_spread:
-        return (
-            f"Repeated looks at this photo disagreed (about {low:g} g to "
-            f"{high:g} g) -- treat this as a rough guess, not a measurement."
-        )
     if aggregate.samples_ok <= 1:
         return "Estimated from a single read of the photo, so confidence is low."
+    if aggregate.wide_spread:
+        return (
+            f"Repeated looks at this photo disagreed a lot (about {low:g} g to "
+            f"{high:g} g) -- treat this as a rough guess, not a measurement."
+        )
+    if aggregate.confidence != meal_estimate_aggregate.CONFIDENCE_HIGH:
+        # Medium band: real variation between reads, just not wild -- name the
+        # spread rather than offering a reassuring "estimated from N reads".
+        return (
+            f"Reads of this photo varied somewhat (about {low:g} g to {high:g} g) "
+            "-- treat this as approximate."
+        )
     return f"Estimated from {aggregate.samples_ok} reads of the photo."
 
 
 def _build_dispersion_detail(
     aggregate: meal_estimate_aggregate.AggregatedEstimate,
 ) -> EstimateDispersion:
+    note = _dispersion_note(aggregate)
+    # Defence in depth at the user-facing sink: never surface dosing phrasing.
+    if find_dosing_violations(note):
+        logger.warning("Dispersion note tripped dosing scan; using safe fallback")
+        note = _SAFE_DISPERSION_NOTE
     return EstimateDispersion(
         confidence=aggregate.confidence,
         coefficient_of_variation=aggregate.dispersion_cv,
@@ -390,7 +408,7 @@ def _build_dispersion_detail(
         identity_agreement=aggregate.identity_agreement,
         distinct_identities=aggregate.distinct_identities,
         wide_spread=aggregate.wide_spread,
-        note=_dispersion_note(aggregate),
+        note=note,
     )
 
 

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -349,13 +349,14 @@ async def create_food_record_from_image(
         except Exception:
             logger.warning("RAG indexing failed for food record", exc_info=True)
 
-    # Persist the audit/provenance trail (Story 50.H3): the raw per-sample outputs
-    # + dispersion + the (vision-only) precedence. Best-effort -- auditability must
-    # never break the upload; the grounding decision is appended at confirm time.
-    try:
-        await meal_audit.record_estimate_audit(record.id, user.id, aggregate)
-    except Exception:
-        logger.warning("Estimate audit write failed", exc_info=True)
+        # Persist the audit/provenance trail (Story 50.H3): the raw per-sample
+        # outputs + dispersion + the (vision-only) precedence. Behind the same
+        # flag as the other best-effort side-effects so the flag stays a true
+        # kill switch; the grounding decision is appended at confirm time.
+        try:
+            await meal_audit.record_estimate_audit(record.id, user.id, aggregate)
+        except Exception:
+            logger.warning("Estimate audit write failed", exc_info=True)
 
     # No grounding at create time (identity unconfirmed) -- grounding actually
     # happens later in ``common_food.confirm_food_identity`` once the user confirms

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -270,13 +270,12 @@ async def create_food_record_from_image(
         desc_violation = bool(
             sample.food_description and find_dosing_violations(sample.food_description)
         )
-        if sample.dosing_violations or desc_violation:
-            scrubbed += 1
         if desc_violation:
             sample.food_description = ""
+            scrubbed += 1
     if scrubbed:
         logger.warning(
-            "Dosing phrasing detected in vision sample(s); scrubbed",
+            "Dosing phrasing detected in vision sample description(s); scrubbed",
             sample_count=scrubbed,
         )
 

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -36,7 +36,7 @@ from src.logging_config import get_logger
 from src.models.ai_provider import AIProviderConfig
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.models.user import User
-from src.schemas.food_record import EstimateDispersion, GroundingDetail
+from src.schemas.food_record import EstimateDispersion
 from src.services import food_image, meal_estimate_aggregate, meal_grounding, meal_rag
 from src.services.ai_client import DEFAULT_MODELS
 from src.vision.carb_contract import (
@@ -292,12 +292,13 @@ async def create_food_record_from_image(
     if food_description:
         food_description = food_description[:_MAX_DESCRIPTION_CHARS]
 
-    # Ground the descriptive estimate against the user's own history (RAG) and
-    # published nutrition (USDA / OFF), best-effort. Computed before persisting so
-    # the own-history recall sees only prior records, not this one. Any failure
-    # falls back to a vision-only (ungrounded) estimate -- grounding never blocks
-    # or alters the core estimate, and never produces a dose.
-    grounding = await _ground_estimate(user, food_description)
+    # Story 50.H2: identity is unconfirmed at creation (cold start), so external
+    # authoritative grounding is gated OFF here -- a fresh vision label is never
+    # silently certified with a USDA / restaurant citation. We only *suggest* an
+    # identity from the user's own history (RAG) so a repeat food is a one-tap
+    # confirm; grounding runs after the user confirms (the confirm-identity flow).
+    # The estimate itself stays vision-only (range + empirical confidence).
+    suggested_identity = await _suggest_identity(user, food_description)
 
     storage_path, size_bytes = food_image.store_image(user.id, processed)
     filename = Path(storage_path).name
@@ -318,9 +319,9 @@ async def create_food_record_from_image(
         ai_model=model,
         ai_provider=provider_label,
         source=FoodRecordSource.AI_ESTIMATE,
-        grounding_source=grounding.source if grounding else None,
-        grounding_source_url=grounding.source_url if grounding else None,
-        grounding_trust_tier=grounding.trust_tier if grounding else None,
+        # Identity is unconfirmed until the user confirms it; grounding_* stay
+        # NULL until then (the gate is enforced in meal_grounding too).
+        identity_confirmed=False,
     )
     db.add(record)
     try:
@@ -342,14 +343,12 @@ async def create_food_record_from_image(
         except Exception:
             logger.warning("RAG indexing failed for food record", exc_info=True)
 
-    # Attach the grounding detail (grounded range + citation + disclaimer) for the
-    # response. Transient -- not a persisted column; reads of the record later
-    # carry only the flat grounding_* attribution fields.
-    record.grounding = grounding
-    # Attach the multi-sample dispersion detail (empirical confidence + observed
-    # spread + visceral note) for the response. Transient -- 50.H3 adds durable
-    # audit retention of the raw samples; H1 keeps it create-time only.
+    # No grounding at create time (identity unconfirmed). Attach transient
+    # response detail: the multi-sample dispersion (Story 50.H1) and the suggested
+    # identity to confirm (Story 50.H2). Neither is a persisted column.
+    record.grounding = None
     record.estimate_dispersion = _build_dispersion_detail(aggregate)
+    record.suggested_identity = suggested_identity
     return record
 
 
@@ -412,14 +411,12 @@ def _build_dispersion_detail(
     )
 
 
-async def _ground_estimate(
-    user: User, food_description: str | None
-) -> GroundingDetail | None:
-    """Compute grounding for an estimate; never raise (fall back to vision-only)."""
+async def _suggest_identity(user: User, food_description: str | None) -> str | None:
+    """Suggest an identity from own history for one-tap confirm; never raise."""
     if not settings.meal_intelligence_enabled:
         return None
     try:
-        return await meal_grounding.ground_estimate(user.id, food_description)
+        return await meal_grounding.suggest_identity(user.id, food_description)
     except Exception:
-        logger.warning("Estimate grounding failed; using vision-only", exc_info=True)
+        logger.warning("Identity suggestion failed", exc_info=True)
         return None

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -37,7 +37,13 @@ from src.models.ai_provider import AIProviderConfig
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.models.user import User
 from src.schemas.food_record import EstimateDispersion
-from src.services import food_image, meal_estimate_aggregate, meal_grounding, meal_rag
+from src.services import (
+    food_image,
+    meal_audit,
+    meal_estimate_aggregate,
+    meal_grounding,
+    meal_rag,
+)
 from src.services.ai_client import DEFAULT_MODELS
 from src.vision.carb_contract import (
     SYSTEM_PROMPT,
@@ -342,6 +348,14 @@ async def create_food_record_from_image(
             await meal_rag.index_food_record(record)
         except Exception:
             logger.warning("RAG indexing failed for food record", exc_info=True)
+
+    # Persist the audit/provenance trail (Story 50.H3): the raw per-sample outputs
+    # + dispersion + the (vision-only) precedence. Best-effort -- auditability must
+    # never break the upload; the grounding decision is appended at confirm time.
+    try:
+        await meal_audit.record_estimate_audit(record.id, user.id, aggregate)
+    except Exception:
+        logger.warning("Estimate audit write failed", exc_info=True)
 
     # No grounding at create time (identity unconfirmed) -- grounding actually
     # happens later in ``common_food.confirm_food_identity`` once the user confirms

--- a/apps/api/src/services/meal_audit.py
+++ b/apps/api/src/services/meal_audit.py
@@ -1,0 +1,183 @@
+"""Persist and retrieve a meal estimate's audit/provenance trail (Story 50.H3).
+
+Writes the ``food_record_audits`` row that makes an estimate answerable after the
+fact: the raw per-sample vision outputs (50.H1), the empirical dispersion summary,
+and the precedence decision + identity used (50.H2). The audit is written at
+create time (vision-only outcome) and updated at identity-confirmation time (the
+grounding decision).
+
+Best-effort everywhere: a failed audit write must never break the estimate or the
+confirmation -- the same posture as RAG indexing. Each call runs on its own
+session (decoupled from the caller's transaction). Owner-scoped; nothing here is
+read by dosing math, and sample content is never logged (only ids/counts).
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.database import get_session_maker
+from src.logging_config import get_logger
+from src.models.food_record_audit import FoodRecordAudit
+from src.schemas.food_record import GroundingDetail
+from src.services.meal_estimate_aggregate import AggregatedEstimate
+
+logger = get_logger(__name__)
+
+# The implemented precedence ladder, recorded for the audit trail so "which source
+# won and why" is interpretable. Restaurant slots in above USDA once 50.E2 lands.
+_PRECEDENCE_LADDER = [
+    "own-history corrected",
+    "USDA FoodData Central",
+    "Open Food Facts",
+    "own-history uncorrected",
+    "vision-only",
+]
+
+
+def _samples_payload(aggregate: AggregatedEstimate) -> list[dict]:
+    """Lean per-sample audit rows. ``self_reported_confidence`` is internal-only."""
+    return [
+        {
+            "carbs_low": s.carbs_low,
+            "carbs_high": s.carbs_high,
+            "identity": s.food_description or None,
+            "self_reported_confidence": s.self_reported_confidence,
+            "parse_ok": s.parse_ok,
+        }
+        for s in aggregate.samples
+    ]
+
+
+def _dispersion_payload(aggregate: AggregatedEstimate) -> dict:
+    return {
+        "confidence": aggregate.confidence,
+        "coefficient_of_variation": aggregate.dispersion_cv,
+        "samples_requested": aggregate.samples_requested,
+        "samples_used": aggregate.samples_ok,
+        "identity_agreement": aggregate.identity_agreement,
+        "distinct_identities": aggregate.distinct_identities,
+        "wide_spread": aggregate.wide_spread,
+    }
+
+
+async def record_estimate_audit(
+    food_record_id: uuid.UUID,
+    user_id: uuid.UUID,
+    aggregate: AggregatedEstimate,
+) -> None:
+    """Persist the create-time audit (raw samples + dispersion + vision-only).
+
+    Idempotent on the 1:1 ``food_record_id`` so a retried create updates rather
+    than duplicates. Best-effort: never raises into the caller.
+    """
+    precedence = {
+        "outcome": "vision_only",
+        "identity_confirmed": False,
+        "reason": "Identity not yet confirmed; estimate is vision-only.",
+        "ladder": _PRECEDENCE_LADDER,
+    }
+    values = {
+        "food_record_id": food_record_id,
+        "user_id": user_id,
+        "samples_json": _samples_payload(aggregate),
+        "dispersion_json": _dispersion_payload(aggregate),
+        "precedence_json": precedence,
+    }
+    stmt = pg_insert(FoodRecordAudit).values(**values)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["food_record_id"],
+        set_={
+            "samples_json": stmt.excluded.samples_json,
+            "dispersion_json": stmt.excluded.dispersion_json,
+            "precedence_json": stmt.excluded.precedence_json,
+            "updated_at": stmt.excluded.updated_at,
+        },
+    )
+    try:
+        async with get_session_maker()() as db:
+            await db.execute(stmt)
+            await db.commit()
+    except Exception:
+        logger.warning(
+            "Failed to write estimate audit",
+            food_record_id=str(food_record_id),
+            exc_info=True,
+        )
+
+
+async def record_grounding_decision(
+    food_record_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    grounding: GroundingDetail | None,
+    identity: str,
+    identity_confirmed: bool,
+) -> None:
+    """Update the audit's precedence trail after an identity confirmation.
+
+    Records which grounding source won (or vision-only) and the identity it was
+    keyed on. Idempotent upsert so a re-confirm overwrites the prior decision
+    (and a missing create-time audit is still captured, sans samples). Best-effort.
+    """
+    if grounding is not None:
+        precedence = {
+            "outcome": "grounded",
+            "chosen_source": grounding.source,
+            "trust_tier": grounding.trust_tier,
+            "source_url": grounding.source_url,
+            "identity_used": identity,
+            "identity_confirmed": identity_confirmed,
+            "ladder": _PRECEDENCE_LADDER,
+        }
+    else:
+        precedence = {
+            "outcome": "vision_only",
+            "chosen_source": "vision-only",
+            "identity_used": identity,
+            "identity_confirmed": identity_confirmed,
+            "reason": "No source matched the confirmed identity.",
+            "ladder": _PRECEDENCE_LADDER,
+        }
+    stmt = pg_insert(FoodRecordAudit).values(
+        food_record_id=food_record_id,
+        user_id=user_id,
+        precedence_json=precedence,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["food_record_id"],
+        set_={
+            "precedence_json": stmt.excluded.precedence_json,
+            "updated_at": stmt.excluded.updated_at,
+        },
+    )
+    try:
+        async with get_session_maker()() as db:
+            await db.execute(stmt)
+            await db.commit()
+    except Exception:
+        logger.warning(
+            "Failed to update grounding audit",
+            food_record_id=str(food_record_id),
+            exc_info=True,
+        )
+
+
+async def get_audit(
+    db: AsyncSession,
+    food_record_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> FoodRecordAudit | None:
+    """Owner-scoped fetch of a record's audit trail, or None.
+
+    Scoped by ``user_id`` (IDOR defence) in addition to the caller's ownership
+    check on the food record itself.
+    """
+    return await db.scalar(
+        select(FoodRecordAudit).where(
+            FoodRecordAudit.food_record_id == food_record_id,
+            FoodRecordAudit.user_id == user_id,
+        )
+    )

--- a/apps/api/src/services/meal_audit.py
+++ b/apps/api/src/services/meal_audit.py
@@ -13,6 +13,7 @@ read by dosing math, and sample content is never logged (only ids/counts).
 """
 
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -26,8 +27,10 @@ from src.services.meal_estimate_aggregate import AggregatedEstimate
 
 logger = get_logger(__name__)
 
-# The implemented precedence ladder, recorded for the audit trail so "which source
-# won and why" is interpretable. Restaurant slots in above USDA once 50.E2 lands.
+# The precedence ladder AS IT STOOD WHEN THE DECISION WAS MADE -- recorded per row
+# (not just in code) so an audit reads the ordering that actually applied, even
+# after 50.E2 reorders it (restaurant slots in above USDA). That decision-time
+# fidelity is the point of storing it rather than referencing a live constant.
 _PRECEDENCE_LADDER = [
     "own-history corrected",
     "USDA FoodData Central",
@@ -35,6 +38,36 @@ _PRECEDENCE_LADDER = [
     "own-history uncorrected",
     "vision-only",
 ]
+
+_OUTCOME_GROUNDED = "grounded"
+_OUTCOME_VISION_ONLY = "vision_only"
+
+
+def _precedence(
+    outcome: str,
+    *,
+    identity_confirmed: bool,
+    chosen_source: str | None = None,
+    trust_tier: str | None = None,
+    source_url: str | None = None,
+    identity_used: str | None = None,
+    reason: str | None = None,
+) -> dict:
+    """Build a precedence-trail payload with a consistent key set.
+
+    Every key is always present (``None`` when not applicable) so a downstream
+    reader never has to guess which keys a given row carries.
+    """
+    return {
+        "outcome": outcome,
+        "chosen_source": chosen_source,
+        "trust_tier": trust_tier,
+        "source_url": source_url,
+        "identity_used": identity_used,
+        "identity_confirmed": identity_confirmed,
+        "reason": reason,
+        "ladder": _PRECEDENCE_LADDER,
+    }
 
 
 def _samples_payload(aggregate: AggregatedEstimate) -> list[dict]:
@@ -73,12 +106,12 @@ async def record_estimate_audit(
     Idempotent on the 1:1 ``food_record_id`` so a retried create updates rather
     than duplicates. Best-effort: never raises into the caller.
     """
-    precedence = {
-        "outcome": "vision_only",
-        "identity_confirmed": False,
-        "reason": "Identity not yet confirmed; estimate is vision-only.",
-        "ladder": _PRECEDENCE_LADDER,
-    }
+    now = datetime.now(UTC)
+    precedence = _precedence(
+        _OUTCOME_VISION_ONLY,
+        identity_confirmed=False,
+        reason="Identity not yet confirmed; estimate is vision-only.",
+    )
     values = {
         "food_record_id": food_record_id,
         "user_id": user_id,
@@ -93,7 +126,7 @@ async def record_estimate_audit(
             "samples_json": stmt.excluded.samples_json,
             "dispersion_json": stmt.excluded.dispersion_json,
             "precedence_json": stmt.excluded.precedence_json,
-            "updated_at": stmt.excluded.updated_at,
+            "updated_at": now,
         },
     )
     try:
@@ -122,25 +155,26 @@ async def record_grounding_decision(
     keyed on. Idempotent upsert so a re-confirm overwrites the prior decision
     (and a missing create-time audit is still captured, sans samples). Best-effort.
     """
+    now = datetime.now(UTC)
     if grounding is not None:
-        precedence = {
-            "outcome": "grounded",
-            "chosen_source": grounding.source,
-            "trust_tier": grounding.trust_tier,
-            "source_url": grounding.source_url,
-            "identity_used": identity,
-            "identity_confirmed": identity_confirmed,
-            "ladder": _PRECEDENCE_LADDER,
-        }
+        precedence = _precedence(
+            _OUTCOME_GROUNDED,
+            identity_confirmed=identity_confirmed,
+            chosen_source=grounding.source,
+            trust_tier=grounding.trust_tier,
+            source_url=grounding.source_url,
+            identity_used=identity,
+        )
     else:
-        precedence = {
-            "outcome": "vision_only",
-            "chosen_source": "vision-only",
-            "identity_used": identity,
-            "identity_confirmed": identity_confirmed,
-            "reason": "No source matched the confirmed identity.",
-            "ladder": _PRECEDENCE_LADDER,
-        }
+        precedence = _precedence(
+            _OUTCOME_VISION_ONLY,
+            identity_confirmed=identity_confirmed,
+            chosen_source="vision-only",
+            identity_used=identity,
+            reason="No source matched the confirmed identity.",
+        )
+    # Upsert only the precedence: a re-confirm overwrites the decision while the
+    # create-time samples_json / dispersion_json are deliberately left intact.
     stmt = pg_insert(FoodRecordAudit).values(
         food_record_id=food_record_id,
         user_id=user_id,
@@ -150,7 +184,7 @@ async def record_grounding_decision(
         index_elements=["food_record_id"],
         set_={
             "precedence_json": stmt.excluded.precedence_json,
-            "updated_at": stmt.excluded.updated_at,
+            "updated_at": now,
         },
     )
     try:

--- a/apps/api/src/services/meal_estimate_aggregate.py
+++ b/apps/api/src/services/meal_estimate_aggregate.py
@@ -1,0 +1,290 @@
+"""Multi-sample aggregation for vision carb estimates (Story 50.H1).
+
+The research-driven amendment (2026-06-15): a model's *self-reported* confidence
+is uncorrelated with accuracy (diabettech's 27,000-run study measured r ~= -0.01,
+with accuracy *declining* above 0.85 self-reported confidence). The only
+validated uncertainty signal is **querying the same photo several times and
+observing how much the answers disagree.** So the pipeline now samples one image
+N times and this module turns those N samples into:
+
+  * an **empirical carb range** from the observed spread (not one response's
+    self-described range), and
+  * an **empirical confidence band** from the dispersion (coefficient of
+    variation) of the samples, NOT the model's self-reported confidence, and
+  * an **identity-agreement** signal: when the samples disagree on *what the
+    food is* (the dominant, upstream error), that is surfaced as low confidence
+    and flagged so the 50.H2 identity-confirmation gate is required before any
+    grounding can certify a label.
+
+Safety posture (NON-NEGOTIABLE):
+  * Consistency is NOT correctness. A tight spread must never be presented as
+    "safe to dose" -- a systematically-wrong-but-consistent estimate (the study's
+    cheese-sandwich class) would have low dispersion yet be wrong. The
+    verify-before-dosing framing stays dominant regardless of dispersion; this
+    module never emits a dose and nothing here is read by IoB / treatment_safety.
+  * The model's self-reported confidence is retained ONLY as internal audit/eval
+    data (for 50.H3), never surfaced as a user-facing safety signal.
+"""
+
+from __future__ import annotations
+
+import re
+import statistics
+from dataclasses import dataclass, field
+
+from src.vision.carb_contract import (
+    CARB_GRAMS_MAX,
+    CARB_GRAMS_MIN,
+    ParsedEstimate,
+)
+
+# Coefficient-of-variation thresholds mapping sample dispersion -> a confidence
+# band. Deliberately conservative: anything but tight agreement lands at medium
+# or low. These are the H1 starting points; 50.H4's variance harness tunes them
+# (and N) against the accuracy-vs-cost curve.
+_CV_HIGH_MAX = 0.10  # CV below this -> tight agreement -> "high"
+_CV_MEDIUM_MAX = 0.25  # CV below this -> "medium"; at/above -> "low"
+
+# Confidence bands (mirror carb_contract.CONFIDENCE_LEVELS ordering).
+CONFIDENCE_HIGH = "high"
+CONFIDENCE_MEDIUM = "medium"
+CONFIDENCE_LOW = "low"
+
+# Token-set Jaccard at or above this means two food descriptions name the same
+# food for agreement purposes. Below it (e.g. "creme brulee" vs "crema catalana",
+# disjoint tokens -> 0.0) the samples disagree on identity.
+_IDENTITY_AGREEMENT_JACCARD = 0.5
+
+# Common filler words stripped before comparing food identities, so "a plate of
+# grilled chicken" and "grilled chicken breast" still cluster together.
+_IDENTITY_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "of",
+        "with",
+        "and",
+        "on",
+        "in",
+        "plate",
+        "bowl",
+        "serving",
+        "some",
+        "dish",
+        "food",
+        "meal",
+        "fresh",
+        "homemade",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SampleRecord:
+    """One vision sample's salient values, retained for 50.H3 audit.
+
+    ``self_reported_confidence`` is captured for audit/eval ONLY -- it is never
+    surfaced as a user-facing safety signal (the whole point of H1).
+    """
+
+    carbs_low: float | None
+    carbs_high: float | None
+    midpoint: float | None
+    food_description: str
+    self_reported_confidence: str | None
+    parse_ok: bool
+
+
+@dataclass(frozen=True)
+class AggregatedEstimate:
+    """The aggregate of N vision samples for one photo.
+
+    ``carbs_low`` / ``carbs_high`` are the empirical band; ``confidence`` is the
+    dispersion-derived band (never self-reported). ``samples`` is the raw
+    per-sample audit data (for 50.H3 retention).
+    """
+
+    carbs_low: float
+    carbs_high: float
+    confidence: str
+    food_description: str
+    nutrition: dict
+    dispersion_cv: float | None
+    identity_agreement: bool
+    distinct_identities: list[str]
+    samples_requested: int
+    samples_ok: int
+    wide_spread: bool
+    samples: list[SampleRecord] = field(default_factory=list)
+
+
+def _sample_in_bounds(sample: ParsedEstimate) -> bool:
+    """True when a sample's carb range is present and within absolute bounds."""
+    low, high = sample.carbs_low, sample.carbs_high
+    return (
+        low is not None
+        and high is not None
+        and CARB_GRAMS_MIN <= low <= high <= CARB_GRAMS_MAX
+    )
+
+
+def _identity_tokens(description: str) -> frozenset[str]:
+    """Normalize a food description to a comparable token set."""
+    tokens = re.findall(r"[a-z0-9]+", (description or "").lower())
+    return frozenset(t for t in tokens if t not in _IDENTITY_STOPWORDS)
+
+
+def _jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _largest_identity_cluster(
+    descriptions: list[str],
+) -> tuple[list[int], list[str]]:
+    """Greedily cluster sample descriptions by identity similarity.
+
+    Returns ``(indices_of_largest_cluster, distinct_identity_labels)``. A simple
+    greedy single-link clustering is enough here: we only need "do the samples
+    largely agree on the food, and which one represents the majority", not a
+    perfect partition.
+    """
+    token_sets = [_identity_tokens(d) for d in descriptions]
+    clusters: list[list[int]] = []
+    for i, tokens in enumerate(token_sets):
+        placed = False
+        for cluster in clusters:
+            # Compare against the cluster's first member (single-link anchor).
+            if _jaccard(tokens, token_sets[cluster[0]]) >= _IDENTITY_AGREEMENT_JACCARD:
+                cluster.append(i)
+                placed = True
+                break
+        if not placed:
+            clusters.append([i])
+
+    largest = max(clusters, key=len) if clusters else []
+    distinct = [
+        descriptions[c[0]].strip() for c in clusters if descriptions[c[0]].strip()
+    ]
+    return largest, distinct
+
+
+def _confidence_from_cv(cv: float | None, samples_ok: int) -> str:
+    """Map sample dispersion to a confidence band.
+
+    A single usable sample cannot measure dispersion at all, so it can never earn
+    more than low confidence -- one draw is exactly the lucky/unlucky-draw problem
+    multi-sampling exists to expose.
+    """
+    if samples_ok <= 1 or cv is None:
+        return CONFIDENCE_LOW
+    if cv < _CV_HIGH_MAX:
+        return CONFIDENCE_HIGH
+    if cv < _CV_MEDIUM_MAX:
+        return CONFIDENCE_MEDIUM
+    return CONFIDENCE_LOW
+
+
+def _pick_representative(
+    ok_samples: list[ParsedEstimate], cluster_indices: list[int]
+) -> ParsedEstimate:
+    """Choose the sample whose midpoint is the cluster's median.
+
+    Its description + nutrition represent the aggregate. Using the median (not the
+    first) avoids letting a tail-outlier sample's prose stand in for the group.
+    """
+    cluster = [ok_samples[i] for i in cluster_indices] or ok_samples
+    midpoints = sorted(
+        (s for s in cluster if s.midpoint is not None),
+        key=lambda s: s.midpoint,  # type: ignore[arg-type, return-value]
+    )
+    if not midpoints:
+        return cluster[0]
+    return midpoints[len(midpoints) // 2]
+
+
+def aggregate_samples(
+    samples: list[ParsedEstimate],
+    *,
+    samples_requested: int,
+    wide_spread_cv: float | None = None,
+) -> AggregatedEstimate | None:
+    """Aggregate N parsed vision samples into one empirical estimate.
+
+    Returns ``None`` when no sample is usable (the caller raises a clear error
+    rather than persisting a fabricated estimate). Uses only the samples that
+    parsed into an in-range numeric estimate; a failed/partial sample degrades
+    gracefully (AC6).
+    """
+    audit = [
+        SampleRecord(
+            carbs_low=s.carbs_low,
+            carbs_high=s.carbs_high,
+            midpoint=s.midpoint,
+            food_description=s.food_description,
+            self_reported_confidence=s.confidence,
+            parse_ok=s.parse_ok,
+        )
+        for s in samples
+    ]
+
+    # Reject-not-clamp, enforced PER SAMPLE (AC7): a single hallucinated
+    # out-of-range sample is dropped here so it can't poison the union band or
+    # the dispersion. If every sample is unusable, return None (the caller raises
+    # a clear error rather than persisting a fabricated estimate).
+    ok = [s for s in samples if s.parse_ok and _sample_in_bounds(s)]
+    if not ok:
+        return None
+
+    # Empirical band = the union of every usable sample's own range. This folds
+    # both each sample's stated uncertainty AND cross-sample disagreement into
+    # one honest band: wide when the model contradicts itself, tight only when
+    # every look agrees.
+    carbs_low = min(s.carbs_low for s in ok)  # type: ignore[type-var]
+    carbs_high = max(s.carbs_high for s in ok)  # type: ignore[type-var]
+
+    # Dispersion is measured on the per-sample point estimates (midpoints): the
+    # run-to-run swing the study cares about. Needs >=2 samples and a non-zero
+    # mean to be meaningful.
+    midpoints = [s.midpoint for s in ok if s.midpoint is not None]
+    cv: float | None = None
+    if len(midpoints) >= 2:
+        mean = statistics.fmean(midpoints)
+        if mean > 0:
+            cv = statistics.pstdev(midpoints) / mean
+
+    largest_cluster, distinct = _largest_identity_cluster(
+        [s.food_description for s in ok]
+    )
+    # Identity agrees when a strict majority of usable samples fall in one
+    # identity cluster. Disagreement is the dominant upstream error -- force low
+    # confidence and flag it so H2 requires confirmation before any grounding.
+    identity_agreement = len(largest_cluster) * 2 > len(ok)
+
+    confidence = _confidence_from_cv(cv, len(ok))
+    if not identity_agreement:
+        confidence = CONFIDENCE_LOW
+
+    threshold = wide_spread_cv if wide_spread_cv is not None else _CV_MEDIUM_MAX
+    wide_spread = (cv is not None and cv >= threshold) or not identity_agreement
+
+    representative = _pick_representative(ok, largest_cluster)
+
+    return AggregatedEstimate(
+        carbs_low=carbs_low,
+        carbs_high=carbs_high,
+        confidence=confidence,
+        food_description=representative.food_description,
+        nutrition=representative.nutrition or {},
+        dispersion_cv=cv,
+        identity_agreement=identity_agreement,
+        distinct_identities=distinct,
+        samples_requested=samples_requested,
+        samples_ok=len(ok),
+        wide_spread=wide_spread,
+        samples=audit,
+    )

--- a/apps/api/src/services/meal_estimate_aggregate.py
+++ b/apps/api/src/services/meal_estimate_aggregate.py
@@ -164,8 +164,12 @@ def _largest_identity_cluster(
     for i, tokens in enumerate(token_sets):
         placed = False
         for cluster in clusters:
-            # Compare against the cluster's first member (single-link anchor).
-            if _jaccard(tokens, token_sets[cluster[0]]) >= _IDENTITY_AGREEMENT_JACCARD:
+            # True single-link: match if this sample is close to ANY member, so
+            # transitive matches (A≈B, B≈C) aren't split into false disagreement.
+            if any(
+                _jaccard(tokens, token_sets[idx]) >= _IDENTITY_AGREEMENT_JACCARD
+                for idx in cluster
+            ):
                 cluster.append(i)
                 placed = True
                 break

--- a/apps/api/src/services/meal_estimate_aggregate.py
+++ b/apps/api/src/services/meal_estimate_aggregate.py
@@ -45,6 +45,12 @@ from src.vision.carb_contract import (
 _CV_HIGH_MAX = 0.10  # CV below this -> tight agreement -> "high"
 _CV_MEDIUM_MAX = 0.25  # CV below this -> "medium"; at/above -> "low"
 
+# A "high" band needs enough draws to be evidence of stability, not luck: two
+# agreeing samples is just the lucky/unlucky-draw problem one level up (and a
+# single tolerated partial failure routinely leaves exactly two). So "high"
+# requires at least this many usable samples; fewer caps at "medium".
+_MIN_SAMPLES_FOR_HIGH = 3
+
 # Confidence bands (mirror carb_contract.CONFIDENCE_LEVELS ordering).
 CONFIDENCE_HIGH = "high"
 CONFIDENCE_MEDIUM = "medium"
@@ -52,7 +58,7 @@ CONFIDENCE_LOW = "low"
 
 # Token-set Jaccard at or above this means two food descriptions name the same
 # food for agreement purposes. Below it (e.g. "creme brulee" vs "crema catalana",
-# disjoint tokens -> 0.0) the samples disagree on identity.
+# disjoint tokens -> 0.0) the samples disagree on identity. (50.H4 tunes this.)
 _IDENTITY_AGREEMENT_JACCARD = 0.5
 
 # Common filler words stripped before comparing food identities, so "a plate of
@@ -176,13 +182,15 @@ def _largest_identity_cluster(
 def _confidence_from_cv(cv: float | None, samples_ok: int) -> str:
     """Map sample dispersion to a confidence band.
 
-    A single usable sample cannot measure dispersion at all, so it can never earn
-    more than low confidence -- one draw is exactly the lucky/unlucky-draw problem
-    multi-sampling exists to expose.
+    A single usable sample cannot measure dispersion at all, and two agreeing
+    samples are weak evidence of stability, so "high" requires both tight
+    agreement AND at least ``_MIN_SAMPLES_FOR_HIGH`` usable samples -- the
+    lucky/unlucky-draw problem multi-sampling exists to expose. A 2-sample run
+    can reach at most "medium".
     """
     if samples_ok <= 1 or cv is None:
         return CONFIDENCE_LOW
-    if cv < _CV_HIGH_MAX:
+    if cv < _CV_HIGH_MAX and samples_ok >= _MIN_SAMPLES_FOR_HIGH:
         return CONFIDENCE_HIGH
     if cv < _CV_MEDIUM_MAX:
         return CONFIDENCE_MEDIUM
@@ -198,20 +206,17 @@ def _pick_representative(
     first) avoids letting a tail-outlier sample's prose stand in for the group.
     """
     cluster = [ok_samples[i] for i in cluster_indices] or ok_samples
-    midpoints = sorted(
-        (s for s in cluster if s.midpoint is not None),
-        key=lambda s: s.midpoint,  # type: ignore[arg-type, return-value]
-    )
-    if not midpoints:
+    with_midpoint = [s for s in cluster if s.midpoint is not None]
+    if not with_midpoint:
         return cluster[0]
-    return midpoints[len(midpoints) // 2]
+    with_midpoint.sort(key=lambda s: s.midpoint or 0.0)
+    return with_midpoint[len(with_midpoint) // 2]
 
 
 def aggregate_samples(
     samples: list[ParsedEstimate],
     *,
     samples_requested: int,
-    wide_spread_cv: float | None = None,
 ) -> AggregatedEstimate | None:
     """Aggregate N parsed vision samples into one empirical estimate.
 
@@ -248,29 +253,41 @@ def aggregate_samples(
     carbs_high = max(s.carbs_high for s in ok)  # type: ignore[type-var]
 
     # Dispersion is measured on the per-sample point estimates (midpoints): the
-    # run-to-run swing the study cares about. Needs >=2 samples and a non-zero
-    # mean to be meaningful.
+    # run-to-run swing the study cares about. Uses the unbiased sample stdev
+    # (N-1) -- these N draws are a *sample* of the model's output distribution,
+    # not the whole population, and at the small N this runs (2-3) the population
+    # stdev would understate the true spread and lean optimistic. Needs >=2
+    # samples and a non-zero mean to be meaningful.
     midpoints = [s.midpoint for s in ok if s.midpoint is not None]
     cv: float | None = None
     if len(midpoints) >= 2:
         mean = statistics.fmean(midpoints)
         if mean > 0:
-            cv = statistics.pstdev(midpoints) / mean
+            cv = statistics.stdev(midpoints) / mean
 
-    largest_cluster, distinct = _largest_identity_cluster(
-        [s.food_description for s in ok]
-    )
-    # Identity agrees when a strict majority of usable samples fall in one
-    # identity cluster. Disagreement is the dominant upstream error -- force low
-    # confidence and flag it so H2 requires confirmation before any grounding.
-    identity_agreement = len(largest_cluster) * 2 > len(ok)
+    # Identity agreement is judged ONLY over samples that still have a usable
+    # description: a description emptied by the dosing scrub carries no identity
+    # signal, so it must not count as a distinct "disagreeing" food (which would
+    # surface a misleading "the AI couldn't agree what this is" to the user).
+    described_indices = [i for i, s in enumerate(ok) if s.food_description.strip()]
+    if described_indices:
+        local_cluster, distinct = _largest_identity_cluster(
+            [ok[i].food_description for i in described_indices]
+        )
+        largest_cluster = [described_indices[j] for j in local_cluster]
+        # A strict majority of *described* samples sharing one identity = agreement.
+        identity_agreement = len(largest_cluster) * 2 > len(described_indices)
+    else:
+        # No description survived to compare -- no evidence of disagreement.
+        largest_cluster = []
+        distinct = []
+        identity_agreement = True
 
     confidence = _confidence_from_cv(cv, len(ok))
     if not identity_agreement:
         confidence = CONFIDENCE_LOW
 
-    threshold = wide_spread_cv if wide_spread_cv is not None else _CV_MEDIUM_MAX
-    wide_spread = (cv is not None and cv >= threshold) or not identity_agreement
+    wide_spread = (cv is not None and cv >= _CV_MEDIUM_MAX) or not identity_agreement
 
     representative = _pick_representative(ok, largest_cluster)
 

--- a/apps/api/src/services/meal_grounding.py
+++ b/apps/api/src/services/meal_grounding.py
@@ -61,24 +61,36 @@ def _fact_detail(fact: nutrition_sources.NutritionFact) -> GroundingDetail:
 
 async def ground_estimate(
     user_id: uuid.UUID,
-    food_description: str | None,
+    identity: str | None,
+    *,
+    identity_confirmed: bool,
 ) -> GroundingDetail | None:
-    """Return the best grounding for a vision estimate, or None (pure vision).
+    """Return the best grounding for a *confirmed-identity* estimate, or None.
+
+    Story 50.H2 wraps the whole precedence ladder in a food-identity gate: food
+    misidentification is the dominant, upstream error, and grounding a
+    misidentified label to USDA / Open Food Facts / a restaurant page certifies a
+    confident-wrong answer with an authoritative citation. So nothing here runs
+    until the user has confirmed (or corrected) *what the food is*; an unconfirmed
+    vision label stays vision-only (range + empirical confidence) and is grounded
+    only after confirmation, against the confirmed ``identity``.
 
     Decoupled from any caller transaction: the own-history recall and the external
     lookups each manage their own DB sessions and each fails open to None
-    internally (``recall_similar_meal`` and ``lookup_published_nutrition`` never
-    raise), so this orchestrator stays free of redundant try/except layers. The
-    single hard fail-open boundary for any truly unexpected error is the caller
-    (``food_vision._ground_estimate``).
+    internally, so this orchestrator stays free of redundant try/except layers.
+    The single hard fail-open boundary is the caller (``food_vision``).
     """
-    # Defence in depth: the only caller is already flag-gated, but enforce the
+    # Defence in depth: the only callers are already flag-gated, but enforce the
     # feature flag at this boundary too so a future caller can't run grounding
     # (embedding + external fetch) while meal intelligence is off.
     if not settings.meal_intelligence_enabled:
         return None
 
-    description = (food_description or "").strip()
+    # The identity gate (AC3): never ground an unconfirmed / uncorrected label.
+    if not identity_confirmed:
+        return None
+
+    description = (identity or "").strip()
     if not description:
         return None
 
@@ -102,3 +114,24 @@ async def ground_estimate(
 
     # 5. Pure vision.
     return None
+
+
+async def suggest_identity(
+    user_id: uuid.UUID,
+    food_description: str | None,
+) -> str | None:
+    """Suggest a confirmable identity from the user's own history (Story 50.H2 AC4).
+
+    Read-only own-history RAG recall used to PRE-FILL the identity field ("looks
+    like your saved <X>") so a repeat food is a one-tap confirm. This is only a
+    suggestion -- it never grounds anything by itself (that waits for the user to
+    confirm); the safe fast path is the user confirming the suggestion. Returns
+    the recalled food name, or None when nothing close enough was logged before.
+    """
+    if not settings.meal_intelligence_enabled:
+        return None
+    description = (food_description or "").strip()
+    if not description:
+        return None
+    recall = await meal_rag.recall_similar_meal(user_id, description)
+    return recall.name if recall is not None else None

--- a/apps/api/src/services/meal_rag.py
+++ b/apps/api/src/services/meal_rag.py
@@ -240,11 +240,14 @@ def _record_effective_carbs(record: FoodRecord) -> tuple[float, float, bool]:
 async def index_food_record(record: FoodRecord) -> None:
     """Index a food record into own-history RAG (best-effort, owner-scoped).
 
-    Embeds the food description so a re-photograph of the same food recalls it.
-    A record with no description is skipped (nothing to match on). Reads the
-    record's already-loaded fields, then persists on its own session.
+    Embeds the food's identity so a re-photograph of the same food recalls it.
+    Prefers the user's **confirmed** identity (Story 50.H2) over the AI-identified
+    ``food_description`` -- so once the user corrects "soup" to "chili", a future
+    photo recalls/suggests the user's truth, not the stale AI label. A record with
+    no usable name is skipped. Reads already-loaded fields, persists on its own
+    session.
     """
-    description = (record.food_description or "").strip()
+    description = (record.confirmed_food_name or record.food_description or "").strip()
     if not description:
         return
     low, high, corrected = _record_effective_carbs(record)

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -710,6 +710,41 @@ class TestIdentityConfirmation:
 
 
 # --------------------------------------------------------------------------- #
+# Estimate auditability & provenance (Story 50.H3)
+# --------------------------------------------------------------------------- #
+class TestEstimateAudit:
+    async def test_audit_endpoint_returns_provenance(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        # Confirm identity so the precedence reflects a grounding decision.
+        await client.post(
+            f"/api/food-records/{record_id}/confirm-identity",
+            json={"confirmed_food_name": "bowl of pasta"},
+        )
+        resp = await client.get(f"/api/food-records/{record_id}/audit")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["food_record_id"] == record_id
+        assert body["samples"]  # raw per-sample reads present
+        assert body["precedence"]["identity_confirmed"] is True
+        # Self-reported confidence is internal-only -- never in the response.
+        assert "self_reported_confidence" not in resp.text
+
+    async def test_audit_endpoint_is_owner_scoped(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as other:
+            cookie = await _register_login(other)
+            other.cookies.set(settings.jwt_cookie_name, cookie)
+            resp = await other.get(f"/api/food-records/{record_id}/audit")
+        assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
 # Common foods: promotion, dedupe, linking, management (AC2/AC3)
 # --------------------------------------------------------------------------- #
 class TestCommonFoods:

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -644,6 +644,72 @@ class TestCorrection:
 
 
 # --------------------------------------------------------------------------- #
+# Food-identity confirmation gate (Story 50.H2)
+# --------------------------------------------------------------------------- #
+class TestIdentityConfirmation:
+    async def test_fresh_estimate_is_unconfirmed(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        # A fresh estimate is never auto-grounded: identity unconfirmed, no
+        # grounding source attached.
+        assert created["identity_confirmed"] is False
+        assert created["confirmed_food_name"] is None
+        assert created["grounding_source"] is None
+
+    async def test_confirm_identity_persists_and_opens_gate(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        resp = await client.post(
+            f"/api/food-records/{record_id}/confirm-identity",
+            json={"confirmed_food_name": "bowl of pasta"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["identity_confirmed"] is True
+        assert body["confirmed_food_name"] == "bowl of pasta"
+        # Carbs are untouched by an identity confirmation (never a dose).
+        assert body["carbs_low"] == created["carbs_low"]
+        assert body["carbs_high"] == created["carbs_high"]
+
+    async def test_confirm_identity_rejects_blank(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        for bad in ({"confirmed_food_name": "   "}, {"confirmed_food_name": ""}, {}):
+            resp = await client.post(
+                f"/api/food-records/{record_id}/confirm-identity", json=bad
+            )
+            assert resp.status_code == 422, bad
+
+    async def test_confirm_identity_rejects_extra_fields(self, auth_client):
+        # extra=forbid: a smuggled dose field is rejected at the boundary.
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        resp = await client.post(
+            f"/api/food-records/{record_id}/confirm-identity",
+            json={"confirmed_food_name": "pasta", "insulin_units": 5},
+        )
+        assert resp.status_code == 422
+
+    async def test_cannot_confirm_other_users_record(self, auth_client):
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as other:
+            cookie = await _register_login(other)
+            other.cookies.set(settings.jwt_cookie_name, cookie)
+            resp = await other.post(
+                f"/api/food-records/{record_id}/confirm-identity",
+                json={"confirmed_food_name": "pasta"},
+            )
+        assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
 # Common foods: promotion, dedupe, linking, management (AC2/AC3)
 # --------------------------------------------------------------------------- #
 class TestCommonFoods:

--- a/apps/api/tests/test_meal_audit.py
+++ b/apps/api/tests/test_meal_audit.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from PIL import Image
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 
 from src.config import settings
 from src.database import get_session_maker
@@ -195,6 +195,33 @@ class TestGroundingDecisionAudit:
         assert audit.precedence_json["identity_confirmed"] is True
         assert audit.precedence_json["identity_used"] == "mystery dish"
 
+    async def test_confirm_preserves_create_time_samples(self):
+        # Re-confirm upserts only precedence -- the create-time raw samples and
+        # dispersion must survive (the on-conflict set_ must not clobber them).
+        desc = _uniq("preserve samples")
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            record = await _create(db, user, desc)
+            before = await _fetch_audit(record.id)
+            assert before.samples_json and len(before.samples_json) == 3
+            with (
+                patch.object(
+                    meal_rag, "recall_similar_meal", AsyncMock(return_value=None)
+                ),
+                patch.object(
+                    nutrition_sources,
+                    "lookup_published_nutrition",
+                    AsyncMock(return_value=(None, None)),
+                ),
+            ):
+                await common_food_service.confirm_food_identity(db, record, desc)
+
+        after = await _fetch_audit(record.id)
+        assert after.precedence_json["identity_confirmed"] is True
+        # Samples + dispersion were NOT clobbered by the precedence upsert.
+        assert after.samples_json and len(after.samples_json) == 3
+        assert after.dispersion_json is not None
+
 
 class TestAuditRetention:
     async def test_get_audit_is_owner_scoped(self):
@@ -229,3 +256,19 @@ class TestAuditRetention:
                 .where(FoodRecordAudit.food_record_id == record_id)
             )
         assert remaining == 0
+
+    async def test_bulk_delete_cascades_audit(self):
+        # The retention purge path is a Core bulk DELETE on food_records
+        # (data_purge.purge_all_user_data); it must also drop audit rows via the
+        # FK cascade, not just the ORM single-delete path (AC5).
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            record = await _create(db, user, _uniq("noodles"))
+            record_id = record.id
+        assert await _fetch_audit(record_id) is not None
+
+        async with get_session_maker()() as db:
+            await db.execute(delete(FoodRecord).where(FoodRecord.user_id == user.id))
+            await db.commit()
+
+        assert await _fetch_audit(record_id) is None

--- a/apps/api/tests/test_meal_audit.py
+++ b/apps/api/tests/test_meal_audit.py
@@ -1,0 +1,231 @@
+"""Story 50.H3: estimate auditability & provenance retention.
+
+Covers: the create-time audit (raw samples + dispersion + vision-only precedence),
+the grounding decision appended at identity confirmation, the self-reported
+confidence being stored-but-not-surfaced, owner-scoped retrieval, and the
+cascade-delete that ties the audit's lifetime to the food record (AC5).
+
+External HTTP is mocked; embeddings are stubbed by the autouse conftest fixture.
+"""
+
+import json
+import uuid
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from PIL import Image
+from sqlalchemy import func, select
+
+from src.config import settings
+from src.database import get_session_maker
+from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProviderType
+from src.models.food_record import FoodRecord
+from src.models.food_record_audit import FoodRecordAudit
+from src.models.knowledge_chunk import KnowledgeChunk
+from src.models.user import User, UserRole
+from src.schemas.food_record import FoodRecordAuditResponse
+from src.services import common_food as common_food_service
+from src.services import food_vision, meal_audit, meal_rag, nutrition_sources
+
+
+@pytest.fixture(autouse=True)
+def _enable(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "upload_dir", str(tmp_path / "uploads"))
+    monkeypatch.setattr(settings, "meal_intelligence_enabled", True)
+    monkeypatch.setattr(settings, "meal_estimate_sample_count", 3)
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (16, 16), (50, 60, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _estimate_json(desc, low=40, high=55, confidence="high") -> str:
+    return json.dumps(
+        {
+            "food_description": desc,
+            "carbs_grams_low": low,
+            "carbs_grams_high": high,
+            "confidence": confidence,
+        }
+    )
+
+
+async def _user_with_provider(db) -> User:
+    user = User(
+        email=f"h3_{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        role=UserRole.DIABETIC,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    db.add(
+        AIProviderConfig(
+            user_id=user.id,
+            provider_type=AIProviderType.CLAUDE_API,
+            model_name="claude-sonnet-4-5-20250929",
+            status=AIProviderStatus.CONNECTED,
+        )
+    )
+    await db.commit()
+    return user
+
+
+async def _create(db, user, desc) -> FoodRecord:
+    with patch.object(
+        food_vision, "_call_vision", AsyncMock(return_value=_estimate_json(desc))
+    ):
+        return await food_vision.create_food_record_from_image(
+            db=db, user=user, raw_image=_png_bytes()
+        )
+
+
+async def _fetch_audit(food_record_id) -> FoodRecordAudit | None:
+    async with get_session_maker()() as db:
+        return await db.scalar(
+            select(FoodRecordAudit).where(
+                FoodRecordAudit.food_record_id == food_record_id
+            )
+        )
+
+
+class TestCreateAudit:
+    async def test_create_writes_raw_samples_and_dispersion(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            record = await _create(db, user, _uniq("oatmeal"))
+
+        audit = await _fetch_audit(record.id)
+        assert audit is not None
+        assert audit.user_id == user.id
+        # Raw per-sample outputs retained (3 samples).
+        assert isinstance(audit.samples_json, list) and len(audit.samples_json) == 3
+        sample = audit.samples_json[0]
+        assert "carbs_low" in sample and "identity" in sample
+        # Self-reported confidence retained in STORAGE (internal eval data).
+        assert "self_reported_confidence" in sample
+        # Dispersion summary captured.
+        assert audit.dispersion_json["samples_used"] == 3
+        # Precedence is vision-only at create (identity not yet confirmed).
+        assert audit.precedence_json["outcome"] == "vision_only"
+        assert audit.precedence_json["identity_confirmed"] is False
+
+    async def test_audit_response_hides_self_reported_confidence(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            record = await _create(db, user, _uniq("toast"))
+        audit = await _fetch_audit(record.id)
+
+        response = FoodRecordAuditResponse.from_audit(audit)
+        dumped = response.model_dump()
+        # The surfaced samples carry carbs + identity but NOT the self-reported
+        # confidence, which is internal-only (50.H1).
+        assert dumped["samples"]
+        for s in dumped["samples"]:
+            assert "self_reported_confidence" not in s
+            assert "carbs_low" in s and "identity" in s
+        # The full serialized response (what the endpoint returns) never leaks it.
+        assert "self_reported_confidence" not in response.model_dump_json()
+
+
+class TestGroundingDecisionAudit:
+    async def test_confirm_records_grounded_precedence(self):
+        desc = _uniq("greek yogurt")
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            record = await _create(db, user, desc)
+
+            usda = nutrition_sources.NutritionFact(
+                source_name="USDA FoodData Central",
+                source_url="https://fdc.nal.usda.gov/x",
+                trust_tier=KnowledgeChunk.TIER_AUTHORITATIVE,
+                name="greek yogurt",
+                carbs_grams=6,
+                serving="per 100 g",
+                disclaimer=None,
+            )
+            with (
+                patch.object(
+                    meal_rag, "recall_similar_meal", AsyncMock(return_value=None)
+                ),
+                patch.object(
+                    nutrition_sources,
+                    "lookup_published_nutrition",
+                    AsyncMock(return_value=(usda, None)),
+                ),
+            ):
+                await common_food_service.confirm_food_identity(
+                    db, record, "greek yogurt"
+                )
+
+        audit = await _fetch_audit(record.id)
+        assert audit.precedence_json["outcome"] == "grounded"
+        assert audit.precedence_json["chosen_source"] == "USDA FoodData Central"
+        assert audit.precedence_json["identity_used"] == "greek yogurt"
+        assert audit.precedence_json["identity_confirmed"] is True
+
+    async def test_confirm_without_match_records_vision_only(self):
+        desc = _uniq("mystery dish")
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            record = await _create(db, user, desc)
+            with (
+                patch.object(
+                    meal_rag, "recall_similar_meal", AsyncMock(return_value=None)
+                ),
+                patch.object(
+                    nutrition_sources,
+                    "lookup_published_nutrition",
+                    AsyncMock(return_value=(None, None)),
+                ),
+            ):
+                await common_food_service.confirm_food_identity(
+                    db, record, "mystery dish"
+                )
+
+        audit = await _fetch_audit(record.id)
+        assert audit.precedence_json["outcome"] == "vision_only"
+        assert audit.precedence_json["identity_confirmed"] is True
+        assert audit.precedence_json["identity_used"] == "mystery dish"
+
+
+class TestAuditRetention:
+    async def test_get_audit_is_owner_scoped(self):
+        async with get_session_maker()() as db:
+            owner = await _user_with_provider(db)
+            other = await _user_with_provider(db)
+            record = await _create(db, owner, _uniq("salad"))
+
+        async with get_session_maker()() as db:
+            assert await meal_audit.get_audit(db, record.id, owner.id) is not None
+            # Another user must never retrieve it.
+            assert await meal_audit.get_audit(db, record.id, other.id) is None
+
+    async def test_deleting_record_cascades_audit(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            record = await _create(db, user, _uniq("burrito"))
+            record_id = record.id
+
+        assert await _fetch_audit(record_id) is not None
+
+        # Deleting the food record drops its audit trail (FK ON DELETE CASCADE).
+        async with get_session_maker()() as db:
+            row = await db.get(FoodRecord, record_id)
+            await db.delete(row)
+            await db.commit()
+
+        async with get_session_maker()() as db:
+            remaining = await db.scalar(
+                select(func.count())
+                .select_from(FoodRecordAudit)
+                .where(FoodRecordAudit.food_record_id == record_id)
+            )
+        assert remaining == 0

--- a/apps/api/tests/test_meal_e2e_chain.py
+++ b/apps/api/tests/test_meal_e2e_chain.py
@@ -1,0 +1,173 @@
+"""End-to-end H1->H2->H3 chain over HTTP (real ASGI app + real DB, vision mocked).
+
+Exercises the *composed* flow the per-story tests don't: a meal photo goes
+upload -> multi-sample dispersion (H1) -> identity confirmation that opens the
+grounding gate + re-indexes own history (H2) -> auditable provenance with the
+self-reported confidence hidden (H3) -> delete that cascades the audit. Only the
+vision LLM (``_call_vision``) is mocked; everything else is the real pipeline,
+router, schemas, and database. Embeddings are the autouse conftest stub, so
+own-history recall is deterministic (identical text -> distance 0).
+"""
+
+import uuid
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from PIL import Image
+
+from src.config import settings
+from src.database import get_session_maker
+from src.main import app
+from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProviderType
+from src.services import food_vision
+from src.vision.carb_contract import find_dosing_violations
+
+
+def _png() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (16, 16), (60, 40, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _vision(desc: str, low: float, high: float, confidence: str = "high") -> str:
+    import json
+
+    return json.dumps(
+        {
+            "food_description": desc,
+            "carbs_grams_low": low,
+            "carbs_grams_high": high,
+            "confidence": confidence,
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enable(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "upload_dir", str(tmp_path / "uploads"))
+    monkeypatch.setattr(settings, "meal_intelligence_enabled", True)
+    monkeypatch.setattr(settings, "meal_estimate_sample_count", 3)
+    # Keep grounding deterministic: no external sources, only own-history.
+    monkeypatch.setattr(settings, "usda_fdc_api_key", "")
+    monkeypatch.setattr(settings, "open_food_facts_enabled", False)
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        email = f"e2e_{uuid.uuid4().hex[:8]}@example.com"
+        await c.post(
+            "/api/auth/register", json={"email": email, "password": "SecurePass123"}
+        )
+        login = await c.post(
+            "/api/auth/login", json={"email": email, "password": "SecurePass123"}
+        )
+        c.cookies.set(
+            settings.jwt_cookie_name, login.cookies.get(settings.jwt_cookie_name)
+        )
+        me = await c.get("/api/auth/me")
+        user_id = uuid.UUID(me.json()["id"])
+        async with get_session_maker()() as db:
+            db.add(
+                AIProviderConfig(
+                    user_id=user_id,
+                    provider_type=AIProviderType.CLAUDE_API,
+                    model_name="claude-sonnet-4-5-20250929",
+                    status=AIProviderStatus.CONNECTED,
+                )
+            )
+            await db.commit()
+        yield c
+
+
+async def _upload(client: AsyncClient, *responses: str) -> dict:
+    with patch.object(
+        food_vision, "_call_vision", AsyncMock(side_effect=list(responses))
+    ):
+        resp = await client.post(
+            "/api/food-records", files={"file": ("m.png", _png(), "image/png")}
+        )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def test_full_chain_upload_confirm_audit_delete(client):
+    desc = f"spaghetti bolognese {uuid.uuid4().hex[:6]}"
+
+    # --- H1: upload A, three disagreeing samples -> empirical dispersion ---
+    rec_a = await _upload(
+        client,
+        _vision(desc, 40, 50),
+        _vision(desc, 90, 100),
+        _vision(desc, 60, 70),
+    )
+    disp = rec_a["estimate_dispersion"]
+    assert disp is not None, "H1 dispersion detail missing from create response"
+    assert disp["samples_used"] == 3
+    assert disp["wide_spread"] is True  # 45..95 midpoints -> wide
+    assert rec_a["carbs_low"] == 40 and rec_a["carbs_high"] == 100  # union band
+    assert "self_reported_confidence" not in rec_a  # H1: never surfaced
+    assert rec_a["identity_confirmed"] is False  # H2: unconfirmed at create
+    assert rec_a["grounding_source"] is None  # gate: no grounding yet
+    assert not find_dosing_violations(disp["note"] or "")
+
+    # Correct A's carbs so own-history holds a corrected value for this food.
+    corr = await client.post(
+        f"/api/food-records/{rec_a['id']}/correct",
+        json={"corrected_carbs_low": 75, "corrected_carbs_high": 85},
+    )
+    assert corr.status_code == 200, corr.text
+
+    # --- H1+H2: upload B (same food), then confirm identity -> grounds to A ---
+    rec_b = await _upload(
+        client, _vision(desc, 50, 60), _vision(desc, 55, 65), _vision(desc, 52, 62)
+    )
+    rec_b_band = (rec_b["carbs_low"], rec_b["carbs_high"])
+    assert rec_b["grounding_source"] is None  # vision-only at create
+    assert rec_b["suggested_identity"] is not None  # own-history pre-fill (H2 AC4)
+
+    confirm = await client.post(
+        f"/api/food-records/{rec_b['id']}/confirm-identity",
+        json={"confirmed_food_name": desc},
+    )
+    assert confirm.status_code == 200, confirm.text
+    body = confirm.json()
+    assert body["identity_confirmed"] is True
+    assert (
+        body["grounding_source"] == "Your meal history"
+    )  # H2: gate opened -> grounded
+    assert body["grounding"]["carbs_low"] == 75  # the corrected own-history value
+    # Carbs are the create-time empirical band, untouched by the confirmation.
+    assert (body["carbs_low"], body["carbs_high"]) == rec_b_band
+
+    # --- H3: audit provenance, self-reported confidence hidden ---
+    audit = await client.get(f"/api/food-records/{rec_b['id']}/audit")
+    assert audit.status_code == 200, audit.text
+    a = audit.json()
+    assert len(a["samples"]) == 3  # raw per-sample retained
+    assert a["precedence"]["outcome"] == "grounded"
+    assert a["precedence"]["chosen_source"] == "Your meal history"
+    assert a["precedence"]["identity_used"] == desc
+    assert "self_reported_confidence" not in audit.text  # H3: internal-only
+
+    # --- H3 AC5: deleting the record cascades its audit ---
+    assert (await client.delete(f"/api/food-records/{rec_b['id']}")).status_code == 204
+    assert (
+        await client.get(f"/api/food-records/{rec_b['id']}/audit")
+    ).status_code == 404
+
+
+async def test_unconfirmed_identity_audit_is_vision_only(client):
+    desc = f"mystery stew {uuid.uuid4().hex[:6]}"
+    rec = await _upload(
+        client, _vision(desc, 30, 40), _vision(desc, 32, 42), _vision(desc, 31, 41)
+    )
+    # Never confirmed -> audit records a vision-only precedence, no grounding.
+    audit = (await client.get(f"/api/food-records/{rec['id']}/audit")).json()
+    assert audit["precedence"]["outcome"] == "vision_only"
+    assert audit["precedence"]["identity_confirmed"] is False
+    assert rec["grounding_source"] is None

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -850,3 +850,97 @@ class TestEstimatePipelineGrounding:
         assert record.identity_confirmed is True  # identity still confirmed
         assert record.grounding_source is None  # grounding degraded cleanly
         assert record.grounding is None
+
+    async def test_reconfirm_regrounds_and_clears_stale_citation(self):
+        # Re-confirming with a corrected identity that grounds to nothing must
+        # CLEAR the prior authoritative citation -- otherwise a stale citation
+        # from the first (wrong) identity would survive the correction, the exact
+        # misID-amplification H2 exists to prevent.
+        from src.services import common_food as common_food_service
+
+        desc = _uniq("reconfirm food")
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with patch.object(
+                food_vision,
+                "_call_vision",
+                AsyncMock(return_value=_estimate_json(desc, 40, 50)),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+            usda = nutrition_sources.NutritionFact(
+                source_name="USDA FoodData Central",
+                source_url="https://fdc.nal.usda.gov/x",
+                trust_tier=KnowledgeChunk.TIER_AUTHORITATIVE,
+                name="pasta",
+                carbs_grams=43,
+                serving="per 100 g",
+                disclaimer=None,
+            )
+            # First confirm -> grounds to a USDA fact.
+            with (
+                patch.object(
+                    meal_rag, "recall_similar_meal", AsyncMock(return_value=None)
+                ),
+                patch.object(
+                    nutrition_sources,
+                    "lookup_published_nutrition",
+                    AsyncMock(return_value=(usda, None)),
+                ),
+            ):
+                record = await common_food_service.confirm_food_identity(
+                    db, record, "pasta"
+                )
+            assert record.grounding_source == "USDA FoodData Central"
+            assert record.grounding_trust_tier == KnowledgeChunk.TIER_AUTHORITATIVE
+
+            # Re-confirm with a corrected identity nothing matches -> citation
+            # must be cleared, not left stale.
+            with (
+                patch.object(
+                    meal_rag, "recall_similar_meal", AsyncMock(return_value=None)
+                ),
+                patch.object(
+                    nutrition_sources,
+                    "lookup_published_nutrition",
+                    AsyncMock(return_value=(None, None)),
+                ),
+            ):
+                record = await common_food_service.confirm_food_identity(
+                    db, record, "obscure nonfood item"
+                )
+
+        assert record.confirmed_food_name == "obscure nonfood item"
+        assert record.grounding_source is None
+        assert record.grounding_source_url is None
+        assert record.grounding_trust_tier is None
+        assert record.grounding is None
+
+    async def test_corrected_identity_feeds_future_suggestion(self):
+        # Correcting the identity re-indexes own-history RAG on the confirmed
+        # name, so the next photo of the same food suggests the user's truth, not
+        # the stale AI label -- closing the one-tap-confirm loop (AC4).
+        from src.services import common_food as common_food_service
+
+        ai_label = _uniq("ai mislabel soup")
+        corrected = _uniq("my homemade chili")
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with patch.object(
+                food_vision,
+                "_call_vision",
+                AsyncMock(return_value=_estimate_json(ai_label, 40, 50)),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+            record = await common_food_service.confirm_food_identity(
+                db, record, corrected
+            )
+
+        # The corrected identity is now what own-history suggests...
+        assert await meal_grounding.suggest_identity(user.id, corrected) == corrected
+        # ...and the stale AI label no longer recalls this record.
+        assert await meal_grounding.suggest_identity(user.id, ai_label) is None

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -537,7 +537,9 @@ class TestPrecedence:
                 nutrition_sources, "lookup_published_nutrition", AsyncMock()
             ) as lookup,
         ):
-            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "stew")
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "stew", identity_confirmed=True
+            )
         assert detail is not None
         assert detail.source == "Your meal history"
         assert detail.trust_tier == KnowledgeChunk.TIER_USER_PROVIDED
@@ -558,7 +560,9 @@ class TestPrecedence:
                 AsyncMock(return_value=(usda, off)),
             ),
         ):
-            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "oatmeal")
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "oatmeal", identity_confirmed=True
+            )
         assert detail.source == "USDA FoodData Central"
         assert detail.carbs_low == 12
 
@@ -577,7 +581,9 @@ class TestPrecedence:
                 AsyncMock(return_value=(None, off)),
             ),
         ):
-            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "cereal")
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "cereal", identity_confirmed=True
+            )
         assert detail.source == "Open Food Facts"
         assert detail.disclaimer  # OFF disclaimer carried through
 
@@ -595,7 +601,9 @@ class TestPrecedence:
                 AsyncMock(return_value=(None, None)),
             ),
         ):
-            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "stew")
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "stew", identity_confirmed=True
+            )
         assert detail.source == "Your meal history"
 
     async def test_pure_vision_when_nothing_grounds(self):
@@ -607,11 +615,47 @@ class TestPrecedence:
                 AsyncMock(return_value=(None, None)),
             ),
         ):
-            assert await meal_grounding.ground_estimate(uuid.uuid4(), "x") is None
+            assert (
+                await meal_grounding.ground_estimate(
+                    uuid.uuid4(), "x", identity_confirmed=True
+                )
+                is None
+            )
 
     async def test_empty_description_is_ungrounded(self):
-        assert await meal_grounding.ground_estimate(uuid.uuid4(), "") is None
-        assert await meal_grounding.ground_estimate(uuid.uuid4(), None) is None
+        assert (
+            await meal_grounding.ground_estimate(
+                uuid.uuid4(), "", identity_confirmed=True
+            )
+            is None
+        )
+        assert (
+            await meal_grounding.ground_estimate(
+                uuid.uuid4(), None, identity_confirmed=True
+            )
+            is None
+        )
+
+    async def test_unconfirmed_identity_is_never_grounded(self):
+        # The H2 gate: even with a strong corrected own-history match and a
+        # published fact available, an UNCONFIRMED identity grounds to nothing.
+        with (
+            patch.object(
+                meal_rag,
+                "recall_similar_meal",
+                AsyncMock(return_value=self._recall(corrected=True)),
+            ) as recall,
+            patch.object(
+                nutrition_sources, "lookup_published_nutrition", AsyncMock()
+            ) as lookup,
+        ):
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "stew", identity_confirmed=False
+            )
+        assert detail is None
+        # The gate short-circuits before any recall or external lookup runs.
+        recall.assert_not_awaited()
+        lookup.assert_not_awaited()
 
 
 # --------------------------------------------------------------------------- #
@@ -697,7 +741,9 @@ class TestNoTherapyCoupling:
                 meal_rag, "recall_similar_meal", AsyncMock(return_value=recall)
             ),
         ):
-            detail = await meal_grounding.ground_estimate(uuid.uuid4(), "oatmeal")
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "oatmeal", identity_confirmed=True
+            )
         for field in (detail.source, detail.note, detail.serving):
             assert not find_dosing_violations(field or "")
 
@@ -719,7 +765,10 @@ class TestEstimatePipelineGrounding:
         monkeypatch.setattr(settings, "upload_dir", str(tmp_path / "uploads"))
         monkeypatch.setattr(settings, "meal_intelligence_enabled", True)
 
-    async def test_estimate_grounds_against_own_corrected_history(self):
+    async def test_create_is_vision_only_then_confirm_grounds(self):
+        # Story 50.H2: a fresh estimate is NOT grounded (identity unconfirmed);
+        # it surfaces a suggested identity from own history for a one-tap confirm,
+        # and grounding runs only after the user confirms.
         from src.services import common_food as common_food_service
 
         desc = _uniq("homemade lasagna")
@@ -749,39 +798,55 @@ class TestEstimatePipelineGrounding:
                     db=db, user=user, raw_image=_png_bytes()
                 )
 
-        # The persisted carbs stay the fresh vision estimate...
-        assert record.carbs_low == 45 and record.carbs_high == 60
-        # ...but it is grounded against the user's own corrected history.
+            # Create: vision-only, identity unconfirmed, but own history is
+            # suggested for confirmation (the safe fast path).
+            assert record.carbs_low == 45 and record.carbs_high == 60
+            assert record.identity_confirmed is False
+            assert record.grounding_source is None
+            assert record.grounding is None
+            assert record.suggested_identity is not None
+
+            # Confirm the identity -> NOW it grounds against the user's own
+            # corrected history.
+            record = await common_food_service.confirm_food_identity(db, record, desc)
+
+        assert record.identity_confirmed is True
+        assert record.confirmed_food_name == desc
+        assert record.carbs_low == 45 and record.carbs_high == 60  # carbs unchanged
         assert record.grounding_source == "Your meal history"
         assert record.grounding_trust_tier == KnowledgeChunk.TIER_USER_PROVIDED
         assert record.grounding is not None
         assert record.grounding.carbs_low == 70 and record.grounding.carbs_high == 80
         assert "logged this before" in (record.grounding.note or "")
-        # Safety: nothing in the grounding output is dosing guidance.
         assert not find_dosing_violations(record.grounding.note or "")
 
-    async def test_estimate_falls_back_to_vision_only_on_grounding_failure(self):
+    async def test_confirm_falls_back_to_vision_only_on_grounding_failure(self):
+        from src.services import common_food as common_food_service
+
         desc = _uniq("mystery casserole")
         async with get_session_maker()() as db:
             user = await _user_with_provider(db)
-            with (
-                patch.object(
-                    food_vision,
-                    "_call_vision",
-                    AsyncMock(return_value=_estimate_json(desc, 30, 45)),
-                ),
-                patch.object(
-                    meal_grounding,
-                    "ground_estimate",
-                    AsyncMock(side_effect=RuntimeError("source down")),
-                ),
+            with patch.object(
+                food_vision,
+                "_call_vision",
+                AsyncMock(return_value=_estimate_json(desc, 30, 45)),
             ):
                 record = await food_vision.create_food_record_from_image(
                     db=db, user=user, raw_image=_png_bytes()
                 )
 
-        # Estimate still persists; grounding degraded cleanly to vision-only.
+            # Confirm, but grounding blows up -> the confirmation still succeeds
+            # and the estimate degrades cleanly to vision-only (never a dose).
+            with patch.object(
+                meal_grounding,
+                "ground_estimate",
+                AsyncMock(side_effect=RuntimeError("source down")),
+            ):
+                record = await common_food_service.confirm_food_identity(
+                    db, record, "mystery casserole"
+                )
+
         assert record.carbs_low == 30 and record.carbs_high == 45
-        assert record.grounding_source is None
-        assert record.grounding_trust_tier is None
+        assert record.identity_confirmed is True  # identity still confirmed
+        assert record.grounding_source is None  # grounding degraded cleanly
         assert record.grounding is None

--- a/apps/api/tests/test_meal_multi_sample.py
+++ b/apps/api/tests/test_meal_multi_sample.py
@@ -1,0 +1,394 @@
+"""Story 50.H1: multi-sample estimation + empirical confidence.
+
+Covers the safety rework: confidence/range come from how much N samples of the
+same photo disagree (empirical), NOT the model's self-reported confidence; wide
+spread is surfaced viscerally; identity disagreement forces low confidence and
+flags the H2 gate; per-sample reject-not-clamp bounds; graceful partial-failure;
+and the cornerstone safety invariant (no dosing output, nothing coupled to
+therapy math).
+
+Pure-aggregation tests build ``ParsedEstimate`` samples directly. Pipeline tests
+patch ``food_vision._call_vision`` with a ``side_effect`` list so the N concurrent
+samples return controlled, differing responses. Embeddings are stubbed by the
+autouse conftest fixture; no live vision calls are made.
+"""
+
+import json
+import uuid
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from PIL import Image
+
+from src.config import settings
+from src.database import get_session_maker
+from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProviderType
+from src.models.user import User, UserRole
+from src.services import food_vision
+from src.services import meal_estimate_aggregate as agg
+from src.vision.carb_contract import ParsedEstimate, find_dosing_violations
+
+# (asyncio_mode = "auto" in pyproject -- async tests need no explicit mark.)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _sample(
+    low: float | None,
+    high: float | None,
+    desc: str = "a bowl of pasta",
+    *,
+    confidence: str | None = "high",
+    parse_ok: bool = True,
+) -> ParsedEstimate:
+    return ParsedEstimate(
+        carbs_low=low,
+        carbs_high=high,
+        confidence=confidence,
+        food_description=desc,
+        raw_text="{}",
+        nutrition={"protein_grams": 10},
+        parse_ok=parse_ok,
+    )
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (16, 16), (70, 40, 20)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _estimate_json(low=40, high=55, desc="a bowl of pasta", confidence="high") -> str:
+    return json.dumps(
+        {
+            "food_description": desc,
+            "carbs_grams_low": low,
+            "carbs_grams_high": high,
+            "confidence": confidence,
+        }
+    )
+
+
+async def _user_with_provider(db) -> User:
+    user = User(
+        email=f"h1_{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        role=UserRole.DIABETIC,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    db.add(
+        AIProviderConfig(
+            user_id=user.id,
+            provider_type=AIProviderType.CLAUDE_API,
+            model_name="claude-sonnet-4-5-20250929",
+            status=AIProviderStatus.CONNECTED,
+        )
+    )
+    await db.commit()
+    return user
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation: empirical range + dispersion -> confidence band (AC2/AC3)
+# --------------------------------------------------------------------------- #
+class TestAggregation:
+    def test_tight_agreement_is_high_confidence(self):
+        samples = [_sample(40, 50), _sample(41, 51), _sample(40, 50)]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result is not None
+        assert result.confidence == agg.CONFIDENCE_HIGH
+        assert result.wide_spread is False
+
+    def test_empirical_band_is_union_of_sample_ranges(self):
+        # The presented band spans every usable sample's own range.
+        samples = [_sample(40, 50), _sample(45, 60), _sample(38, 52)]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.carbs_low == 38
+        assert result.carbs_high == 60
+
+    def test_moderate_spread_is_medium(self):
+        # Midpoints 45 / 55 / 50 -> CV ~0.08... tune inputs to land in [0.10,0.25).
+        samples = [_sample(30, 40), _sample(54, 64), _sample(42, 52)]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.confidence == agg.CONFIDENCE_MEDIUM
+
+    def test_wide_spread_is_low_and_flagged(self):
+        samples = [_sample(40, 50), _sample(120, 140), _sample(80, 100)]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.confidence == agg.CONFIDENCE_LOW
+        assert result.wide_spread is True
+        # CV is real and large.
+        assert result.dispersion_cv is not None and result.dispersion_cv > 0.25
+
+    def test_single_sample_can_never_exceed_low_confidence(self):
+        # One draw can't measure dispersion -- exactly the lucky-draw problem.
+        result = agg.aggregate_samples([_sample(40, 50)], samples_requested=1)
+        assert result is not None
+        assert result.confidence == agg.CONFIDENCE_LOW
+        assert result.samples_ok == 1
+
+    def test_identity_disagreement_forces_low_and_flags(self):
+        # Same numbers, but the model can't agree what the food IS.
+        samples = [
+            _sample(40, 50, "creme brulee"),
+            _sample(41, 51, "crema catalana"),
+            _sample(42, 52, "flan custard tart"),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is False
+        assert result.confidence == agg.CONFIDENCE_LOW
+        assert result.wide_spread is True
+        assert len(result.distinct_identities) >= 2
+
+    def test_identity_clusters_through_filler_words(self):
+        # Wording noise must not read as disagreement.
+        samples = [
+            _sample(40, 50, "a plate of grilled chicken"),
+            _sample(41, 51, "grilled chicken breast"),
+            _sample(40, 52, "grilled chicken"),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is True
+
+    def test_no_usable_samples_returns_none(self):
+        samples = [_sample(None, None, parse_ok=False), _sample(10, 20, parse_ok=False)]
+        assert agg.aggregate_samples(samples, samples_requested=2) is None
+
+    def test_partial_failure_uses_only_successes(self):
+        samples = [
+            _sample(40, 50),
+            _sample(None, None, parse_ok=False),
+            _sample(44, 54),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result is not None
+        assert result.samples_ok == 2
+        assert result.samples_requested == 3
+        assert result.carbs_low == 40 and result.carbs_high == 54
+
+    def test_out_of_bounds_sample_dropped_not_poisoning_union(self):
+        # A hallucinated 99999 g sample is rejected per-sample (AC7), not folded
+        # into the union where it would blow the absolute bound.
+        samples = [_sample(40, 50), _sample(10, 99999), _sample(42, 52)]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result is not None
+        assert result.samples_ok == 2
+        assert result.carbs_high == 52  # the 99999 sample was dropped
+
+    def test_self_reported_confidence_kept_in_audit_only(self):
+        # Self-reported "high" survives in per-sample audit, but the aggregate's
+        # surfaced confidence is dispersion-derived and can disagree with it.
+        samples = [
+            _sample(40, 50, confidence="high"),
+            _sample(120, 140, confidence="high"),
+            _sample(80, 100, confidence="high"),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.confidence == agg.CONFIDENCE_LOW  # NOT "high"
+        assert {s.self_reported_confidence for s in result.samples} == {"high"}
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline: multi-sample wired end-to-end (AC1/AC4/AC6/AC7)
+# --------------------------------------------------------------------------- #
+class TestPipelineMultiSample:
+    @pytest.fixture(autouse=True)
+    def _uploads(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "upload_dir", str(tmp_path / "uploads"))
+        monkeypatch.setattr(settings, "meal_estimate_sample_count", 3)
+
+    def _patch_vision(self, *responses):
+        return patch.object(
+            food_vision, "_call_vision", AsyncMock(side_effect=list(responses))
+        )
+
+    async def test_persists_empirical_band_and_dispersion(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with self._patch_vision(
+                _estimate_json(40, 50, "pasta"),
+                _estimate_json(44, 54, "pasta"),
+                _estimate_json(42, 52, "pasta"),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        assert record.carbs_low == 40 and record.carbs_high == 54  # union
+        assert record.estimate_dispersion is not None
+        d = record.estimate_dispersion
+        assert d.samples_requested == 3 and d.samples_used == 3
+        assert d.confidence == record.confidence  # surfaced band is the empirical one
+        assert d.identity_agreement is True
+
+    async def test_wide_spread_low_confidence_and_visceral_note(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with self._patch_vision(
+                _estimate_json(40, 50, "pasta", confidence="high"),
+                _estimate_json(120, 140, "pasta", confidence="high"),
+                _estimate_json(80, 100, "pasta", confidence="high"),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        d = record.estimate_dispersion
+        # Despite every sample self-reporting "high", the surfaced confidence is
+        # low -- proving self-reported confidence is not what we show.
+        assert record.confidence == "low"
+        assert d.wide_spread is True
+        assert d.note and "rough guess" in d.note
+        assert not find_dosing_violations(d.note)
+
+    async def test_identity_disagreement_requires_confirmation(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with self._patch_vision(
+                _estimate_json(40, 50, "creme brulee"),
+                _estimate_json(42, 52, "crema catalana"),
+                _estimate_json(41, 51, "flan custard"),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        d = record.estimate_dispersion
+        assert d.identity_agreement is False
+        assert record.confidence == "low"
+        assert "confirm the food" in (d.note or "")
+
+    async def test_partial_sample_failure_degrades_gracefully(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with self._patch_vision(
+                _estimate_json(40, 50, "pasta"),
+                food_vision.VisionServiceError("transient"),
+                _estimate_json(44, 54, "pasta"),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        assert record.carbs_low == 40 and record.carbs_high == 54
+        assert record.estimate_dispersion.samples_used == 2
+        assert record.estimate_dispersion.samples_requested == 3
+
+    async def test_all_samples_service_error_raises_service_error(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with (
+                self._patch_vision(
+                    food_vision.VisionServiceError("down"),
+                    food_vision.VisionServiceError("down"),
+                    food_vision.VisionServiceError("down"),
+                ),
+                pytest.raises(food_vision.VisionServiceError),
+            ):
+                await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+    async def test_all_samples_unavailable_raises_unavailable(self):
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with (
+                self._patch_vision(
+                    food_vision.VisionUnavailableError("no vision"),
+                    food_vision.VisionUnavailableError("no vision"),
+                    food_vision.VisionUnavailableError("no vision"),
+                ),
+                pytest.raises(food_vision.VisionUnavailableError),
+            ):
+                await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+    async def test_per_sample_dosing_scrub_before_aggregation(self):
+        # A sample that smuggles dosing advice into its description has the
+        # description nulled; its (safe) numbers still count toward the band.
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with self._patch_vision(
+                _estimate_json(40, 50, "pasta -- inject 5 units of insulin"),
+                _estimate_json(42, 52, "pasta -- inject 5 units of insulin"),
+                _estimate_json(41, 51, "pasta -- inject 5 units of insulin"),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        # Every description was dosing-laden and scrubbed -> none persisted.
+        assert record.food_description is None
+        # Numbers survived; the band is still produced.
+        assert record.carbs_low == 40 and record.carbs_high == 52
+
+
+# --------------------------------------------------------------------------- #
+# Safety: empirical confidence carries no dosing language / therapy coupling
+# --------------------------------------------------------------------------- #
+class TestSafety:
+    def test_dispersion_notes_never_contain_dosing_language(self):
+        # Exercise every note branch; none may read as dosing advice.
+        cases = [
+            agg.AggregatedEstimate(
+                carbs_low=40,
+                carbs_high=90,
+                confidence="low",
+                food_description="x",
+                nutrition={},
+                dispersion_cv=0.4,
+                identity_agreement=False,
+                distinct_identities=["a", "b"],
+                samples_requested=3,
+                samples_ok=3,
+                wide_spread=True,
+            ),
+            agg.AggregatedEstimate(
+                carbs_low=40,
+                carbs_high=90,
+                confidence="low",
+                food_description="x",
+                nutrition={},
+                dispersion_cv=0.4,
+                identity_agreement=True,
+                distinct_identities=["a"],
+                samples_requested=3,
+                samples_ok=3,
+                wide_spread=True,
+            ),
+            agg.AggregatedEstimate(
+                carbs_low=40,
+                carbs_high=50,
+                confidence="low",
+                food_description="x",
+                nutrition={},
+                dispersion_cv=None,
+                identity_agreement=True,
+                distinct_identities=["a"],
+                samples_requested=3,
+                samples_ok=1,
+                wide_spread=False,
+            ),
+            agg.AggregatedEstimate(
+                carbs_low=40,
+                carbs_high=50,
+                confidence="high",
+                food_description="x",
+                nutrition={},
+                dispersion_cv=0.02,
+                identity_agreement=True,
+                distinct_identities=["a"],
+                samples_requested=3,
+                samples_ok=3,
+                wide_spread=False,
+            ),
+        ]
+        for case in cases:
+            note = food_vision._dispersion_note(case)
+            assert note
+            assert not find_dosing_violations(note)

--- a/apps/api/tests/test_meal_multi_sample.py
+++ b/apps/api/tests/test_meal_multi_sample.py
@@ -111,10 +111,23 @@ class TestAggregation:
         assert result.carbs_high == 60
 
     def test_moderate_spread_is_medium(self):
-        # Midpoints 45 / 55 / 50 -> CV ~0.08... tune inputs to land in [0.10,0.25).
-        samples = [_sample(30, 40), _sample(54, 64), _sample(42, 52)]
+        # Midpoints 38 / 52 / 45 -> sample stdev 7, mean 45 -> CV ~0.156, in the
+        # medium band [0.10, 0.25).
+        samples = [_sample(33, 43), _sample(47, 57), _sample(40, 50)]
         result = agg.aggregate_samples(samples, samples_requested=3)
         assert result.confidence == agg.CONFIDENCE_MEDIUM
+
+    def test_two_agreeing_samples_capped_at_medium(self):
+        # Two near-identical samples have CV ~0 but are weak evidence of
+        # stability -- "high" must require >= 3 usable samples (the lucky-draw
+        # problem one level up). A single tolerated partial failure routinely
+        # leaves exactly two, so this path is real.
+        result = agg.aggregate_samples(
+            [_sample(40, 50), _sample(41, 51)], samples_requested=3
+        )
+        assert result is not None
+        assert result.samples_ok == 2
+        assert result.confidence == agg.CONFIDENCE_MEDIUM  # NOT high
 
     def test_wide_spread_is_low_and_flagged(self):
         samples = [_sample(40, 50), _sample(120, 140), _sample(80, 100)]
@@ -153,6 +166,26 @@ class TestAggregation:
         ]
         result = agg.aggregate_samples(samples, samples_requested=3)
         assert result.identity_agreement is True
+
+    def test_scrubbed_description_not_counted_as_disagreement(self):
+        # An emptied (dosing-scrubbed) description carries no identity signal and
+        # must not count as a distinct disagreeing food, else the user is told
+        # "the AI couldn't agree what this is" when it actually did (M3).
+        samples = [
+            _sample(40, 50, "pasta"),
+            _sample(42, 52, "pasta"),
+            _sample(41, 51, ""),  # scrubbed empty
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is True
+        assert result.distinct_identities == ["pasta"]
+
+    def test_all_descriptions_empty_is_not_disagreement(self):
+        samples = [_sample(40, 50, ""), _sample(42, 52, ""), _sample(41, 51, "")]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        # No description evidence at all -> we don't manufacture disagreement.
+        assert result.identity_agreement is True
+        assert result.distinct_identities == []
 
     def test_no_usable_samples_returns_none(self):
         samples = [_sample(None, None, parse_ok=False), _sample(10, 20, parse_ok=False)]
@@ -387,8 +420,23 @@ class TestSafety:
                 samples_ok=3,
                 wide_spread=False,
             ),
+            agg.AggregatedEstimate(
+                carbs_low=40,
+                carbs_high=60,
+                confidence="medium",
+                food_description="x",
+                nutrition={},
+                dispersion_cv=0.15,
+                identity_agreement=True,
+                distinct_identities=["a"],
+                samples_requested=3,
+                samples_ok=3,
+                wide_spread=False,
+            ),
         ]
         for case in cases:
-            note = food_vision._dispersion_note(case)
-            assert note
-            assert not find_dosing_violations(note)
+            # Assert on the value that actually reaches the response (production
+            # sink), not just the raw note helper.
+            detail = food_vision._build_dispersion_detail(case)
+            assert detail.note
+            assert not find_dosing_violations(detail.note)

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/CarbEstimateContentUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/CarbEstimateContentUiTest.kt
@@ -1,0 +1,109 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.data.meal.CarbConfidence
+import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.data.meal.MealDispersion
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Story 50.H1: the multi-sample dispersion actually renders on the estimate card.
+ *
+ * The card merges its descendants' semantics for screen readers, so tagged
+ * children are queried on the *unmerged* tree.
+ */
+@RunWith(AndroidJUnit4::class)
+class CarbEstimateContentUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun render(dispersion: MealDispersion?) {
+        compose.setContent {
+            GlycemicGptTheme {
+                CarbEstimateContent(
+                    range = CarbRange(40.0, 100.0),
+                    confidence = CarbConfidence.LOW,
+                    dispersion = dispersion,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun wideSpread_rendersVisceralCautionNote() {
+        val note = "Repeated looks at this photo disagreed a lot (about 40 g to " +
+            "100 g) -- treat this as a rough guess, not a measurement."
+        render(MealDispersion(note = note, wideSpread = true, identityAgreement = true))
+
+        compose.onNodeWithTag("meal_dispersion_note", useUnmergedTree = true)
+            .assertIsDisplayed()
+        // A wide spread gets the emphasized caution treatment.
+        compose.onNodeWithTag("meal_wide_spread", useUnmergedTree = true)
+            .assertIsDisplayed()
+        compose.onNodeWithText(note, substring = true, useUnmergedTree = true)
+            .assertIsDisplayed()
+        // The carb range + confidence are still shown alongside it.
+        compose.onNodeWithTag("meal_carb_range", useUnmergedTree = true)
+            .assertIsDisplayed()
+        compose.onNodeWithTag("meal_confidence", useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun identityDisagreement_isFlaggedDistinctly() {
+        render(
+            MealDispersion(
+                note = "The AI didn't consistently agree on what this food is -- " +
+                    "confirm the food before relying on it.",
+                wideSpread = true,
+                identityAgreement = false,
+            )
+        )
+        compose.onNodeWithTag("meal_identity_disagreement", useUnmergedTree = true)
+            .assertIsDisplayed()
+        compose.onAllNodesWithTag("meal_wide_spread", useUnmergedTree = true)
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun tightAgreement_isAQuietLine_notACautionStrip() {
+        render(
+            MealDispersion(
+                note = "Estimated from 3 reads of the photo.",
+                wideSpread = false,
+                identityAgreement = true,
+            )
+        )
+        compose.onNodeWithTag("meal_dispersion_note", useUnmergedTree = true)
+            .assertIsDisplayed()
+        // The quiet form carries no caution flag.
+        compose.onAllNodesWithTag("meal_wide_spread", useUnmergedTree = true)
+            .assertCountEquals(0)
+        compose.onAllNodesWithTag("meal_identity_disagreement", useUnmergedTree = true)
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun noDispersion_rendersNoNote() {
+        render(null)
+        compose.onAllNodesWithTag("meal_dispersion_note", useUnmergedTree = true)
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun blankNote_rendersNoNote() {
+        render(MealDispersion(note = null, wideSpread = true, identityAgreement = false))
+        compose.onAllNodesWithTag("meal_dispersion_note", useUnmergedTree = true)
+            .assertCountEquals(0)
+    }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealIdentityAuditUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealIdentityAuditUiTest.kt
@@ -1,0 +1,135 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.data.meal.AuditSample
+import com.glycemicgpt.mobile.data.meal.CarbConfidence
+import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.FoodRecordSource
+import com.glycemicgpt.mobile.data.meal.MealAudit
+import com.glycemicgpt.mobile.data.meal.MealDispersion
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Stories 50.H2 / 50.H3: the identity-confirm section and the "how was this
+ * estimated" audit affordance render their states correctly on-device.
+ */
+@RunWith(AndroidJUnit4::class)
+class MealIdentityAuditUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun record(
+        confirmed: String? = null,
+        identityConfirmed: Boolean = false,
+        suggested: String? = null,
+        identityAgreement: Boolean = true,
+    ) = FoodRecord(
+        id = "r",
+        mealTimestamp = null,
+        foodDescription = "spaghetti",
+        estimate = CarbRange(40.0, 60.0),
+        confidence = CarbConfidence.MEDIUM,
+        source = FoodRecordSource.AI_ESTIMATE,
+        correction = null,
+        correctedAt = null,
+        commonFoodId = null,
+        createdAt = null,
+        dispersion = MealDispersion(
+            note = "Estimated from 3 reads of the photo.",
+            wideSpread = false,
+            identityAgreement = identityAgreement,
+        ),
+        confirmedFoodName = confirmed,
+        identityConfirmed = identityConfirmed,
+        suggestedIdentity = suggested,
+    )
+
+    private fun renderIdentity(record: FoodRecord, uiState: MealLogUiState = MealLogUiState()) {
+        compose.setContent {
+            GlycemicGptTheme {
+                MealIdentitySection(
+                    record = record,
+                    uiState = uiState,
+                    onStartEdit = {},
+                    onCancelEdit = {},
+                    onConfirm = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun unconfirmed_showsConfirmAndCorrect() {
+        renderIdentity(record(suggested = "my lasagna"))
+        compose.onNodeWithTag("meal_identity", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithTag("meal_identity_confirm", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithTag("meal_identity_correct", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun identityDisagreement_showsCautionCue() {
+        renderIdentity(record(identityAgreement = false))
+        compose.onNodeWithTag("meal_identity_disagreement_cue", useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun confirmed_showsCheckmarkAndEdit_notConfirmButton() {
+        renderIdentity(record(confirmed = "homemade lasagna", identityConfirmed = true))
+        compose.onNodeWithTag("meal_identity_confirmed", useUnmergedTree = true)
+            .assertIsDisplayed()
+        compose.onNodeWithTag("meal_identity_edit", useUnmergedTree = true).assertIsDisplayed()
+        compose.onAllNodesWithTag("meal_identity_confirm", useUnmergedTree = true)
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun editing_showsTextField() {
+        renderIdentity(record(), MealLogUiState(isEditingIdentity = true))
+        compose.onNodeWithTag("meal_identity_editor", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithTag("meal_identity_input", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    private fun renderAudit(uiState: MealLogUiState) {
+        compose.setContent {
+            GlycemicGptTheme {
+                MealAuditSection(uiState = uiState, onLoad = {}, onHide = {})
+            }
+        }
+    }
+
+    @Test
+    fun audit_collapsed_showsLoadButton() {
+        renderAudit(MealLogUiState())
+        compose.onNodeWithTag("meal_audit_button", useUnmergedTree = true).assertIsDisplayed()
+        compose.onAllNodesWithTag("meal_audit_detail", useUnmergedTree = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun audit_loaded_showsProvenance() {
+        val audit = MealAudit(
+            foodRecordId = "r",
+            samples = listOf(AuditSample(CarbRange(40.0, 50.0), "pasta")),
+            confidence = CarbConfidence.MEDIUM,
+            samplesUsed = 3,
+            wideSpread = false,
+            identityAgreement = true,
+            grounded = true,
+            groundingSource = "Your meal history",
+            identityUsed = "pasta",
+        )
+        renderAudit(MealLogUiState(audit = audit))
+        compose.onNodeWithTag("meal_audit_detail", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithTag("meal_audit_precedence", useUnmergedTree = true).assertIsDisplayed()
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealModels.kt
@@ -1,6 +1,7 @@
 package com.glycemicgpt.mobile.data.meal
 
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordAuditResponse
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
 import java.time.Instant
 
@@ -122,12 +123,24 @@ data class FoodRecord(
     val createdAt: Instant?,
     /** Multi-sample dispersion detail (Story 50.H1). Null on history reads. */
     val dispersion: MealDispersion? = null,
+    /**
+     * Food-identity confirmation (Story 50.H2). [foodDescription] is the AI's
+     * guess; [confirmedFoodName] is the user's confirmed/corrected identity (null
+     * until confirmed). External grounding only runs once [identityConfirmed].
+     */
+    val confirmedFoodName: String? = null,
+    val identityConfirmed: Boolean = false,
+    /** Own-history pre-fill ("looks like your saved X"); fresh estimate only. */
+    val suggestedIdentity: String? = null,
 ) {
     /** Whether the user has corrected the AI estimate. */
     val isCorrected: Boolean get() = correction != null
 
     /** The carb range to show as the headline value: the correction if present, else the estimate. */
     val displayRange: CarbRange get() = correction ?: estimate
+
+    /** The identity to show: the user's confirmed name if present, else the AI's guess. */
+    val displayIdentity: String? get() = confirmedFoodName?.takeIf { it.isNotBlank() } ?: foodDescription
 }
 
 /** A saved per-user food baseline that future estimates can be grounded against. */
@@ -182,8 +195,52 @@ fun FoodRecordResponse.toDomain(): FoodRecord {
                 identityAgreement = it.identityAgreement,
             )
         },
+        confirmedFoodName = confirmedFoodName,
+        identityConfirmed = identityConfirmed,
+        suggestedIdentity = suggestedIdentity?.takeIf { it.isNotBlank() },
     )
 }
+
+/**
+ * The "how was this estimated" provenance trail (Story 50.H3). Descriptive only;
+ * the model's self-reported confidence is intentionally not represented here.
+ */
+data class MealAudit(
+    val foodRecordId: String,
+    val samples: List<AuditSample>,
+    val confidence: CarbConfidence,
+    val samplesUsed: Int?,
+    val wideSpread: Boolean?,
+    val identityAgreement: Boolean?,
+    val grounded: Boolean,
+    val groundingSource: String?,
+    val identityUsed: String?,
+)
+
+/** One raw vision sample as shown in the audit trail. */
+data class AuditSample(
+    val carbs: CarbRange?,
+    val identity: String?,
+)
+
+fun FoodRecordAuditResponse.toDomain(): MealAudit = MealAudit(
+    foodRecordId = foodRecordId,
+    samples = samples.map {
+        val low = it.carbsLow
+        val high = it.carbsHigh
+        AuditSample(
+            carbs = if (low != null && high != null) CarbRange(low, high) else null,
+            identity = it.identity,
+        )
+    },
+    confidence = CarbConfidence.fromApi(dispersion?.confidence),
+    samplesUsed = dispersion?.samplesUsed,
+    wideSpread = dispersion?.wideSpread,
+    identityAgreement = dispersion?.identityAgreement,
+    grounded = precedence?.outcome == "grounded",
+    groundingSource = precedence?.chosenSource,
+    identityUsed = precedence?.identityUsed,
+)
 
 fun CommonFoodResponse.toDomain(): CommonFood = CommonFood(
     id = id,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealModels.kt
@@ -90,6 +90,22 @@ enum class FoodRecordSource {
     }
 }
 
+/**
+ * How much the AI's repeated reads of one photo disagreed (Story 50.H1).
+ *
+ * The [confidence] on a [FoodRecord] is already the empirical band derived from
+ * this spread; this carries the visceral, human-readable detail. Present only on
+ * a fresh estimate (the create response); null on records loaded from history.
+ */
+data class MealDispersion(
+    /** Plain-language uncertainty note (already dosing-scrubbed server-side). */
+    val note: String?,
+    /** The reads disagreed enough to warrant a visible "rough guess" treatment. */
+    val wideSpread: Boolean,
+    /** Whether the reads agreed on *what the food is* (false => confirm identity). */
+    val identityAgreement: Boolean,
+)
+
 /** A persisted meal photo + carb estimate, optionally corrected by the user. */
 data class FoodRecord(
     val id: String,
@@ -104,6 +120,8 @@ data class FoodRecord(
     val correctedAt: Instant?,
     val commonFoodId: String?,
     val createdAt: Instant?,
+    /** Multi-sample dispersion detail (Story 50.H1). Null on history reads. */
+    val dispersion: MealDispersion? = null,
 ) {
     /** Whether the user has corrected the AI estimate. */
     val isCorrected: Boolean get() = correction != null
@@ -157,6 +175,13 @@ fun FoodRecordResponse.toDomain(): FoodRecord {
         correctedAt = parseInstantOrNull(correctedAt),
         commonFoodId = commonFoodId,
         createdAt = parseInstantOrNull(createdAt),
+        dispersion = estimateDispersion?.let {
+            MealDispersion(
+                note = it.note?.takeIf { note -> note.isNotBlank() },
+                wideSpread = it.wideSpread,
+                identityAgreement = it.identityAgreement,
+            )
+        },
     )
 }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -23,7 +23,9 @@ import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodListResponse
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodUpdateRequest
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordAuditResponse
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordCorrectionRequest
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordIdentityRequest
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordListResponse
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
 import com.glycemicgpt.mobile.data.remote.dto.SaveAsCommonFoodRequest
@@ -134,6 +136,21 @@ interface GlycemicGptApi {
         @Path("recordId") recordId: String,
         @Body request: FoodRecordCorrectionRequest,
     ): Response<FoodRecordResponse>
+
+    // Food-identity confirmation (Story 50.H2): confirming/correcting *what the
+    // food is* opens the grounding gate. Distinct from carb correction.
+    @POST("/api/food-records/{recordId}/confirm-identity")
+    suspend fun confirmFoodIdentity(
+        @Path("recordId") recordId: String,
+        @Body request: FoodRecordIdentityRequest,
+    ): Response<FoodRecordResponse>
+
+    // "How was this estimated" provenance trail (Story 50.H3). 404 until an
+    // audit exists for the record.
+    @GET("/api/food-records/{recordId}/audit")
+    suspend fun getFoodRecordAudit(
+        @Path("recordId") recordId: String,
+    ): Response<FoodRecordAuditResponse>
 
     @POST("/api/food-records/{recordId}/save-as-common-food")
     suspend fun saveRecordAsCommonFood(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
@@ -29,6 +29,14 @@ data class FoodRecordResponse(
     @Json(name = "corrected_carbs_high") val correctedCarbsHigh: Double? = null,
     @Json(name = "corrected_at") val correctedAt: String? = null,
     @Json(name = "common_food_id") val commonFoodId: String? = null,
+    // Food-identity confirmation (Story 50.H2). food_description is the
+    // AI-identified name; confirmed_food_name is the user's confirmed/corrected
+    // identity (null until confirmed); external grounding only runs once
+    // identity_confirmed is true. suggested_identity is a transient own-history
+    // pre-fill ("looks like your saved X"), present on a fresh estimate only.
+    @Json(name = "confirmed_food_name") val confirmedFoodName: String? = null,
+    @Json(name = "identity_confirmed") val identityConfirmed: Boolean = false,
+    @Json(name = "suggested_identity") val suggestedIdentity: String? = null,
     // Multi-sample dispersion detail (Story 50.H1). Present only on a fresh
     // estimate (create response); absent on later reads.
     @Json(name = "estimate_dispersion") val estimateDispersion: EstimateDispersionResponse? = null,
@@ -57,6 +65,48 @@ data class FoodRecordListResponse(
 data class FoodRecordCorrectionRequest(
     @Json(name = "corrected_carbs_low") val correctedCarbsLow: Double,
     @Json(name = "corrected_carbs_high") val correctedCarbsHigh: Double,
+)
+
+@JsonClass(generateAdapter = true)
+data class FoodRecordIdentityRequest(
+    @Json(name = "confirmed_food_name") val confirmedFoodName: String,
+)
+
+/**
+ * The "how was this estimated" provenance trail (Story 50.H3). Descriptive only.
+ * The model's self-reported confidence is intentionally NOT part of this contract
+ * (the server strips it). Only consumed fields are declared.
+ */
+@JsonClass(generateAdapter = true)
+data class FoodRecordAuditResponse(
+    @Json(name = "food_record_id") val foodRecordId: String,
+    val samples: List<AuditSampleResponse> = emptyList(),
+    val dispersion: AuditDispersionResponse? = null,
+    val precedence: AuditPrecedenceResponse? = null,
+    @Json(name = "created_at") val createdAt: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class AuditSampleResponse(
+    @Json(name = "carbs_low") val carbsLow: Double? = null,
+    @Json(name = "carbs_high") val carbsHigh: Double? = null,
+    val identity: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class AuditDispersionResponse(
+    val confidence: String? = null,
+    @Json(name = "samples_used") val samplesUsed: Int? = null,
+    @Json(name = "wide_spread") val wideSpread: Boolean? = null,
+    @Json(name = "identity_agreement") val identityAgreement: Boolean? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class AuditPrecedenceResponse(
+    val outcome: String? = null,
+    @Json(name = "chosen_source") val chosenSource: String? = null,
+    @Json(name = "identity_used") val identityUsed: String? = null,
+    @Json(name = "identity_confirmed") val identityConfirmed: Boolean? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
@@ -21,13 +21,30 @@ data class FoodRecordResponse(
     @Json(name = "food_description") val foodDescription: String? = null,
     @Json(name = "carbs_low") val carbsLow: Double,
     @Json(name = "carbs_high") val carbsHigh: Double,
+    // The empirical, dispersion-derived band (Story 50.H1) -- not the model's
+    // self-reported confidence, which is no longer surfaced.
     val confidence: String? = null,
     val source: String,
     @Json(name = "corrected_carbs_low") val correctedCarbsLow: Double? = null,
     @Json(name = "corrected_carbs_high") val correctedCarbsHigh: Double? = null,
     @Json(name = "corrected_at") val correctedAt: String? = null,
     @Json(name = "common_food_id") val commonFoodId: String? = null,
+    // Multi-sample dispersion detail (Story 50.H1). Present only on a fresh
+    // estimate (create response); absent on later reads.
+    @Json(name = "estimate_dispersion") val estimateDispersion: EstimateDispersionResponse? = null,
     @Json(name = "created_at") val createdAt: String,
+)
+
+/**
+ * How much the N vision samples of one photo disagreed (Story 50.H1). The UI uses
+ * this to communicate uncertainty viscerally; only the consumed fields are
+ * declared (Moshi tolerates the rest).
+ */
+@JsonClass(generateAdapter = true)
+data class EstimateDispersionResponse(
+    val note: String? = null,
+    @Json(name = "wide_spread") val wideSpread: Boolean = false,
+    @Json(name = "identity_agreement") val identityAgreement: Boolean = true,
 )
 
 @JsonClass(generateAdapter = true)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/MealRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/MealRepository.kt
@@ -2,11 +2,13 @@ package com.glycemicgpt.mobile.data.repository
 
 import com.glycemicgpt.mobile.data.meal.CommonFood
 import com.glycemicgpt.mobile.data.meal.FoodRecord
+import com.glycemicgpt.mobile.data.meal.MealAudit
 import com.glycemicgpt.mobile.data.meal.MealException
 import com.glycemicgpt.mobile.data.meal.toDomain
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodUpdateRequest
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordCorrectionRequest
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordIdentityRequest
 import com.glycemicgpt.mobile.data.remote.dto.SaveAsCommonFoodRequest
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -75,6 +77,19 @@ class MealRepository @Inject constructor(
             ),
         )
     }.map { it.toDomain() }
+
+    /** Confirm/correct *what the food is* (Story 50.H2); opens the grounding gate. */
+    suspend fun confirmIdentity(recordId: String, confirmedFoodName: String): Result<FoodRecord> =
+        body {
+            api.confirmFoodIdentity(
+                recordId,
+                FoodRecordIdentityRequest(confirmedFoodName = confirmedFoodName.trim()),
+            )
+        }.map { it.toDomain() }
+
+    /** Fetch the "how was this estimated" provenance trail (Story 50.H3). */
+    suspend fun getAudit(recordId: String): Result<MealAudit> =
+        body { api.getFoodRecordAudit(recordId) }.map { it.toDomain() }
 
     suspend fun saveAsCommonFood(recordId: String, name: String): Result<CommonFood> =
         body { api.saveRecordAsCommonFood(recordId, SaveAsCommonFoodRequest(name = name)) }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.glycemicgpt.mobile.data.meal.CarbConfidence
 import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.data.meal.MealDispersion
 import com.glycemicgpt.mobile.presentation.theme.MealConfidenceColors
 import com.glycemicgpt.mobile.presentation.theme.safetyPalette
 import java.time.Instant
@@ -94,10 +95,14 @@ fun CarbEstimateContent(
     modifier: Modifier = Modifier,
     isCorrected: Boolean = false,
     originalRange: CarbRange? = null,
+    dispersion: MealDispersion? = null,
 ) {
     // The qualifier is announced as part of the value so it's never separable from the carbs (§12).
+    // The dispersion note rides in the same merged phrase so a screen-reader hears the uncertainty
+    // alongside the number, never as a detached afterthought.
+    val dispersionSpeech = dispersion?.note?.let { " $it" }.orEmpty()
     val description = "${carbRangeForSpeech(range)}, ${confidenceLabel(confidence).lowercase()}. " +
-        "$VERIFY_BEFORE_DOSING_TEXT."
+        "$VERIFY_BEFORE_DOSING_TEXT.$dispersionSpeech"
     Column(
         // Merge so the carb value + confidence + qualifier are announced as one phrase, not three.
         modifier = modifier.semantics(mergeDescendants = true) { contentDescription = description },
@@ -117,12 +122,70 @@ fun CarbEstimateContent(
             modifier = Modifier.testTag("meal_confidence"),
         )
         ConfidenceBar(confidence)
+        // Story 50.H1: when present (fresh estimate only), surface how much the AI's repeated reads
+        // disagreed. A wide spread / identity disagreement gets a visceral caution treatment so a
+        // shaky guess never reads as calm and trustworthy; a confident read stays a quiet line.
+        if (dispersion != null && !dispersion.note.isNullOrBlank()) {
+            MealDispersionNote(dispersion)
+        }
         if (isCorrected && originalRange != null) {
             Text(
                 text = "You corrected this. AI estimated ${formatCarbRange(originalRange)}.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.testTag("meal_corrected_note"),
+            )
+        }
+    }
+}
+
+/**
+ * The multi-sample uncertainty note (Story 50.H1). A wide spread or an identity disagreement is
+ * shown viscerally -- a caution strip the eye can't skip -- so "the AI wasn't sure" lands; a
+ * tight, agreeing read is a plain quiet line. Consistency is NOT correctness, so even the quiet
+ * form never reads as "safe to dose": the standing verify-before-dosing qualifier carries that.
+ */
+@Composable
+private fun MealDispersionNote(dispersion: MealDispersion) {
+    val note = dispersion.note ?: return
+    val emphasize = dispersion.wideSpread || !dispersion.identityAgreement
+    if (!emphasize) {
+        Text(
+            text = note,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag("meal_dispersion_note"),
+        )
+        return
+    }
+    val palette = safetyPalette()
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_dispersion_note"),
+        color = palette.background,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Info,
+                contentDescription = null,
+                tint = palette.icon,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = note,
+                style = MaterialTheme.typography.bodyMedium,
+                color = palette.foreground,
+                fontWeight = FontWeight.Medium,
+                // Flag the disagreement case for tests / downstream H2 identity affordance.
+                modifier = Modifier.testTag(
+                    if (!dispersion.identityAgreement) "meal_identity_disagreement" else "meal_wide_spread",
+                ),
             )
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -361,6 +361,8 @@ private fun ResultContent(
                 confidence = record.confidence,
                 isCorrected = record.isCorrected,
                 originalRange = record.estimate,
+                // Only the fresh-estimate surface carries dispersion (transient on create).
+                dispersion = record.dispersion,
             )
             Text(
                 text = formatMealTimestamp(record.mealTimestamp),

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -600,12 +600,15 @@ internal fun MealIdentitySection(
                     if (disagreed) "meal_identity_disagreement_cue" else "meal_identity_prompt",
                 ),
             )
+            // One normalized candidate drives both the submitted value and the
+            // enable check, so a valid suggestion can't leave Confirm disabled.
+            val candidateIdentity = (record.suggestedIdentity ?: record.displayIdentity)
+                .orEmpty()
+                .trim()
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 Button(
-                    onClick = {
-                        onConfirm(record.suggestedIdentity ?: record.displayIdentity.orEmpty())
-                    },
-                    enabled = !uiState.isSavingIdentity && !record.displayIdentity.isNullOrBlank(),
+                    onClick = { onConfirm(candidateIdentity) },
+                    enabled = !uiState.isSavingIdentity && candidateIdentity.isNotBlank(),
                     modifier = Modifier.testTag("meal_identity_confirm"),
                 ) { Text(if (uiState.isSavingIdentity) "Confirming…" else "Confirm") }
                 OutlinedButton(
@@ -660,6 +663,7 @@ private fun IdentityEditor(
                     color = MaterialTheme.colorScheme.error,
                 )
             }
+            val normalized = text.trim()
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
                 OutlinedButton(
                     onClick = onCancel,
@@ -667,8 +671,8 @@ private fun IdentityEditor(
                     modifier = Modifier.weight(1f),
                 ) { Text("Cancel") }
                 Button(
-                    onClick = { onConfirm(text) },
-                    enabled = !isSaving,
+                    onClick = { onConfirm(normalized) },
+                    enabled = !isSaving && normalized.isNotBlank(),
                     modifier = Modifier
                         .weight(1f)
                         .testTag("meal_identity_save"),

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -541,7 +541,7 @@ private fun CorrectionEditor(
  * and a sample-level identity disagreement is surfaced as the reason to confirm.
  */
 @Composable
-private fun MealIdentitySection(
+internal fun MealIdentitySection(
     record: FoodRecord,
     uiState: MealLogUiState,
     onStartEdit: () -> Unit,
@@ -684,7 +684,7 @@ private fun IdentityEditor(
  * it. Descriptive only -- no dose, and no self-reported confidence.
  */
 @Composable
-private fun MealAuditSection(
+internal fun MealAuditSection(
     uiState: MealLogUiState,
     onLoad: () -> Unit,
     onHide: () -> Unit,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -160,6 +160,11 @@ fun MealLogScreen(
                     onCancelCorrection = viewModel::cancelCorrection,
                     onSubmitCorrection = viewModel::submitCorrection,
                     onSaveAsCommonFood = viewModel::saveAsCommonFood,
+                    onStartIdentityEdit = viewModel::startIdentityEdit,
+                    onCancelIdentityEdit = viewModel::cancelIdentityEdit,
+                    onConfirmIdentity = viewModel::confirmIdentity,
+                    onLoadAudit = viewModel::loadAudit,
+                    onHideAudit = viewModel::hideAudit,
                     onReset = viewModel::reset,
                     onClearError = viewModel::clearError,
                 )
@@ -180,6 +185,11 @@ private fun ReadyContent(
     onCancelCorrection: () -> Unit,
     onSubmitCorrection: (String, String) -> Unit,
     onSaveAsCommonFood: (String) -> Unit,
+    onStartIdentityEdit: () -> Unit,
+    onCancelIdentityEdit: () -> Unit,
+    onConfirmIdentity: (String) -> Unit,
+    onLoadAudit: () -> Unit,
+    onHideAudit: () -> Unit,
     onReset: () -> Unit,
     onClearError: () -> Unit,
 ) {
@@ -215,6 +225,11 @@ private fun ReadyContent(
                     onCancelCorrection = onCancelCorrection,
                     onSubmitCorrection = onSubmitCorrection,
                     onSaveAsCommonFood = onSaveAsCommonFood,
+                    onStartIdentityEdit = onStartIdentityEdit,
+                    onCancelIdentityEdit = onCancelIdentityEdit,
+                    onConfirmIdentity = onConfirmIdentity,
+                    onLoadAudit = onLoadAudit,
+                    onHideAudit = onHideAudit,
                     onReset = onReset,
                 )
 
@@ -331,6 +346,11 @@ private fun ResultContent(
     onCancelCorrection: () -> Unit,
     onSubmitCorrection: (String, String) -> Unit,
     onSaveAsCommonFood: (String) -> Unit,
+    onStartIdentityEdit: () -> Unit,
+    onCancelIdentityEdit: () -> Unit,
+    onConfirmIdentity: (String) -> Unit,
+    onLoadAudit: () -> Unit,
+    onHideAudit: () -> Unit,
     onReset: () -> Unit,
 ) {
     var showSaveDialog by remember { mutableStateOf(false) }
@@ -349,13 +369,16 @@ private fun ResultContent(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            if (!record.foodDescription.isNullOrBlank()) {
-                Text(
-                    text = record.foodDescription,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-            }
+            // Food identity is a first-class, confirmable thing (Story 50.H2) --
+            // distinct from carb correction. Grounding only applies once it's
+            // confirmed, so a confident misidentification isn't certified.
+            MealIdentitySection(
+                record = record,
+                uiState = uiState,
+                onStartEdit = onStartIdentityEdit,
+                onCancelEdit = onCancelIdentityEdit,
+                onConfirm = onConfirmIdentity,
+            )
             CarbEstimateContent(
                 range = record.displayRange,
                 confidence = record.confidence,
@@ -407,6 +430,13 @@ private fun ResultContent(
             modifier = Modifier.testTag("meal_saved_common_confirmation"),
         )
     }
+
+    // "How was this estimated" provenance (Story 50.H3) -- on demand, descriptive.
+    MealAuditSection(
+        uiState = uiState,
+        onLoad = onLoadAudit,
+        onHide = onHideAudit,
+    )
 
     TextButton(
         onClick = onReset,
@@ -500,6 +530,234 @@ private fun CorrectionEditor(
                         .testTag("meal_correct_save"),
                 ) { Text(if (isSaving) "Saving…" else "Save") }
             }
+        }
+    }
+}
+
+/**
+ * Food-identity confirmation (Story 50.H2). The AI's guess is shown as a
+ * confirmable thing -- distinct from carb correction. Confirming opens the
+ * grounding gate server-side; an own-history match pre-fills a one-tap confirm,
+ * and a sample-level identity disagreement is surfaced as the reason to confirm.
+ */
+@Composable
+private fun MealIdentitySection(
+    record: FoodRecord,
+    uiState: MealLogUiState,
+    onStartEdit: () -> Unit,
+    onCancelEdit: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    if (uiState.isEditingIdentity) {
+        IdentityEditor(
+            initial = record.displayIdentity.orEmpty(),
+            isSaving = uiState.isSavingIdentity,
+            error = uiState.identityError,
+            onConfirm = onConfirm,
+            onCancel = onCancelEdit,
+        )
+        return
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = record.displayIdentity ?: "Unidentified food",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.testTag("meal_identity"),
+        )
+        if (record.identityConfirmed) {
+            Text(
+                text = "✓ You confirmed this food.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.testTag("meal_identity_confirmed"),
+            )
+            TextButton(
+                onClick = onStartEdit,
+                modifier = Modifier.testTag("meal_identity_edit"),
+            ) { Text("Change what this is") }
+        } else {
+            val disagreed = record.dispersion?.identityAgreement == false
+            Text(
+                text = when {
+                    disagreed ->
+                        "The AI wasn't sure what this is. Confirm it so we can look " +
+                            "up its nutrition."
+                    record.suggestedIdentity != null ->
+                        "Looks like your saved \"${record.suggestedIdentity}\" -- confirm?"
+                    else ->
+                        "Confirm what this food is so we can ground it against real " +
+                            "nutrition data."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = if (disagreed) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                modifier = Modifier.testTag(
+                    if (disagreed) "meal_identity_disagreement_cue" else "meal_identity_prompt",
+                ),
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(
+                    onClick = {
+                        onConfirm(record.suggestedIdentity ?: record.displayIdentity.orEmpty())
+                    },
+                    enabled = !uiState.isSavingIdentity && !record.displayIdentity.isNullOrBlank(),
+                    modifier = Modifier.testTag("meal_identity_confirm"),
+                ) { Text(if (uiState.isSavingIdentity) "Confirming…" else "Confirm") }
+                OutlinedButton(
+                    onClick = onStartEdit,
+                    enabled = !uiState.isSavingIdentity,
+                    modifier = Modifier.testTag("meal_identity_correct"),
+                ) { Text("Correct") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IdentityEditor(
+    initial: String,
+    isSaving: Boolean,
+    error: String?,
+    onConfirm: (String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var text by remember(initial) { mutableStateOf(initial) }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_identity_editor"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "What is this food?",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text("Food name") },
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("meal_identity_input"),
+            )
+            if (error != null) {
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(
+                    onClick = onCancel,
+                    enabled = !isSaving,
+                    modifier = Modifier.weight(1f),
+                ) { Text("Cancel") }
+                Button(
+                    onClick = { onConfirm(text) },
+                    enabled = !isSaving,
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("meal_identity_save"),
+                ) { Text(if (isSaving) "Saving…" else "Confirm") }
+            }
+        }
+    }
+}
+
+/**
+ * "How was this estimated" provenance (Story 50.H3). Loaded on demand: the raw
+ * per-sample reads, how many reads there were, and which source (if any) grounded
+ * it. Descriptive only -- no dose, and no self-reported confidence.
+ */
+@Composable
+private fun MealAuditSection(
+    uiState: MealLogUiState,
+    onLoad: () -> Unit,
+    onHide: () -> Unit,
+) {
+    val audit = uiState.audit
+    if (audit == null) {
+        TextButton(
+            onClick = onLoad,
+            enabled = !uiState.isLoadingAudit,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("meal_audit_button"),
+        ) { Text(if (uiState.isLoadingAudit) "Loading…" else "How was this estimated?") }
+        uiState.auditError?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.testTag("meal_audit_error"),
+            )
+        }
+        return
+    }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_audit_detail"),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = "How this estimate was reached",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = audit.samplesUsed?.let {
+                    "Read the photo $it time(s); the range reflects how much those " +
+                        "reads disagreed."
+                } ?: "Estimated from multiple reads of the photo.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            audit.samples.forEach { sample ->
+                val carbs = sample.carbs?.let {
+                    "${formatEditableGrams(it.lowGrams)}–${formatEditableGrams(it.highGrams)} g"
+                } ?: "—"
+                Text(
+                    text = "• ${sample.identity ?: "unnamed"}: $carbs",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = if (audit.grounded) {
+                    "Grounded against ${audit.groundingSource ?: "a source"}" +
+                        (audit.identityUsed?.let { " (as \"$it\")" } ?: "") + "."
+                } else {
+                    "Vision-only -- not grounded against an external source."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("meal_audit_precedence"),
+            )
+            TextButton(
+                onClick = onHide,
+                modifier = Modifier.testTag("meal_audit_hide"),
+            ) { Text("Hide") }
         }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
@@ -252,6 +252,9 @@ class MealLogViewModel @Inject constructor(
     /** Confirm (or correct) what the food is. Opens the grounding gate server-side. */
     fun confirmIdentity(name: String) {
         val record = _uiState.value.record ?: return
+        // Pin the record this request belongs to; a response that lands after the
+        // user switched photos must not overwrite the now-active record's state.
+        val requestRecordId = record.id
         val trimmed = name.trim()
         if (trimmed.isEmpty()) {
             _uiState.update { it.copy(identityError = "Tell us what this food is.") }
@@ -259,21 +262,24 @@ class MealLogViewModel @Inject constructor(
         }
         _uiState.update { it.copy(isSavingIdentity = true, identityError = null) }
         viewModelScope.launch {
-            repository.confirmIdentity(record.id, trimmed)
+            repository.confirmIdentity(requestRecordId, trimmed)
                 .onSuccess { updated ->
                     // The grounding/precedence changed, so any loaded audit is stale.
-                    _uiState.update {
-                        it.copy(
+                    _uiState.update { state ->
+                        if (state.record?.id != requestRecordId) return@update state
+                        state.copy(
                             isSavingIdentity = false,
                             isEditingIdentity = false,
                             record = updated,
                             audit = null,
+                            auditError = null,
                         )
                     }
                 }
                 .onFailure { e ->
-                    _uiState.update {
-                        it.copy(isSavingIdentity = false, identityError = messageFor(e))
+                    _uiState.update { state ->
+                        if (state.record?.id != requestRecordId) return@update state
+                        state.copy(isSavingIdentity = false, identityError = messageFor(e))
                     }
                 }
         }
@@ -283,12 +289,21 @@ class MealLogViewModel @Inject constructor(
 
     fun loadAudit() {
         val record = _uiState.value.record ?: return
+        val requestRecordId = record.id
         _uiState.update { it.copy(isLoadingAudit = true, auditError = null) }
         viewModelScope.launch {
-            repository.getAudit(record.id)
-                .onSuccess { a -> _uiState.update { it.copy(isLoadingAudit = false, audit = a) } }
+            repository.getAudit(requestRecordId)
+                .onSuccess { a ->
+                    _uiState.update { state ->
+                        if (state.record?.id != requestRecordId) return@update state
+                        state.copy(isLoadingAudit = false, audit = a)
+                    }
+                }
                 .onFailure { e ->
-                    _uiState.update { it.copy(isLoadingAudit = false, auditError = messageFor(e)) }
+                    _uiState.update { state ->
+                        if (state.record?.id != requestRecordId) return@update state
+                        state.copy(isLoadingAudit = false, auditError = messageFor(e))
+                    }
                 }
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogViewModel.kt
@@ -8,6 +8,7 @@ import com.glycemicgpt.mobile.data.meal.CarbBounds
 import com.glycemicgpt.mobile.data.meal.CarbInputResult
 import com.glycemicgpt.mobile.data.meal.FoodRecord
 import com.glycemicgpt.mobile.data.meal.ImageCompressor
+import com.glycemicgpt.mobile.data.meal.MealAudit
 import com.glycemicgpt.mobile.data.meal.MealException
 import com.glycemicgpt.mobile.data.meal.MealPhotoFiles
 import com.glycemicgpt.mobile.data.repository.MealRepository
@@ -62,6 +63,14 @@ data class MealLogUiState(
     val correctionError: String? = null,
     val isSavingCommonFood: Boolean = false,
     val savedCommonFoodName: String? = null,
+    // Food-identity confirmation (Story 50.H2).
+    val isEditingIdentity: Boolean = false,
+    val isSavingIdentity: Boolean = false,
+    val identityError: String? = null,
+    // "How was this estimated" audit detail (Story 50.H3); loaded on demand.
+    val audit: MealAudit? = null,
+    val isLoadingAudit: Boolean = false,
+    val auditError: String? = null,
 )
 
 @HiltViewModel
@@ -230,6 +239,64 @@ class MealLogViewModel @Inject constructor(
         }
     }
 
+    // --- Food-identity confirmation (Story 50.H2) ---
+
+    fun startIdentityEdit() {
+        _uiState.update { it.copy(isEditingIdentity = true, identityError = null) }
+    }
+
+    fun cancelIdentityEdit() {
+        _uiState.update { it.copy(isEditingIdentity = false, identityError = null) }
+    }
+
+    /** Confirm (or correct) what the food is. Opens the grounding gate server-side. */
+    fun confirmIdentity(name: String) {
+        val record = _uiState.value.record ?: return
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) {
+            _uiState.update { it.copy(identityError = "Tell us what this food is.") }
+            return
+        }
+        _uiState.update { it.copy(isSavingIdentity = true, identityError = null) }
+        viewModelScope.launch {
+            repository.confirmIdentity(record.id, trimmed)
+                .onSuccess { updated ->
+                    // The grounding/precedence changed, so any loaded audit is stale.
+                    _uiState.update {
+                        it.copy(
+                            isSavingIdentity = false,
+                            isEditingIdentity = false,
+                            record = updated,
+                            audit = null,
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(isSavingIdentity = false, identityError = messageFor(e))
+                    }
+                }
+        }
+    }
+
+    // --- "How was this estimated" audit (Story 50.H3) ---
+
+    fun loadAudit() {
+        val record = _uiState.value.record ?: return
+        _uiState.update { it.copy(isLoadingAudit = true, auditError = null) }
+        viewModelScope.launch {
+            repository.getAudit(record.id)
+                .onSuccess { a -> _uiState.update { it.copy(isLoadingAudit = false, audit = a) } }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isLoadingAudit = false, auditError = messageFor(e)) }
+                }
+        }
+    }
+
+    fun hideAudit() {
+        _uiState.update { it.copy(audit = null, auditError = null) }
+    }
+
     /** Return to the idle capture state to log another meal. */
     fun reset() {
         // No capture is in flight here, so sweep the kept result thumbnail + any orphaned originals.
@@ -246,6 +313,12 @@ class MealLogViewModel @Inject constructor(
                 correctionError = null,
                 isSavingCommonFood = false,
                 savedCommonFoodName = null,
+                isEditingIdentity = false,
+                isSavingIdentity = false,
+                identityError = null,
+                audit = null,
+                isLoadingAudit = false,
+                auditError = null,
             )
         }
     }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/MealModelsTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/MealModelsTest.kt
@@ -1,6 +1,7 @@
 package com.glycemicgpt.mobile.data.meal
 
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
+import com.glycemicgpt.mobile.data.remote.dto.EstimateDispersionResponse
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -16,6 +17,7 @@ class MealModelsTest {
         confidence: String? = "high",
         correctedLow: Double? = null,
         correctedHigh: Double? = null,
+        dispersion: EstimateDispersionResponse? = null,
     ) = FoodRecordResponse(
         id = "rec-1",
         mealTimestamp = "2026-06-14T12:00:00Z",
@@ -26,6 +28,7 @@ class MealModelsTest {
         source = source,
         correctedCarbsLow = correctedLow,
         correctedCarbsHigh = correctedHigh,
+        estimateDispersion = dispersion,
         createdAt = "2026-06-14T12:00:05Z",
     )
 
@@ -38,6 +41,36 @@ class MealModelsTest {
         assertFalse(domain.isCorrected)
         assertEquals(domain.estimate, domain.displayRange)
         assertEquals(Instant.parse("2026-06-14T12:00:00Z"), domain.mealTimestamp)
+    }
+
+    @Test
+    fun `maps multi-sample dispersion when present (Story 50_H1)`() {
+        val domain = record(
+            dispersion = EstimateDispersionResponse(
+                note = "Repeated looks at this photo disagreed a lot -- treat this as a rough guess.",
+                wideSpread = true,
+                identityAgreement = false,
+            ),
+        ).toDomain()
+        val dispersion = domain.dispersion
+        assertTrue("dispersion should be mapped", dispersion != null)
+        assertEquals(true, dispersion?.wideSpread)
+        assertEquals(false, dispersion?.identityAgreement)
+        assertTrue(dispersion?.note?.contains("rough guess") == true)
+    }
+
+    @Test
+    fun `dispersion is null on a history read that omits it`() {
+        // History/list responses do not carry the transient create-time detail.
+        assertNull(record(dispersion = null).toDomain().dispersion)
+    }
+
+    @Test
+    fun `a blank dispersion note maps to null so the UI shows nothing`() {
+        val domain = record(
+            dispersion = EstimateDispersionResponse(note = "   ", wideSpread = false),
+        ).toDomain()
+        assertNull(domain.dispersion?.note)
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/MealModelsTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/MealModelsTest.kt
@@ -1,7 +1,11 @@
 package com.glycemicgpt.mobile.data.meal
 
+import com.glycemicgpt.mobile.data.remote.dto.AuditDispersionResponse
+import com.glycemicgpt.mobile.data.remote.dto.AuditPrecedenceResponse
+import com.glycemicgpt.mobile.data.remote.dto.AuditSampleResponse
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
 import com.glycemicgpt.mobile.data.remote.dto.EstimateDispersionResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordAuditResponse
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -18,6 +22,9 @@ class MealModelsTest {
         correctedLow: Double? = null,
         correctedHigh: Double? = null,
         dispersion: EstimateDispersionResponse? = null,
+        confirmedFoodName: String? = null,
+        identityConfirmed: Boolean = false,
+        suggestedIdentity: String? = null,
     ) = FoodRecordResponse(
         id = "rec-1",
         mealTimestamp = "2026-06-14T12:00:00Z",
@@ -28,6 +35,9 @@ class MealModelsTest {
         source = source,
         correctedCarbsLow = correctedLow,
         correctedCarbsHigh = correctedHigh,
+        confirmedFoodName = confirmedFoodName,
+        identityConfirmed = identityConfirmed,
+        suggestedIdentity = suggestedIdentity,
         estimateDispersion = dispersion,
         createdAt = "2026-06-14T12:00:05Z",
     )
@@ -143,5 +153,78 @@ class MealModelsTest {
         assertTrue(CarbBounds.validate(0.0, 1001.0)!!.contains("exceed"))
         assertTrue(CarbBounds.validate(60.0, 40.0)!!.contains("must not exceed"))
         assertTrue(CarbBounds.validate(Double.NaN, 40.0)!!.isNotEmpty())
+    }
+
+    // --- Food-identity confirmation mapping (Story 50.H2) ---
+
+    @Test
+    fun `unconfirmed estimate maps identity from the AI description`() {
+        val domain = record().toDomain()
+        assertFalse(domain.identityConfirmed)
+        assertNull(domain.confirmedFoodName)
+        assertEquals("pasta bowl", domain.displayIdentity) // the AI's guess
+    }
+
+    @Test
+    fun `confirmed identity is surfaced and preferred over the AI description`() {
+        val domain = record(
+            confirmedFoodName = "homemade lasagna",
+            identityConfirmed = true,
+        ).toDomain()
+        assertTrue(domain.identityConfirmed)
+        assertEquals("homemade lasagna", domain.confirmedFoodName)
+        assertEquals("homemade lasagna", domain.displayIdentity) // confirmed wins
+    }
+
+    @Test
+    fun `own-history suggestion is mapped (blank to null)`() {
+        assertEquals("my chili", record(suggestedIdentity = "my chili").toDomain().suggestedIdentity)
+        assertNull(record(suggestedIdentity = "  ").toDomain().suggestedIdentity)
+    }
+
+    // --- Audit provenance mapping (Story 50.H3) ---
+
+    @Test
+    fun `grounded audit maps samples, precedence, and dispersion`() {
+        val domain = FoodRecordAuditResponse(
+            foodRecordId = "rec-1",
+            samples = listOf(
+                AuditSampleResponse(carbsLow = 40.0, carbsHigh = 50.0, identity = "pasta"),
+                AuditSampleResponse(carbsLow = 60.0, carbsHigh = 70.0, identity = "pasta"),
+            ),
+            dispersion = AuditDispersionResponse(
+                confidence = "medium",
+                samplesUsed = 2,
+                wideSpread = true,
+                identityAgreement = true,
+            ),
+            precedence = AuditPrecedenceResponse(
+                outcome = "grounded",
+                chosenSource = "Your meal history",
+                identityUsed = "pasta",
+                identityConfirmed = true,
+            ),
+            createdAt = "2026-06-14T12:00:05Z",
+        ).toDomain()
+
+        assertEquals(2, domain.samples.size)
+        assertEquals(CarbRange(40.0, 50.0), domain.samples[0].carbs)
+        assertEquals("pasta", domain.samples[0].identity)
+        assertEquals(CarbConfidence.MEDIUM, domain.confidence)
+        assertEquals(2, domain.samplesUsed)
+        assertTrue(domain.grounded)
+        assertEquals("Your meal history", domain.groundingSource)
+        assertEquals("pasta", domain.identityUsed)
+    }
+
+    @Test
+    fun `vision-only audit is not grounded`() {
+        val domain = FoodRecordAuditResponse(
+            foodRecordId = "rec-1",
+            samples = emptyList(),
+            precedence = AuditPrecedenceResponse(outcome = "vision_only", identityConfirmed = false),
+        ).toDomain()
+        assertFalse(domain.grounded)
+        assertNull(domain.groundingSource)
     }
 }

--- a/sidecar/src/providers/claude.ts
+++ b/sidecar/src/providers/claude.ts
@@ -9,7 +9,8 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   flattenVisionRequest,
@@ -79,31 +80,95 @@ function getToken(): string | null {
   return null;
 }
 
-/** Flatten messages into a single prompt string for the CLI */
-function messagesToPrompt(messages: ChatMessage[]): string {
-  const prompt = messages
-    .map((m) => {
-      if (m.role === "system") return `[System]: ${m.content}`;
-      if (m.role === "user") return m.content;
-      return `[Assistant]: ${m.content}`;
-    })
-    .join("\n\n");
+interface TempSystemPrompt {
+  /** Absolute path of the written system-prompt file. */
+  path: string;
+  /** Remove the temp file and its directory. Call once the subprocess has
+   *  finished reading it (in a finally, or after the spawned CLI settles). */
+  cleanup: () => void;
+}
 
-  if (prompt.length > MAX_PROMPT_LENGTH) {
-    throw new Error(
-      `Prompt too long (${prompt.length} chars, max ${MAX_PROMPT_LENGTH})`,
-    );
+/**
+ * Write the caller's system prompt to a fresh, private temp file so it can be
+ * handed to the CLI via `--system-prompt-file`. The prompt is the app's
+ * GlycemicGPT instructions; delivering it as a real system prompt (not inline
+ * `[System]:` text in the user turn) is what makes the model actually adopt the
+ * persona instead of answering as the default Claude Code agent.
+ */
+function writeSystemPromptFile(systemPrompt: string): TempSystemPrompt {
+  const dir = mkdtempSync(join(tmpdir(), "gg-sys-"));
+  chmodSync(dir, 0o700); // private to this process, not reliant on umask
+  const path = join(dir, "system-prompt.txt");
+  try {
+    writeFileSync(path, systemPrompt, { mode: 0o600 });
+  } catch (err) {
+    rmSync(dir, { recursive: true, force: true });
+    throw err;
   }
-  return prompt;
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/**
+ * CLI flag that installs an authoritative system prompt from a file, replacing
+ * the CLI's default prompt (which carries Claude Code's identity and dynamic
+ * cwd/env sections) so only the app's persona drives the session. Returns no
+ * flags when there is no system prompt, leaving the CLI default in place. The
+ * prompt is passed by file path, never as an argv value, so its contents can't
+ * be parsed as flags.
+ */
+function systemPromptArgs(systemPromptFile: string | null): string[] {
+  return systemPromptFile ? ["--system-prompt-file", systemPromptFile] : [];
+}
+
+/**
+ * Split chat messages into the authoritative system prompt (delivered via
+ * `--system-prompt-file`) and the conversation turns (sent on stdin). System
+ * content is deliberately NOT inlined into the conversation: inline `[System]:`
+ * text is treated by the model as quoted user content it can disown, which is
+ * how the GlycemicGPT persona leaked back to the default Claude Code identity.
+ */
+function splitSystemPrompt(messages: ChatMessage[]): {
+  systemPrompt: string;
+  conversation: string;
+} {
+  const systemParts: string[] = [];
+  const turnParts: string[] = [];
+  for (const m of messages) {
+    if (m.role === "system") {
+      systemParts.push(m.content);
+    } else if (m.role === "assistant") {
+      turnParts.push(`[Assistant]: ${m.content}`);
+    } else {
+      turnParts.push(m.content);
+    }
+  }
+  const systemPrompt = systemParts.join("\n\n").trim();
+  const conversation = turnParts.join("\n\n");
+  // Bound the combined payload as the old inline flattening did: the system
+  // prompt now travels by file rather than on the user turn, but it still
+  // counts against the model's input budget, so cap system + conversation.
+  const total = systemPrompt.length + conversation.length;
+  if (total > MAX_PROMPT_LENGTH) {
+    throw new Error(`Prompt too long (${total} chars, max ${MAX_PROMPT_LENGTH})`);
+  }
+  return { systemPrompt, conversation };
 }
 
 /**
  * Spawn the Claude CLI as a child process.
  * Prompt is passed via stdin (not as a CLI argument) to prevent injection.
  *
+ * @param systemPromptFile Path to the app system prompt, installed via
+ *   `--system-prompt-file` so the model adopts the GlycemicGPT persona; null
+ *   leaves the CLI default in place.
  * @param extraArgs Additional CLI flags (e.g. output format overrides).
  */
-function spawnClaude(prompt: string, model: string, extraArgs: string[] = []): ChildProcess {
+function spawnClaude(
+  prompt: string,
+  model: string,
+  systemPromptFile: string | null,
+  extraArgs: string[] = [],
+): ChildProcess {
   const token = getToken();
   const env: Record<string, string> = { ...process.env } as Record<
     string,
@@ -118,6 +183,7 @@ function spawnClaude(prompt: string, model: string, extraArgs: string[] = []): C
       "--no-session-persistence",
       "--model",
       model, // Already validated by resolveModel()
+      ...systemPromptArgs(systemPromptFile),
       ...extraArgs,
       "-", // Read prompt from stdin
     ],
@@ -184,16 +250,13 @@ function cleanupChild(child: ChildProcess, timer: ReturnType<typeof setTimeout>)
 }
 
 /**
- * Build the prompt for the CLI vision path. The model is told the meal photo(s)
- * are on disk and instructed to read them; the system + user text follow.
+ * Build the positional prompt for the CLI vision path. The model is told the
+ * meal photo(s) are on disk and instructed to read them; the user text follows.
+ * The system prompt (the carb contract) is delivered separately via
+ * `--system-prompt-file`, not inlined here.
  */
-function buildVisionPrompt(
-  systemText: string,
-  userText: string,
-  imagePaths: string[],
-): string {
+function buildVisionPrompt(userText: string, imagePaths: string[]): string {
   const lines: string[] = [];
-  if (systemText) lines.push(systemText);
   lines.push(
     imagePaths.length === 1
       ? `A meal photo has been provided as the file ${imagePaths[0]}. Read that image file and analyze the food shown in it.`
@@ -214,6 +277,7 @@ async function runClaudeVision(
   prompt: string,
   cliModel: string,
   imageDir: string,
+  systemPromptFile: string | null,
 ): Promise<ProviderResult> {
   const token = getToken();
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
@@ -232,6 +296,10 @@ async function runClaudeVision(
       // Read-only: Read renders the image; Write/Edit/Bash are blocked.
       "--permission-mode",
       "plan",
+      // Install the carb-contract system prompt authoritatively (by file path,
+      // never as an argv value) so the model follows it rather than the default
+      // Claude Code agent prompt.
+      ...systemPromptArgs(systemPromptFile),
       // End-of-options: the prompt is positional and never parsed as a flag.
       "--",
       prompt,
@@ -265,14 +333,21 @@ export class ClaudeProvider implements AIProvider, VisionRunner {
       throw new InvalidImageError("no image provided for a vision request");
     }
     const temp = writeImagesToTempDir(images);
+    // Allocate the system-prompt temp file inside the try: if it throws (e.g. a
+    // transient FS error), the finally still runs temp.cleanup() so the decoded
+    // meal-photo bytes never leak under /tmp. (writeImagesToTempDir self-cleans
+    // on its own throw, before temp is bound.)
+    let sys: TempSystemPrompt | null = null;
     try {
-      const prompt = buildVisionPrompt(systemText, userText, temp.paths);
+      sys = systemText ? writeSystemPromptFile(systemText) : null;
+      const prompt = buildVisionPrompt(userText, temp.paths);
       if (prompt.length > MAX_PROMPT_LENGTH) {
         throw new Error(`Prompt too long (${prompt.length} chars, max ${MAX_PROMPT_LENGTH})`);
       }
-      return await runClaudeVision(prompt, resolveModel(options.model), temp.dir);
+      return await runClaudeVision(prompt, resolveModel(options.model), temp.dir, sys?.path ?? null);
     } finally {
       temp.cleanup();
+      sys?.cleanup();
     }
   }
 
@@ -291,11 +366,12 @@ export class ClaudeProvider implements AIProvider, VisionRunner {
     messages: ChatMessage[],
     model?: string,
   ): Promise<ProviderResult> {
-    const prompt = messagesToPrompt(messages);
+    const { systemPrompt, conversation } = splitSystemPrompt(messages);
     const cliModel = resolveModel(model);
+    const sys = systemPrompt ? writeSystemPromptFile(systemPrompt) : null;
 
-    return new Promise((resolve, reject) => {
-      const child = spawnClaude(prompt, cliModel, [
+    return new Promise<ProviderResult>((resolve, reject) => {
+      const child = spawnClaude(conversation, cliModel, sys?.path ?? null, [
         "--output-format", "json",
       ]);
       let stdout = "";
@@ -348,6 +424,11 @@ export class ClaudeProvider implements AIProvider, VisionRunner {
           resolve({ content: stdout.trim(), model: `claude-${cliModel}` });
         }
       });
+    }).finally(() => {
+      // Cleanup runs after the Promise settles: the spawned CLI reads the
+      // system-prompt file asynchronously, so removing it earlier would race the
+      // subprocess. (completeVision uses a synchronous try/finally instead.)
+      sys?.cleanup();
     });
   }
 
@@ -356,11 +437,12 @@ export class ClaudeProvider implements AIProvider, VisionRunner {
     model?: string,
     onChunk?: (text: string) => void,
   ): Promise<ProviderResult> {
-    const prompt = messagesToPrompt(messages);
+    const { systemPrompt, conversation } = splitSystemPrompt(messages);
     const cliModel = resolveModel(model);
+    const sys = systemPrompt ? writeSystemPromptFile(systemPrompt) : null;
 
-    return new Promise((resolve, reject) => {
-      const child = spawnClaude(prompt, cliModel, [
+    return new Promise<ProviderResult>((resolve, reject) => {
+      const child = spawnClaude(conversation, cliModel, sys?.path ?? null, [
         "--output-format", "stream-json",
         "--verbose",
         "--include-partial-messages",
@@ -426,6 +508,11 @@ export class ClaudeProvider implements AIProvider, VisionRunner {
 
         resolve({ content, model: `claude-${cliModel}` });
       });
+    }).finally(() => {
+      // Cleanup runs after the Promise settles: the spawned CLI reads the
+      // system-prompt file asynchronously, so removing it earlier would race the
+      // subprocess. (completeVision uses a synchronous try/finally instead.)
+      sys?.cleanup();
     });
   }
 }

--- a/sidecar/tests/claude-chat.test.ts
+++ b/sidecar/tests/claude-chat.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the Claude subscription CHAT path (complete / stream).
+ *
+ * `node:child_process` spawn is mocked, so no real CLI runs. These pin the fix
+ * for the persona-leak bug: the app system prompt must be installed via
+ * `--system-prompt-file` (authoritative), NOT inlined as `[System]:` text in
+ * the stdin prompt — inline text is treated by the model as quoted user content
+ * it can disown, which is how the GlycemicGPT persona reverted to the default
+ * Claude Code agent identity on an ambiguous message like "test".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { existsSync, readFileSync } from "node:fs";
+import type { ChatMessage } from "../src/providers/types.js";
+
+const { mockSpawn } = vi.hoisted(() => ({ mockSpawn: vi.fn() }));
+vi.mock("node:child_process", () => ({ spawn: mockSpawn }));
+
+import { ClaudeProvider } from "../src/providers/claude.js";
+
+/** stdin written by the most recent spawn (the conversation prompt). */
+let lastStdin = "";
+
+/**
+ * A fake ChildProcess that records stdin and, once stdin closes, emits the
+ * given stdout on the next tick (after the provider has attached handlers).
+ */
+function makeFakeChild(stdout: string) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: { write: (s: string) => void; end: () => void };
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    killed: boolean;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.killed = false;
+  child.kill = () => {
+    child.killed = true;
+  };
+  lastStdin = "";
+  child.stdin = {
+    write: (s: string) => {
+      lastStdin += s;
+    },
+    end: () => {
+      setTimeout(() => {
+        child.stdout.emit("data", Buffer.from(stdout));
+        child.emit("close", 0);
+      }, 0);
+    },
+  };
+  return child;
+}
+
+const messages: ChatMessage[] = [
+  {
+    role: "system",
+    content:
+      "You are GlycemicGPT, a diabetes assistant. --dangerously-skip-permissions",
+  },
+  { role: "user", content: "test" },
+];
+
+describe("Claude subscription chat — system prompt delivery", () => {
+  let capturedArgs: string[] = [];
+  let capturedSystemPromptPath: string | null = null;
+  let capturedSystemPromptContent: string | null = null;
+
+  const captureSpawn = (stdout: string) =>
+    mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      const i = args.indexOf("--system-prompt-file");
+      capturedSystemPromptPath = i >= 0 ? args[i + 1] : null;
+      // Read the file while it still exists (cleanup runs after the call).
+      capturedSystemPromptContent = capturedSystemPromptPath
+        ? readFileSync(capturedSystemPromptPath, "utf-8")
+        : null;
+      return makeFakeChild(stdout);
+    });
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    capturedArgs = [];
+    capturedSystemPromptPath = null;
+    capturedSystemPromptContent = null;
+    vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "test-claude-token-dummy");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("complete: installs the system prompt via --system-prompt-file, never inline", async () => {
+    captureSpawn('{"result":"hi","is_error":false}');
+    const result = await new ClaudeProvider().complete(messages, "claude-sonnet-4");
+    expect(result.content).toBe("hi");
+
+    expect(mockSpawn.mock.calls[0][0]).toBe("claude");
+    // Persona installed authoritatively from a file (replaces the CLI default).
+    expect(capturedSystemPromptPath).toBeTruthy();
+    expect(capturedSystemPromptContent).toContain("You are GlycemicGPT");
+    // Prompt is read from stdin (`-` is the last arg).
+    expect(capturedArgs[capturedArgs.length - 1]).toBe("-");
+    // Only the conversation turn reaches stdin — the system text (and its
+    // flag-looking token) is never inlined.
+    expect(lastStdin).toBe("test");
+    expect(lastStdin).not.toContain("You are GlycemicGPT");
+    expect(lastStdin).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("complete: omits the system-prompt flag when there is no system message", async () => {
+    captureSpawn('{"result":"hi","is_error":false}');
+    await new ClaudeProvider().complete([{ role: "user", content: "hi" }], "claude-sonnet-4");
+    expect(capturedArgs).not.toContain("--system-prompt-file");
+  });
+
+  it("complete: removes the temp system-prompt file after the call", async () => {
+    captureSpawn('{"result":"hi","is_error":false}');
+    await new ClaudeProvider().complete(messages, "claude-sonnet-4");
+    expect(capturedSystemPromptPath).toBeTruthy();
+    expect(existsSync(capturedSystemPromptPath as string)).toBe(false);
+  });
+
+  it("complete: keeps conversation turns on stdin (assistant prefixed) and concatenates system parts in the file", async () => {
+    captureSpawn('{"result":"hi","is_error":false}');
+    const convo: ChatMessage[] = [
+      { role: "system", content: "Persona A." },
+      { role: "system", content: "Persona B." },
+      { role: "user", content: "q1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "q2" },
+    ];
+    await new ClaudeProvider().complete(convo, "claude-sonnet-4");
+    // Conversation turns reach stdin in order; the assistant turn is labelled.
+    expect(lastStdin).toBe("q1\n\n[Assistant]: a1\n\nq2");
+    // Both system parts are concatenated into the system-prompt file, off-stdin.
+    expect(capturedSystemPromptContent).toBe("Persona A.\n\nPersona B.");
+    expect(lastStdin).not.toContain("Persona A.");
+  });
+
+  it("stream: installs the system prompt via --system-prompt-file, never inline", async () => {
+    captureSpawn('{"type":"assistant","message":{"content":"ok"}}\n');
+    const chunks: string[] = [];
+    const result = await new ClaudeProvider().stream(messages, "claude-sonnet-4", (c) =>
+      chunks.push(c),
+    );
+    expect(result.content).toBe("ok");
+    expect(chunks.join("")).toBe("ok");
+    expect(capturedSystemPromptPath).toBeTruthy();
+    expect(lastStdin).toBe("test");
+    expect(lastStdin).not.toContain("--dangerously-skip-permissions");
+    // The temp file is cleaned up once the stream settles.
+    expect(existsSync(capturedSystemPromptPath as string)).toBe(false);
+  });
+});

--- a/sidecar/tests/vision-cli.test.ts
+++ b/sidecar/tests/vision-cli.test.ts
@@ -2,9 +2,10 @@
  * Tests for the CLI vision argv construction (claude / codex).
  *
  * `runCapture` is mocked, so no subprocess is spawned. These assert the
- * security-critical argv shape: read-only mode, and a `--` end-of-options
- * separator immediately before the (attacker-influenced) positional prompt so a
- * prompt that looks like a flag can never be parsed as one.
+ * security-critical argv shape: read-only mode, a `--` end-of-options separator
+ * immediately before the (attacker-influenced) positional prompt so a prompt
+ * that looks like a flag can never be parsed as one, and (for claude) that the
+ * system prompt is installed authoritatively from a file rather than inlined.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -38,7 +39,7 @@ describe("CLI vision argv construction", () => {
     vi.unstubAllEnvs();
   });
 
-  it("claude: runs read-only plan mode with -- before the prompt", async () => {
+  it("claude: read-only plan mode, system prompt by file, -- before the prompt", async () => {
     vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "test-claude-token-dummy");
     await new ClaudeProvider().completeVision(flagInjection);
 
@@ -49,9 +50,15 @@ describe("CLI vision argv construction", () => {
     const pmIdx = args.indexOf("--permission-mode");
     expect(pmIdx).toBeGreaterThanOrEqual(0);
     expect(args[pmIdx + 1]).toBe("plan");
+    // The carb-contract system prompt is installed authoritatively from a file
+    // (its contents are never an argv value), replacing the CLI default prompt.
+    const spIdx = args.indexOf("--system-prompt-file");
+    expect(spIdx).toBeGreaterThanOrEqual(0);
+    expect(typeof args[spIdx + 1]).toBe("string");
     // the prompt is the last arg, and `--` is immediately before it
     expect(args[args.length - 2]).toBe("--");
-    expect(args[args.length - 1]).toContain("--dangerously-skip-permissions");
+    // The flag-looking system text never appears on argv — it lives in the file.
+    expect(args.some((a: string) => a.includes("--dangerously-skip-permissions"))).toBe(false);
   });
 
   it("codex: runs read-only sandbox with -- before the prompt", async () => {


### PR DESCRIPTION
## Milestone H — Meal Intelligence safety rework

Reworks the meal-photo carb-estimation pipeline to match the measured reality of LLM carb vision: a model's self-reported confidence is uncorrelated with accuracy, and food misidentification is the dominant upstream error that grounding amplifies. This is the safety floor that restaurant grounding (E2) builds on.

### H1 — Multi-sample estimation + empirical confidence
- Samples the same photo N times (default 3, concurrent) and derives the carb range + confidence from the observed spread, not the model's self-reported confidence (retained only as internal audit data).
- Empirical band = union of usable samples; confidence = coefficient-of-variation band, with `high` requiring at least three usable samples (two agreeing draws is the lucky-draw problem one level up). Sample-level identity disagreement forces low confidence and flags the H2 gate.
- Per-sample reject-not-clamp bounds; graceful partial-failure. Mobile renders a visceral wide-spread caution treatment — consistency is never framed as "safe to dose."

### H2 —Food-identity confirmation gate
- Identity becomes a first-class, confirmable thing, distinct from carb correction. External grounding (USDA / Open Food Facts) runs only on a confirmed-or-corrected identity, so a confident misidentification is never certified with an authoritative citation.
- New `POST /api/food-records/{id}/confirm-identity`. Create is vision-only with an own-history suggested-identity pre-fill (one-tap confirm); confirming re-grounds and re-indexes own-history recall against the confirmed name.
- Mobile: identity field on the result card with confirm/correct, the own-history suggestion, and a disagreement cue.

### H3 — Estimate auditability & provenance retention
- New `food_record_audits` table stores the raw per-sample reads, the dispersion summary, and the precedence decision + identity used, so any estimate is answerable after the fact.
- Owner-scoped `GET /api/food-records/{id}/audit` ("how was this estimated"). The model's self-reported confidence is stored for internal eval but structurally stripped from the response. FK cascade ties the audit's lifetime to the record (single delete, retention purge, and user deletion all cascade).
- Mobile: a "How was this estimated?" affordance.

### Safety
Descriptive only — no dosing output anywhere, and nothing here is read by IoB / treatment_safety / carb-ratio math. The verify-before-dosing qualifier is preserved on every estimate surface.

### Migrations
`070_food_record_identity`, `071_food_record_audit_provenance` — single-head, chained off `069`.

### Testing and review
- Backend: pytest green across the meal/grounding cluster plus a full H1→H2→H3 end-to-end chain test (real HTTP + database, vision mocked); ruff check + format clean.
- Mobile: compiles; unit tests green (DTO→domain mappings); instrumented Compose UI tests for the H1 dispersion, H2 identity, and H3 audit surfaces.
- Adversarial + senior code review per story (all HIGH/MEDIUM addressed); security review of the diff passed (no secrets; SSRF / PHI / IDOR / authz clean).
- Sentry runtime validation gate: to run before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added food identity confirmation: confirm or correct the identified food label for a record.
  * Added multi-sample meal estimation with empirically derived confidence/range.
  * Added an estimate audit trail (“How was this estimated?”) with provenance and per-sample details.
  * Added dispersion uncertainty notes in the meal UI (wide-spread and identity-disagreement cautions), plus an on-demand audit panel.

* **Bug Fixes**
  * Ensured audit/grounding behavior matches identity-confirmation state, and self-reported confidence is not shown. 
  * Improved robustness for partial multi-sample vision failures and tightened safety text handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Update — review findings addressed + subscription chat persona fix folded in

Resolved all review threads (4 CodeRabbit + 1 Sentry):
- `food_vision`: the dosing-scrub warning counted samples whose description was never nulled — now counts only actual scrubs.
- `meal_estimate_aggregate`: identity clustering is now true single-link (match any cluster member, not just the anchor), so transitive matches don't read as false disagreement.
- `MealLogScreen`: Confirm is driven by one normalized identity candidate; the editor blocks blank submissions.
- `MealLogViewModel`: confirm-identity and audit responses are guarded against record switches (stale responses can't overwrite the active record).

Also folds in a fix discovered during this milestone's subscription-path validation: on the Claude **subscription** path the sidecar inlined the app system prompt as `[System]:` text, so `claude --print` answered under its default Claude Code identity and disowned the GlycemicGPT persona on ambiguous input. It now installs the system prompt authoritatively via `--system-prompt-file` for chat and vision (latent bug, predates the vision work). Verified end-to-end live and with new sidecar tests.
