### PR TITLE
fix(sidecar): route codex (ChatGPT subscription) chat through codex exec --json

### DIFF
--- a/sidecar/src/providers/codex.ts
+++ b/sidecar/src/providers/codex.ts
@@ -37,26 +37,24 @@ const AUTH_FILE = join(CODEX_HOME, "auth.json");
 const SUBPROCESS_TIMEOUT_MS = 120_000;
 /** Maximum buffer size (10 MB) */
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
-/** Maximum prompt length (100 KB) */
+/**
+ * Maximum prompt size, in UTF-8 bytes. The prompt is passed to the codex CLI as
+ * a single positional argv element, and the Linux kernel caps one argument at
+ * MAX_ARG_STRLEN (128 KB) regardless of the much larger total ARG_MAX — so this
+ * must be measured in bytes, not JS string length, to stay safely under it.
+ */
 const MAX_PROMPT_LENGTH = 100_000;
 
-/** Strict allowlist of model names */
-const MODEL_MAP: Record<string, string> = {
-  "gpt-4o": "gpt-4o",
-  "gpt-4": "gpt-4",
-  "gpt-4-turbo": "gpt-4-turbo",
-  "o3-mini": "o3-mini",
-  "chatgpt-subscription": "gpt-4o",
-};
-
-/** Resolve model name. Rejects unknown models. */
-export function resolveModel(model?: string): string {
-  if (!model) return "gpt-4o";
-  const resolved = MODEL_MAP[model];
-  if (!resolved) {
-    throw new Error(`Unsupported model: ${model}`);
+/**
+ * Reject a prompt that would exceed the single-argv byte limit. Measured on
+ * UTF-8 bytes (not `.length`, which counts UTF-16 code units) so multibyte text
+ * cannot slip past the guard and trip an opaque E2BIG at spawn.
+ */
+function assertPromptWithinLimit(prompt: string): void {
+  const bytes = Buffer.byteLength(prompt, "utf8");
+  if (bytes > MAX_PROMPT_LENGTH) {
+    throw new Error(`Prompt too long (${bytes} bytes, max ${MAX_PROMPT_LENGTH})`);
   }
-  return resolved;
 }
 
 /** Check whether a Codex credential (ChatGPT account or API key) is configured. */
@@ -101,11 +99,7 @@ function messagesToPrompt(messages: ChatMessage[]): string {
     })
     .join("\n\n");
 
-  if (prompt.length > MAX_PROMPT_LENGTH) {
-    throw new Error(
-      `Prompt too long (${prompt.length} chars, max ${MAX_PROMPT_LENGTH})`,
-    );
-  }
+  assertPromptWithinLimit(prompt);
   return prompt;
 }
 
@@ -239,9 +233,7 @@ export class CodexProvider implements AIProvider, VisionRunner {
       throw new InvalidImageError("no image provided for a vision request");
     }
     const prompt = [systemText, userText].filter(Boolean).join("\n\n");
