### PR TITLE
test(meal): end-to-end coverage for the meal-logging core loop and failure modes

### DIFF
--- a/apps/api/tests/test_meal_e2e_chain.py
+++ b/apps/api/tests/test_meal_e2e_chain.py
@@ -1,17 +1,34 @@
-"""End-to-end H1->H2->H3 chain over HTTP (real ASGI app + real DB, vision mocked).
+"""End-to-end meal-intelligence journeys over HTTP (real ASGI app + real DB).
 
-Exercises the *composed* flow the per-story tests don't: a meal photo goes
-upload -> multi-sample dispersion (H1) -> identity confirmation that opens the
-grounding gate + re-indexes own history (H2) -> auditable provenance with the
-self-reported confidence hidden (H3) -> delete that cascades the audit. Only the
-vision LLM (``_call_vision``) is mocked; everything else is the real pipeline,
-router, schemas, and database. Embeddings are the autouse conftest stub, so
-own-history recall is deterministic (identical text -> distance 0).
+Two layers live here:
+
+* The original composed estimate->confirm->audit->delete chain: a meal photo
+  goes upload -> multi-sample dispersion -> identity confirmation that opens the
+  grounding gate + re-indexes own history -> auditable provenance with the
+  self-reported confidence hidden -> delete that cascades the audit.
+* The user-journey backfill (the safety net the live feature lacked): the core
+  loop a real user walks -- first estimate -> correct -> save & recognize a
+  common food -> meal-aware chat with a verified citation -- plus the failure
+  modes users actually hit (no provider, no-vision provider, feature flag off, a
+  hallucinated chat carb number, an external-grounding fetch failure, and
+  cross-user isolation).
+
+Only the vision LLM (``_call_vision``) and the chat model (``get_ai_client``)
+are mocked; the pipeline, router, schemas, grounding precedence, citation
+verifier, and database are all real. Embeddings are the autouse conftest stub,
+so own-history recall is deterministic (identical text -> distance 0).
+
+Assertions are behavioral, never exact carb values from the model: a range is
+present, the safety qualifier is present, a cited number traces to a stored
+record, a correction persists, recognition fires, and an unconfirmed identity is
+not certified. The only hard numbers asserted are user-supplied (a correction)
+or model-mocked inputs we control in the test.
 """
 
+import contextlib
 import uuid
 from io import BytesIO
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -22,8 +39,9 @@ from src.config import settings
 from src.database import get_session_maker
 from src.main import app
 from src.models.ai_provider import AIProviderConfig, AIProviderStatus, AIProviderType
+from src.schemas.ai_response import AIResponse, AIUsage
 from src.services import food_vision
-from src.vision.carb_contract import find_dosing_violations
+from src.vision.carb_contract import MEAL_ESTIMATE_QUALIFIER, find_dosing_violations
 
 
 def _png() -> bytes:
@@ -45,6 +63,16 @@ def _vision(desc: str, low: float, high: float, confidence: str = "high") -> str
     )
 
 
+# Digits map to letters so a unique food name interpolated into a mocked chat
+# reply can never be misread as a (carb-anchored) figure by the F2 verifier.
+_ALPHA_SUFFIX = str.maketrans("0123456789", "ghijklmnop")
+
+
+def _uniq() -> str:
+    """A short, digit-free unique token for food names."""
+    return uuid.uuid4().hex[:6].translate(_ALPHA_SUFFIX)
+
+
 @pytest.fixture(autouse=True)
 def _enable(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "upload_dir", str(tmp_path / "uploads"))
@@ -55,22 +83,27 @@ def _enable(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "open_food_facts_enabled", False)
 
 
-@pytest_asyncio.fixture
-async def client():
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
-        email = f"e2e_{uuid.uuid4().hex[:8]}@example.com"
-        await c.post(
-            "/api/auth/register", json={"email": email, "password": "SecurePass123"}
-        )
-        login = await c.post(
-            "/api/auth/login", json={"email": email, "password": "SecurePass123"}
-        )
-        c.cookies.set(
-            settings.jwt_cookie_name, login.cookies.get(settings.jwt_cookie_name)
-        )
-        me = await c.get("/api/auth/me")
-        user_id = uuid.UUID(me.json()["id"])
+async def _provision(c: AsyncClient, *, with_provider: bool = True) -> uuid.UUID:
+    """Register + log in a fresh user on ``c``; optionally give them a provider.
+
+    Returns the new user's id. ``with_provider=False`` leaves the user with no AI
+    provider so the upload path raises ``ProviderNotConfiguredError`` (FM1). The
+    provider is seeded directly (the same pattern the original chain test used)
+    because the public provider API requires a real key-validation round-trip.
+    """
+    email = f"e2e_{uuid.uuid4().hex[:8]}@example.com"
+    register = await c.post(
+        "/api/auth/register", json={"email": email, "password": "SecurePass123"}
+    )
+    assert register.status_code == 201, register.text
+    login = await c.post(
+        "/api/auth/login", json={"email": email, "password": "SecurePass123"}
+    )
+    assert login.status_code == 200, login.text
+    c.cookies.set(settings.jwt_cookie_name, login.cookies.get(settings.jwt_cookie_name))
+    me = await c.get("/api/auth/me")
+    user_id = uuid.UUID(me.json()["id"])
+    if with_provider:
         async with get_session_maker()() as db:
             db.add(
                 AIProviderConfig(
@@ -81,7 +114,60 @@ async def client():
                 )
             )
             await db.commit()
+    return user_id
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await _provision(c)
         yield c
+
+
+@contextlib.asynccontextmanager
+async def _second_client(*, with_provider: bool = True):
+    """A second authenticated client against the same app (cross-user tests)."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await _provision(c, with_provider=with_provider)
+        yield c
+
+
+def _ai_client(content: str) -> MagicMock:
+    """A fake AI client whose ``generate`` returns a canned response."""
+    fake = MagicMock()
+    fake.generate = AsyncMock(
+        return_value=AIResponse(
+            content=content,
+            model="claude-sonnet-4-5-20250929",
+            provider=AIProviderType.CLAUDE_API,
+            usage=AIUsage(input_tokens=10, output_tokens=10),
+        )
+    )
+    return fake
+
+
+async def _chat(client: AsyncClient, message: str, *, ai_says: str) -> str:
+    """Drive a web chat turn with the model output mocked; return the reply text.
+
+    The diabetes-context build is stubbed (its builders have their own tests and
+    cannot affect a mocked reply), but the meal-citation verifier runs for real
+    against the user's logged meals in the database.
+    """
+    with (
+        patch(
+            "src.services.telegram_chat.get_ai_client",
+            AsyncMock(return_value=_ai_client(ai_says)),
+        ),
+        patch(
+            "src.services.telegram_chat.build_diabetes_context",
+            AsyncMock(return_value="[context]"),
+        ),
+    ):
+        resp = await client.post("/api/ai/chat", json={"message": message})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["response"]
 
 
 async def _upload(client: AsyncClient, *responses: str) -> dict:
