### PR TITLE
feat: meal-vision safety-language hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,12 @@ jobs:
           ENCRYPTION_KEY: dGVzdC1lbmNyeXB0aW9uLWtleS0zMi1ieXRlcw==
         run: uv run pytest --tb=short -q
 
+      # Story 50.S: gate the vision carb-estimate contract — including the
+      # dosing-language safety scanner — in CI. These tests import the backend
+      # contract via a shim, so they run with the apps/api venv.
+      - name: Run vision eval-harness contract tests
+        run: uv run pytest --tb=short -q ../../evals/vision_carb/tests/
+
   test-frontend:
     name: Frontend Tests
     needs: detect-changes

--- a/apps/api/migrations/versions/072_add_user_disclaimer_version.py
+++ b/apps/api/migrations/versions/072_add_user_disclaimer_version.py
@@ -1,0 +1,40 @@
+"""Add disclaimer_version column to users (version-aware re-acknowledgment).
+
+The authenticated disclaimer flow previously stored only a boolean
+``disclaimer_acknowledged``, so a version bump had to force re-consent with a
+one-shot reset migration (see ``056_reset_disclaimer_for_v1_1``, whose own note
+recommends adding this column instead). This adds the column so the auth flow
+mirrors the session flow: ``has_acknowledged_current`` counts an acknowledgment
+only when the stored version equals the current DISCLAIMER_VERSION.
+
+The column is nullable with no backfill: every existing acknowledged user has
+``disclaimer_version = NULL``, which does not equal the current version, so they
+are re-prompted exactly once for the v1.2 (Story 50.S photo carb-estimate)
+wording -- and every future bump re-prompts automatically with no new migration.
+
+Revision ID: 072_add_user_disclaimer_version
+Revises: 071_food_record_audit_provenance
+Create Date: 2026-06-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "072_add_user_disclaimer_version"
+down_revision = "071_food_record_audit_provenance"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Nullable, no server default: a NULL on existing rows is intentional -- it
+    # means "acknowledged an unknown/older version" and re-prompts those users
+    # for the current disclaimer. New acknowledgments set it via /acknowledge-auth.
+    op.add_column(
+        "users",
+        sa.Column("disclaimer_version", sa.String(length=10), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "disclaimer_version")

--- a/apps/api/src/core/disclaimer.py
+++ b/apps/api/src/core/disclaimer.py
@@ -1,0 +1,45 @@
+"""Single source of truth for the safety-disclaimer version and its check.
+
+Lives in ``core`` (a leaf module) so the disclaimer router, the auth router, and
+the user response schema can share the version-gating logic without importing
+one another.
+
+Version-bump contract: incrementing :data:`DISCLAIMER_VERSION` must re-prompt
+*every* surface.
+
+* Session (pre-auth) flow: ``/api/disclaimer/status`` compares the stored
+  ``DisclaimerAcknowledgment.disclaimer_version``; ``/acknowledge`` advances it.
+* Authenticated flow: the ``users.disclaimer_version`` column is compared via
+  :func:`has_acknowledged_current`; ``/acknowledge-auth`` advances it. This
+  replaces the one-shot reset migration used for v1.1 (see migration
+  ``056_reset_disclaimer_for_v1_1`` -- its own note recommends this column).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+# Current disclaimer version -- increment when the disclaimer text changes.
+# 1.1: added AI data-handling acknowledgment (cloud vs local provider data flow).
+# 1.2: added photo carb-estimate (vision) acknowledgment (Story 50.S).
+DISCLAIMER_VERSION = "1.2"
+
+
+class _AcknowledgingUser(Protocol):
+    """Structural type for the user fields the version check reads."""
+
+    disclaimer_acknowledged: bool
+    disclaimer_version: str | None
+
+
+def has_acknowledged_current(user: _AcknowledgingUser) -> bool:
+    """Return ``True`` only if the user acknowledged the *current* disclaimer.
+
+    An acknowledgment recorded for an older version (or none at all) does not
+    count, so bumping :data:`DISCLAIMER_VERSION` re-prompts authenticated users
+    on their next request -- mirroring the session-based flow and removing the
+    need for a reset migration on every bump.
+    """
+    return bool(user.disclaimer_acknowledged) and (
+        user.disclaimer_version == DISCLAIMER_VERSION
+    )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -38,6 +38,9 @@ class User(Base, TimestampMixin):
         is_active: Whether the account is active
         email_verified: Whether the email has been verified
         disclaimer_acknowledged: Whether user has acknowledged the disclaimer
