### PR TITLE
ci(android): run instrumented tests on an emulator in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -79,6 +79,111 @@ jobs:
             apps/mobile/wear-device/build/outputs/apk/debug/*.apk
           retention-days: 14
 
+  instrumented-tests:
+    name: Instrumented Tests (emulator)
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.should_build == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    # Non-required check while it beds in: this job reports its own status and is
+    # intentionally NOT folded into the required "Android Gate" below, so a flaky
+    # emulator can't wedge unrelated PRs. Promote it to a required check in branch
+    # protection once it has proven stable. See docs/dev/instrumented-tests-ci.md.
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      # Single pinned API level to start (matches the app's targetSdk). The emulator
+      # uses the google_apis x86_64 image so KVM acceleration is available on the runner.
+      API_LEVEL: 35
+    steps:
+      # ubuntu-latest exposes /dev/kvm but not to the runner user by default; this udev
+      # rule grants access so the x86_64 emulator boots with hardware acceleration.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
+      # Restore the cached AVD + its boot snapshot so subsequent runs skip image
+      # download and cold boot. Restore + explicit save (rather than the combined
+      # cache action) so the snapshot is persisted ONLY after a clean generation:
+      # the save step below is skipped on cancellation/failure, which prevents a
+      # partial, corrupt snapshot from poisoning the cache. The `-v1` key prefix
+      # also gives a one-line manual eviction path if a bad snapshot ever lands.
+      - name: Restore AVD cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-v1-${{ env.API_LEVEL }}-google_apis-x86_64
+
+      # On a cache miss, create the AVD and generate a boot snapshot.
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      # Persist the freshly generated snapshot only when generation succeeded (a
+      # cancelled/failed Create step skips this, so no partial snapshot is saved).
+      - name: Save AVD cache
+        if: steps.avd-cache.outputs.cache-hit != 'true' && success()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-v1-${{ env.API_LEVEL }}-google_apis-x86_64
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          # The action manages emulator boot/readiness; this runs the debug instrumented
+          # suite (Compose/espresso UI + Room migration tests) and installs both APKs.
+          script: cd apps/mobile && ./gradlew :app:connectedDebugAndroidTest
+
+      # Always publish the report so a red run is debuggable from the PR (and so a real
+      # failure is distinguishable from a compile-only skip).
+      - name: Upload instrumented test report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: instrumented-test-report
+          path: |
+            apps/mobile/app/build/reports/androidTests/connected/**
+            apps/mobile/app/build/outputs/androidTest-results/connected/**
+          retention-days: 14
+          if-no-files-found: ignore
+
   android-gate:
     name: Android Gate
     runs-on: ubuntu-latest

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.navigation.compose.NavHost
@@ -88,19 +89,20 @@ class MealFullFlowE2ETest {
         compose.onNodeWithTag("meal_carb_range", useUnmergedTree = true).assertIsDisplayed()
 
         // GJ2: correct the estimate; the corrected note proves it persisted + re-rendered.
-        compose.onNodeWithTag("meal_correct_button").performClick()
+        tapInScroll("meal_correct_button")
         awaitTag("meal_correction_editor")
         compose.onNodeWithTag("meal_correct_low_input").performTextReplacement("70")
         compose.onNodeWithTag("meal_correct_high_input").performTextReplacement("80")
         // Editing the number fields raises the soft keyboard, which on a real emulator
-        // overlays the inline Save button; dismiss it (as a user would) so the click
-        // lands on the button and not on the IME window.
+        // overlays the inline Save button; dismiss it (as a user would) and scroll the
+        // button into view so the click lands on the button, not the IME or the void
+        // below a short screen's fold.
         dismissKeyboard()
-        compose.onNodeWithTag("meal_correct_save").performClick()
+        tapInScroll("meal_correct_save")
         awaitTag("meal_corrected_note")
 
         // GJ3: save the corrected estimate as a common food.
-        compose.onNodeWithTag("meal_save_common_button").performClick()
+        tapInScroll("meal_save_common_button")
         awaitTag("meal_save_common_name_input")
         compose.onNodeWithTag("meal_save_common_name_input").performTextInput("Chicken Burrito")
         dismissKeyboard() // same IME-overlay guard before the dialog's confirm button
@@ -109,9 +111,9 @@ class MealFullFlowE2ETest {
         check(api.commonFoods.isNotEmpty()) { "save-as-common-food never reached the API" }
 
         // Navigate to history (result -> idle -> History) and see the saved record.
-        compose.onNodeWithTag("meal_log_another").performClick()
+        tapInScroll("meal_log_another")
         awaitTag("meal_history_button")
-        compose.onNodeWithTag("meal_history_button").performClick()
+        tapInScroll("meal_history_button")
         awaitTag("meal_history_item")
         // The qualifier rides every estimate surface, history included.
         compose.onNodeWithTag("meal_safety_qualifier", useUnmergedTree = true).assertIsDisplayed()
@@ -204,6 +206,14 @@ class MealFullFlowE2ETest {
 
     /** Hide the soft keyboard and wait for it to be gone, so it can't overlay a tap target. */
     private fun dismissKeyboard() = Espresso.closeSoftKeyboard()