@@ -171,3 +257,265 @@ async def test_unconfirmed_identity_audit_is_vision_only(client):
     assert audit["precedence"]["outcome"] == "vision_only"
     assert audit["precedence"]["identity_confirmed"] is False
     assert rec["grounding_source"] is None
+
+
+# ── Core-loop user journey (GJ1 -> GJ2 -> GJ3 -> GJ6) ──
+# The single loop a real user walks across the merged milestones: photograph a
+# meal, correct the estimate, save & recognize it as a common food, then ask the
+# AI about it and get a citation that traces to the saved value. Behavioral
+# assertions only -- the model's carb numbers are never asserted, but the
+# user-supplied correction and the mocked-model citation (both inputs we control)
+# are.
+
+# Carb figures that, if they showed up as response *fields*, would mean food
+# records had been coupled into dosing/treatment math -- the one thing this
+# feature must never do.
+_DOSE_FIELDS = {"dose", "insulin", "bolus", "iob", "units", "carb_ratio"}
+
+
+async def test_core_loop_estimate_correct_save_recognize_cite(client):
+    desc = f"chicken burrito {_uniq()}"
+
+    # --- GJ1: first estimate (cold start) -> range + qualifier, no dose ---
+    rec = await _upload(
+        client, _vision(desc, 45, 55), _vision(desc, 50, 60), _vision(desc, 48, 58)
+    )
+    assert rec["carbs_low"] < rec["carbs_high"]  # a range, not a lone integer
+    assert "Never use it" in rec["safety_qualifier"]  # qualifier present
+    assert rec["identity_confirmed"] is False  # unconfirmed at create
+    assert rec["grounding_source"] is None  # gate closed -> no grounding yet
+    assert rec["suggested_identity"] is None  # nothing logged before this
+    disp = rec["estimate_dispersion"]
+    assert disp is not None and disp["samples_used"] == 3
+    assert not find_dosing_violations(disp["note"] or "")  # uncertainty note is safe
+    # No dosing/IoB coupling: food records never expose a dose-shaped field.
+    assert _DOSE_FIELDS.isdisjoint(rec.keys())
+    rec_id = rec["id"]
+
+    # --- GJ2: correct the estimate -> persists, source flips, original kept ---
+    corr = await client.post(
+        f"/api/food-records/{rec_id}/correct",
+        json={"corrected_carbs_low": 70, "corrected_carbs_high": 80},
+    )
+    assert corr.status_code == 200, corr.text
+    cbody = corr.json()
+    assert (cbody["corrected_carbs_low"], cbody["corrected_carbs_high"]) == (70, 80)
+    assert cbody["source"] == "user_corrected"  # provenance flipped
+    # The original AI estimate is preserved alongside the correction.
+    assert (cbody["carbs_low"], cbody["carbs_high"]) == (
+        rec["carbs_low"],
+        rec["carbs_high"],
+    )
+
+    # --- GJ3a: save the corrected estimate as a named common food ---
+    # Save under a distinct canonical name (not the vision description). The
+    # common-food baseline is the user's curated truth; grounding the re-shoot
+    # against this name resolves to exactly this one corrected baseline -- which
+    # makes the "prefers the corrected value" assertion deterministic. Confirming
+    # against the bare description instead would leave the recall query equidistant
+    # (under the conftest fake embedding) to BOTH the corrected baseline and the
+    # re-shoot's own uncorrected chunk, and the production recall currently has no
+    # tie-breaker to deterministically prefer the corrected one.
+    saved_name = f"my usual {desc}"
+    save = await client.post(
+        f"/api/food-records/{rec_id}/save-as-common-food", json={"name": saved_name}
+    )
+    assert save.status_code == 201, save.text
+    cf = save.json()
+    assert (cf["carbs_low"], cf["carbs_high"]) == (70, 80)  # the corrected value
+    listing = (await client.get("/api/common-foods")).json()
+    assert any(item["id"] == cf["id"] for item in listing["common_foods"])
+
+    # --- GJ3b: re-shoot the same food -> recall recognizes it ---
+    rec2 = await _upload(
+        client, _vision(desc, 52, 62), _vision(desc, 54, 64), _vision(desc, 53, 63)
+    )
+    assert rec2["suggested_identity"] is not None  # "you've logged this before"
+    assert rec2["grounding_source"] is None  # still vision-only until confirmed
+
+    # Confirm the re-shoot as the saved common food -> grounding resolves to that
+    # one corrected baseline and prefers the corrected value over the vision band.
+    confirm = await client.post(
+        f"/api/food-records/{rec2['id']}/confirm-identity",
+        json={"confirmed_food_name": saved_name},
+    )
+    assert confirm.status_code == 200, confirm.text
+    g = confirm.json()
+    assert g["identity_confirmed"] is True
+    assert g["grounding_source"] == "Your meal history"  # own-history grounded
+    assert g["grounding"]["carbs_low"] == 70  # the corrected value, not vision
+    assert "corrected value" in g["grounding"]["note"]
+
+    # --- GJ6: meal-aware chat references the meal with a VERIFIED citation ---
+    # The model utters a carb figure that traces to the corrected record (70-80g):
+    # within tolerance, so the verifier leaves it byte-for-byte unchanged.
+    reply = await _chat(
+        client,
+        "what have I eaten lately?",
+        ai_says=f"You logged {desc} with about 75g of carbs recently. How did it sit?",
+    )
+    assert "75g" in reply  # the verified figure survived untouched
+    assert desc in reply  # the AI referenced the logged meal
+    assert "can't verify" not in reply  # not scrubbed -- it matched a record
+
+
+# ── Failure modes users actually hit (FM1, FM2, FM3, FM5, FM6, FM7) ──
+
+
+async def test_fm1_no_provider_returns_structured_error():
+    """FM1: a user with no AI provider gets a clear 4xx, never a crash."""
+    async with _second_client(with_provider=False) as c:
+        resp = await c.post(
+            "/api/food-records", files={"file": ("m.png", _png(), "image/png")}
+        )
+    assert resp.status_code == 404
+    assert "provider" in resp.json()["detail"].lower()
+
+
+async def test_fm2_provider_without_vision_returns_vision_unavailable(client):
+    """FM2: a provider with no vision route -> 422, never a fabricated estimate."""
+    with patch.object(
+        food_vision,
+        "_call_vision",
+        AsyncMock(
+            side_effect=food_vision.VisionUnavailableError(
+                "Vision is not available on your current AI provider."
+            )
+        ),
+    ):
+        resp = await client.post(
+            "/api/food-records", files={"file": ("m.png", _png(), "image/png")}
+        )
+    assert resp.status_code == 422
+    assert "vision" in resp.json()["detail"].lower()
+
+
+async def test_fm3_feature_flag_off_returns_404(client, monkeypatch):
+    """FM3: with the feature flag off, the meal endpoints are invisible (404)."""
+    monkeypatch.setattr(settings, "meal_intelligence_enabled", False)
+    upload = await client.post(
+        "/api/food-records", files={"file": ("m.png", _png(), "image/png")}
+    )
+    assert upload.status_code == 404
+    assert (await client.get("/api/food-records")).status_code == 404
+    assert (await client.get("/api/common-foods")).status_code == 404
+
+
+async def test_fm5_wrong_chat_carb_number_is_scrubbed(client):
+    """FM5: a carb figure the model invents is corrected/scrubbed before the user sees it."""
+    desc = f"oatmeal {_uniq()}"
+    rec = await _upload(
+        client, _vision(desc, 30, 40), _vision(desc, 32, 42), _vision(desc, 31, 41)
+    )
+    low, high = rec["carbs_low"], rec["carbs_high"]
+
+    # Exactly one logged meal -> a single unambiguous referent, so an unverifiable
+    # figure is corrected to the stored range rather than scrubbed to prose.
+    reply = await _chat(
+        client,
+        "how many carbs was breakfast?",
+        ai_says="Your breakfast had about 200g of carbs.",
+    )
+    assert "200" not in reply  # the invented number is gone
+    assert f"~{low:g}-{high:g}g carbs" in reply  # rewritten to the stored range
+    assert MEAL_ESTIMATE_QUALIFIER in reply  # carries the never-dose framing
+
+
+async def test_fm5_wrong_chat_carb_number_scrubbed_when_ambiguous(client):
+    """FM5 (multi-referent): with >1 meal, an unverifiable figure is scrubbed."""
+    a = f"toast {_uniq()}"
+    b = f"yogurt {_uniq()}"
+    await _upload(client, _vision(a, 20, 30), _vision(a, 22, 32), _vision(a, 21, 31))
+    await _upload(client, _vision(b, 10, 18), _vision(b, 12, 20), _vision(b, 11, 19))
+
+    reply = await _chat(
+        client,
+        "what did I eat today?",
+        ai_says="Across the day you had about 999g of carbs.",
+    )
+    assert "999" not in reply  # can't be pinned to one meal -> not guessed
+    assert "can't verify" in reply
+    assert MEAL_ESTIMATE_QUALIFIER in reply
+
+
+async def test_fm6_external_grounding_failure_degrades_to_vision_only(client):
+    """FM6: an external nutrition fetch failure degrades gracefully (no crash)."""
+    from src.services import nutrition_sources
+
+    desc = f"unique dish {_uniq()}"
+    rec = await _upload(
+        client, _vision(desc, 40, 50), _vision(desc, 42, 52), _vision(desc, 41, 51)
+    )
+    assert rec["carbs_low"] < rec["carbs_high"]  # the user already got an estimate
+
+    # Confirm a never-before-grounded identity (so own-history can't ground it)
+    # while both published-source lookups blow up. End to end, the grounding path
+    # must swallow the failure: confirmation still succeeds, gracefully vision-only,
+    # and the user keeps their estimate. This asserts the end-to-end degradation,
+    # not which specific fail-open layer caught it (the orchestrator's own wrapper
+    # has focused unit coverage). The novel name keeps the recall query off the
+    # record's freshly-indexed chunk, so the external-failure path is what's tested
+    # rather than the own-history fallback.
+    novel = f"never grounded {_uniq()}"
+    with (
+        patch.object(
+            nutrition_sources,
+            "lookup_usda",
+            AsyncMock(side_effect=RuntimeError("down")),
+        ),
+        patch.object(
+            nutrition_sources,
+            "lookup_open_food_facts",
+            AsyncMock(side_effect=RuntimeError("down")),
+        ),
+    ):
+        confirm = await client.post(
+            f"/api/food-records/{rec['id']}/confirm-identity",
+            json={"confirmed_food_name": novel},
+        )
+    assert confirm.status_code == 200, confirm.text  # no crash
+    body = confirm.json()
+    assert body["identity_confirmed"] is True
+    assert body["grounding_source"] is None  # gracefully vision-only
+    # The estimate band is untouched by the failed grounding attempt.
+    assert (body["carbs_low"], body["carbs_high"]) == (
+        rec["carbs_low"],
+        rec["carbs_high"],
+    )
+
+
+async def test_fm7_cross_user_isolation(client):
+    """FM7 (IDOR): user B can never see user A's records or common foods."""
+    desc = f"private meal {_uniq()}"
+    rec_a = await _upload(
+        client, _vision(desc, 60, 70), _vision(desc, 62, 72), _vision(desc, 61, 71)
+    )
+    cf_a = (
+        await client.post(
+            f"/api/food-records/{rec_a['id']}/save-as-common-food",
+            json={"name": desc},
+        )
+    ).json()
+
+    async with _second_client() as b:
+        # Direct object access is a not-found, not a forbidden (no existence leak).
+        assert (await b.get(f"/api/food-records/{rec_a['id']}")).status_code == 404
+        assert (
+            await b.get(f"/api/food-records/{rec_a['id']}/audit")
+        ).status_code == 404
+        correct_b = await b.post(
+            f"/api/food-records/{rec_a['id']}/correct",
+            json={"corrected_carbs_low": 1, "corrected_carbs_high": 2},
+        )
+        assert correct_b.status_code == 404
+        assert (await b.get(f"/api/common-foods/{cf_a['id']}")).status_code == 404
+
+        # Listings never surface another user's rows.
+        assert (await b.get("/api/food-records")).json()["total"] == 0
+        assert (await b.get("/api/common-foods")).json()["total"] == 0
+
+        # Own-history recall is owner-scoped: B shooting A's food gets no recall.
+        rec_b = await _upload(
+            b, _vision(desc, 60, 70), _vision(desc, 62, 72), _vision(desc, 61, 71)
+        )
+        assert rec_b["suggested_identity"] is None

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
@@ -1,0 +1,326 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.ChatRequest
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
+import com.glycemicgpt.mobile.data.remote.dto.CommonFoodUpdateRequest
+import com.glycemicgpt.mobile.data.remote.dto.DeviceRegistrationRequest
+import com.glycemicgpt.mobile.data.remote.dto.EstimateDispersionResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordCorrectionRequest
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordIdentityRequest
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordListResponse
+import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
+import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
+import com.glycemicgpt.mobile.data.remote.dto.PluginDeclarationRequest
+import com.glycemicgpt.mobile.data.remote.dto.PumpPushRequest
+import com.glycemicgpt.mobile.data.remote.dto.RefreshTokenRequest
+import com.glycemicgpt.mobile.data.remote.dto.SaveAsCommonFoodRequest
+import com.glycemicgpt.mobile.data.repository.MealRepository
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.Dispatchers
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import retrofit2.Response
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+
+/**
+ * Full-flow meal-logging journey across screens (GJ1->GJ2->GJ3 + FM8), with the
+ * backend faked at the Retrofit-API seam. Unlike the per-component Compose tests
+ * (e.g. [CarbEstimateContentUiTest]), this drives the *real* screens and *real*
+ * view models through a [NavHost]: capture -> result (qualifier present) ->
+ * correct -> save-as-common-food -> history. Nothing here asserts an exact carb
+ * value -- only that the structure and safety behavior a user depends on hold:
+ * the never-dose qualifier is always on the estimate surface, a correction
+ * persists through the flow, and an upload error never strands the spinner (the
+ * FM8 stuck-spinner guard).
+ *
+ * The fake API is stateful so the cross-screen assertions are coherent (the
+ * record saved on the result screen is the one history later lists).
+ */
+@RunWith(AndroidJUnit4::class)
+class MealFullFlowE2ETest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun fullFlow_capture_result_correct_save_history() {
+        val api = FakeMealApi()
+        setContentWithNav(api)
+        awaitTag("meal_capture_camera") // probe resolved -> Ready (capture UI shown)
+
+        // GJ1: capture -> estimate result. Drive the picked-image callback directly
+        // (the system picker can't be fulfilled in a test) with a real decodable image.
+        val photo = writeImage()
+        runOnUi { mealLogVm.onImagePicked(Uri.fromFile(photo)) }
+        awaitTag("meal_result_card")
+
+        // The non-negotiable safety qualifier is present on the estimate surface,
+        // and the estimate shows a carb range (not a lone number).
+        compose.onNodeWithTag("meal_safety_qualifier", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithTag("meal_carb_range", useUnmergedTree = true).assertIsDisplayed()
+
+        // GJ2: correct the estimate; the corrected note proves it persisted + re-rendered.
+        compose.onNodeWithTag("meal_correct_button").performClick()
+        awaitTag("meal_correction_editor")
+        compose.onNodeWithTag("meal_correct_low_input").performTextReplacement("70")
+        compose.onNodeWithTag("meal_correct_high_input").performTextReplacement("80")
+        compose.onNodeWithTag("meal_correct_save").performClick()
+        awaitTag("meal_corrected_note")
+
+        // GJ3: save the corrected estimate as a common food.
+        compose.onNodeWithTag("meal_save_common_button").performClick()
+        awaitTag("meal_save_common_name_input")
+        compose.onNodeWithTag("meal_save_common_name_input").performTextInput("Chicken Burrito")
+        compose.onNodeWithTag("meal_save_common_confirm").performClick()
+        awaitTag("meal_saved_common_confirmation")
+        check(api.commonFoods.isNotEmpty()) { "save-as-common-food never reached the API" }
+
+        // Navigate to history (result -> idle -> History) and see the saved record.
+        compose.onNodeWithTag("meal_log_another").performClick()
+        awaitTag("meal_history_button")
+        compose.onNodeWithTag("meal_history_button").performClick()
+        awaitTag("meal_history_item")
+        // The qualifier rides every estimate surface, history included.
+        compose.onNodeWithTag("meal_safety_qualifier", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun uploadError_neverLeavesSpinnerStuck_onUndecodableImage() {
+        // The exact FM8 stuck-spinner bug: a photo that can't be decoded must
+        // surface an error, never leave the estimate spinner running forever.
+        val api = FakeMealApi()
+        setContentSingle(api)
+        awaitTag("meal_capture_camera")
+
+        val notAnImage = File.createTempFile("e2e_meal_bad", ".txt", context.cacheDir)
+            .apply { writeText("this is not an image") }
+        runOnUi { mealLogVm.onImagePicked(Uri.fromFile(notAnImage)) }
+
+        awaitTag("meal_error")
+        compose.onAllNodesWithTag("meal_uploading", useUnmergedTree = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun uploadError_neverLeavesSpinnerStuck_onApiFailure() {
+        // A backend failure mid-upload must also clear the spinner, not strand it.
+        val api = FakeMealApi().apply { failUpload = true }
+        setContentSingle(api)
+        awaitTag("meal_capture_camera")
+
+        val photo = writeImage()
+        runOnUi { mealLogVm.onImagePicked(Uri.fromFile(photo)) }
+
+        awaitTag("meal_error")
+        compose.onAllNodesWithTag("meal_uploading", useUnmergedTree = true).assertCountEquals(0)
+    }
+
+    // ── Harness ──
+
+    private lateinit var mealLogVm: MealLogViewModel
+    private lateinit var historyVm: MealHistoryViewModel
+
+    /** Build the real repository + view models against [api] (same instance for both API seams). */
+    private fun buildViewModels(api: FakeMealApi) {
+        val repository = MealRepository(api, api, Moshi.Builder().build())
+        mealLogVm = MealLogViewModel(repository, context, Dispatchers.IO)
+        historyVm = MealHistoryViewModel(repository)
+    }
+
+    /** Host the meal-log and history screens in a NavHost so navigation is exercised for real. */
+    private fun setContentWithNav(api: FakeMealApi) {
+        buildViewModels(api)
+        compose.setContent {
+            GlycemicGptTheme {
+                val nav = rememberNavController()
+                NavHost(navController = nav, startDestination = "log") {
+                    composable("log") {
+                        MealLogScreen(
+                            onBack = {},
+                            onNavigateToHistory = { nav.navigate("history") },
+                            onNavigateToCommonFoods = {},
+                            viewModel = mealLogVm,
+                        )
+                    }
+                    composable("history") {
+                        // A fresh hiltViewModel reloads on entry in production; mirror that
+                        // by reloading the (shared) view model when this destination shows.
+                        LaunchedEffect(Unit) { historyVm.load() }
+                        MealHistoryScreen(onBack = { nav.popBackStack() }, viewModel = historyVm)
+                    }
+                }
+            }
+        }
+    }
+
+    /** Host only the meal-log screen (the FM8 stuck-spinner guards need no navigation). */
+    private fun setContentSingle(api: FakeMealApi) {
+        buildViewModels(api)
+        compose.setContent {
+            GlycemicGptTheme {
+                MealLogScreen(
+                    onBack = {},
+                    onNavigateToHistory = {},
+                    onNavigateToCommonFoods = {},
+                    viewModel = mealLogVm,
+                )
+            }
+        }
+    }
+
+    private fun runOnUi(block: () -> Unit) = compose.runOnUiThread(block)
+
+    private fun awaitTag(tag: String, timeoutMs: Long = 10_000) {
+        compose.waitUntil(timeoutMs) {
+            compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /** A small but genuinely decodable PNG written to the cache for the capture path. */
+    private fun writeImage(): File {
+        val bitmap = Bitmap.createBitmap(16, 16, Bitmap.Config.ARGB_8888)
+        return File.createTempFile("e2e_meal", ".png", context.cacheDir).also { file ->
+            FileOutputStream(file).use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            bitmap.recycle()
+        }
+    }
+}
+
+/**
+ * In-memory [GlycemicGptApi] for the meal flow. Only the food-record / common-food
+ * endpoints the journey touches are implemented (statefully, so cross-screen reads
+ * are coherent); every other endpoint is unreachable in this flow.
+ */
+@Suppress("TooManyFunctions") // Implements the full GlycemicGptApi; only the meal endpoints are live.
+private class FakeMealApi : GlycemicGptApi {
+
+    val records = mutableListOf<FoodRecordResponse>()
+    val commonFoods = mutableListOf<CommonFoodResponse>()
+
+    /** When set, the upload returns a 502 so the FM8 API-failure path can be exercised. */
+    var failUpload = false
+
+    override suspend fun uploadFoodPhoto(file: MultipartBody.Part): Response<FoodRecordResponse> {
+        if (failUpload) return error502()
+        val record = FoodRecordResponse(
+            id = UUID.randomUUID().toString(),
+            mealTimestamp = TS,
+            foodDescription = "chicken burrito",
+            carbsLow = 45.0,
+            carbsHigh = 60.0,
+            confidence = "low",
+            source = "ai_estimate",
+            createdAt = TS,
+            estimateDispersion = EstimateDispersionResponse(
+                note = "Reads of this photo varied somewhat -- treat this as approximate.",
+                wideSpread = false,
+                identityAgreement = true,
+            ),
+        )
+        records.add(record)
+        return Response.success(record)
+    }
+
+    override suspend fun listFoodRecords(limit: Int, offset: Int): Response<FoodRecordListResponse> =
+        Response.success(FoodRecordListResponse(records = records.toList(), total = records.size))
+
+    override suspend fun correctFoodRecord(
+        recordId: String,
+        request: FoodRecordCorrectionRequest,
+    ): Response<FoodRecordResponse> {
+        val index = records.indexOfFirst { it.id == recordId }
+        if (index < 0) return error404()
+        val corrected = records[index].copy(
+            source = "user_corrected",
+            correctedCarbsLow = request.correctedCarbsLow,
+            correctedCarbsHigh = request.correctedCarbsHigh,
+            correctedAt = TS,
+        )
+        records[index] = corrected
+        return Response.success(corrected)
+    }
+
+    override suspend fun saveRecordAsCommonFood(
+        recordId: String,
+        request: SaveAsCommonFoodRequest,
+    ): Response<CommonFoodResponse> {
+        val record = records.firstOrNull { it.id == recordId } ?: return error404()
+        val common = CommonFoodResponse(
+            id = UUID.randomUUID().toString(),
+            name = request.name,
+            // Prefer the corrected value, like the backend's promotion does.
+            carbsLow = record.correctedCarbsLow ?: record.carbsLow,
+            carbsHigh = record.correctedCarbsHigh ?: record.carbsHigh,
+            createdAt = TS,
+            updatedAt = TS,
+        )
+        commonFoods.add(common)
+        return Response.success(common)
+    }
+
+    private fun <T> error502(): Response<T> =
+        Response.error(502, "{\"detail\":\"AI vision service unavailable\"}".toResponseBody(JSON))
+
+    private fun <T> error404(): Response<T> =
+        Response.error(404, "{\"detail\":\"Food record not found.\"}".toResponseBody(JSON))
+
+    // Endpoints outside the journey under test are never invoked here.
+    override suspend fun healthCheck() = notUsed()
+    override suspend fun login(request: LoginRequest) = notUsed()
+    override suspend fun refreshToken(request: RefreshTokenRequest) = notUsed()
+    override suspend fun pushPumpEvents(request: PumpPushRequest) = notUsed()
+    override suspend fun sendChatMessage(request: ChatRequest) = notUsed()
+    override suspend fun getAiProvider() = notUsed()
+    override suspend fun registerDevice(request: DeviceRegistrationRequest) = notUsed()
+    override suspend fun unregisterDevice(deviceToken: String) = notUsed()
+    override suspend fun getPendingAlerts() = notUsed()
+    override suspend fun acknowledgeAlert(alertId: String) = notUsed()
+    override suspend fun getGlucoseRange() = notUsed()
+    override suspend fun getSafetyLimits() = notUsed()
+    override suspend fun getAnalyticsConfig() = notUsed()
+    override suspend fun getPumpProfile() = notUsed()
+    override suspend fun putPluginDeclarations(body: PluginDeclarationRequest) = notUsed()
+    override suspend fun deletePluginDeclarations() = notUsed()
+    override suspend fun listNightscoutConnections() = notUsed()
+    override suspend fun getNightscoutData(connectionId: String, since: String?, limit: Int) = notUsed()
+    override suspend fun deleteFoodRecord(recordId: String) = notUsed()
+    override suspend fun confirmFoodIdentity(recordId: String, request: FoodRecordIdentityRequest) = notUsed()
+    override suspend fun getFoodRecordAudit(recordId: String) = notUsed()
+    override suspend fun listCommonFoods(limit: Int, offset: Int) = notUsed()
+    override suspend fun updateCommonFood(commonFoodId: String, request: CommonFoodUpdateRequest) = notUsed()
+    override suspend fun deleteCommonFood(commonFoodId: String) = notUsed()
+
+    private fun notUsed(): Nothing =
+        throw UnsupportedOperationException("Endpoint not used in the meal full-flow test")
+
+    private companion object {
+        const val TS = "2026-06-18T05:00:00Z"
+        val JSON = "application/json".toMediaType()
+    }
+}


### PR DESCRIPTION
## What

Backfills automated **end-to-end / user-journey** coverage for the shipped meal-logging feature. Until now this feature — one of the most-used surfaces — had only isolated unit tests and component-level Compose tests; the journeys a real user actually walks had no E2E safety net.

## Coverage added

**API journey (`apps/api/tests/test_meal_e2e_chain.py`)** — drives the flow over the real ASGI app + database, with only the vision and chat models mocked (the pipeline, grounding precedence, and the output-side citation verifier all run for real):

- **Core loop:** upload → carb-range estimate (+ safety qualifier) → user correction (provenance flips, original estimate preserved) → save & recognize a common food → re-shoot recognized from own history (prefers the corrected value) → meal-aware chat that references the meal with a **verified** citation.
- **Failure modes:** no AI provider (404), provider without vision (422), feature flag off (404), a hallucinated chat carb number (corrected for a single meal / scrubbed when ambiguous), an external-nutrition fetch failure (graceful, vision-only), and cross-user isolation (a second user can never see the first's records or common foods, and own-history recall is owner-scoped).

**Mobile full-flow (`apps/mobile/.../androidTest/.../meal/MealFullFlowE2ETest.kt`)** — a Compose `NavHost` navigation test driving capture → result (safety qualifier present) → correct → save-as-common-food → history **across screens** with the backend faked at the Retrofit seam, plus the **stuck-spinner guards**: an undecodable image and an upload failure must each surface an error and never leave the UI loading forever.

## Notes

- Assertions are **behavioral only** — no exact AI carb values are asserted (the model is non-deterministic): a range is present, the never-dose qualifier is present, a cited number traces to a stored record, a correction persists, recognition fires, and an unconfirmed identity is never certified.
- No production code changes — coverage only.

## Verification

- `pytest`: new journeys green; meal-adjacent regression green; full-suite collection clean.
- `ruff check` + `ruff format --check` on `src/` and `tests/`: clean.
- Mobile: `compileDebugAndroidTestKotlin` and `testDebugUnitTest` both build successfully. The instrumented test runs under the CI Android Gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end testing for meal estimation, correction, saving, and history workflows across backend and mobile
  * Added comprehensive error scenario coverage including provider unavailability, feature flags, and invalid data handling
  * Implemented cross-user isolation verification to ensure data privacy and security
  * Added mobile UI testing for the complete meal-logging journey

<!-- end of auto-generated comment: release notes by coderabbit.ai -->