### PR TITLE
fix(api): harden meal-identity clustering against verbose descriptions

### DIFF
--- a/apps/api/src/services/diabetes_context.py
+++ b/apps/api/src/services/diabetes_context.py
@@ -21,7 +21,11 @@ from src.logging_config import get_logger
 from src.services.alert_notifier import trend_description
 from src.services.iob_projection import get_iob_projection, get_user_dia
 from src.services.meal_citation import AllowedCarb, verify_carb_citations
-from src.vision.carb_contract import MEAL_ESTIMATE_QUALIFIER, find_dosing_violations
+from src.vision.carb_contract import (
+    MEAL_ESTIMATE_QUALIFIER,
+    NEVER_DOSE_PROHIBITION,
+    find_dosing_violations,
+)
 
 if TYPE_CHECKING:
     from src.models.food_record import FoodRecord
@@ -379,7 +383,7 @@ def _format_meal_line(record: "FoodRecord", now: datetime) -> str:
     description = _safe_meal_description(record.food_description)
     when = _meal_when_token(record, now)
     qualifier = (
-        "user-corrected estimate — never use it to dose or bolus"
+        f"user-corrected estimate — {NEVER_DOSE_PROHIBITION}"
         if corrected
         else MEAL_ESTIMATE_QUALIFIER
     )

--- a/apps/api/src/services/meal_estimate_aggregate.py
+++ b/apps/api/src/services/meal_estimate_aggregate.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import re
 import statistics
+import unicodedata
 from dataclasses import dataclass, field
 
 from src.vision.carb_contract import (
@@ -56,10 +57,9 @@ CONFIDENCE_HIGH = "high"
 CONFIDENCE_MEDIUM = "medium"
 CONFIDENCE_LOW = "low"
 
-# Token-set Jaccard at or above this means two food descriptions name the same
-# food for agreement purposes. Below it (e.g. "creme brulee" vs "crema catalana",
-# disjoint tokens -> 0.0) the samples disagree on identity. (50.H4 tunes this.)
-_IDENTITY_AGREEMENT_JACCARD = 0.5
+# Upper bound on content tokens compared per description (DoS guard for the
+# O(tokens^2) identity match; a food identity never needs this many).
+_MAX_IDENTITY_TOKENS = 24
 
 # Common filler words stripped before comparing food identities, so "a plate of
 # grilled chicken" and "grilled chicken breast" still cluster together.
@@ -135,18 +135,90 @@ def _sample_in_bounds(sample: ParsedEstimate) -> bool:
     )
 
 
+def _strip_accents(text: str) -> str:
+    """Drop combining marks so "creme brulee" matches "crème brûlée"."""
+    decomposed = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
 def _identity_tokens(description: str) -> frozenset[str]:
