### PR TITLE
ci(security): suppress false-positive AES-ECB SAST finding in vendored SAKE crypto (#695/#696)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -184,11 +184,18 @@ jobs:
           github.event_name == 'workflow_dispatch'
         run: |
           EXIT=0
+          # AesEcb.java is vendored verbatim from OpenMinimed JavaSake (re-vendor, do not
+          # edit). Its single-block AES-ECB is a wire-mandated KDF / key-unwrap in the SAKE
+          # handshake -- integrity is provided by AES-CMAC and confidentiality by AES-CTR at
+          # other layers, so the ecb-cipher / use-of-aes-ecb findings are false positives
+          # (see #695/#696). Exclude the vendored file rather than adding an inline nosemgrep
+          # that would break its byte-for-byte vendoring.
           semgrep scan \
             --config p/kotlin \
             --config p/java \
             --config p/secrets \
             --exclude '.gradle' \
+            --exclude 'AesEcb.java' \
             --json --output semgrep-kotlin.json \
             apps/mobile/ plugins/ || EXIT=$?
           echo "semgrep_kotlin_exit=$EXIT" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Resolves #695 and #696 — Semgrep `ecb-cipher` / `use-of-aes-ecb` (CWE-327) findings in `plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/AesEcb.java`.

A due-diligence security review (multi-lens code + protocol + adversarial-crypto analysis) concluded these are **false positives with no fixable weakness**:

- **Single-block primitive.** `AesEcb` rejects any non-16-byte key/block. Used at exactly two sites, each on one 16-byte block: a one-shot **KDF** (`Session.java:201`, `sessionKey = AES_ECB(derivationKey, serverKM‖clientKM)`) and a 16-byte **permit key-unwrap** (`Session.java:220`) immediately gated by an AES-CMAC verify that throws on mismatch.
- **The cited ECB risks don't apply:** cross-block pattern leakage is impossible on a single block of fresh key material; integrity is provided by **AES-CMAC** at every layer; confidentiality of session traffic is **AES-CTR** (`SeqCrypt`); replay/ordering is bounded by `SeqCrypt` 40-bit sequence counters (in the CTR IV *and* CMAC input), a reorder window, an IV-reuse guard, and direction-distinct nonces. Keys are domain-separated (5 distinct 16-byte keys in `StaticKeys`).
- **Wire-mandated / unfixable.** `SessionTest` pins the ECB-derived session key (`99ab5c7c…`) to a real Medtronic 780G pairing trace — changing the mode breaks pairing. The file is vendored byte-identical from upstream commit `00c08ae` (re-vendor, do not edit); upstream has no fixed version.

## Change

Scoped `--exclude 'AesEcb.java'` on the Kotlin/Java Semgrep step. Chosen over an inline `nosemgrep` (would break the byte-for-byte vendoring) and over a repo-root `.semgrepignore` (would override Semgrep's default ignores for the whole `plugins/` tree). All other plugin code remains scanned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security scanning configuration to reduce false positives in automated scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->