-    if (prompt.length > MAX_PROMPT_LENGTH) {
-      throw new Error(`Prompt too long (${prompt.length} chars, max ${MAX_PROMPT_LENGTH})`);
-    }
+    assertPromptWithinLimit(prompt);
     const temp = writeImagesToTempDir(images);
     try {
       return await runCodexVision(prompt, temp.paths, temp.dir);

--- a/sidecar/src/providers/codex.ts
+++ b/sidecar/src/providers/codex.ts
@@ -7,8 +7,8 @@
  * OPENAI_API_KEY env var as fallback for direct API usage.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   flattenVisionRequest,
@@ -109,38 +109,65 @@ function messagesToPrompt(messages: ChatMessage[]): string {
   return prompt;
 }
 
-/** Spawn the Codex CLI, passing prompt via stdin */
-function spawnCodex(prompt: string, model: string): ChildProcess {
-  const env: Record<string, string> = { ...process.env } as Record<
-    string,
-    string
-  >;
-  env.CODEX_HOME = CODEX_HOME;
-
-  const child = spawn(
-    "codex",
-    [
-      "--model",
-      model, // Already validated by resolveModel()
-      "--quiet",
-    ],
-    {
-      env,
-      stdio: ["pipe", "pipe", "pipe"],
-    },
-  );
-
-  // Write prompt to stdin and close
-  child.stdin?.write(prompt);
-  child.stdin?.end();
-
-  return child;
+/**
+ * Extract the assistant's final message from `codex exec --json` JSONL output.
+ * The clean reply is the text of each `agent_message` item; non-JSON lines
+ * (e.g. the CLI's "Reading additional input…" notice) are ignored.
+ */
+export function extractCodexMessage(stdout: string): string {
+  const parts: string[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const event = JSON.parse(trimmed);
+      if (
+        event?.type === "item.completed" &&
+        event?.item?.type === "agent_message" &&
+        typeof event.item.text === "string"
+      ) {
+        parts.push(event.item.text);
+      }
+    } catch {
+      // Not a JSON event line — skip.
+    }
+  }
+  return parts.join("\n").trim();
 }
 
-/** Kill a child process and clear its timeout */
-function cleanupChild(child: ChildProcess, timer: ReturnType<typeof setTimeout>): void {
-  clearTimeout(timer);
-  if (!child.killed) child.kill();
+/**
+ * Run the Codex CLI non-interactively for a text turn:
+ * `codex exec --json --sandbox read-only --skip-git-repo-check -- <prompt>`.
+ *
+ * Mirrors the vision path (runCodexVision): read-only sandbox, an end-of-options
+ * `--` before the (attacker-influenced) prompt, and NO forced `--model` — a
+ * ChatGPT-account Codex only accepts its own models (e.g. gpt-5.5) and rejects
+ * API names like gpt-4o. `--json` yields structured events so we return the
+ * agent's final message without the session preamble / token-usage noise that
+ * the plain text output carries.
+ */
+async function runCodexExec(prompt: string): Promise<ProviderResult> {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  env.CODEX_HOME = CODEX_HOME;
+  const { stdout, code } = await runCapture(
+    "codex",
+    ["exec", "--json", "--sandbox", "read-only", "--skip-git-repo-check", "--", prompt],
+    {
+      env,
+      cwd: tmpdir(),
+      timeoutMs: SUBPROCESS_TIMEOUT_MS,
+      maxBufferBytes: MAX_BUFFER_BYTES,
+      label: "Codex",
+    },
+  );
+  if (code !== 0) {
+    throw new Error("AI provider returned an error");
+  }
+  const content = extractCodexMessage(stdout);
+  if (!content) {
+    throw new Error("AI provider returned no usable output");
+  }
+  return { content, model: "codex" };
 }
 
 /**
@@ -236,107 +263,23 @@ export class CodexProvider implements AIProvider, VisionRunner {
 
   async complete(
     messages: ChatMessage[],
-    model?: string,
+    _model?: string,
   ): Promise<ProviderResult> {
-    const prompt = messagesToPrompt(messages);
-    const cliModel = resolveModel(model);
-
-    return new Promise((resolve, reject) => {
-      const child = spawnCodex(prompt, cliModel);
-      let stdout = "";
-      let stdoutSize = 0;
-      let stderrSize = 0;
-
-      const timer = setTimeout(() => {
-        child.kill();
-        reject(new Error("AI provider request timed out"));
-      }, SUBPROCESS_TIMEOUT_MS);
-
-      child.stdout?.on("data", (chunk: Buffer) => {
-        stdoutSize += chunk.length;
-        if (stdoutSize > MAX_BUFFER_BYTES) {
-          cleanupChild(child, timer);
-          reject(new Error("AI provider response too large"));
-          return;
-        }
-        stdout += chunk.toString();
-      });
-      child.stderr?.on("data", (chunk: Buffer) => {
-        stderrSize += chunk.length;
-        if (stderrSize > MAX_BUFFER_BYTES) {
-          cleanupChild(child, timer);
-          reject(new Error("AI provider error output too large"));
-        }
-      });
-
-      child.on("error", (err) => {
-        clearTimeout(timer);
-        reject(new Error(`Codex CLI failed to start: ${err.message}`));
-      });
-
-      child.on("close", (code) => {
-        clearTimeout(timer);
-        if (code !== 0) {
-          reject(new Error("AI provider returned an error"));
-          return;
-        }
-        resolve({ content: stdout.trim(), model: cliModel });
-      });
-    });
+    // The prompt carries the system text inline (messagesToPrompt); authoritative
+    // persona delivery for codex is tracked separately (Epic 52 M4). The model is
+    // not forwarded — a ChatGPT-account Codex picks its own model (see runCodexExec).
+    return runCodexExec(messagesToPrompt(messages));
   }
 
   async stream(
     messages: ChatMessage[],
-    model?: string,
+    _model?: string,
     onChunk?: (text: string) => void,
   ): Promise<ProviderResult> {
-    const prompt = messagesToPrompt(messages);
-    const cliModel = resolveModel(model);
-
-    return new Promise((resolve, reject) => {
-      const child = spawnCodex(prompt, cliModel);
-      let content = "";
-      let totalSize = 0;
-      let stderrSize = 0;
-
-      const timer = setTimeout(() => {
-        child.kill();
-        reject(new Error("AI provider request timed out"));
-      }, SUBPROCESS_TIMEOUT_MS);
-
-      child.stdout?.on("data", (chunk: Buffer) => {
-        totalSize += chunk.length;
-        if (totalSize > MAX_BUFFER_BYTES) {
-          cleanupChild(child, timer);
-          reject(new Error("AI provider response too large"));
-          return;
-        }
-        const text = chunk.toString();
-        content += text;
-        onChunk?.(text);
-      });
-
-      child.stderr?.on("data", (chunk: Buffer) => {
-        stderrSize += chunk.length;
-        if (stderrSize > MAX_BUFFER_BYTES) {
-          cleanupChild(child, timer);
-          reject(new Error("AI provider error output too large"));
-        }
-      });
-
-      child.on("error", (err) => {
-        clearTimeout(timer);
-        reject(new Error(`Codex CLI failed to start: ${err.message}`));
-      });
-
-      child.on("close", (code) => {
-        clearTimeout(timer);
-        if (code !== 0 && !content) {
-          reject(new Error("AI provider returned an error"));
-          return;
-        }
-        resolve({ content: content.trim(), model: cliModel });
-      });
-    });
+    // `codex exec` returns a single final message rather than a token stream, so
+    // surface it as one chunk. (The web chat path uses complete(), not stream.)
+    const result = await runCodexExec(messagesToPrompt(messages));
+    onChunk?.(result.content);
+    return result;
   }
 }

--- a/sidecar/src/server.ts
+++ b/sidecar/src/server.ts
@@ -143,8 +143,9 @@ app.use((req, res, next) => {
 function isCodexModel(model?: string): boolean {
   if (!model) return false;
   const lower = model.toLowerCase();
-  // Only models the Codex provider actually resolves (see codex.ts MODEL_MAP):
-  // gpt-*, codex, and o3-mini. (No o1 alias is supported.)
+  // Provider-selection heuristic: gpt-*, codex, and o3 names route to the Codex
+  // CLI (which then picks the account-appropriate model itself; we don't forward
+  // a model name). No o1 alias is supported.
   return lower.includes("gpt") || lower.includes("codex") || lower.includes("o3");
 }
 

--- a/sidecar/tests/codex-chat.test.ts
+++ b/sidecar/tests/codex-chat.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tmpdir } from "node:os";
 
 const { mockRunCapture } = vi.hoisted(() => ({ mockRunCapture: vi.fn() }));
 vi.mock("../src/providers/subprocess.js", () => ({ runCapture: mockRunCapture }));
@@ -40,6 +41,17 @@ describe("extractCodexMessage", () => {
   it("returns empty when there is no agent_message", () => {
     expect(extractCodexMessage('{"type":"turn.completed"}')).toBe("");
   });
+
+  it("excludes item.completed events whose item.type is not agent_message", () => {
+    // codex exec --json also emits reasoning / command_execution / etc. items;
+    // only the agent_message text may reach the user-facing reply.
+    const raw = [
+      '{"type":"item.completed","item":{"type":"reasoning","text":"internal thoughts"}}',
+      '{"type":"item.completed","item":{"type":"agent_message","text":"visible reply"}}',
+      '{"type":"item.completed","item":{"type":"command_execution","text":"ls -la"}}',
+    ].join("\n");
+    expect(extractCodexMessage(raw)).toBe("visible reply");
+  });
 });
 
 describe("CodexProvider.complete — chat via `codex exec`", () => {
@@ -61,7 +73,7 @@ describe("CodexProvider.complete — chat via `codex exec`", () => {
     expect(result.model).toBe("codex");
 
     expect(mockRunCapture).toHaveBeenCalledTimes(1);
-    const [command, args] = mockRunCapture.mock.calls[0];
+    const [command, args, opts] = mockRunCapture.mock.calls[0];
     expect(command).toBe("codex");
     expect(args.slice(0, 5)).toEqual([
       "exec",
@@ -74,7 +86,16 @@ describe("CodexProvider.complete — chat via `codex exec`", () => {
     expect(args).not.toContain("--model");
     // End-of-options separator immediately before the positional prompt.
     expect(args[args.length - 2]).toBe("--");
-    expect(typeof args[args.length - 1]).toBe("string");
+    // The positional prompt carries the flattened system + user text.
+    const prompt = args[args.length - 1];
+    expect(prompt).toContain("You are GlycemicGPT.");
+    expect(prompt).toContain("test");
+    // Run isolated (outside any git repo) with codex auth discovery wired up.
+    expect(opts.cwd).toBe(tmpdir());
+    expect(opts.label).toBe("Codex");
+    expect(opts.timeoutMs).toBe(120_000);
+    expect(opts.maxBufferBytes).toBe(10 * 1024 * 1024);
+    expect(opts.env.CODEX_HOME).toBeTruthy();
   });
 
   it("throws when codex exits non-zero", async () => {
@@ -82,5 +103,53 @@ describe("CodexProvider.complete — chat via `codex exec`", () => {
     await expect(new CodexProvider().complete(messages)).rejects.toThrow(
       "AI provider returned an error",
     );
+  });
+
+  it("throws 'no usable output' when codex exits 0 but emits no agent_message", async () => {
+    mockRunCapture.mockResolvedValue({ stdout: '{"type":"turn.completed"}', code: 0 });
+    await expect(new CodexProvider().complete(messages)).rejects.toThrow(
+      "AI provider returned no usable output",
+    );
+  });
+
+  it("rejects an oversize prompt by UTF-8 bytes (not chars) before spawning codex", async () => {
+    // 40k multibyte chars = 40k UTF-16 code units (well under the old char cap)
+    // but 120k UTF-8 bytes — which would trip an opaque E2BIG at spawn. The
+    // byte-measured guard rejects it cleanly and never invokes the CLI.
+    const oversize: ChatMessage[] = [{ role: "user", content: "あ".repeat(40_000) }];
+    await expect(new CodexProvider().complete(oversize)).rejects.toThrow(
+      /Prompt too long \(\d+ bytes/,
+    );
+    expect(mockRunCapture).not.toHaveBeenCalled();
+  });
+});
+
+describe("CodexProvider.stream — chat via `codex exec`", () => {
+  const messages: ChatMessage[] = [
+    { role: "system", content: "You are GlycemicGPT." },
+    { role: "user", content: "test" },
+  ];
+
+  beforeEach(() => {
+    mockRunCapture.mockReset();
+  });
+
+  it("emits the extracted message as a single chunk and returns it", async () => {
+    mockRunCapture.mockResolvedValue({ stdout: AGENT_JSONL, code: 0 });
+    const chunks: string[] = [];
+    const result = await new CodexProvider().stream(messages, "gpt-4o", (c) =>
+      chunks.push(c),
+    );
+    // codex exec yields a final message, not a token stream → exactly one chunk.
+    expect(chunks).toEqual(["hi from chatgpt"]);
+    expect(result.content).toBe("hi from chatgpt");
+    expect(result.model).toBe("codex");
+  });
+
+  it("throws when codex exits non-zero", async () => {
+    mockRunCapture.mockResolvedValue({ stdout: "", code: 1 });
+    await expect(
+      new CodexProvider().stream(messages, undefined, () => {}),
+    ).rejects.toThrow("AI provider returned an error");
   });
 });

--- a/sidecar/tests/codex-chat.test.ts
+++ b/sidecar/tests/codex-chat.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the Codex (ChatGPT subscription) CHAT path.
+ *
+ * `runCapture` is mocked, so no subprocess runs. These pin the fix that routes
+ * chat through `codex exec --json` (the same invocation as the vision path),
+ * with NO forced `--model` (a ChatGPT-account Codex rejects API model names like
+ * gpt-4o), and that the clean agent message is extracted from the JSONL events
+ * rather than returning the raw session preamble / token-usage noise.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockRunCapture } = vi.hoisted(() => ({ mockRunCapture: vi.fn() }));
+vi.mock("../src/providers/subprocess.js", () => ({ runCapture: mockRunCapture }));
+
+import { CodexProvider, extractCodexMessage } from "../src/providers/codex.js";
+import type { ChatMessage } from "../src/providers/types.js";
+
+const AGENT_JSONL = [
+  '{"type":"thread.started","thread_id":"t1"}',
+  '{"type":"turn.started"}',
+  '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi from chatgpt"}}',
+  '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":3}}',
+].join("\n");
+
+describe("extractCodexMessage", () => {
+  it("returns the agent_message text, ignoring non-JSON lines and other events", () => {
+    const raw = "Reading additional input from stdin...\n" + AGENT_JSONL;
+    expect(extractCodexMessage(raw)).toBe("hi from chatgpt");
+  });
+
+  it("joins multiple agent messages and trims", () => {
+    const raw = [
+      '{"type":"item.completed","item":{"type":"agent_message","text":"line1"}}',
+      '{"type":"item.completed","item":{"type":"agent_message","text":"line2"}}',
+    ].join("\n");
+    expect(extractCodexMessage(raw)).toBe("line1\nline2");
+  });
+
+  it("returns empty when there is no agent_message", () => {
+    expect(extractCodexMessage('{"type":"turn.completed"}')).toBe("");
+  });
+});
+
+describe("CodexProvider.complete — chat via `codex exec`", () => {
+  const messages: ChatMessage[] = [
+    { role: "system", content: "You are GlycemicGPT." },
+    { role: "user", content: "test" },
+  ];
+
+  beforeEach(() => {
+    mockRunCapture.mockReset();
+  });
+
+  it("runs `codex exec --json` read-only, with no forced --model and -- before the prompt", async () => {
+    mockRunCapture.mockResolvedValue({ stdout: AGENT_JSONL, code: 0 });
+
+    const result = await new CodexProvider().complete(messages, "gpt-4o");
+    // Clean message extracted from the JSONL, not the raw transcript.
+    expect(result.content).toBe("hi from chatgpt");
+    expect(result.model).toBe("codex");
+
+    expect(mockRunCapture).toHaveBeenCalledTimes(1);
+    const [command, args] = mockRunCapture.mock.calls[0];
+    expect(command).toBe("codex");
+    expect(args.slice(0, 5)).toEqual([
+      "exec",
+      "--json",
+      "--sandbox",
+      "read-only",
+      "--skip-git-repo-check",
+    ]);
+    // A ChatGPT-account Codex rejects forced API model names — none must be sent.
+    expect(args).not.toContain("--model");
+    // End-of-options separator immediately before the positional prompt.
+    expect(args[args.length - 2]).toBe("--");
+    expect(typeof args[args.length - 1]).toBe("string");
+  });
+
+  it("throws when codex exits non-zero", async () => {
+    mockRunCapture.mockResolvedValue({ stdout: "", code: 1 });
+    await expect(new CodexProvider().complete(messages)).rejects.toThrow(
+      "AI provider returned an error",
+    );
+  });
+});

--- a/sidecar/tests/providers.test.ts
+++ b/sidecar/tests/providers.test.ts
@@ -162,19 +162,6 @@ describe("CodexProvider", () => {
     expect(state.authenticated).toBe(false);
   });
 
-  it("resolves known model names", async () => {
-    const { resolveModel } = await import("../src/providers/codex.js");
-    expect(resolveModel("gpt-4o")).toBe("gpt-4o");
-    expect(resolveModel("o3-mini")).toBe("o3-mini");
-    expect(resolveModel()).toBe("gpt-4o"); // default
-  });
-
-  it("rejects unknown model names", async () => {
-    const { resolveModel } = await import("../src/providers/codex.js");
-    expect(() => resolveModel("claude-sonnet-4")).toThrow("Unsupported model");
-    expect(() => resolveModel("--some-flag")).toThrow("Unsupported model");
-  });
-
   it("supportsVision tracks Codex auth availability", async () => {
     delete process.env.OPENAI_API_KEY;
     const { CodexProvider } = await import("../src/providers/codex.js");


### PR DESCRIPTION
## Summary

ChatGPT-subscription **chat** was broken even after auth: the sidecar's codex chat path ran `codex --model <model> --quiet`, which omits the `exec` subcommand (launches the interactive CLI → fails when piped), uses an invalid `--quiet` flag, and **forces `--model gpt-4o`** — which a ChatGPT-*account* Codex rejects (it only accepts its own models, e.g. `gpt-5.5`). Chat 500'd while auth and the model were fine.

This routes `complete()`/`stream()` through the **same invocation the vision path already uses** — `codex exec --json --sandbox read-only --skip-git-repo-check -- <prompt>`, **no forced model** — and extracts the agent's final message from the `--json` JSONL events (the `agent_message` item) so the reply is clean (no session preamble / token-usage noise). Removes the now-dead `spawnCodex`/`cleanupChild`.

## Verification

- 112 sidecar tests pass (incl. new `codex-chat.test.ts`: argv shape, no `--model`, clean-message extraction); `tsc` clean.
- **Live:** ChatGPT-subscription chat via `/api/ai/chat` returns HTTP 200 with a clean, on-persona reply (was a 502).

## Notes

- **Independent of #748 in code** (this only touches `codex.ts`), but #748 (`ca-certificates`) is required **at runtime** for codex to reach OpenAI over TLS — so both must land for ChatGPT subscription to actually work, though they merge independently.
- Codex still receives the system prompt **inline** — authoritative persona delivery for codex (codex has no `--system-prompt` flag) is tracked in the Epic 52 plan (M4), along with the per-surface central system/conversation split.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Codex provider to use JSON-based execution via the CLI in a read-only sandbox.

* **Improvements**
  * Completion and streaming now both use extracted `agent_message` output, producing a single final stream chunk.
  * Prompt size validation is enforced consistently across text and vision requests.
  * The provider no longer relies on the previously supported model resolution behavior.

* **Tests**
  * Added comprehensive coverage for JSONL message extraction, sandbox invocation, prompt-size rejection, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->