+        disclaimer_version: Version of the disclaimer the user acknowledged
+            (NULL until first acknowledged). A mismatch with the current
+            DISCLAIMER_VERSION re-prompts the user; see src.core.disclaimer.
         last_login_at: Timestamp of last successful login
     """
 
@@ -76,6 +79,13 @@ class User(Base, TimestampMixin):
     )
     disclaimer_acknowledged: Mapped[bool] = mapped_column(
         default=False,
+    )
+    # Version the user acknowledged; NULL until first ack. Gated against the
+    # current DISCLAIMER_VERSION so a bump re-prompts (see src.core.disclaimer).
+    disclaimer_version: Mapped[str | None] = mapped_column(
+        String(10),
+        nullable=True,
+        default=None,
     )
     display_name: Mapped[str | None] = mapped_column(
         String(100),

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
 from src.core.auth import CurrentUser
+from src.core.disclaimer import has_acknowledged_current
 from src.core.security import (
     _DUMMY_HASH,
     create_access_token,
@@ -165,7 +166,7 @@ async def register_user(
             email=user.email,
             role=user.role,
             message="Registration successful",
-            disclaimer_required=not user.disclaimer_acknowledged,
+            disclaimer_required=not has_acknowledged_current(user),
         )
 
     except IntegrityError:
@@ -299,7 +300,7 @@ async def login(
     return LoginResponse(
         message="Login successful",
         user=UserResponse.model_validate(user),
-        disclaimer_required=not user.disclaimer_acknowledged,
+        disclaimer_required=not has_acknowledged_current(user),
     )
 
 

--- a/apps/api/src/routers/disclaimer.py
+++ b/apps/api/src/routers/disclaimer.py
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/api/disclaimer", tags=["Disclaimer"])
 
 # Current disclaimer version - increment when disclaimer text changes.
 # 1.1: added AI data-handling acknowledgment (cloud vs local provider data flow).
-DISCLAIMER_VERSION = "1.1"
+DISCLAIMER_VERSION = "1.2"
 
 
 @router.get("/status", response_model=DisclaimerStatusResponse)
@@ -227,6 +227,18 @@ async def get_disclaimer_content() -> dict[str, Any]:
                 "icon": "brain",
                 "title": "AI Limitations",
                 "text": "AI can and will make mistakes. All suggestions should be verified with your healthcare provider before acting on them.",
+            },
+            {
+                "icon": "camera",
+                "title": "Photo Carb Estimates Are Guesses",
+                "text": (
+                    "If you use the meal-photo feature, the carbohydrate numbers "
+                    "are AI estimates from an image and are frequently wrong -- "
+                    "including misidentifying the food entirely. They are a rough "
+                    "starting point only. Never use a photo carb estimate to "
+                    "calculate an insulin dose or bolus, and always verify carbs "
+                    "yourself before dosing."
+                ),
             },
             {
                 "icon": "shield-x",

--- a/apps/api/src/routers/disclaimer.py
+++ b/apps/api/src/routers/disclaimer.py
@@ -6,6 +6,7 @@ FR51: User must acknowledge disclaimer before using system
 """
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -14,6 +15,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import CurrentUser
+
+# DISCLAIMER_VERSION is canonical in src.core.disclaimer; re-exported here because
+# tests and historical callers import it from this router module.
+from src.core.disclaimer import DISCLAIMER_VERSION, has_acknowledged_current
 from src.database import get_db, get_session_maker
 from src.models.disclaimer import DisclaimerAcknowledgment
 from src.schemas.disclaimer import (
@@ -25,10 +30,6 @@ from src.schemas.disclaimer import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/disclaimer", tags=["Disclaimer"])
-
-# Current disclaimer version - increment when disclaimer text changes.
-# 1.1: added AI data-handling acknowledgment (cloud vs local provider data flow).
-DISCLAIMER_VERSION = "1.2"
 
 
 @router.get("/status", response_model=DisclaimerStatusResponse)
@@ -112,6 +113,32 @@ async def acknowledge_disclaimer(
         existing = result.scalar_one_or_none()
 
         if existing:
+            if existing.disclaimer_version != DISCLAIMER_VERSION:
+                # Re-acknowledgment of a newer disclaimer version. session_id is
+                # unique and never rotates client-side, so we must advance the
+                # stored version here -- otherwise /status keeps reporting
+                # not-acknowledged and the user is trapped in a re-acknowledge
+                # loop after a version bump.
+                existing.disclaimer_version = DISCLAIMER_VERSION
+                existing.acknowledged_at = datetime.now(UTC)
+                existing.ip_address = client_ip
+                existing.user_agent = user_agent
+                await session.commit()
+                await session.refresh(existing)
+                logger.info(
+                    "Disclaimer re-acknowledged for new version",
+                    extra={
+                        "session_id": data.session_id,
+                        "ip_address": client_ip,
+                        "version": DISCLAIMER_VERSION,
+                    },
+                )
+                return DisclaimerAcknowledgeResponse(
+                    success=True,
+                    acknowledged_at=existing.acknowledged_at,
+                    message="Disclaimer acknowledged successfully",
+                )
+
             logger.info(
                 "Disclaimer already acknowledged",
                 extra={
@@ -180,6 +207,10 @@ async def acknowledge_disclaimer_auth(
     This is separate from the session-based acknowledgment used on the
     landing page (pre-auth).
 
+    Records the acknowledged version too, so a future DISCLAIMER_VERSION bump
+    re-prompts authenticated users (mirrors the session flow) without a one-shot
+    reset migration.
+
     Args:
         current_user: The authenticated user from the session cookie
         db: Database session
@@ -187,10 +218,11 @@ async def acknowledge_disclaimer_auth(
     Returns:
         Success response
     """
-    if current_user.disclaimer_acknowledged:
+    if has_acknowledged_current(current_user):
         return {"success": True, "message": "Disclaimer was previously acknowledged"}
 
     current_user.disclaimer_acknowledged = True
+    current_user.disclaimer_version = DISCLAIMER_VERSION
     await db.commit()
     await db.refresh(current_user)
 

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -7,8 +7,9 @@ import re
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
 
+from src.core.disclaimer import has_acknowledged_current
 from src.models.user import UserRole
 
 
@@ -67,7 +68,20 @@ class UserResponse(BaseModel):
     is_active: bool
     email_verified: bool
     disclaimer_acknowledged: bool
+    disclaimer_version: str | None = None
     created_at: datetime
+
+    @model_validator(mode="after")
+    def _gate_acknowledged_on_version(self) -> "UserResponse":
+        """Report ``disclaimer_acknowledged`` as version-aware.
+
+        A stored acknowledgment for an older disclaimer version reads as
+        not-acknowledged, so clients that gate on this field (the web
+        AuthDisclaimerGate) re-prompt on a version bump without needing to know
+        the current version themselves.
+        """
+        self.disclaimer_acknowledged = has_acknowledged_current(self)
+        return self
 
 
 class ErrorResponse(BaseModel):

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel, Field, model_validator
 
 from src.models.food_record import FoodRecordSource
-from src.vision.carb_contract import CARB_GRAMS_MAX, CARB_GRAMS_MIN
+from src.vision.carb_contract import CARB_GRAMS_MAX, CARB_GRAMS_MIN, SAFETY_QUALIFIER
 
 if TYPE_CHECKING:
     from src.models.food_record_audit import FoodRecordAudit
@@ -115,6 +115,10 @@ class FoodRecordResponse(BaseModel):
     carbs_low: float = Field(ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
     carbs_high: float = Field(ge=CARB_GRAMS_MIN, le=CARB_GRAMS_MAX)
     confidence: str | None = None
+    # Server-emitted safety qualifier (Story 50.S): a constant that travels with
+    # every estimate so a non-mobile client can't render carbs without the
+    # "this is a guess, never dose from it" framing. Mirrors the mobile string.
+    safety_qualifier: str = Field(default=SAFETY_QUALIFIER)
     nutrition_json: dict | None = None
     source: FoodRecordSource
     corrected_carbs_low: float | None = Field(

--- a/apps/api/src/vision/carb_contract.py
+++ b/apps/api/src/vision/carb_contract.py
@@ -111,18 +111,30 @@ USER_PROMPT = (
 )
 
 # Phrasing that would turn a description into dosing advice. Its presence in a
-# response is a safety-posture violation. Bare "units" is NOT
-# flagged on its own (it has benign uses, e.g. "unit of measurement") -- only
-# insulin units / a dosing verb near "units" / explicit dosing terms.
+# response is a safety-posture violation. Bare "units" is NOT flagged on its own
+# (it has benign uses, e.g. "unit of measurement") -- only insulin units / a
+# dosing-or-suggestion verb near "units" / the "Nu"/"NU" insulin-unit
+# abbreviation (e.g. "6u", "take 4U") / explicit dosing terms.
 _DOSING_PATTERNS = re.compile(
     r"\b("
     r"insulin|bolus(?:es|ing)?|"
     r"units?\s+of\s+insulin|"
-    r"(?:take|inject|administer|give|deliver|dose|dosing)\b[^.]{0,40}\bunits?\b|"
+    r"(?:take|inject|administer|give|deliver|dose|dosing|suggest|recommend"
+    r"|consider|cover|need)\b[^.]{0,40}\bunits?\b|"
+    r"\d{1,3}\s*u\b|"
     r"carb\s*ratio|insulin[- ]to[- ]carb|correction\s+factor|"
     r"how\s+much\s+insulin"
     r")\b",
     re.IGNORECASE,
+)
+
+# Canonical user-facing safety qualifier for a vision carb estimate. Names the
+# prohibited action explicitly (never dose/bolus) rather than the softer
+# "verify before dosing". Single source of truth for the API surfaces; the
+# mobile client mirrors this string in MealComponents.kt.
+SAFETY_QUALIFIER = (
+    "Rough estimate — an AI guess that's often wrong. "
+    "Never use it to calculate an insulin dose or bolus."
 )
 
 

--- a/apps/api/tests/test_disclaimer.py
+++ b/apps/api/tests/test_disclaimer.py
@@ -59,7 +59,7 @@ class TestDisclaimerStatus:
             data = response.json()
             assert data["acknowledged"] is False
             assert data["acknowledged_at"] is None
-            assert data["disclaimer_version"] == "1.1"
+            assert data["disclaimer_version"] == "1.2"
 
     @pytest.mark.asyncio
     async def test_returns_acknowledged_for_existing_session(self, client):
@@ -138,7 +138,7 @@ class TestDisclaimerStatus:
             data = response.json()
             assert data["acknowledged"] is False
             assert data["acknowledged_at"] is None
-            assert data["disclaimer_version"] == "1.1"
+            assert data["disclaimer_version"] == "1.2"
 
 
 class TestDisclaimerAcknowledge:
@@ -338,14 +338,15 @@ class TestDisclaimerContent:
     async def test_returns_disclaimer_content(self, client):
         """
         AC1: Disclaimer content includes all required warnings.
-        v1.1 adds an AI Data Processing warning.
+        v1.1 adds an AI Data Processing warning; v1.2 adds a photo-carb-estimate
+        warning (Story 50.S).
         """
         response = await client.get("/api/disclaimer/content")
 
         assert response.status_code == 200
         data = response.json()
 
-        assert data["version"] == "1.1"
+        assert data["version"] == "1.2"
         assert data["title"] == "Important Safety Information"
 
         # Check all required warnings are present
@@ -355,6 +356,7 @@ class TestDisclaimerContent:
         assert "Not FDA Approved" in warning_titles
         assert "Consult Your Healthcare Provider" in warning_titles
         assert "AI Data Processing" in warning_titles
+        assert "Photo Carb Estimates Are Guesses" in warning_titles
 
         # Check warning text contains required phrases
         warning_texts = " ".join([w["text"] for w in data["warnings"]])
@@ -362,6 +364,8 @@ class TestDisclaimerContent:
         assert "ai" in warning_texts.lower()
         assert "fda" in warning_texts.lower()
         assert "healthcare provider" in warning_texts.lower()
+        # The photo-carb warning must name the prohibited action explicitly.
+        assert "insulin dose or bolus" in warning_texts.lower()
         # v1.1: AI data-flow disclosure uses vendor-agnostic cloud/local framing
         assert "cloud" in warning_texts.lower()
         assert "local" in warning_texts.lower()

--- a/apps/api/tests/test_disclaimer.py
+++ b/apps/api/tests/test_disclaimer.py
@@ -255,6 +255,95 @@ class TestDisclaimerAcknowledge:
             assert data["acknowledged_at"] is not None
             assert "successfully" in data["message"].lower()
 
+    @pytest.mark.asyncio
+    async def test_advances_version_on_reacknowledge(self, client):
+        """Regression (Story 50.S): re-acknowledging a session whose stored
+        version is outdated advances the stored version + persists it, so /status
+        stops re-prompting. Without this, session_id never rotates and the user
+        is trapped in an inescapable disclaimer loop after a version bump."""
+        from datetime import datetime
+
+        from src.routers.disclaimer import DISCLAIMER_VERSION
+
+        session_id = str(uuid.uuid4())
+
+        with patch(
+            "src.routers.disclaimer.get_session_maker"
+        ) as mock_get_session_maker:
+            existing = MagicMock()
+            existing.disclaimer_version = "1.1"  # outdated
+            existing.acknowledged_at = datetime.now(UTC)
+
+            mock_session = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = existing
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_session.commit = AsyncMock()
+            mock_session.refresh = AsyncMock()
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+            mock_get_session_maker.return_value.return_value = mock_session
+
+            response = await client.post(
+                "/api/disclaimer/acknowledge",
+                json={
+                    "session_id": session_id,
+                    "checkbox_experimental": True,
+                    "checkbox_not_medical_advice": True,
+                    "checkbox_ai_data_flow": True,
+                },
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "successfully" in data["message"].lower()
+            # The stored row was advanced to the current version and committed.
+            assert existing.disclaimer_version == DISCLAIMER_VERSION
+            mock_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_when_session_version_is_current(self, client):
+        """A session already at the current version is a no-op: no version
+        rewrite, no commit, and the 'previously acknowledged' message."""
+        from datetime import datetime
+
+        from src.routers.disclaimer import DISCLAIMER_VERSION
+
+        session_id = str(uuid.uuid4())
+
+        with patch(
+            "src.routers.disclaimer.get_session_maker"
+        ) as mock_get_session_maker:
+            existing = MagicMock()
+            existing.disclaimer_version = DISCLAIMER_VERSION  # already current
+            existing.acknowledged_at = datetime.now(UTC)
+
+            mock_session = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = existing
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_session.commit = AsyncMock()
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+            mock_get_session_maker.return_value.return_value = mock_session
+
+            response = await client.post(
+                "/api/disclaimer/acknowledge",
+                json={
+                    "session_id": session_id,
+                    "checkbox_experimental": True,
+                    "checkbox_not_medical_advice": True,
+                    "checkbox_ai_data_flow": True,
+                },
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "previously" in data["message"].lower()
+            mock_session.commit.assert_not_awaited()
+
 
 class TestDisclaimerAcknowledgeAuth:
     """Tests for POST /api/disclaimer/acknowledge-auth endpoint.
@@ -271,14 +360,16 @@ class TestDisclaimerAcknowledgeAuth:
 
     @pytest.mark.asyncio
     async def test_sets_disclaimer_acknowledged_on_user(self, client):
-        """Sets disclaimer_acknowledged=True, commits, and returns success."""
+        """Sets disclaimer_acknowledged=True + the version, commits, succeeds."""
         from src.core.auth import get_current_user
         from src.database import get_db
+        from src.routers.disclaimer import DISCLAIMER_VERSION
 
         mock_user = MagicMock()
         mock_user.id = uuid.uuid4()
         mock_user.email = "test@example.com"
         mock_user.disclaimer_acknowledged = False
+        mock_user.disclaimer_version = None
         mock_user.is_active = True
 
         mock_db = AsyncMock()
@@ -296,21 +387,25 @@ class TestDisclaimerAcknowledgeAuth:
             assert data["success"] is True
             assert "successfully" in data["message"].lower()
             assert mock_user.disclaimer_acknowledged is True
+            # The acknowledged version is recorded so a future bump re-prompts.
+            assert mock_user.disclaimer_version == DISCLAIMER_VERSION
             mock_db.commit.assert_awaited_once()
             mock_db.refresh.assert_awaited_once_with(mock_user)
         finally:
             app.dependency_overrides.clear()
 
     @pytest.mark.asyncio
-    async def test_idempotent_when_already_acknowledged(self, client):
-        """Returns early without DB write if already acknowledged."""
+    async def test_idempotent_when_current_version_acknowledged(self, client):
+        """Returns early without DB write if the CURRENT version is acked."""
         from src.core.auth import get_current_user
         from src.database import get_db
+        from src.routers.disclaimer import DISCLAIMER_VERSION
 
         mock_user = MagicMock()
         mock_user.id = uuid.uuid4()
         mock_user.email = "test@example.com"
         mock_user.disclaimer_acknowledged = True
+        mock_user.disclaimer_version = DISCLAIMER_VERSION
         mock_user.is_active = True
 
         mock_db = AsyncMock()
@@ -327,6 +422,41 @@ class TestDisclaimerAcknowledgeAuth:
             assert data["success"] is True
             assert "previously" in data["message"].lower()
             mock_db.commit.assert_not_awaited()
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_reacknowledges_when_stored_version_is_outdated(self, client):
+        """Regression (Story 50.S): an authenticated user whose stored version is
+        outdated re-acknowledges and the new version is recorded -- the 1.x->1.2
+        bump must not be a silent no-op for logged-in users."""
+        from src.core.auth import get_current_user
+        from src.database import get_db
+        from src.routers.disclaimer import DISCLAIMER_VERSION
+
+        mock_user = MagicMock()
+        mock_user.id = uuid.uuid4()
+        mock_user.email = "test@example.com"
+        mock_user.disclaimer_acknowledged = True
+        mock_user.disclaimer_version = "1.1"  # outdated
+        mock_user.is_active = True
+
+        mock_db = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        app.dependency_overrides[get_current_user] = lambda: mock_user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        try:
+            response = await client.post("/api/disclaimer/acknowledge-auth")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "successfully" in data["message"].lower()
+            assert mock_user.disclaimer_version == DISCLAIMER_VERSION
+            mock_db.commit.assert_awaited_once()
         finally:
             app.dependency_overrides.clear()
 
@@ -398,3 +528,55 @@ class TestDisclaimerContent:
         data = response.json()
 
         assert "I Understand & Accept" in data["button_text"]
+
+
+class TestUserResponseDisclaimerGating:
+    """The authenticated /me + login user payload must report
+    disclaimer_acknowledged as version-aware, so clients re-prompt on a bump
+    (Story 50.S) without knowing the current version themselves."""
+
+    def _base_fields(self) -> dict:
+        from datetime import datetime
+
+        from src.models.user import UserRole
+
+        return {
+            "id": uuid.uuid4(),
+            "email": "user@example.com",
+            "display_name": None,
+            "role": UserRole.DIABETIC,
+            "is_active": True,
+            "email_verified": True,
+            "created_at": datetime.now(UTC),
+        }
+
+    def test_current_version_reads_acknowledged(self):
+        from src.routers.disclaimer import DISCLAIMER_VERSION
+        from src.schemas.auth import UserResponse
+
+        resp = UserResponse(
+            **self._base_fields(),
+            disclaimer_acknowledged=True,
+            disclaimer_version=DISCLAIMER_VERSION,
+        )
+        assert resp.disclaimer_acknowledged is True
+
+    def test_outdated_version_reads_not_acknowledged(self):
+        from src.schemas.auth import UserResponse
+
+        resp = UserResponse(
+            **self._base_fields(),
+            disclaimer_acknowledged=True,
+            disclaimer_version="1.1",
+        )
+        assert resp.disclaimer_acknowledged is False
+
+    def test_never_acknowledged_reads_not_acknowledged(self):
+        from src.schemas.auth import UserResponse
+
+        resp = UserResponse(
+            **self._base_fields(),
+            disclaimer_acknowledged=False,
+            disclaimer_version=None,
+        )
+        assert resp.disclaimer_acknowledged is False

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -451,6 +451,10 @@ class TestFoodRecordsApi:
         assert body["carbs_high"] == 45
         assert body["source"] == "ai_estimate"
         assert "dose" not in body and "insulin" not in body
+        # Story 50.S: the response carries a server-side safety qualifier that
+        # explicitly names the prohibition, so a non-mobile client can't render
+        # carbs without it.
+        assert "insulin dose or bolus" in body["safety_qualifier"].lower()
 
         listing = await client.get("/api/food-records")
         assert listing.status_code == 200

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/VerifyBeforeDosingQualifierUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/VerifyBeforeDosingQualifierUiTest.kt
@@ -1,0 +1,40 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Story 50.S: the safety qualifier actually renders on screen under the tag that
+ * every estimate surface (result, history, common-foods, edit dialog, home card)
+ * relies on, and its visible text names the prohibited action -- not merely that
+ * the [VERIFY_BEFORE_DOSING_TEXT] string constant is correct (that is the unit
+ * test). This guards the "every surface shows the words, never just a number"
+ * charter rule against a regression that drops or mis-tags the strip.
+ */
+@RunWith(AndroidJUnit4::class)
+class VerifyBeforeDosingQualifierUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun qualifier_rendersTaggedAndNamesTheProhibition() {
+        compose.setContent {
+            GlycemicGptTheme {
+                VerifyBeforeDosingQualifier()
+            }
+        }
+
+        compose.onNodeWithTag(TAG_SAFETY_QUALIFIER).assertIsDisplayed()
+        // The strengthened wording must be visible, not just present as a constant.
+        compose.onNodeWithText("insulin dose or bolus", substring = true)
+            .assertIsDisplayed()
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
@@ -252,6 +252,9 @@ private fun EditCommonFoodDialog(
         title = { Text("Edit common food") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                // Story 50.S: the AlertDialog scrim dims the screen-level qualifier,
+                // so embed it inside the modal above the editable carb grams.
+                VerifyBeforeDosingQualifier()
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -251,7 +253,12 @@ private fun EditCommonFoodDialog(
         onDismissRequest = onDismiss,
         title = { Text("Edit common food") },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            // Scrollable so the embedded qualifier + fields can't clip (and block
+            // the buttons) on small screens or large accessibility font sizes.
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+            ) {
                 // Story 50.S: the AlertDialog scrim dims the screen-level qualifier,
                 // so embed it inside the modal above the editable carb grams.
                 VerifyBeforeDosingQualifier()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
@@ -42,8 +42,13 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
 
-/** The text shown on every estimate surface. A single source of truth for the safety wording. */
-const val VERIFY_BEFORE_DOSING_TEXT = "Estimate — verify before dosing"
+/**
+ * The text shown on every estimate surface. A single source of truth for the safety wording.
+ * Names the prohibited action explicitly (Story 50.S); mirrors the API SAFETY_QUALIFIER constant.
+ */
+const val VERIFY_BEFORE_DOSING_TEXT =
+    "Rough estimate — an AI guess that's often wrong. " +
+        "Never use it to calculate an insulin dose or bolus."
 
 /** testTag for the always-on safety qualifier. Present on result, history, and common-food surfaces. */
 const val TAG_SAFETY_QUALIFIER = "meal_safety_qualifier"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.LocalHospital
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Security
@@ -443,6 +444,17 @@ private fun DisclaimerPage() {
             icon = Icons.Default.Psychology,
             title = "AI Limitations",
             description = "AI can hallucinate, misinterpret data, and provide outdated or incorrect information. Never rely solely on AI suggestions.",
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Story 50.S: consent must explicitly cover photo carb estimation, the
+        // only AI-vision feature, and name the prohibited action. Mirrors the
+        // server disclaimer's "Photo Carb Estimates Are Guesses" warning.
+        DisclaimerCard(
+            icon = Icons.Default.PhotoCamera,
+            title = "Photo Carb Estimates Are Guesses",
+            description = "If you use the meal-photo feature, the carb numbers are AI estimates from an image and are frequently wrong, including misidentifying the food entirely. Never use a photo carb estimate to calculate an insulin dose or bolus. Always verify carbs yourself before dosing.",
         )
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealComponentsTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealComponentsTest.kt
@@ -47,8 +47,10 @@ class MealComponentsTest {
     }
 
     @Test
-    fun `the verify-before-dosing qualifier text mentions both estimate and dosing`() {
-        assertTrue(VERIFY_BEFORE_DOSING_TEXT.contains("Estimate", ignoreCase = true))
-        assertTrue(VERIFY_BEFORE_DOSING_TEXT.contains("dosing", ignoreCase = true))
+    fun `the qualifier text names that it is a guess and forbids dosing`() {
+        assertTrue(VERIFY_BEFORE_DOSING_TEXT.contains("estimate", ignoreCase = true))
+        // Story 50.S: must name the prohibited action explicitly, not just "verify".
+        assertTrue(VERIFY_BEFORE_DOSING_TEXT.contains("insulin dose", ignoreCase = true))
+        assertTrue(VERIFY_BEFORE_DOSING_TEXT.contains("bolus", ignoreCase = true))
     }
 }

--- a/apps/web/src/components/auth-disclaimer-gate.tsx
+++ b/apps/web/src/components/auth-disclaimer-gate.tsx
@@ -16,6 +16,7 @@ import {
   ShieldOff,
   Stethoscope,
   AlertTriangle,
+  Camera,
   Check,
   Cloud,
   Loader2,
@@ -33,6 +34,7 @@ const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   "shield-x": ShieldOff,
   stethoscope: Stethoscope,
   cloud: Cloud,
+  camera: Camera,
 };
 
 export function AuthDisclaimerGate({
@@ -139,9 +141,11 @@ export function AuthDisclaimerGate({
     }
   };
 
-  // Fallback content if API failed
+  // Fallback content if API failed. Mirror the server /content payload
+  // (src/routers/disclaimer.py) so a fetch failure still shows the current
+  // version and the photo-carb warning -- keep this in sync on every bump.
   const displayContent: DisclaimerContent = content ?? {
-    version: "1.1",
+    version: "1.2",
     title: "Important Safety Information",
     warnings: [
       {
@@ -153,6 +157,11 @@ export function AuthDisclaimerGate({
         icon: "brain",
         title: "AI Limitations",
         text: "AI can and will make mistakes. All suggestions should be verified with your healthcare provider before acting on them.",
+      },
+      {
+        icon: "camera",
+        title: "Photo Carb Estimates Are Guesses",
+        text: "If you use the meal-photo feature, the carbohydrate numbers are AI estimates from an image and are frequently wrong -- including misidentifying the food entirely. They are a rough starting point only. Never use a photo carb estimate to calculate an insulin dose or bolus, and always verify carbs yourself before dosing.",
       },
       {
         icon: "shield-x",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1206,7 +1206,10 @@ export interface CurrentUserResponse {
   role: "diabetic" | "caregiver" | "admin";
   is_active: boolean;
   email_verified: boolean;
+  // Version-aware: the API reports `false` when the stored acknowledgment is for
+  // an older disclaimer version, so the gate re-prompts on a version bump.
   disclaimer_acknowledged: boolean;
+  disclaimer_version: string | null;
   created_at: string;
 }
 

--- a/docs/daily-use/_meta.json
+++ b/docs/daily-use/_meta.json
@@ -9,6 +9,7 @@
     "connecting-medtronic-pump",
     "ai-chat",
     "briefs",
+    "meal-intelligence",
     "alerts",
     "data-export"
   ]

--- a/docs/daily-use/meal-intelligence.md
+++ b/docs/daily-use/meal-intelligence.md
@@ -1,0 +1,41 @@
+---
+title: Meal Intelligence (Photo Carb Estimates)
+description: Snap a photo of a meal to get a rough carb range — a starting point, never a dose.
+---
+
+Meal Intelligence lets you take a photo of a meal and get an AI **estimate** of its carbohydrate content as a range (for example, "≈ 40–55 g carbs"), with a confidence signal. You can correct the estimate, save foods you eat often, and the AI can reference your logged meals in chat and daily briefs.
+
+> **Photo carb estimates are AI guesses, frequently wrong, and a rough starting point only — never calculate an insulin dose or bolus from them.** The AI looks at an image and *guesses*; it regularly misjudges portions and sometimes misidentifies the food entirely. Treat every number as a ballpark to sanity-check against your own carb counting. Always verify carbs yourself before dosing, and consult your healthcare provider about your diabetes management.
+
+This is an **experimental (alpha) feature**, off by default, that you turn on explicitly. It is **not** FDA-cleared and is **not** a carb-counting authority.
+
+## What it does
+
+1. **Estimate** — you take or pick a meal photo; the AI returns a carb **range** and a confidence level (low / medium / high).
+2. **Correct** — if the estimate is off, you correct it. Your correction becomes the truth the app remembers — it never silently overwrites your number with a guess.
+3. **Save** — foods you eat often can be saved so a re-photographed meal recognizes them ("you've logged this before") instead of re-guessing.
+4. **Aware** — when you've logged meals, chat and daily briefs can reflect them back to you ("you logged a high-carb dinner — how did that sit with you?"). They never tell you how much insulin to take.
+
+## How it's built to be safe
+
+The feature is designed so a guess can never quietly turn into a dose:
+
+- **A range, not a single confident number.** Real plates are uncertain; a single integer invites you to dose off it.
+- **Confidence comes from disagreement, not the model's self-rating.** The same photo is sampled several times; the spread between answers drives the confidence. (A model's own "I'm confident" score does not track accuracy and is never shown as a safety signal.) A wide spread is shown plainly — "this could be 40 g or 90 g, we're not sure."
+- **You confirm what the food is** before the app grounds it against nutrition data, so a misidentified food can't be "certified" with an authoritative-looking citation.
+- **Carb estimates never flow into insulin-on-board, safety limits, or any dosing math.** They are descriptive notes, structurally isolated from the dosing engine.
+- **Every screen that shows a carb estimate carries a persistent reminder** — *"Rough estimate — an AI guess that's often wrong. Never use it to calculate an insulin dose or bolus."*
+
+## Known limitations
+
+- **Misidentification is the most common error** — look-alike foods (a Linzer torte read as a Bakewell tart, crème catalana as crème brûlée) can be confidently wrong.
+- **Run-to-run variance** — the same photo can yield different numbers; the confidence range is meant to surface that, not hide it.
+- **Accuracy is honest, not perfect** — on a labeled test set the estimate was within a useful band most of the time, but tail cases can be far off. This is why it's alpha and why you must verify.
+
+## Turning it on
+
+Meal Intelligence is flag-gated and off by default. When enabled, it appears in the mobile app's meal-capture surfaces. Because it sends a food photo to your configured AI provider, the same BYOAI data-handling rules apply as the rest of the app — review your provider's policy.
+
+## The bottom line
+
+A carb estimate from a photo is a **guess about a picture**, not a measurement and never a dose. Use it to get a baseline, correct it when it's wrong, and **count your carbs and decide your insulin the way you and your healthcare provider do today.**

--- a/evals/vision_carb/tests/test_contract.py
+++ b/evals/vision_carb/tests/test_contract.py
@@ -169,6 +169,29 @@ def test_take_units_is_flagged():
     assert est.dosing_violations
 
 
+def test_insulin_unit_abbreviation_is_flagged():
+    # The "Nu"/"NU" insulin-unit shorthand (Story 50.S hardening).
+    for text in ("give yourself 6u for this", "take 4U now", "about 10u of rapid"):
+        assert contract.find_dosing_violations(text), text
+
+
+def test_suggestion_verbs_near_units_are_flagged():
+    # Dosing-suggestion verbs near "units", not just take/inject (Story 50.S).
+    for text in (
+        "I suggest about 5 units for this meal",
+        "you could cover this with 3 units",
+        "consider 4 units to match these carbs",
+    ):
+        assert contract.find_dosing_violations(text), text
+
+
+def test_iu_and_oz_not_flagged_as_insulin_units():
+    # International units (IU), ounces (oz), and cups must not trip the
+    # abbreviation rule — only a bare number + "u" does.
+    for text in ("vitamin D about 400 IU", "a 6 oz portion", "12 cups of broth"):
+        assert contract.find_dosing_violations(text) == [], text
+
+
 def test_benign_unit_language_is_not_flagged():
     # "units" / "unit" appear in benign contexts and must not trip the scanner.
     for text in (


### PR DESCRIPTION
## Summary

Safety-language hardening for the Epic 50 meal-vision feature, closing the liability/disclaimer gaps surfaced by a safety audit (0 HIGH gaps overall; this addresses the actionable MEDIUM/LOW set). A carb estimate is a guess about a photo — this makes "never dose from it" explicit on every surface.

- **Stronger qualifier wording** that names the prohibited action: *"Rough estimate — an AI guess that's often wrong. Never use it to calculate an insulin dose or bolus."* Single source of truth on mobile (`VERIFY_BEFORE_DOSING_TEXT`) plus a new server-emitted `FoodRecordResponse.safety_qualifier`, so a non-mobile client can't render carbs without it.
- **`EditCommonFoodDialog`** embeds the qualifier inside the modal (the scrim hid the screen-level strip).
- **Consent:** new "Photo Carb Estimates Are Guesses" disclaimer warning + `DISCLAIMER_VERSION 1.1 → 1.2` (one-time re-acknowledge) so the consent covers vision carb estimation.
- **Dosing scrub** now catches the `Nu`/`NU` insulin-unit abbreviation (`6u`, `take 4U`) and suggestion verbs (`suggest/cover/consider … units`).
- **Docs:** new `docs/daily-use/meal-intelligence.md` leading with a strong safety blockquote, registered in the nav.
- **Tests:** scrub cases (incl. IU/oz benign-guard), `safety_qualifier` on the upload response, disclaimer v1.2 content, the mobile qualifier-string unit test, and a new **instrumented Compose test** asserting the qualifier renders with its tag + the prohibition wording; the vision eval-harness contract tests (incl. the dosing scanner) now run in CI.

## Validation

- API pytest (food_records, disclaimer, meal cluster) + 31 eval-harness tests pass; ruff clean.
- **Live-verified:** `/disclaimer/content` returns v1.2 with the photo-carb warning; a real upload response carries `safety_qualifier`.
- **Sentry validation gate: PASS** (0 new issues, api + sidecar).
- Mobile build/instrumented tests run on the Android Gate.

Note: bumping `DISCLAIMER_VERSION` forces a one-time re-acknowledge for existing users — intentional, so the consent explicitly covers photo carb estimation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Food-record API responses now include a server-emitted `safety_qualifier` to reinforce “guess, never dose”.
  * Disclaimer acknowledgement is now version-aware (v1.2), so users are prompted to re-acknowledge after updates.
  * Updated mobile/web onboarding and meal/disclaimer flows with a stronger photo-carb warning and qualifier presentation.
* **Documentation**
  * Added “Meal Intelligence (Photo Carb Estimates)” guide covering workflow, limitations, and safety boundaries.
* **Bug Fixes**
  * Improved detection of unsafe insulin/dosing language to better catch “units”/shorthand phrasing while avoiding false positives.
* **Tests**
  * Updated API/mobile/web assertions and added UI + contract-test coverage for the qualifier and disclaimer gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->