+
+    /**
+     * Scroll a node in the result/idle scroll column into view, then click it. The result
+     * surface is a [androidx.compose.foundation.verticalScroll] column, so on a shorter
+     * screen a button can sit below the fold where a positional click would miss it.
+     */
+    private fun tapInScroll(tag: String) =
+        compose.onNodeWithTag(tag).performScrollTo().performClick()
 
     private fun awaitTag(tag: String, timeoutMs: Long = 10_000) {
         compose.waitUntil(timeoutMs) {

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.ChatRequest
@@ -91,6 +92,10 @@ class MealFullFlowE2ETest {
         awaitTag("meal_correction_editor")
         compose.onNodeWithTag("meal_correct_low_input").performTextReplacement("70")
         compose.onNodeWithTag("meal_correct_high_input").performTextReplacement("80")
+        // Editing the number fields raises the soft keyboard, which on a real emulator
+        // overlays the inline Save button; dismiss it (as a user would) so the click
+        // lands on the button and not on the IME window.
+        dismissKeyboard()
         compose.onNodeWithTag("meal_correct_save").performClick()
         awaitTag("meal_corrected_note")
 
@@ -98,6 +103,7 @@ class MealFullFlowE2ETest {
         compose.onNodeWithTag("meal_save_common_button").performClick()
         awaitTag("meal_save_common_name_input")
         compose.onNodeWithTag("meal_save_common_name_input").performTextInput("Chicken Burrito")
+        dismissKeyboard() // same IME-overlay guard before the dialog's confirm button
         compose.onNodeWithTag("meal_save_common_confirm").performClick()
         awaitTag("meal_saved_common_confirmation")
         check(api.commonFoods.isNotEmpty()) { "save-as-common-food never reached the API" }
@@ -195,6 +201,9 @@ class MealFullFlowE2ETest {
     }
 
     private fun runOnUi(block: () -> Unit) = compose.runOnUiThread(block)
+
+    /** Hide the soft keyboard and wait for it to be gone, so it can't overlay a tap target. */
+    private fun dismissKeyboard() = Espresso.closeSoftKeyboard()
 
     private fun awaitTag(tag: String, timeoutMs: Long = 10_000) {
         compose.waitUntil(timeoutMs) {

--- a/docs/dev/_meta.json
+++ b/docs/dev/_meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "branching-strategy",
     "testing-checklist",
+    "instrumented-tests-ci",
     "docker-integration-testing",
     "real-data-pipeline-verification",
     "security-testing",

--- a/docs/dev/instrumented-tests-ci.md
+++ b/docs/dev/instrumented-tests-ci.md
@@ -1,0 +1,93 @@
+---
+title: Instrumented Android Tests in CI
+description: How the emulator-backed androidTest job runs in CI, and how to run instrumented tests locally.
+---
+
+# Instrumented Android Tests in CI
+
+The Android workflow (`.github/workflows/android.yml`) runs three fast checks on every
+mobile-relevant change — `testDebugUnitTest`, `lintDebug`, and `assembleDebug`. Those
+compile and unit-test the app, but they do **not** execute the instrumented
+`androidTest` suite (Compose/espresso UI tests and the Room migration test). A test that
+only compiles provides false confidence: it can rot into a non-running state without
+anyone noticing.
+
+The **Instrumented Tests (emulator)** job closes that gap. It boots an Android emulator
+and runs `:app:connectedDebugAndroidTest` — actually executing the UI and migration
+tests against a real Android runtime.
+
+## What runs
+
+`:app:connectedDebugAndroidTest` builds the debug app + its androidTest APK, installs
+both on the emulator, and runs every test under
+`apps/mobile/app/src/androidTest/`. This is repo-wide infrastructure: any instrumented
+test added to `:app` is executed automatically, no workflow change required.
+
+## How the CI job is configured
+
+- **Emulator:** a single pinned API level (`API_LEVEL` in the job, currently **35**, the
+  app's `targetSdk`), `google_apis` system image, `x86_64`. KVM hardware acceleration is
+  enabled on the runner via a udev rule so the x86_64 emulator boots fast.
+- **Action:** [`reactivecircus/android-emulator-runner`](https://github.com/ReactiveCircus/android-emulator-runner)
+  (SHA-pinned), which manages emulator creation, boot, and readiness.
+- **Caching:** the AVD and its boot snapshot are cached (`actions/cache`, keyed on the API
+  level) so subsequent runs skip the image download and cold boot; Gradle is cached via
+  `gradle/actions/setup-gradle`. Animations are disabled on the emulator for stable UI
+  assertions.
+- **Triggering:** the job reuses the same `detect-changes` path filter as the rest of the
+  Android workflow, so it runs only on mobile-relevant PRs — the paths the filter matches
+  today are `apps/mobile/**`, `plugins/pump-driver-api/**`, `plugins/shipped/**`, and
+  `.github/workflows/android.yml` — never on backend-only changes. (The filter lives in
+  `android.yml`; that is the source of truth if the matched paths change.)
+- **Timeout:** the job is bounded (45 min) so a wedged emulator can't run indefinitely.
+- **Report:** the HTML/XML test report is uploaded as the `instrumented-test-report`
+  artifact (even on failure) so a red run is debuggable from the PR.
+
+## Rollout posture (non-required while it beds in)
+
+The job reports its **own** status and is intentionally **not** folded into the required
+**Android Gate** aggregate check. Emulator-backed jobs are inherently more prone to
+infrastructure flakiness (boot timeouts, image-download hiccups) than pure-JVM steps, so
+during the bed-in period a transient emulator failure should not block an otherwise-green
+PR.
+
+**Flaky-retry posture:** the job does not auto-retry tests — a red result reflects a real
+test failure or a genuine infrastructure problem, and we keep that signal honest. If a run
+fails for an obviously transient reason (emulator boot timeout, network blip during image
+download), **re-run the single job** rather than disabling the test. Once the job has
+proven stable over a stretch of mobile PRs, promote it to a **required** status check in
+branch protection.
+
+A real, reproducible test failure here is a bug to fix or surface — not to suppress or
+retry away.
+
+## Running instrumented tests locally
+
+You need an Android emulator (or a connected device) running before the tests start;
+`connectedDebugAndroidTest` connects to an already-running device, it does not boot one.
+
+```bash
+# 1. Start the emulator (non-headless, so you can watch). Uses the provisioned AVD.
+./scripts/mobile-dev.sh emulator start
+
+# 2. (Recommended) disable animations for stable Compose/espresso assertions:
+adb shell settings put global window_animation_scale 0
+adb shell settings put global transition_animation_scale 0
+adb shell settings put global animator_duration_scale 0
+
+# 3. Run the full instrumented suite (from apps/mobile):
+cd apps/mobile
+./gradlew :app:connectedDebugAndroidTest
+```
+
+Run a single test class while iterating:
+
+```bash
+cd apps/mobile
+./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.glycemicgpt.mobile.presentation.meal.MealFullFlowE2ETest
+```
+
+The local Android toolchain (SDK, emulator, system images) is provisioned by
+`apps/mobile/shell.nix`. After a run, the HTML report is at
+`apps/mobile/app/build/reports/androidTests/connected/debug/index.html`.


### PR DESCRIPTION
## What

Adds an **Instrumented Tests (emulator)** job to the Android workflow that runs `:app:connectedDebugAndroidTest` on an emulator. Until now CI ran only `testDebugUnitTest`, `lintDebug`, and `assembleDebug`, so the instrumented `androidTest` suite (Compose UI tests, the full-flow meal E2E test, and the Room migration test) was **compiled but never executed** anywhere automated. This makes those tests a real safety net instead of green-by-compilation.

This is repo-wide infrastructure: any instrumented test added to `:app` is now executed automatically.

## How

- `reactivecircus/android-emulator-runner` (SHA-pinned) boots an emulator at a single pinned **API 35** (`google_apis`, `x86_64`, matching `targetSdk`), KVM-accelerated.
- AVD boot snapshot cached via `actions/cache` (restore + conditional save on a clean snapshot, versioned key) and Gradle cached via `gradle/actions/setup-gradle` for speed.
- Bounded with a 45-minute timeout; the HTML/XML test report is uploaded as an artifact even on failure.
- Reuses the existing `detect-changes` path filter, so it runs only on mobile-relevant PRs — never on backend-only changes.

## Rollout posture

The job reports its **own** status and is intentionally **not** folded into the required **Android Gate** aggregate check, so a flaky emulator can't wedge unrelated PRs while it beds in. Promote it to a required check in branch protection once it has proven stable. The flaky-retry posture (manual single-job re-run; no auto-retry, to keep the signal honest) is documented in `docs/dev/instrumented-tests-ci.md`.

## Proof it executes (not just compiles)

Standing the job up immediately paid off — the **first real execution caught a genuine bug** in the full-flow meal test that compile-only never could:

- **Run 1 — red:** `MealFullFlowE2ETest` failed with a real `ComposeTimeoutException`. Root cause (from the uploaded report): on the emulator's screen the result surface's scroll column pushes the correction **Save button below the fold**, and editing the number fields raises the soft keyboard that overlays it, so the positional tap missed.
- **Fix (test-only):** dismiss the soft keyboard and scroll in-scroll buttons into view before tapping. Reproduced deterministically by shrinking a local emulator (fails without the fix, passes with it).
- **Run 3 — green:** all **16 instrumented tests pass** on the emulator.

That natural red → green is the evidence the job runs tests rather than compiling them; a planted failing assertion was also confirmed to turn the run red and revert green.

## Docs

`docs/dev/instrumented-tests-ci.md` (registered in `docs/dev/_meta.json`) covers how the job runs in CI and how to run instrumented tests locally.