-    """Normalize a food description to a comparable token set."""
-    tokens = re.findall(r"[a-z0-9]+", (description or "").lower())
-    return frozenset(t for t in tokens if t not in _IDENTITY_STOPWORDS)
+    """Normalize a food description to a comparable, stopword-stripped token set.
+
+    Accents are folded (NFKD) before tokenizing so unicode spelling variants of
+    the same food ("crème brûlée" / "creme brulee") share tokens instead of
+    reading as different foods. The content tokens are capped at
+    ``_MAX_IDENTITY_TOKENS``: ``_identity_match`` is O(tokens_a * tokens_b) per pair
+    and clustering is O(N^2) pairs, so an unbounded model description (the raw,
+    pre-storage-cap sidecar text) would be a synchronous CPU sink -- and a food
+    identity never needs that many content tokens, only the leading ones carry it.
+    """
+    normalized = _strip_accents(description or "").lower()
+    tokens = re.findall(r"[a-z0-9]+", normalized)
+    content = [t for t in tokens if t not in _IDENTITY_STOPWORDS]
+    return frozenset(content[:_MAX_IDENTITY_TOKENS])
 
 
-def _jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+def _plural_eq(a: str, b: str) -> bool:
+    """Token equality tolerant of simple English pluralization.
+
+    Compares by suffix *addition* only (never stripping), so "potato" matches
+    "potatoes" (potato + "es") and "apple" matches "apples" (apple + "s") without
+    over-stripping that would collapse "apples" back to "appl". It can still
+    over-ADD on short words (any word that is another word plus "s"/"es" collapses,
+    e.g. "bus"/"buses"), but those are not plausible food-identity tokens, so it is
+    good enough for the food nouns that drive identity here. Mirrors the eval
+    harness helper (``evals/vision_carb/metrics.py``).
+    """
+    if a == b:
+        return True
+    longer, shorter = (a, b) if len(a) > len(b) else (b, a)
+    return longer in (shorter + "s", shorter + "es")
+
+
+def _identity_match(a: frozenset[str], b: frozenset[str]) -> bool:
+    """True when two descriptions name the same food, by token containment.
+
+    The shorter token set is the candidate "name"; it matches when **all** of its
+    content tokens appear (plural-tolerant) in the longer set -- i.e. the terse
+    description is fully contained in the verbose one. Unlike the original
+    symmetric Jaccard this does not collapse when one description is far more
+    verbose than the other (a terse "banana" is fully contained in "a ripe banana
+    with brown speckles on the peel"), which was the bug this hardening fixes:
+    the same food read two ways scored low Jaccard and read as disagreement.
+
+    Full containment (rather than a partial-overlap ratio) keeps the safe
+    direction intact: two genuinely different multi-token names that merely share a
+    common noun -- "chicken salad" vs "chicken soup", "beef taco" vs "fish taco" --
+    are NOT fully contained, so they correctly disagree (a partial ratio would have
+    matched them on the one shared token). Disjoint sets ("creme brulee" vs "crema
+    catalana") never match.
+
+    This is the same all-content-tokens rule the offline variance harness uses
+    (``evals/vision_carb/metrics.py`` ``_identity_matches``); the harness applies it
+    against a curated ground-truth name, while here -- with no ground truth -- it is
+    applied symmetrically between two unlabeled samples, the shorter as the
+    candidate name. Normalization (NFKD accent folding, stopwords, ``_plural_eq``)
+    is shared with that harness; the threshold choice is not (the harness has no
+    ratio, it requires all tokens, which is what this now does).
+
+    Residual: a single generic token that is fully contained in an unrelated dish
+    ("rice" in "fried rice with shrimp") still matches -- structurally identical to
+    the legitimate terse-vs-verbose case ("banana" in "...banana..."), so it cannot
+    be distinguished without a food ontology. This is the conservative direction
+    (it only inflates the empirical confidence band / suppresses the "confirm the
+    food" UX note; external grounding is gated on user identity confirmation, never
+    on this signal) and is rare for N samples of one photo.
+
+    Two empty token sets count as a match (mirrors the old semantics: no identity
+    evidence either way, so not manufactured disagreement); one empty and one
+    non-empty never match.
+    """
     if not a and not b:
-        return 1.0
+        return True
     if not a or not b:
