### PR TITLE
fix(api): deterministic, self-excluding own-history meal recall

### DIFF
--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -132,7 +132,12 @@ async def confirm_food_identity(
     if settings.meal_intelligence_enabled:
         try:
             grounding = await meal_grounding.ground_estimate(
-                record.user_id, name, identity_confirmed=True
+                record.user_id,
+                name,
+                identity_confirmed=True,
+                # Don't let a record ground to its own freshly-indexed chunk; a
+                # first-ever log must not cite itself as "your meal history".
+                exclude_food_record_id=record.id,
             )
         except Exception:
             logger.warning(

--- a/apps/api/src/services/meal_grounding.py
+++ b/apps/api/src/services/meal_grounding.py
@@ -64,6 +64,7 @@ async def ground_estimate(
     identity: str | None,
     *,
     identity_confirmed: bool,
+    exclude_food_record_id: uuid.UUID | str | None = None,
 ) -> GroundingDetail | None:
     """Return the best grounding for a *confirmed-identity* estimate, or None.
 
@@ -79,6 +80,9 @@ async def ground_estimate(
     lookups each manage their own DB sessions and each fails open to None
     internally, so this orchestrator stays free of redundant try/except layers.
     The single hard fail-open boundary is the caller (``food_vision``).
+
+    ``exclude_food_record_id`` is forwarded to own-history recall so the record
+    being grounded never recalls itself (a first log must not cite itself).
     """
     # Defence in depth: the only callers are already flag-gated, but enforce the
     # feature flag at this boundary too so a future caller can't run grounding
@@ -94,7 +98,9 @@ async def ground_estimate(
     if not description:
         return None
 
-    recall = await meal_rag.recall_similar_meal(user_id, description)
+    recall = await meal_rag.recall_similar_meal(
+        user_id, description, exclude_food_record_id=exclude_food_record_id
+    )
 
     # 1. A corrected own-history match is the user's own truth -- top precedence,
     # and lets us skip the external calls entirely.

--- a/apps/api/src/services/meal_rag.py
+++ b/apps/api/src/services/meal_rag.py
@@ -25,7 +25,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import case, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from src.database import get_session_maker
@@ -104,12 +104,25 @@ def _coerce_float(value: object) -> float | None:
 async def recall_similar_meal(
     user_id: uuid.UUID,
     food_description: str,
+    *,
+    exclude_food_record_id: uuid.UUID | str | None = None,
 ) -> MealRecall | None:
     """Return the user's closest prior logged food, or None.
 
     Owner-scoped vector search over the user's own food-history chunks only. The
     carb range comes from the chunk metadata (already the user's corrected value
     when one exists -- see ``index_food_record``).
+
+    ``exclude_food_record_id`` drops the chunk for the record currently being
+    grounded, so a freshly-uploaded record can't recall *itself* as history (its
+    own chunk is indexed at upload). A common-food baseline carries
+    ``common_food_id`` (not ``food_record_id``), so ``IS DISTINCT FROM`` is used
+    to keep those rows rather than drop them on a NULL comparison.
+
+    Ties on distance are broken deterministically: the user's **corrected** value
+    wins, then the **most-recently** indexed -- so when a corrected and an
+    uncorrected chunk for one food are equidistant or near-equidistant, grounding
+    reliably prefers the correction instead of an implementation-defined row.
 
     Runs on its own short-lived session, decoupled from any caller transaction:
     embedding offloads to a worker thread, and reusing the request session across
@@ -121,25 +134,47 @@ async def recall_similar_meal(
         return None
 
     distance = KnowledgeChunk.embedding.cosine_distance(embedding)
+    conditions = [
+        # Strictly owner-scoped: never another user's history, and never the
+        # shared (NULL) clinical/external chunks.
+        KnowledgeChunk.user_id == user_id,
+        KnowledgeChunk.source_type.in_(OWN_HISTORY_SOURCE_TYPES),
+        KnowledgeChunk.valid_to.is_(None),
+        KnowledgeChunk.embedding.is_not(None),
+        # Only chunks carrying a usable carb range (BOTH bounds) -- so the closest
+        # match with complete metadata is chosen, not a closer-but-unusable row
+        # that would then return None.
+        KnowledgeChunk.metadata_json["carbs_low"].astext.isnot(None),
+        KnowledgeChunk.metadata_json["carbs_high"].astext.isnot(None),
+        distance < RECALL_MAX_DISTANCE,
+    ]
+    if exclude_food_record_id is not None:
+        conditions.append(
+            KnowledgeChunk.metadata_json["food_record_id"].astext.is_distinct_from(
+                str(exclude_food_record_id)
+            )
+        )
+    # Corrected (the user's truth) wins a distance tie; CASE maps the JSON bool to
+    # 1/0 so a missing/false flag never sorts ahead of a corrected match.
+    corrected_first = case(
+        (KnowledgeChunk.metadata_json["is_corrected"].astext == "true", 1),
+        else_=0,
+    ).desc()
+    # Full deterministic order: nearest, then corrected, then most-recent
+    # (NULLS LAST so a missing timestamp can't outrank a real one), then a stable
+    # tie-break on the PK so even an all-keys tie resolves to a single fixed row.
+    ordering = (
+        distance,
+        corrected_first,
+        KnowledgeChunk.retrieved_at.desc().nulls_last(),
+        KnowledgeChunk.id,
+    )
     try:
         async with get_session_maker()() as db:
             result = await db.execute(
                 select(KnowledgeChunk, distance.label("distance"))
-                .where(
-                    # Strictly owner-scoped: never another user's history, and
-                    # never the shared (NULL) clinical/external chunks.
-                    KnowledgeChunk.user_id == user_id,
-                    KnowledgeChunk.source_type.in_(OWN_HISTORY_SOURCE_TYPES),
-                    KnowledgeChunk.valid_to.is_(None),
-                    KnowledgeChunk.embedding.is_not(None),
-                    # Only chunks carrying a usable carb range (BOTH bounds) -- so
-                    # the closest match with complete metadata is chosen, not a
-                    # closer-but-unusable row that would then return None.
-                    KnowledgeChunk.metadata_json["carbs_low"].astext.isnot(None),
-                    KnowledgeChunk.metadata_json["carbs_high"].astext.isnot(None),
-                    distance < RECALL_MAX_DISTANCE,
-                )
-                .order_by(distance)
+                .where(*conditions)
+                .order_by(*ordering)
                 .limit(1)
             )
             row = result.first()

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -13,6 +13,7 @@ own-history recall is exercised without the real model. External HTTP is mocked.
 
 import json
 import uuid
+from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -84,6 +85,23 @@ async def _new_record(
     await db.commit()
     await db.refresh(record)
     return record
+
+
+async def _set_chunk_retrieved_at(food_record_id: uuid.UUID, when: datetime) -> None:
+    """Pin a food-record chunk's ``retrieved_at`` so most-recent ties are stable
+    (rather than racing on the sub-millisecond gap between two index calls)."""
+    from sqlalchemy import update
+
+    async with get_session_maker()() as db:
+        await db.execute(
+            update(KnowledgeChunk)
+            .where(
+                KnowledgeChunk.metadata_json["food_record_id"].astext
+                == str(food_record_id)
+            )
+            .values(retrieved_at=when)
+        )
+        await db.commit()
 
 
 async def _user_with_provider(db) -> User:
@@ -261,6 +279,130 @@ class TestOwnHistoryRecall:
         assert recall is not None
         assert recall.common_food_id == str(cf.id)
         assert recall.is_corrected is True  # a curated baseline is the truth
+
+    async def test_recall_breaks_distance_tie_toward_corrected(self):
+        # Two own-history chunks for one food embed to an EXACT distance tie (same
+        # description). The corrected one -- the user's truth -- must win. This is
+        # the HIGH bug: without a deterministic order the tie resolved
+        # implementation-defined, so grounding could fall back to the uncorrected
+        # guess. Indexing the uncorrected one first means a naive ORDER BY distance
+        # would surface it.
+        #
+        # Pin the CORRECTED chunk as the OLDER one so the recency fallback
+        # (retrieved_at DESC) would actually prefer the uncorrected row -- only the
+        # corrected-first ordering can surface the correction here. That isolates
+        # the corrected-first term: drop it and this test fails on the recency tie.
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            desc = _uniq("turkey sandwich")
+            uncorrected = await _new_record(db, user, desc, low=40, high=50)
+            corrected = await _new_record(
+                db, user, desc, low=40, high=50, corrected=(70, 80)
+            )
+
+        await meal_rag.index_food_record(uncorrected)
+        await meal_rag.index_food_record(corrected)
+        now = datetime.now(UTC)
+        await _set_chunk_retrieved_at(corrected.id, now - timedelta(hours=2))
+        await _set_chunk_retrieved_at(uncorrected.id, now)
+
+        recall = await meal_rag.recall_similar_meal(user.id, desc)
+        assert recall is not None
+        assert recall.is_corrected is True
+        assert recall.food_record_id == str(corrected.id)
+        assert recall.carbs_low == 70 and recall.carbs_high == 80
+
+    async def test_recall_tie_among_corrected_prefers_most_recent(self):
+        # Two equidistant CORRECTED chunks -> the most-recently indexed wins,
+        # deterministically (a later correction supersedes an earlier one).
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            desc = _uniq("veggie curry")
+            older = await _new_record(
+                db, user, desc, low=40, high=50, corrected=(60, 70)
+            )
+            newer = await _new_record(
+                db, user, desc, low=40, high=50, corrected=(90, 100)
+            )
+
+        await meal_rag.index_food_record(older)
+        await meal_rag.index_food_record(newer)
+        now = datetime.now(UTC)
+        await _set_chunk_retrieved_at(older.id, now - timedelta(hours=2))
+        await _set_chunk_retrieved_at(newer.id, now)
+
+        recall = await meal_rag.recall_similar_meal(user.id, desc)
+        assert recall is not None
+        assert recall.food_record_id == str(newer.id)
+        assert recall.carbs_low == 90 and recall.carbs_high == 100
+
+    async def test_recall_excludes_the_record_being_grounded(self):
+        # A first-ever log must not recall ITSELF as own-history (self-exclusion).
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            desc = _uniq("first ever log")
+            record = await _new_record(db, user, desc, low=30, high=40)
+
+        await meal_rag.index_food_record(record)
+
+        assert (
+            await meal_rag.recall_similar_meal(
+                user.id, desc, exclude_food_record_id=record.id
+            )
+            is None
+        )
+        # Sanity: the chunk does exist -- without the exclusion it is found.
+        assert await meal_rag.recall_similar_meal(user.id, desc) is not None
+
+    async def test_recall_excludes_self_but_finds_genuine_prior(self):
+        # Excluding the re-shoot's own chunk still recalls a genuine prior log.
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            desc = _uniq("repeat meal")
+            prior = await _new_record(
+                db, user, desc, low=40, high=50, corrected=(70, 80)
+            )
+            reshoot = await _new_record(db, user, desc, low=45, high=55)
+
+        await meal_rag.index_food_record(prior)
+        await meal_rag.index_food_record(reshoot)
+
+        recall = await meal_rag.recall_similar_meal(
+            user.id, desc, exclude_food_record_id=reshoot.id
+        )
+        assert recall is not None
+        assert recall.food_record_id == str(prior.id)
+        assert recall.is_corrected is True
+        assert recall.carbs_low == 70 and recall.carbs_high == 80
+
+    async def test_self_exclusion_keeps_common_food_baseline(self):
+        # A common-food chunk carries common_food_id, not food_record_id, so the
+        # IS DISTINCT FROM exclusion must KEEP it (a NULL "!=" would wrongly drop
+        # it). Excluding the record's own chunk still recalls the baseline.
+        async with get_session_maker()() as db:
+            user = await _new_user(db)
+            name = _uniq("my saved bowl")
+            cf = CommonFood(
+                user_id=user.id,
+                name=name,
+                normalized_name=normalize_common_food_name(name),
+                carbs_low=55,
+                carbs_high=65,
+            )
+            db.add(cf)
+            await db.commit()
+            await db.refresh(cf)
+            record = await _new_record(db, user, name, low=40, high=50)
+
+        await meal_rag.index_common_food(cf)
+        await meal_rag.index_food_record(record)
+
+        recall = await meal_rag.recall_similar_meal(
+            user.id, name, exclude_food_record_id=record.id
+        )
+        assert recall is not None
+        assert recall.common_food_id == str(cf.id)
+        assert recall.is_corrected is True
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Fixes two correctness bugs in own-history meal recall (`meal_rag.recall_similar_meal`), both surfaced by the recent meal-logging E2E coverage work.

1. **No tie-breaker (user-facing).** Recall used `ORDER BY distance LIMIT 1` with no secondary sort. When a **corrected** and an **uncorrected** own-history chunk for the same food were equidistant — which happens whenever the food description matches — the returned row was implementation-defined, so grounding could fall back to the *uncorrected* guess even though the user's correction was an equally-close match. This silently broke the "prefers your correction" promise.
2. **Self-recall.** Recall was owner-scoped but not self-excluding, so confirming a freshly-uploaded record under its own description recalled that same record as "history" — a first-ever log could cite *itself*.

## Fix

- **Deterministic order:** `distance`, then **corrected-first**, then **most-recent** (`retrieved_at DESC NULLS LAST`), then a stable PK tie-break — so a corrected (and freshest) own-history value reliably wins a distance tie.
- **Self-exclusion:** new `exclude_food_record_id` drops the record being grounded, using `IS DISTINCT FROM` so a common-food baseline (which carries `common_food_id`, not `food_record_id`) is kept rather than dropped on a NULL comparison. Threaded through `ground_estimate` → `confirm_food_identity`.

Single-module change plus tests. Grounding precedence (own-history-corrected > USDA > OFF > vision) is unchanged; descriptive only — nothing couples into IoB/treatment_safety.

## Tests

New `TestOwnHistoryRecall` cases: corrected-wins-tie (isolated to the corrected-first term), most-recent-among-corrected, and self-exclusion (a fresh record doesn't recall itself, a genuine prior still recalls, and a common-food baseline is **not** dropped by the exclusion). The proof tests were verified to **fail on the pre-fix ordering** and pass after the fix; the pre-existing chain test is now deterministic via self-exclusion (no change needed).

## Verification

- `pytest` (meal suite + full backend suite) green; `ruff check` + `format` clean. Backend-only change.
- Security review of the diff: PASS (parameterized queries; the exclusion id is the owner-verified record id; owner-scoping intact).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved food identification accuracy by preventing newly-indexed food records from self-referencing during the grounding process, ensuring more reliable meal recognition when logging similar items.

* **Tests**
  * Added comprehensive test coverage for food grounding logic, including tie-breaking behavior, exclusion scenarios, and recall validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->