### PR TITLE
fix(sidecar): install ca-certificates so codex (ChatGPT subscription) works

### DIFF
--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -6,8 +6,14 @@
 
 FROM node:22-slim AS base
 
-# Install curl for healthcheck
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+# curl: healthcheck. ca-certificates: the Rust `codex` binary uses the system
+# trust store for TLS (unlike the Node-based `claude`, which bundles its own CA
+# roots), and node:*-slim ships no CA bundle — without this, every codex HTTPS
+# call to OpenAI fails and ChatGPT subscription can't authenticate or run.
+# (codex's read-only sandbox uses a bundled bubblewrap; we deliberately do NOT
+# apt-install bubblewrap, which would need user-namespace perms and can fail in
+# unprivileged containers.)
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI and Codex CLI globally

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -10,9 +10,10 @@ FROM node:22-slim AS base
 # trust store for TLS (unlike the Node-based `claude`, which bundles its own CA
 # roots), and node:*-slim ships no CA bundle — without this, every codex HTTPS
 # call to OpenAI fails and ChatGPT subscription can't authenticate or run.
-# (codex's read-only sandbox uses a bundled bubblewrap; we deliberately do NOT
-# apt-install bubblewrap, which would need user-namespace perms and can fail in
-# unprivileged containers.)
+# (codex bundles its own bubblewrap for its read-only sandbox, so we do not
+# apt-install a second copy. Note: both the bundled and a system bwrap rely on
+# unprivileged user namespaces, so the deployment must permit them for
+# `codex exec --sandbox read-only` to engage.)
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

The AI sidecar image (`node:22-slim`) ships **no system CA bundle**, so the Rust `codex` binary — which uses the system trust store — fails every HTTPS call to OpenAI at the TLS layer. The Node-based `claude` CLI bundles its own CA roots, which is why Claude subscription worked while **ChatGPT subscription never could** (codex vision and chat both fail before any request lands).

This installs **`ca-certificates`**, which fixes codex TLS to OpenAI (unblocks ChatGPT subscription auth + vision + chat).

Note: bubblewrap is **intentionally not installed**. codex ships its own bundled `bwrap` for its read-only sandbox, so a system copy would be redundant. (Both the bundled and a system `bwrap` rely on unprivileged user namespaces, which the deployment must permit for `codex exec --sandbox read-only` to engage.)

## Verification (local)

- Before: `codex login --device-auth` → `error sending request for url (auth.openai.com/...)`; `/etc/ssl/certs/ca-certificates.crt` absent (0 certs).
- After: 285 CA certs present; codex device-auth sign-in completes, `codex login status` → "Logged in using ChatGPT", `codex exec` runs cleanly, `/health` → `codex_auth: true`.

Dockerfile-only change; no application code touched. Follow-up (#749) fixes the codex **chat** invocation so ChatGPT chat responds. Merge this PR first (or together with #749): #749's codex chat needs this CA bundle at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the sidecar container image to include additional system trust certificates alongside curl, improving TLS certificate validation at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