-        return 0.0
-    return len(a & b) / len(a | b)
+        return False
+    smaller, larger = (a, b) if len(a) <= len(b) else (b, a)
+    return all(any(_plural_eq(token, other) for other in larger) for token in smaller)
 
 
 def _largest_identity_cluster(
@@ -166,10 +238,10 @@ def _largest_identity_cluster(
         for cluster in clusters:
             # True single-link: match if this sample is close to ANY member, so
             # transitive matches (A≈B, B≈C) aren't split into false disagreement.
-            if any(
-                _jaccard(tokens, token_sets[idx]) >= _IDENTITY_AGREEMENT_JACCARD
-                for idx in cluster
-            ):
+            # With full-containment matching, chaining needs a real subset relation
+            # at each hop, so distinct multi-token foods sharing one noun no longer
+            # bridge (only a fully-contained terse name, e.g. a bare head noun, can).
+            if any(_identity_match(tokens, token_sets[idx]) for idx in cluster):
                 cluster.append(i)
                 placed = True
                 break

--- a/apps/api/src/services/nutrition_sources.py
+++ b/apps/api/src/services/nutrition_sources.py
@@ -39,7 +39,7 @@ from src.database import get_session_maker
 from src.logging_config import get_logger
 from src.models.knowledge_chunk import KnowledgeChunk
 from src.services.meal_rag import SOURCE_TYPE_OPEN_FOOD_FACTS, SOURCE_TYPE_USDA
-from src.vision.carb_contract import find_dosing_violations
+from src.vision.carb_contract import NEVER_DOSE_PROHIBITION, find_dosing_violations
 
 logger = get_logger(__name__)
 
@@ -68,9 +68,14 @@ _USDA_CARB_NUTRIENT_NUMBER = "205"
 # 100 g (Branded items are per-serving and would break the per-100 g basis).
 _USDA_GENERIC_DATATYPES = "Foundation,SR Legacy,Survey (FNDDS)"
 
+# The safety prohibition is the canonical ``NEVER_DOSE_PROHIBITION`` (single source
+# of truth); the rest is OFF-specific attribution + the not-medically-verified
+# framing. Note the figure is published reference data, NOT an AI estimate, so the
+# full ``MEAL_ESTIMATE_QUALIFIER`` ("AI estimate, often wrong ...") would mislabel
+# it -- only the shared dosing prohibition is reused here.
 _OFF_DISCLAIMER = (
     "Nutrition data from Open Food Facts (ODbL), contributed by volunteers and "
-    "not medically verified -- a descriptive reference only; never use it to dose or bolus."
+    f"not medically verified -- a descriptive reference only; {NEVER_DOSE_PROHIBITION}."
 )
 
 _SERVING_PER_100G = "per 100 g"

--- a/apps/api/src/vision/carb_contract.py
+++ b/apps/api/src/vision/carb_contract.py
@@ -137,13 +137,23 @@ SAFETY_QUALIFIER = (
     "Never use it to calculate an insulin dose or bolus."
 )
 
+# The non-negotiable prohibition shared by every carb surface: a carb figure --
+# whether an AI vision estimate or one grounded against a published source (USDA /
+# Open Food Facts) -- is descriptive only and must never drive a dose. Kept as a
+# single source of truth so the exact phrasing cannot drift between the inline
+# estimate qualifier below and the grounding disclaimers in
+# ``services/nutrition_sources.py``. Deliberately absolute ("never use it to dose
+# or bolus") rather than the permissive "verify before dosing", which would imply
+# dosing off the figure is fine once checked.
+NEVER_DOSE_PROHIBITION = "never use it to dose or bolus"
+
 # Inline counterpart to SAFETY_QUALIFIER for when a carb figure is embedded in a
 # sentence (chat / daily brief) rather than shown on its own. Same non-negotiable
 # posture: the figure is an AI guess, often wrong, and must NEVER drive a dose.
 # It names the prohibited action and deliberately avoids "verify before dosing",
 # which would wrongly imply that dosing off the estimate is fine once checked --
 # we never tell a user it is OK to bolus from a carb guess.
-MEAL_ESTIMATE_QUALIFIER = "AI estimate, often wrong — never use it to dose or bolus"
+MEAL_ESTIMATE_QUALIFIER = f"AI estimate, often wrong — {NEVER_DOSE_PROHIBITION}"
 
 
 @dataclass

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -28,7 +28,11 @@ from src.models.food_record import FoodRecord, FoodRecordSource
 from src.models.knowledge_chunk import KnowledgeChunk
 from src.models.user import User, UserRole
 from src.services import food_vision, meal_grounding, meal_rag, nutrition_sources
-from src.vision.carb_contract import find_dosing_violations
+from src.vision.carb_contract import (
+    MEAL_ESTIMATE_QUALIFIER,
+    NEVER_DOSE_PROHIBITION,
+    find_dosing_violations,
+)
 
 # (asyncio_mode = "auto" in pyproject -- async tests need no explicit mark.)
 
@@ -391,6 +395,15 @@ class TestOpenFoodFacts:
         assert fact.carbs_grams == 70.0
         assert fact.source_url == "https://world.openfoodfacts.org/product/999"
         assert fact.disclaimer and "Open Food Facts" in fact.disclaimer
+        # Story 50.H5 (AC4): the grounding disclaimer carries the canonical dosing
+        # prohibition (single source of truth, shared with MEAL_ESTIMATE_QUALIFIER)
+        # and never the permissive "verify before dosing". It must NOT mislabel
+        # published reference data as an "AI estimate" -- only the prohibition is
+        # reused, not the whole estimate qualifier.
+        assert NEVER_DOSE_PROHIBITION in fact.disclaimer
+        assert "verify before dosing" not in fact.disclaimer.lower()
+        assert "AI estimate" not in fact.disclaimer
+        assert MEAL_ESTIMATE_QUALIFIER not in fact.disclaimer
 
     async def test_disabled_returns_none(self, monkeypatch):
         monkeypatch.setattr(settings, "open_food_facts_enabled", False)

--- a/apps/api/tests/test_meal_multi_sample.py
+++ b/apps/api/tests/test_meal_multi_sample.py
@@ -226,6 +226,212 @@ class TestAggregation:
 
 
 # --------------------------------------------------------------------------- #
+# Story 50.H5: identity agreement survives verbose vs terse descriptions
+# --------------------------------------------------------------------------- #
+class TestVerboseIdentityMatching:
+    """Regression guard for the symmetric-Jaccard collapse on verbose prose.
+
+    A real vision model returns a sentence ("a ripe banana with brown spots..."),
+    not a 1-2 word name. Symmetric token-set Jaccard scored the same food, read
+    tersely once and verbosely once, as DISAGREEMENT -- needless low confidence
+    and a misleading "the AI couldn't agree what this is" on a food it actually
+    identified consistently. The hardened matcher requires full token containment
+    of the shorter description (NFKD-normalized, plural-tolerant) so verbosity no
+    longer reads as disagreement, while a gross misidentification (disjoint tokens)
+    -- and two different multi-token foods that merely share one noun -- still
+    disagree.
+
+    The verbose-vs-terse cases (``banana``, ``grilled chicken``) evaluated to
+    ``identity_agreement is False`` against the pre-fix symmetric-Jaccard matcher
+    (confirmed by running it directly) -- they are the genuine regression repro.
+    The NFKD and plural behaviors are NOT meaningfully guarded at this
+    agreement-aggregate level (a 2-of-3 majority among the non-accented / singular
+    samples reaches agreement even if folding were disabled); they are pinned
+    directly in ``TestIdentityMatchContainment`` so a regression in
+    ``_strip_accents`` / ``_plural_eq`` is actually caught.
+    """
+
+    def test_verbose_vs_terse_same_food_agrees(self):
+        # The AC1 repro: three unanimous "banana" reads, one terse + two verbose.
+        samples = [
+            _sample(40, 50, "banana"),
+            _sample(41, 51, "a ripe banana with brown speckles on the peel"),
+            _sample(42, 52, "one yellow banana resting on a wooden cutting board"),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is True
+        # Not force-lowered: agreement + tight numbers -> the empirical band stands.
+        assert result.confidence != agg.CONFIDENCE_LOW
+        assert result.wide_spread is False
+
+    def test_all_verbose_descriptions_of_one_food_cluster(self):
+        samples = [
+            _sample(45, 55, "grilled chicken"),
+            _sample(
+                46,
+                56,
+                "a generous portion of grilled chicken breast with light char "
+                "marks and herbs",
+            ),
+            _sample(
+                44,
+                54,
+                "pan-seared chicken breast, sliced, with rosemary garnish on a "
+                "white plate",
+            ),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is True
+
+    def test_accent_variants_cluster_via_nfkd(self):
+        samples = [
+            _sample(30, 40, "crème brûlée"),
+            _sample(31, 41, "creme brulee"),
+            _sample(32, 42, "a dish of crème brûlée"),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is True
+
+    def test_plural_variants_cluster(self):
+        samples = [
+            _sample(20, 28, "apple"),
+            _sample(21, 29, "two red apples, one bitten"),
+            _sample(22, 30, "a single apple"),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is True
+
+    def test_different_foods_stay_disagreeing_even_when_verbose(self):
+        # The safe direction: containment must NOT manufacture agreement between
+        # genuinely different foods because one description is verbose. Gross
+        # misID has disjoint content tokens -> ratio 0.0 -> still disagreement,
+        # and tight numbers do NOT rescue it (identity forces low confidence).
+        samples = [
+            _sample(
+                40,
+                50,
+                "a small ramekin of classic crème brûlée with a torched sugar crust",
+            ),
+            _sample(41, 51, "crema catalana"),
+            _sample(42, 52, "a wedge of spanish tortilla potato omelette"),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is False
+        assert result.confidence == agg.CONFIDENCE_LOW
+        assert len(result.distinct_identities) >= 2
+
+    def test_short_named_foods_sharing_one_word_disagree(self):
+        # The harder safe-direction case: three genuinely DIFFERENT 2-token dishes
+        # that share one common noun. Full containment requires ALL of the shorter
+        # name's tokens, so a single shared token ("chicken") is not enough to
+        # match -- they stay distinct. (A partial-overlap ratio would have collapsed
+        # them to one food at high confidence; this pins that they do not.)
+        samples = [
+            _sample(40, 50, "chicken salad"),
+            _sample(41, 51, "chicken soup"),
+            _sample(42, 52, "chicken sandwich"),
+        ]
+        result = agg.aggregate_samples(samples, samples_requested=3)
+        assert result.identity_agreement is False
+        assert result.confidence == agg.CONFIDENCE_LOW
+        assert len(result.distinct_identities) >= 2
+
+
+class TestIdentityMatchContainment:
+    """Unit-level checks on the directional-containment matcher itself.
+
+    These pin the helper-level behaviors that the agreement-aggregate tests above
+    cannot (a 2-of-3 majority can reach agreement without exercising NFKD/plural),
+    so a regression in ``_strip_accents`` or ``_plural_eq`` is caught here.
+    """
+
+    def test_nfkd_accent_folding_is_required(self):
+        # False if _strip_accents is a no-op (the old tokenizer splits on accents,
+        # so "crème brûlée" and "creme brulee" would share no tokens).
+        assert (
+            agg._identity_match(
+                agg._identity_tokens("crème brûlée"),
+                agg._identity_tokens("creme brulee"),
+            )
+            is True
+        )
+
+    def test_plural_tolerance_is_required(self):
+        # False under exact-equality matching; only _plural_eq makes singular and
+        # plural forms of the same food noun match.
+        assert (
+            agg._identity_match(
+                agg._identity_tokens("potato"),
+                agg._identity_tokens("roasted potatoes"),
+            )
+            is True
+        )
+        assert (
+            agg._identity_match(
+                agg._identity_tokens("apple"),
+                agg._identity_tokens("two red apples"),
+            )
+            is True
+        )
+
+    def test_full_containment_required_two_token_share_one(self):
+        # A single shared token out of two is NOT a match (full containment): the
+        # regression guard for different short-named foods sharing a common noun.
+        assert (
+            agg._identity_match(
+                agg._identity_tokens("chicken salad"),
+                agg._identity_tokens("chicken soup"),
+            )
+            is False
+        )
+        assert (
+            agg._identity_match(
+                agg._identity_tokens("beef taco"),
+                agg._identity_tokens("fish taco"),
+            )
+            is False
+        )
+
+    def test_plural_eq_does_not_overmatch_unrelated_tokens(self):
+        # _plural_eq is suffix-ADDITION only; unrelated food nouns that are not one
+        # another plus "s"/"es" must not be treated as the same token.
+        assert agg._plural_eq("beef", "bean") is False
+        assert agg._plural_eq("rice", "fries") is False
+
+    def test_identity_tokens_capped_to_bound_match_cost(self):
+        # DoS guard: _identity_match is O(tokens^2) per pair, so the token set must
+        # stay bounded even if the model returns a pathologically long description.
+        long_desc = " ".join(f"token{i}" for i in range(500))
+        tokens = agg._identity_tokens(long_desc)
+        assert len(tokens) <= agg._MAX_IDENTITY_TOKENS
+
+    def test_containment_is_verbosity_robust_and_symmetric_result(self):
+        terse = agg._identity_tokens("banana")
+        verbose = agg._identity_tokens("a ripe banana with brown speckles on the peel")
+        # Argument order must not change the verdict (smaller set is the yardstick).
+        assert agg._identity_match(terse, verbose) is True
+        assert agg._identity_match(verbose, terse) is True
+
+    def test_disjoint_tokens_never_match(self):
+        assert (
+            agg._identity_match(
+                agg._identity_tokens("creme brulee"),
+                agg._identity_tokens("crema catalana"),
+            )
+            is False
+        )
+
+    def test_empty_token_sets_match_only_each_other(self):
+        # An all-stopword description tokenizes to empty; two empties carry no
+        # identity evidence (match -> not manufactured disagreement), but an empty
+        # vs a real food does not match.
+        empty = agg._identity_tokens("a plate of food")
+        assert empty == frozenset()
+        assert agg._identity_match(empty, frozenset()) is True
+        assert agg._identity_match(empty, agg._identity_tokens("pasta")) is False
+
+
+# --------------------------------------------------------------------------- #
 # Pipeline: multi-sample wired end-to-end (AC1/AC4/AC6/AC7)
 # --------------------------------------------------------------------------- #
 class TestPipelineMultiSample:
@@ -277,6 +483,29 @@ class TestPipelineMultiSample:
         assert d.wide_spread is True
         assert d.note and "rough guess" in d.note
         assert not find_dosing_violations(d.note)
+
+    async def test_verbose_same_food_not_flagged_as_disagreement(self):
+        # Story 50.H5 end-to-end: verbose prose of ONE food must reach the
+        # persisted record as agreement, not trip the identity gate. Pre-fix this
+        # surfaced identity_agreement=False + "confirm the food" + forced low.
+        async with get_session_maker()() as db:
+            user = await _user_with_provider(db)
+            with self._patch_vision(
+                _estimate_json(40, 50, "banana"),
+                _estimate_json(41, 51, "a ripe banana with brown speckles on the peel"),
+                _estimate_json(
+                    42, 52, "one yellow banana resting on a wooden cutting board"
+                ),
+            ):
+                record = await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        d = record.estimate_dispersion
+        assert d.identity_agreement is True
+        assert "confirm the food" not in (d.note or "")
+        # Agreement + tight spread -> the empirical band is NOT force-lowered.
+        assert record.confidence != "low"
 
     async def test_identity_disagreement_requires_confirmation(self):
         async with get_session_maker()() as db:


### PR DESCRIPTION
## Problem

When estimating carbs from a meal photo, the app samples the same photo several times and checks whether the samples agree on *what the food is*. That agreement signal drives the empirical confidence band and the "confirm the food" prompt.

The check compared the per-sample food descriptions with a symmetric token-set similarity (Jaccard), which collapses on the verbose prose a real vision model returns: a terse "banana" and a verbose "a ripe banana with brown speckles on the peel" share only a fraction of their combined tokens, so the **same food described two ways scored as disagreement** -- producing needless low confidence and a misleading "the AI couldn't agree what this is" note on a food that was actually identified consistently.

## Change

Replace the symmetric similarity with directional **full token containment** (NFKD accent folding + simple plural tolerance): the shorter description matches when all of its content tokens appear in the longer one. Verbosity no longer reads as disagreement, while:

- gross misidentification (disjoint tokens, e.g. "creme brulee" vs "crema catalana") still disagrees, and
- two different multi-token foods that merely share one noun ("chicken salad" vs "chicken soup") still disagree -- full containment requires *all* of the shorter name's tokens, not a partial overlap.

This mirrors the all-content-tokens rule the offline accuracy harness already uses; here it is applied symmetrically between two unlabeled samples (no ground truth). A token-count cap bounds the matcher's cost so a pathologically long model description cannot become a CPU sink.

Separately, the published-source grounding disclaimer's safety phrasing is folded onto a single shared constant (referenced by both the inline estimate qualifier and the Open Food Facts disclaimer) so the wording cannot drift; the user-facing strings are unchanged.

## Safety

The agreement signal feeds only the empirical confidence band and the "confirm the food" UX note. External grounding that certifies a food against a published source stays gated on explicit user identity confirmation, so a false agreement never certifies a misidentified food, and nothing here emits a dose or is read by dosing/insulin math.

## Testing

- Unit, aggregation, and pipeline tests for the matcher: verbose-vs-terse agreement, NFKD/plural clustering, gross-misID and shared-single-token disagreement, empty-set semantics, and the cost cap. Direct helper-level guards ensure a regression in accent folding or plural tolerance is actually caught.
- Disclaimer test pins the canonical prohibition and that published data is not mislabeled as an AI estimate.
- Backend lint (ruff check + format), the meal test suites, and the broader consumer suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved meal identity matching so the same food is recognized reliably across verbose descriptions, accent differences, and plural variants.
  * Updated safety/disclaimer text to use consistent “never dose/bolus” wording across nutrition and meal estimate messaging.

* **Tests**
  * Added end-to-end and regression coverage to ensure verbose vs terse descriptions agree appropriately and that disclaimers/dispersion behavior remain correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->