### PR TITLE
feat(api): ground branded restaurant items against published chain nutrition

### DIFF
--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -183,6 +183,37 @@ class Settings(BaseSettings):
     # source never stalls the estimate path (it falls back to vision-only).
     nutrition_grounding_timeout_seconds: float = Field(default=6.0, gt=0)
 
+    # Restaurant / fast-food grounding (Story 50.E2). A confirmed branded-chain
+    # item (e.g. a McDonald's Quarter Pounder) is grounded against that chain's
+    # OWN published nutrition, fetched on demand for that one item -- no
+    # pre-crawl, no bulk mirror -- via the per-chain fetcher registry in
+    # ``services/restaurant_nutrition.py``. Compliance mitigations (robots.txt,
+    # rate-limit + back-off, descriptive User-Agent, user-action-triggered, and
+    # OWNER-SCOPED caching -- never the shared mirror USDA/OFF use) are
+    # non-negotiable. Disable to opt out of every restaurant fetch (falls back to
+    # vision-only).
+    restaurant_grounding_enabled: bool = True
+    # Minimum seconds between successive fetches to the same chain host (a simple
+    # per-host rate limit; a 429/503 adds exponential back-off on top).
+    restaurant_min_seconds_between_fetches: float = Field(default=2.0, ge=0)
+    # How long an owner-scoped restaurant cache entry stays fresh. Chain facts
+    # change rarely, so a re-log inside this window reuses the cached value rather
+    # than re-fetching. Owner-scoped only -- never pooled into a shared mirror.
+    restaurant_cache_ttl_hours: float = Field(default=24 * 30, gt=0)
+
+    # Optional FatSecret BYO-key add-on (Story 50.E2, AC5). Broader *commercial*
+    # restaurant coverage via the operator's OWN FatSecret Platform credentials
+    # (self-serve free tier). Empty -> disabled; no shared key is ever shipped.
+    # FatSecret's terms cap value caching at 24 h, so FatSecret-sourced results are
+    # cached owner-scoped for at most ``fatsecret_cache_ttl_hours`` and otherwise
+    # queried fresh.
+    fatsecret_consumer_key: str = ""
+    fatsecret_consumer_secret: str = ""
+    fatsecret_token_url: str = "https://oauth.fatsecret.com/connect/token"
+    fatsecret_api_url: str = "https://platform.fatsecret.com/rest/server.api"
+    # FatSecret's value-cache ToS limit (hours). Hard-capped at 24 h by intent.
+    fatsecret_cache_ttl_hours: float = Field(default=24.0, gt=0, le=24.0)
+
     # Device & API key limits (Story 28.7)
     max_devices_per_user: int = Field(default=10, ge=1)
     debug_device_limit: int = Field(default=50, ge=1)

--- a/apps/api/src/services/meal_audit.py
+++ b/apps/api/src/services/meal_audit.py
@@ -33,6 +33,7 @@ logger = get_logger(__name__)
 # fidelity is the point of storing it rather than referencing a live constant.
 _PRECEDENCE_LADDER = [
     "own-history corrected",
+    "restaurant nutrition",
     "USDA FoodData Central",
     "Open Food Facts",
     "own-history uncorrected",

--- a/apps/api/src/services/meal_grounding.py
+++ b/apps/api/src/services/meal_grounding.py
@@ -4,14 +4,15 @@ Story 50.E1, AC4. Given a vision-identified food, this picks the single best
 grounding source in trust order and returns a descriptive citation. Precedence:
 
   1. own-history **corrected** value  (USER_PROVIDED -- the user's own truth)
-  2. USDA FoodData Central             (AUTHORITATIVE -- official, CC0)
-  3. Open Food Facts                   (RESEARCHED   -- crowd-sourced, ODbL)
-  4. own-history **uncorrected** value (USER_PROVIDED -- a prior estimate)
-  5. none -> pure vision
+  2. branded restaurant chain          (AUTHORITATIVE -- the chain's own menu facts)
+  3. USDA FoodData Central             (AUTHORITATIVE -- official, CC0)
+  4. Open Food Facts                   (RESEARCHED   -- crowd-sourced, ODbL)
+  5. own-history **uncorrected** value (USER_PROVIDED -- a prior estimate)
+  6. none -> pure vision
 
-The two mechanisms stay architecturally distinct (own-history RAG vs external
-research), separated by trust tier; this module only chooses between their
-already-computed results.
+The mechanisms stay architecturally distinct (own-history RAG vs external research
+vs on-demand restaurant fetch), separated by trust tier and source module; this
+module only chooses between their already-computed results.
 
 Safety posture (NON-NEGOTIABLE): grounding sharpens the *descriptive* estimate
 only. It returns a carb range + citation, never a dose, and the result is never
@@ -25,7 +26,7 @@ from src.config import settings
 from src.logging_config import get_logger
 from src.models.knowledge_chunk import KnowledgeChunk
 from src.schemas.food_record import GroundingDetail
-from src.services import meal_rag, nutrition_sources
+from src.services import meal_rag, nutrition_sources, restaurant_nutrition
 
 logger = get_logger(__name__)
 
@@ -107,18 +108,26 @@ async def ground_estimate(
     if recall is not None and recall.is_corrected:
         return _recall_detail(recall)
 
-    # 2/3. Published facts (USDA preferred over OFF). Each fails open to None.
+    # 2. A branded restaurant item, grounded against that chain's OWN published
+    # nutrition (AUTHORITATIVE), above generic USDA -- a chain's figure for its own
+    # menu item beats a generic-food lookup. Owner-scoped + fail-open; returns None
+    # for any non-branded food, so a plain food still flows to USDA/OFF below.
+    restaurant = await restaurant_nutrition.lookup_restaurant(user_id, description)
+    if restaurant is not None:
+        return _fact_detail(restaurant)
+
+    # 3/4. Published facts (USDA preferred over OFF). Each fails open to None.
     usda, off = await nutrition_sources.lookup_published_nutrition(description)
     if usda is not None:
         return _fact_detail(usda)
     if off is not None:
         return _fact_detail(off)
 
-    # 4. An uncorrected prior log still grounds when nothing published matched.
+    # 5. An uncorrected prior log still grounds when nothing published matched.
     if recall is not None:
         return _recall_detail(recall)
 
-    # 5. Pure vision.
+    # 6. Pure vision.
     return None
 
 

--- a/apps/api/src/services/meal_rag.py
+++ b/apps/api/src/services/meal_rag.py
@@ -45,13 +45,28 @@ SOURCE_TYPE_FOOD_RECORD = "user_food_record"
 SOURCE_TYPE_COMMON_FOOD = "user_common_food"
 SOURCE_TYPE_USDA = "usda_fdc"
 SOURCE_TYPE_OPEN_FOOD_FACTS = "open_food_facts"
+# Story 50.E2 restaurant grounding. Unlike USDA/OFF (shared, ``user_id IS NULL``),
+# these cache chunks are OWNER-SCOPED (``user_id`` = the requesting user) because a
+# chain's fetched values must not be pooled into a shared, redistributable mirror.
+SOURCE_TYPE_RESTAURANT_CHAIN = "restaurant_chain"
+SOURCE_TYPE_FATSECRET = "restaurant_fatsecret"
 
 OWN_HISTORY_SOURCE_TYPES = frozenset({SOURCE_TYPE_FOOD_RECORD, SOURCE_TYPE_COMMON_FOOD})
 EXTERNAL_SOURCE_TYPES = frozenset({SOURCE_TYPE_USDA, SOURCE_TYPE_OPEN_FOOD_FACTS})
+# Restaurant grounding chunks are external published facts but cached owner-scoped;
+# kept in their own set so own-history recall (which queries only
+# OWN_HISTORY_SOURCE_TYPES) never matches them, while clinical retrieval still
+# excludes them via FOOD_GROUNDING_SOURCE_TYPES below.
+RESTAURANT_SOURCE_TYPES = frozenset(
+    {SOURCE_TYPE_RESTAURANT_CHAIN, SOURCE_TYPE_FATSECRET}
+)
 # Every source_type used by the meal-grounding feature. Clinical retrieval
 # excludes these so nutrition grounding never pollutes clinical knowledge
-# prompts (the mechanisms stay separate -- AC4).
-FOOD_GROUNDING_SOURCE_TYPES = OWN_HISTORY_SOURCE_TYPES | EXTERNAL_SOURCE_TYPES
+# prompts (the mechanisms stay separate -- AC4). Own-history recall narrows to
+# OWN_HISTORY_SOURCE_TYPES, so restaurant/external chunks never surface there.
+FOOD_GROUNDING_SOURCE_TYPES = (
+    OWN_HISTORY_SOURCE_TYPES | EXTERNAL_SOURCE_TYPES | RESTAURANT_SOURCE_TYPES
+)
 
 # Cosine-distance ceiling for "this is the same food I logged before". Tighter
 # than the clinical retriever's 0.6 (which casts a wide net for related

--- a/apps/api/src/services/restaurant_nutrition.py
+++ b/apps/api/src/services/restaurant_nutrition.py
@@ -127,6 +127,8 @@ def _contains_phrase(haystack_canon: str, needle_canon: str) -> bool:
 # --------------------------------------------------------------------------- #
 # host -> {"last": monotonic, "backoff_until": monotonic, "fails": int}
 _host_state: dict[str, dict] = {}
+# host -> asyncio.Lock serializing the rate-limit check+update for that host.
+_host_locks: dict[str, asyncio.Lock] = {}
 # host -> (RobotFileParser, expiry_monotonic)
 _robots_cache: dict[str, tuple[RobotFileParser, float]] = {}
 
@@ -134,6 +136,7 @@ _robots_cache: dict[str, tuple[RobotFileParser, float]] = {}
 def _reset_state_for_tests() -> None:
     """Clear throttle + robots state. Test-only; keeps cases independent."""
     _host_state.clear()
+    _host_locks.clear()
     _robots_cache.clear()
 
 
@@ -143,14 +146,23 @@ def _in_backoff(host: str) -> bool:
 
 
 async def _respect_rate_limit(host: str) -> None:
-    """Sleep just enough to honour the per-host minimum fetch interval."""
-    st = _host_state.setdefault(host, {})
-    min_interval = settings.restaurant_min_seconds_between_fetches
-    if min_interval > 0:
-        wait = min_interval - (time.monotonic() - st.get("last", 0.0))
-        if wait > 0:
-            await asyncio.sleep(wait)
-    st["last"] = time.monotonic()
+    """Sleep just enough to honour the per-host minimum fetch interval.
+
+    Serialized per host with an ``asyncio.Lock`` so two concurrent fetches to the
+    same host can't both read a stale ``last`` and slip past the gate together --
+    the second waits for the first's slot (the AC2 rate-limit is a per-host
+    politeness guarantee, not best-effort). Different hosts use different locks, so
+    there's no cross-host contention.
+    """
+    lock = _host_locks.setdefault(host, asyncio.Lock())
+    async with lock:
+        st = _host_state.setdefault(host, {})
+        min_interval = settings.restaurant_min_seconds_between_fetches
+        if min_interval > 0:
+            wait = min_interval - (time.monotonic() - st.get("last", 0.0))
+            if wait > 0:
+                await asyncio.sleep(wait)
+        st["last"] = time.monotonic()
 
 
 def _note_success(host: str) -> None:
@@ -501,20 +513,29 @@ _CHAINS: tuple[RestaurantChain, ...] = (_Chipotle(), _McDonalds())
 # item to the optional FatSecret BYO-key provider (broader commercial coverage),
 # never to USDA/OFF -- a branded item is not a generic food. Kept small and
 # data-driven; add a dedicated fetcher to graduate a brand off this list.
+# Include punctuation-free spellings: ``_canon`` turns "wendy's" into "wendy s"
+# and "chick-fil-a" into "chick fil a", which would NOT match a user typing
+# "wendys" / "chickfila", so a branded item would silently skip restaurant
+# grounding. List the common collapsed variants alongside the canonical names.
 _EXTRA_BRANDS: frozenset[str] = frozenset(
     _canon(b)
     for b in (
         "taco bell",
         "starbucks",
         "wendy's",
+        "wendys",
         "burger king",
         "subway",
         "kfc",
         "chick-fil-a",
+        "chick fil a",
+        "chickfila",
         "dunkin",
         "panera",
         "popeyes",
         "in-n-out",
+        "in n out",
+        "innout",
         "five guys",
     )
 )

--- a/apps/api/src/services/restaurant_nutrition.py
+++ b/apps/api/src/services/restaurant_nutrition.py
@@ -1,0 +1,940 @@
+"""On-demand restaurant / fast-food grounding (Story 50.E2).
+
+Grounding mechanism (c): a *branded chain* item -- e.g. a McDonald's Quarter
+Pounder -- is grounded against **that chain's own published nutrition**, fetched
+on demand for that one item via the per-chain fetcher registry below. This is the
+one gap the open/CC0/ODbL sources (USDA / Open Food Facts, Story 50.E1) don't
+cover, and commercial aggregators (Nutritionix, ...) don't fit a free, open,
+self-hosted product (non-redistributable licences, no-cache terms, no shared key).
+
+Legal / compliance posture (a maintainer policy decision, see the user docs):
+  * Nutrition *facts* aren't copyrightable (Feist); a user-triggered single-item
+    fetch is categorically distinct from the bulk scraping that lost hiQ.
+  * We ship code (fetchers), never a licensed dataset -> redistributable.
+  * The AC2 mitigations are HARD requirements and live in this module: respect
+    ``robots.txt``; rate-limit with exponential back-off and a descriptive
+    User-Agent; fetch only on a user action (an identity confirmation); and cache
+    only the *requesting user's own* fetched values -- OWNER-SCOPED, never the
+    shared ``user_id IS NULL`` mirror USDA/OFF use, and never a bulk pre-crawl.
+
+Safety posture (NON-NEGOTIABLE): grounding sharpens the *descriptive* estimate
+only. A chain's published carbs are **reference data, not an AI estimate**, so the
+disclaimer carries the canonical ``NEVER_DOSE_PROHIBITION`` (the OFF pattern), not
+the ``MEAL_ESTIMATE_QUALIFIER`` "AI guess" framing. Nothing here returns a dose,
+and the result is never read by IoB / treatment_safety / carb-ratio math.
+
+Identity gate (AC8): this module is only ever reached from
+``meal_grounding.ground_estimate``, which runs after the food-identity gate -- so a
+chain is fetched-and-cited only for a *confirmed-identity* item. A misidentified or
+unconfirmed label stays vision-only and never gets an authoritative chain citation.
+
+Brittleness is expected: chain endpoints are undocumented internal APIs that change
+without notice. Every fetcher is isolated and fails open to ``None`` (vision-only),
+never breaking logging. The shipped chain endpoint shapes are modelled, not
+live-verified at build time; a maintainer canary (see the user docs) confirms each
+live fetcher still parses and degrades to vision-only when it doesn't.
+"""
+
+import asyncio
+import hashlib
+import json
+import re
+import time
+import unicodedata
+import uuid
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import httpx
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from src.config import settings
+from src.database import get_session_maker
+from src.logging_config import get_logger
+from src.models.knowledge_chunk import KnowledgeChunk
+from src.services.meal_rag import SOURCE_TYPE_FATSECRET, SOURCE_TYPE_RESTAURANT_CHAIN
+from src.services.nutrition_sources import NutritionFact
+from src.vision.carb_contract import (
+    CARB_GRAMS_MAX,
+    CARB_GRAMS_MIN,
+    NEVER_DOSE_PROHIBITION,
+    find_dosing_violations,
+)
+
+logger = get_logger(__name__)
+
+# The figure is published reference data, NOT an AI estimate -- so reuse only the
+# canonical dosing prohibition (single source of truth), never the
+# MEAL_ESTIMATE_QUALIFIER "AI guess" framing which would mislabel a chain's own
+# published facts (mirrors the OFF disclaimer in nutrition_sources.py).
+_RESTAURANT_DISCLAIMER = (
+    "Published nutrition from the restaurant's own menu data -- a descriptive "
+    "reference only (figures vary by location, size, and preparation, and can be "
+    f"out of date); {NEVER_DOSE_PROHIBITION}."
+)
+
+_USER_AGENT = "GlycemicGPT/1.0 (+restaurant-nutrition-grounding)"
+_MAX_RESPONSE_BYTES = 512_000
+# A restaurant item is per-item, not per-100 g, so its carbs are bounded by the
+# absolute single-meal carb range (reject-not-clamp), NOT the per-100 g cap that
+# USDA/OFF use.
+_SERVING_PER_ITEM = "per item"
+
+# Robots cache + per-host throttle/back-off windows (monotonic seconds).
+_ROBOTS_CACHE_TTL_SECONDS = 3600.0
+_BACKOFF_BASE_SECONDS = 30.0
+_BACKOFF_MAX_SECONDS = 3600.0
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+# --------------------------------------------------------------------------- #
+# Text normalization + brand detection
+# --------------------------------------------------------------------------- #
+def _normalize_query(query: str) -> str:
+    return " ".join((query or "").lower().split())[:200]
+
+
+def _canon(text: str) -> str:
+    """Lower-case, fold accents (NFKD), strip punctuation, collapse whitespace.
+
+    So "McDonald's" and "mcdonalds" both canonicalize to a space-delimited token
+    stream that brand-alias matching can compare without apostrophe/case noise.
+    Accent folding mirrors the hardened own-history matcher
+    (``meal_estimate_aggregate``) so an accented menu name normalizes consistently.
+    """
+    folded = unicodedata.normalize("NFKD", (text or "").lower())
+    folded = "".join(ch for ch in folded if not unicodedata.combining(ch))
+    return _NON_ALNUM.sub(" ", folded).strip()
+
+
+def _padded(text: str) -> str:
+    return f" {text} "
+
+
+def _contains_phrase(haystack_canon: str, needle_canon: str) -> bool:
+    """Whole-token (space-bounded) phrase containment, so "mcd" never matches
+    inside "mcdonalds" and "taco" never matches "tacopalooza"."""
+    if not needle_canon:
+        return False
+    return _padded(needle_canon) in _padded(haystack_canon)
+
+
+# --------------------------------------------------------------------------- #
+# Per-host throttle + back-off + robots.txt (AC2 compliance mitigations)
+# --------------------------------------------------------------------------- #
+# host -> {"last": monotonic, "backoff_until": monotonic, "fails": int}
+_host_state: dict[str, dict] = {}
+# host -> (RobotFileParser, expiry_monotonic)
+_robots_cache: dict[str, tuple[RobotFileParser, float]] = {}
+
+
+def _reset_state_for_tests() -> None:
+    """Clear throttle + robots state. Test-only; keeps cases independent."""
+    _host_state.clear()
+    _robots_cache.clear()
+
+
+def _in_backoff(host: str) -> bool:
+    st = _host_state.get(host)
+    return bool(st and st.get("backoff_until", 0.0) > time.monotonic())
+
+
+async def _respect_rate_limit(host: str) -> None:
+    """Sleep just enough to honour the per-host minimum fetch interval."""
+    st = _host_state.setdefault(host, {})
+    min_interval = settings.restaurant_min_seconds_between_fetches
+    if min_interval > 0:
+        wait = min_interval - (time.monotonic() - st.get("last", 0.0))
+        if wait > 0:
+            await asyncio.sleep(wait)
+    st["last"] = time.monotonic()
+
+
+def _note_success(host: str) -> None:
+    st = _host_state.setdefault(host, {})
+    st["fails"] = 0
+    st["backoff_until"] = 0.0
+
+
+def _note_backoff(host: str) -> None:
+    """Record a rate-limit/unavailable response and arm exponential back-off."""
+    st = _host_state.setdefault(host, {})
+    fails = st.get("fails", 0) + 1
+    st["fails"] = fails
+    delay = min(_BACKOFF_BASE_SECONDS * (2 ** (fails - 1)), _BACKOFF_MAX_SECONDS)
+    st["backoff_until"] = time.monotonic() + delay
+
+
+def _host_allowed(url: str, allowed_hosts: frozenset[str]) -> bool:
+    """True only for an https URL whose host is in the caller's allow-list.
+
+    The hosts are operator-fixed per-chain config (never user input -- only the
+    item query rides as an encoded param), so an exact-membership host allow-list
+    plus https-only is the appropriate SSRF guard, mirroring nutrition_sources.
+    """
+    parsed = urlparse(url)
+    return parsed.scheme == "https" and (parsed.hostname or "") in allowed_hosts
+
+
+async def _get_bytes(
+    url: str,
+    params: dict | None,
+    *,
+    allowed_hosts: frozenset[str],
+    host: str,
+    headers: dict | None = None,
+    track_throttle: bool = True,
+) -> bytes | None:
+    """Stream a GET from an allow-listed https host, time-boxed + redirect-free.
+
+    Returns the body bytes, or None on any error. The body is capped mid-stream
+    (an oversized response is aborted, not buffered whole). A 429/503 arms the
+    per-host back-off. Never logs the URL/params/exception text -- a FatSecret
+    Bearer token or query param could ride there.
+
+    ``track_throttle`` is False for the robots.txt fetch so that a side-channel
+    request (robots) never resets or arms the *data* endpoint's back-off counter
+    -- only real data fetches drive the per-host throttle state.
+    """
+    if not _host_allowed(url, allowed_hosts):
+        logger.warning(
+            "Restaurant fetch host not allow-listed", host=urlparse(url).hostname
+        )
+        return None
+    request_headers = {"User-Agent": _USER_AGENT}
+    if headers:
+        request_headers.update(headers)
+    try:
+        async with (
+            httpx.AsyncClient(
+                timeout=settings.nutrition_grounding_timeout_seconds,
+                follow_redirects=False,
+                headers=request_headers,
+            ) as client,
+            client.stream("GET", url, params=params) as resp,
+        ):
+            if resp.status_code != 200:
+                if track_throttle and resp.status_code in (429, 503):
+                    _note_backoff(host)
+                logger.warning("Restaurant source non-200", status=resp.status_code)
+                return None
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.aiter_bytes():
+                total += len(chunk)
+                if total > _MAX_RESPONSE_BYTES:
+                    logger.warning("Restaurant response too large")
+                    return None
+                chunks.append(chunk)
+    except Exception:
+        # Never surface the exception text -- it can echo the URL incl. a token.
+        logger.warning("Restaurant source request failed")
+        return None
+    if track_throttle:
+        _note_success(host)
+    return b"".join(chunks)
+
+
+async def _robots_allows(url: str, allowed_hosts: frozenset[str]) -> bool:
+    """Honour the host's robots.txt for our User-Agent (AC2), cached per host.
+
+    An unreachable / absent robots.txt is treated as allow-all, matching the
+    de-facto crawler convention (RobotFileParser's behaviour for empty input).
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    cached = _robots_cache.get(host)
+    if cached is None or cached[1] <= time.monotonic():
+        robots_url = f"{parsed.scheme}://{host}/robots.txt"
+        raw = await _get_bytes(
+            robots_url,
+            None,
+            allowed_hosts=allowed_hosts,
+            host=host,
+            track_throttle=False,
+        )
+        text = raw.decode("utf-8", errors="replace") if raw is not None else ""
+        parser = RobotFileParser()
+        parser.parse(text.splitlines())
+        cached = (parser, time.monotonic() + _ROBOTS_CACHE_TTL_SECONDS)
+        _robots_cache[host] = cached
+    try:
+        return cached[0].can_fetch(_USER_AGENT, url)
+    except Exception:
+        # A malformed robots file must not hard-fail the fetch path; fail open.
+        return True
+
+
+async def _fetch_json(
+    url: str,
+    params: dict | None,
+    *,
+    host: str,
+    allowed_hosts: frozenset[str],
+    headers: dict | None = None,
+) -> dict | None:
+    """Compliance-gated GET that returns parsed JSON, or None.
+
+    Order: host allow-list -> back-off window -> robots.txt -> rate-limit -> fetch.
+    Every gate fails open to None so a blocked/throttled/broken fetch degrades to
+    vision-only, never an exception into the grounding orchestrator.
+    """
+    if not _host_allowed(url, allowed_hosts):
+        logger.warning(
+            "Restaurant fetch host not allow-listed", host=urlparse(url).hostname
+        )
+        return None
+    if _in_backoff(host):
+        logger.warning("Restaurant host in back-off; skipping fetch", host=host)
+        return None
+    if not await _robots_allows(url, allowed_hosts):
+        logger.warning("Restaurant fetch disallowed by robots.txt", host=host)
+        return None
+    await _respect_rate_limit(host)
+    raw = await _get_bytes(
+        url, params, allowed_hosts=allowed_hosts, host=host, headers=headers
+    )
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw)
+    except Exception:
+        logger.warning("Restaurant source returned non-JSON")
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# --------------------------------------------------------------------------- #
+# Carb + response parsing helpers
+# --------------------------------------------------------------------------- #
+def _valid_item_carbs(value: object) -> float | None:
+    """Per-item carbs within the absolute single-meal bounds, or None.
+
+    Reject-not-clamp (CARB_GRAMS_MIN..CARB_GRAMS_MAX): a value outside the band
+    signals bad/mis-parsed source data, so we drop it and fall back to vision-only
+    rather than cite a wrong "published" number. ``GroundingDetail`` enforces the
+    same bound at construction, so an out-of-range value would otherwise raise.
+    """
+    if isinstance(value, bool):
+        return None
+    carbs: float | None = None
+    if isinstance(value, (int, float)):
+        carbs = float(value)
+    elif isinstance(value, str):
+        match = re.search(r"-?\d+(?:\.\d+)?", value)
+        if match:
+            carbs = float(match.group(0))
+    if carbs is None or not (CARB_GRAMS_MIN <= carbs <= CARB_GRAMS_MAX):
+        return None
+    return carbs
+
+
+def _carb_from_nutrients(
+    nutrients: object, *, name_key: str, value_key: str
+) -> float | None:
+    """Scan a [{name, value}, ...] nutrient list for the carbohydrate entry."""
+    if not isinstance(nutrients, list):
+        return None
+    for nutrient in nutrients:
+        if not isinstance(nutrient, dict):
+            continue
+        name = str(nutrient.get(name_key) or "").lower()
+        if "carbohydrate" in name or name in ("carbs", "total carbs"):
+            return _valid_item_carbs(nutrient.get(value_key))
+    return None
+
+
+def _best_item(items: object, *, name_key: str, item_query: str) -> dict | None:
+    """Pick the response item that matches the requested item, or None.
+
+    Prefers an item whose name contains every query token. The bare first-item
+    fallback is used ONLY for a genuine single-item response: when a multi-item
+    (search-style) response has no token match, returning ``items[0]`` would risk
+    citing a *different* menu item's carbs as the chain's authoritative figure for
+    the confirmed identity -- exactly the wrong-number-with-authority failure the
+    identity gate exists to prevent. So a non-matching multi-item response degrades
+    to None (vision-only) instead of guessing. Returns None when there are no items.
+    """
+    if not isinstance(items, list) or not items:
+        return None
+    dict_items = [it for it in items if isinstance(it, dict)]
+    if not dict_items:
+        return None
+    query_tokens = [t for t in _canon(item_query).split() if t]
+    if query_tokens:
+        for item in dict_items:
+            name_canon = _canon(str(item.get(name_key) or ""))
+            if all(_contains_phrase(name_canon, tok) for tok in query_tokens):
+                return item
+        # Multiple candidates and none matched the confirmed item -> don't guess
+        # which one the user meant; fall back to vision-only.
+        if len(dict_items) > 1:
+            return None
+    return dict_items[0]
+
+
+# --------------------------------------------------------------------------- #
+# Per-chain fetchers (framework)
+# --------------------------------------------------------------------------- #
+class RestaurantChain:
+    """One branded chain's on-demand nutrition fetcher.
+
+    Subclasses declare brand aliases + allow-listed hosts and implement
+    ``fetch_item`` (the chain-specific endpoint + parse). The shared SSRF guard,
+    robots.txt, rate-limit/back-off, and owner-scoped caching live in the module
+    around them, so a new chain only writes its request shape + parser. Every
+    ``fetch_item`` must fail open to None (never raise) so a changed endpoint
+    degrades to vision-only.
+
+    NOTE (brittleness): the endpoint URL/shape below is modelled, not
+    live-verified at build time. The maintainer canary (user docs) confirms it.
+    """
+
+    chain_id: str = ""
+    display_name: str = ""
+    citation_url: str | None = None
+    hosts: frozenset[str] = frozenset()
+    # Raw aliases; canonicalized once at class definition via ``_canon``.
+    _raw_aliases: tuple[str, ...] = ()
+
+    def __init__(self) -> None:
+        self.aliases: tuple[str, ...] = tuple(
+            _canon(alias) for alias in self._raw_aliases if _canon(alias)
+        )
+
+    def match(self, normalized_description: str) -> str | None:
+        """Return the item text (brand stripped) if this chain owns the
+        description, else None. An empty remainder (brand only, no item) is None
+        -- there's nothing to look up."""
+        canon = _canon(normalized_description)
+        for alias in self.aliases:
+            if _contains_phrase(canon, alias):
+                remainder = _padded(canon).replace(_padded(alias), " ").strip()
+                return remainder or None
+        return None
+
+    async def fetch_item(self, item_query: str) -> NutritionFact | None:
+        raise NotImplementedError
+
+
+class _McDonalds(RestaurantChain):
+    chain_id = "mcdonalds"
+    display_name = "McDonald's"
+    citation_url = "https://www.mcdonalds.com/us/en-us/full-menu-explorer.html"
+    hosts = frozenset({"www.mcdonalds.com"})
+    _raw_aliases = ("mcdonalds", "mcdonald's", "mc donalds", "mcd")
+
+    async def fetch_item(self, item_query: str) -> NutritionFact | None:
+        # Modelled shape: an item-search JSON feed returning a nutrient list per
+        # item. The query rides as an encoded param, never the path.
+        data = await _fetch_json(
+            "https://www.mcdonalds.com/dnaapp/itemNutrition",
+            {"name": item_query, "country": "us", "language": "en"},
+            host="www.mcdonalds.com",
+            allowed_hosts=self.hosts,
+        )
+        if data is None:
+            return None
+        item = _best_item(
+            data.get("items"), name_key="item_name", item_query=item_query
+        )
+        if item is None:
+            return None
+        carbs = _carb_from_nutrients(
+            item.get("nutrient_facts"), name_key="name", value_key="value"
+        )
+        if carbs is None:
+            return None
+        name = (
+            str(item.get("item_name") or item_query).strip()[:120] or item_query[:120]
+        )
+        return _build_fact(
+            source_name=self.display_name,
+            source_url=self.citation_url,
+            name=name,
+            carbs=carbs,
+        )
+
+
+class _Chipotle(RestaurantChain):
+    chain_id = "chipotle"
+    display_name = "Chipotle"
+    citation_url = "https://www.chipotle.com/nutrition-calculator"
+    hosts = frozenset({"www.chipotle.com"})
+    _raw_aliases = ("chipotle",)
+
+    async def fetch_item(self, item_query: str) -> NutritionFact | None:
+        # Modelled shape: a menu-item nutrition endpoint returning a nutrition
+        # list per item.
+        data = await _fetch_json(
+            "https://www.chipotle.com/api/nutrition/items",
+            {"q": item_query},
+            host="www.chipotle.com",
+            allowed_hosts=self.hosts,
+        )
+        if data is None:
+            return None
+        item = _best_item(data.get("items"), name_key="itemName", item_query=item_query)
+        if item is None:
+            return None
+        carbs = _carb_from_nutrients(
+            item.get("nutrition"), name_key="name", value_key="value"
+        )
+        if carbs is None:
+            return None
+        name = str(item.get("itemName") or item_query).strip()[:120] or item_query[:120]
+        return _build_fact(
+            source_name=self.display_name,
+            source_url=self.citation_url,
+            name=name,
+            carbs=carbs,
+        )
+
+
+# Chains with a dedicated free fetcher.
+_CHAINS: tuple[RestaurantChain, ...] = (_Chipotle(), _McDonalds())
+
+# Known restaurant brands WITHOUT a dedicated fetcher: detecting one routes the
+# item to the optional FatSecret BYO-key provider (broader commercial coverage),
+# never to USDA/OFF -- a branded item is not a generic food. Kept small and
+# data-driven; add a dedicated fetcher to graduate a brand off this list.
+_EXTRA_BRANDS: frozenset[str] = frozenset(
+    _canon(b)
+    for b in (
+        "taco bell",
+        "starbucks",
+        "wendy's",
+        "burger king",
+        "subway",
+        "kfc",
+        "chick-fil-a",
+        "dunkin",
+        "panera",
+        "popeyes",
+        "in-n-out",
+        "five guys",
+    )
+)
+
+_ALL_BRAND_ALIASES: frozenset[str] = (
+    frozenset(alias for chain in _CHAINS for alias in chain.aliases) | _EXTRA_BRANDS
+)
+
+
+def _build_fact(
+    *,
+    source_name: str,
+    source_url: str | None,
+    name: str,
+    carbs: float,
+    serving: str = _SERVING_PER_ITEM,
+) -> NutritionFact | None:
+    """Build an AUTHORITATIVE reference fact, or None if the (source-controlled)
+    item name carries dosing language.
+
+    Defence in depth: the item name comes from an undocumented third-party
+    endpoint that "changes without notice". If it ever contains dosing-style text
+    (e.g. a tampered/changed feed returning "bolus 6u"), drop the grounding
+    entirely rather than surface that text in the citation note returned to the
+    client -- the same no-dosing-language boundary the rest of the meal pipeline
+    enforces on generated/source text.
+    """
+    if find_dosing_violations(name):
+        logger.warning("Restaurant item name carried dosing language; dropping")
+        return None
+    return NutritionFact(
+        source_name=source_name,
+        source_url=source_url,
+        trust_tier=KnowledgeChunk.TIER_AUTHORITATIVE,
+        name=name,
+        carbs_grams=carbs,
+        serving=serving,
+        disclaimer=_RESTAURANT_DISCLAIMER,
+    )
+
+
+def _identify_chain(description: str) -> tuple[RestaurantChain, str] | None:
+    normalized = _normalize_query(description)
+    if not normalized:
+        return None
+    for chain in _CHAINS:
+        item = chain.match(normalized)
+        if item is not None:
+            return chain, item
+    return None
+
+
+def _has_known_brand(description: str) -> bool:
+    canon = _canon(description)
+    return any(_contains_phrase(canon, alias) for alias in _ALL_BRAND_ALIASES)
+
+
+# --------------------------------------------------------------------------- #
+# Optional FatSecret BYO-key provider (AC5)
+# --------------------------------------------------------------------------- #
+# Fixed FatSecret host allow-list. Unlike the per-chain hosts (which are distinct
+# from the URL under test), the FatSecret api/token URLs are operator config, so
+# the allow-list is a CONSTANT here rather than derived from the URL it guards --
+# otherwise the SSRF check would tautologically accept any misconfigured URL.
+_FATSECRET_HOSTS: frozenset[str] = frozenset(
+    {"platform.fatsecret.com", "oauth.fatsecret.com"}
+)
+
+
+async def _post_form_bytes(
+    url: str, *, data: dict, auth: tuple[str, str]
+) -> bytes | None:
+    """Stream a form POST to an allow-listed https FatSecret host, capped + redirect-free.
+
+    The one place a credential rides in the request body (Basic auth for the
+    OAuth2 token exchange). The same SSRF host allow-list, size cap, redirect
+    refusal, and no-logging guards as the GET path apply. Returns body bytes/None.
+    """
+    if not _host_allowed(url, _FATSECRET_HOSTS):
+        logger.warning(
+            "FatSecret POST host not allow-listed", host=urlparse(url).hostname
+        )
+        return None
+    try:
+        async with (
+            httpx.AsyncClient(
+                timeout=settings.nutrition_grounding_timeout_seconds,
+                follow_redirects=False,
+                headers={"User-Agent": _USER_AGENT},
+            ) as client,
+            client.stream("POST", url, data=data, auth=auth) as resp,
+        ):
+            if resp.status_code != 200:
+                logger.warning("FatSecret token non-200", status=resp.status_code)
+                return None
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.aiter_bytes():
+                total += len(chunk)
+                if total > _MAX_RESPONSE_BYTES:
+                    logger.warning("FatSecret token response too large")
+                    return None
+                chunks.append(chunk)
+    except Exception:
+        # Never log the exception -- the Basic-auth credentials ride in the request.
+        logger.warning("FatSecret token request failed")
+        return None
+    return b"".join(chunks)
+
+
+async def _fatsecret_token() -> str | None:
+    """OAuth2 client-credentials token, or None. Key/secret never logged."""
+    key = settings.fatsecret_consumer_key
+    secret = settings.fatsecret_consumer_secret
+    if not key or not secret:
+        return None
+    raw = await _post_form_bytes(
+        settings.fatsecret_token_url,
+        data={"grant_type": "client_credentials", "scope": "basic"},
+        auth=(key, secret),
+    )
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        logger.warning("FatSecret token returned non-JSON")
+        return None
+    token = payload.get("access_token") if isinstance(payload, dict) else None
+    return token if isinstance(token, str) and token else None
+
+
+# FatSecret v1 foods.search embeds nutrients in a description string, e.g.
+# "Per 1 burrito - Calories: 1050kcal | Fat: 41.00g | Carbs: 122.00g | ...".
+_FATSECRET_CARB_RE = re.compile(r"carbs?:\s*([\d.]+)\s*g", re.IGNORECASE)
+_FATSECRET_SERVING_RE = re.compile(r"^\s*per\s+([^-|]+?)\s*[-|]", re.IGNORECASE)
+
+
+async def _fetch_fatsecret(query: str) -> NutritionFact | None:
+    """Query FatSecret for a branded item via the operator's BYO key, or None.
+
+    Disabled (returns None) when no key is configured. Results are cached
+    owner-scoped for at most ``fatsecret_cache_ttl_hours`` (<=24 h, FatSecret's
+    value-cache ToS limit), never shared. Fails open to None.
+    """
+    token = await _fatsecret_token()
+    if token is None:
+        return None
+    api_url = settings.fatsecret_api_url
+    host = urlparse(api_url).hostname or ""
+    data = await _fetch_json(
+        api_url,
+        {
+            "method": "foods.search",
+            "search_expression": query,
+            "format": "json",
+            "max_results": 1,
+        },
+        host=host,
+        allowed_hosts=_FATSECRET_HOSTS,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    if data is None:
+        return None
+    foods = (
+        (data.get("foods") or {}).get("food")
+        if isinstance(data.get("foods"), dict)
+        else None
+    )
+    if isinstance(foods, dict):  # single result is an object, not a list
+        foods = [foods]
+    if not isinstance(foods, list) or not foods:
+        return None
+    food = foods[0]
+    if not isinstance(food, dict):
+        return None
+    description = str(food.get("food_description") or "")
+    carb_match = _FATSECRET_CARB_RE.search(description)
+    if not carb_match:
+        return None
+    carbs = _valid_item_carbs(carb_match.group(1))
+    if carbs is None:
+        return None
+    name = str(food.get("food_name") or query).strip()[:120] or query[:120]
+    serving_match = _FATSECRET_SERVING_RE.search(description)
+    serving = (
+        serving_match.group(1).strip()[:60] if serving_match else _SERVING_PER_ITEM
+    )
+    food_id = food.get("food_id")
+    source_url = (
+        f"https://www.fatsecret.com/calories-nutrition/food/{food_id}"
+        if food_id
+        else "https://platform.fatsecret.com"
+    )
+    return _build_fact(
+        source_name="FatSecret",
+        source_url=source_url,
+        name=name,
+        carbs=carbs,
+        serving=f"per {serving}" if not serving.lower().startswith("per") else serving,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Owner-scoped cache (the key difference from USDA/OFF's shared mirror)
+# --------------------------------------------------------------------------- #
+# These mirror the nutrition_sources cache family deliberately rather than sharing
+# a helper: the one axis that differs -- writing ``user_id = requester`` here vs
+# ``user_id IS NULL`` (shared) there -- is the owner-scoping safety invariant
+# (FM7). Folding both write paths into one scope-parameterized function would put a
+# cross-user-leak regression one boolean apart, so the paths are kept physically
+# separate on purpose.
+def _cache_key(source_type: str, user_id: uuid.UUID, normalized_query: str) -> str:
+    # user_id is folded in (belt-and-suspenders): two users querying the same item
+    # get distinct rows, so a restaurant fetch can never leak across users even if
+    # the user_id filter were ever loosened.
+    return hashlib.sha256(
+        f"{source_type}:{user_id}:{normalized_query}".encode()
+    ).hexdigest()
+
+
+async def _cache_get(
+    user_id: uuid.UUID, source_type: str, normalized_query: str, *, ttl_hours: float
+) -> NutritionFact | None:
+    """Owner-scoped cache read; a stale row is lazily purged and counts as a miss.
+
+    The lazy purge is what keeps a FatSecret value from being served (or retained)
+    past its 24 h ToS window once it is next touched. Runs on a dedicated session
+    (decoupled from the caller's request transaction).
+    """
+    content_hash = _cache_key(source_type, user_id, normalized_query)
+    cutoff = datetime.now(UTC) - timedelta(hours=ttl_hours)
+    try:
+        async with get_session_maker()() as db:
+            chunk = await db.scalar(
+                select(KnowledgeChunk).where(
+                    KnowledgeChunk.user_id == user_id,
+                    KnowledgeChunk.source_type == source_type,
+                    KnowledgeChunk.content_hash == content_hash,
+                    KnowledgeChunk.valid_to.is_(None),
+                )
+            )
+            if chunk is None:
+                return None
+            if chunk.retrieved_at is None or chunk.retrieved_at < cutoff:
+                await db.delete(chunk)
+                await db.commit()
+                return None
+            meta = chunk.metadata_json or {}
+            carbs = _valid_item_carbs(meta.get("carbs_grams"))
+            if carbs is None:
+                return None
+            return NutritionFact(
+                source_name=meta.get("source_name") or chunk.source_name or source_type,
+                source_url=meta.get("source_url") or chunk.source_url,
+                trust_tier=meta.get("trust_tier") or chunk.trust_tier,
+                name=meta.get("name") or chunk.source_name or normalized_query,
+                carbs_grams=carbs,
+                serving=meta.get("serving") or _SERVING_PER_ITEM,
+                disclaimer=meta.get("disclaimer"),
+            )
+    except Exception:
+        logger.warning("Restaurant cache lookup failed", source=source_type)
+        return None
+
+
+async def _cache_put(
+    user_id: uuid.UUID,
+    source_type: str,
+    normalized_query: str,
+    fact: NutritionFact,
+    *,
+    ttl_hours: float,
+) -> None:
+    """Store a fetched fact as an OWNER-SCOPED cache chunk (best-effort).
+
+    ``user_id`` is the requesting user (never None) -- the owner-scoping that
+    distinguishes restaurant caching from the shared USDA/OFF mirror. Idempotent
+    upsert on the partial UNIQUE(content_hash, user_id) index (migration 050).
+
+    Also actively purges this user's OWN expired rows for this ``source_type``, so
+    a FatSecret value can't be *retained* at rest past its 24 h ToS window even if
+    its exact key is never re-read (the read-side lazy purge alone would leave an
+    unread stale row in place). A scheduled sweep would catch a user who never logs
+    another item of this source; that broader retention pass is a follow-up.
+    """
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(hours=ttl_hours)
+    injection_risk = bool(find_dosing_violations(fact.name))
+    content = (
+        f"{fact.name}: ~{fact.carbs_grams:g} g carbohydrate {fact.serving} "
+        f"({fact.source_name})"
+    )[:1000]
+    metadata = {
+        "query": normalized_query,
+        "name": fact.name,
+        "carbs_grams": fact.carbs_grams,
+        "serving": fact.serving,
+        "disclaimer": fact.disclaimer,
+        "source_name": fact.source_name,
+        "source_url": fact.source_url,
+        "trust_tier": fact.trust_tier,
+    }
+    stmt = pg_insert(KnowledgeChunk).values(
+        user_id=user_id,
+        trust_tier=fact.trust_tier,
+        source_type=source_type,
+        source_url=fact.source_url,
+        source_name=fact.source_name,
+        content=content,
+        embedding=None,
+        content_hash=_cache_key(source_type, user_id, normalized_query),
+        retrieved_at=now,
+        injection_risk=injection_risk,
+        metadata_json=metadata,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["content_hash", "user_id"],
+        index_where=KnowledgeChunk.content_hash.isnot(None),
+        set_={
+            "trust_tier": stmt.excluded.trust_tier,
+            "source_url": stmt.excluded.source_url,
+            "source_name": stmt.excluded.source_name,
+            "content": stmt.excluded.content,
+            "retrieved_at": stmt.excluded.retrieved_at,
+            "injection_risk": stmt.excluded.injection_risk,
+            "metadata_json": stmt.excluded.metadata_json,
+            "updated_at": now,
+        },
+    )
+    try:
+        async with get_session_maker()() as db:
+            await db.execute(stmt)
+            # Purge this user's own expired rows for this source (retention cap).
+            await db.execute(
+                delete(KnowledgeChunk).where(
+                    KnowledgeChunk.user_id == user_id,
+                    KnowledgeChunk.source_type == source_type,
+                    KnowledgeChunk.retrieved_at < cutoff,
+                )
+            )
+            await db.commit()
+    except Exception:
+        logger.warning("Failed to cache restaurant fact", source=source_type)
+
+
+# --------------------------------------------------------------------------- #
+# Public entry point
+# --------------------------------------------------------------------------- #
+async def lookup_restaurant(user_id: uuid.UUID, query: str) -> NutritionFact | None:
+    """Ground a confirmed branded-chain item against the chain's own nutrition.
+
+    On-demand, item-scoped, OWNER-SCOPED-cached, identity-gated by the caller
+    (``meal_grounding.ground_estimate`` only reaches here for a confirmed
+    identity). Returns a ``NutritionFact`` (AUTHORITATIVE) or None -- None means
+    "no branded match / fetch unavailable", and the caller falls back to USDA/OFF
+    then vision-only. Restaurant grounding fires ONLY when a known restaurant
+    brand is present in the identity: a generic food (no brand) is left to
+    USDA/OFF, so a branded chain never overrides USDA for plain foods.
+
+    Every internal step fails open to None; this function never raises.
+    """
+    if not settings.restaurant_grounding_enabled:
+        return None
+    normalized = _normalize_query(query)
+    if not normalized:
+        return None
+
+    # 1. A chain with a dedicated fetcher: try its own published nutrition first.
+    match = _identify_chain(query)
+    if match is not None:
+        chain, item_query = match
+        cached = await _cache_get(
+            user_id,
+            SOURCE_TYPE_RESTAURANT_CHAIN,
+            normalized,
+            ttl_hours=settings.restaurant_cache_ttl_hours,
+        )
+        if cached is not None:
+            return cached
+        try:
+            fact = await chain.fetch_item(item_query)
+        except Exception:
+            logger.warning("Restaurant chain fetch raised", chain=chain.chain_id)
+            fact = None
+        if fact is not None:
+            await _cache_put(
+                user_id,
+                SOURCE_TYPE_RESTAURANT_CHAIN,
+                normalized,
+                fact,
+                ttl_hours=settings.restaurant_cache_ttl_hours,
+            )
+            return fact
+        # Dedicated fetch unavailable -> fall through to the FatSecret breadth path.
+
+    # 2. A known brand without (or beyond) a dedicated fetcher: optional FatSecret
+    #    BYO-key. No brand at all -> not a restaurant item -> leave it to USDA/OFF.
+    if _has_known_brand(query):
+        cached = await _cache_get(
+            user_id,
+            SOURCE_TYPE_FATSECRET,
+            normalized,
+            ttl_hours=settings.fatsecret_cache_ttl_hours,
+        )
+        if cached is not None:
+            return cached
+        try:
+            fact = await _fetch_fatsecret(normalized)
+        except Exception:
+            logger.warning("FatSecret fetch raised")
+            fact = None
+        if fact is not None:
+            await _cache_put(
+                user_id,
+                SOURCE_TYPE_FATSECRET,
+                normalized,
+                fact,
+                ttl_hours=settings.fatsecret_cache_ttl_hours,
+            )
+            return fact
+
+    return None

--- a/apps/api/tests/test_meal_e2e_chain.py
+++ b/apps/api/tests/test_meal_e2e_chain.py
@@ -519,3 +519,125 @@ async def test_fm7_cross_user_isolation(client):
             b, _vision(desc, 60, 70), _vision(desc, 62, 72), _vision(desc, 61, 71)
         )
         assert rec_b["suggested_identity"] is None
+
+
+# ── Story 50.E2: restaurant grounding journeys (GJ5, FM4, FM6) ──
+# The chain HTTP is never hit here -- restaurant_nutrition.lookup_restaurant is
+# patched so the journey asserts the gate + precedence + provenance plumbing.
+# FM7 (owner-scoped restaurant cache isolation) lives in test_restaurant_nutrition
+# where the cache + mocked HTTP are exercised directly.
+
+
+def _chain_fact(carbs: float = 42):
+    from src.services import nutrition_sources
+
+    return nutrition_sources.NutritionFact(
+        source_name="McDonald's",
+        source_url="https://www.mcdonalds.com/x",
+        trust_tier="AUTHORITATIVE",
+        name="Quarter Pounder with Cheese",
+        carbs_grams=carbs,
+        serving="per item",
+        disclaimer="Reference only; never use it to dose or bolus.",
+    )
+
+
+async def test_gj5_confirmed_chain_item_gets_authoritative_citation(client):
+    """GJ5: a chain item is fetched + cited at AUTHORITATIVE only AFTER the user
+    confirms identity; an unconfirmed item never carries a chain citation."""
+    from src.services import restaurant_nutrition
+
+    desc = f"mcdonalds quarter pounder {_uniq()}"
+    rec = await _upload(
+        client, _vision(desc, 40, 50), _vision(desc, 42, 52), _vision(desc, 41, 51)
+    )
+    # Headline AC8 safety point: vision-only at create, no chain citation yet.
+    assert rec["identity_confirmed"] is False
+    assert rec["grounding_source"] is None
+
+    with patch.object(
+        restaurant_nutrition,
+        "lookup_restaurant",
+        AsyncMock(return_value=_chain_fact(42)),
+    ):
+        confirm = await client.post(
+            f"/api/food-records/{rec['id']}/confirm-identity",
+            json={"confirmed_food_name": desc},
+        )
+    assert confirm.status_code == 200, confirm.text
+    body = confirm.json()
+    assert body["identity_confirmed"] is True
+    assert body["grounding_source"] == "McDonald's"
+    assert body["grounding_trust_tier"] == "AUTHORITATIVE"
+    assert body["grounding_source_url"] == "https://www.mcdonalds.com/x"
+    assert body["grounding"]["carbs_low"] == 42  # the chain's own published figure
+    # Grounding is descriptive only -- the user's empirical band is untouched.
+    assert (body["carbs_low"], body["carbs_high"]) == (
+        rec["carbs_low"],
+        rec["carbs_high"],
+    )
+    assert not find_dosing_violations(body["grounding"]["note"] or "")
+
+
+async def test_fm4_misidentified_chain_item_grounds_only_corrected_identity(client):
+    """FM4: the AI's mislabel is never cited; only the user's corrected identity
+    is grounded, and the chain is queried on the corrected name."""
+    from src.services import restaurant_nutrition
+
+    mislabel = f"mystery sandwich {_uniq()}"
+    corrected = f"mcdonalds quarter pounder {_uniq()}"
+    rec = await _upload(
+        client,
+        _vision(mislabel, 35, 45),
+        _vision(mislabel, 36, 46),
+        _vision(mislabel, 34, 44),
+    )
+    assert rec["grounding_source"] is None  # the mislabel is never grounded
+
+    seen = {}
+
+    async def _fake_lookup(user_id, identity):
+        seen["identity"] = identity
+        return _chain_fact(42)
+
+    with patch.object(
+        restaurant_nutrition, "lookup_restaurant", AsyncMock(side_effect=_fake_lookup)
+    ):
+        confirm = await client.post(
+            f"/api/food-records/{rec['id']}/confirm-identity",
+            json={"confirmed_food_name": corrected},
+        )
+    assert confirm.status_code == 200, confirm.text
+    body = confirm.json()
+    assert body["confirmed_food_name"] == corrected
+    assert body["grounding_source"] == "McDonald's"
+    # The chain was queried on the CORRECTED identity, never the AI's mislabel.
+    assert seen["identity"] == corrected
+
+
+async def test_fm6_restaurant_fetch_failure_degrades_to_vision_only(client):
+    """FM6: a restaurant fetch blowing up degrades cleanly -- confirmation still
+    succeeds, the estimate stays vision-only, and the band is untouched."""
+    from src.services import restaurant_nutrition
+
+    desc = f"mcdonalds big mac {_uniq()}"
+    rec = await _upload(
+        client, _vision(desc, 40, 50), _vision(desc, 42, 52), _vision(desc, 41, 51)
+    )
+    with patch.object(
+        restaurant_nutrition,
+        "lookup_restaurant",
+        AsyncMock(side_effect=RuntimeError("endpoint down")),
+    ):
+        confirm = await client.post(
+            f"/api/food-records/{rec['id']}/confirm-identity",
+            json={"confirmed_food_name": desc},
+        )
+    assert confirm.status_code == 200, confirm.text  # no crash
+    body = confirm.json()
+    assert body["identity_confirmed"] is True
+    assert body["grounding_source"] is None  # gracefully vision-only
+    assert (body["carbs_low"], body["carbs_high"]) == (
+        rec["carbs_low"],
+        rec["carbs_high"],
+    )

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -28,7 +28,13 @@ from src.models.common_food import CommonFood, normalize_common_food_name
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.models.knowledge_chunk import KnowledgeChunk
 from src.models.user import User, UserRole
-from src.services import food_vision, meal_grounding, meal_rag, nutrition_sources
+from src.services import (
+    food_vision,
+    meal_grounding,
+    meal_rag,
+    nutrition_sources,
+    restaurant_nutrition,
+)
 from src.vision.carb_contract import (
     MEAL_ESTIMATE_QUALIFIER,
     NEVER_DOSE_PROHIBITION,
@@ -811,6 +817,101 @@ class TestPrecedence:
         # The gate short-circuits before any recall or external lookup runs.
         recall.assert_not_awaited()
         lookup.assert_not_awaited()
+
+    # ── Story 50.E2: restaurant slots in as AUTHORITATIVE above USDA ──
+    def _restaurant_fact(self, carbs=30):
+        return nutrition_sources.NutritionFact(
+            source_name="McDonald's",
+            source_url="https://www.mcdonalds.com/x",
+            trust_tier=KnowledgeChunk.TIER_AUTHORITATIVE,
+            name="Quarter Pounder with Cheese",
+            carbs_grams=carbs,
+            serving="per item",
+            disclaimer="Reference only; never use it to dose or bolus.",
+        )
+
+    async def test_restaurant_preferred_over_usda(self):
+        # A branded chain item grounds to the chain's own facts above generic USDA.
+        usda = self._fact(
+            "USDA FoodData Central", KnowledgeChunk.TIER_AUTHORITATIVE, 12
+        )
+        with (
+            patch.object(meal_rag, "recall_similar_meal", AsyncMock(return_value=None)),
+            patch.object(
+                restaurant_nutrition,
+                "lookup_restaurant",
+                AsyncMock(return_value=self._restaurant_fact(30)),
+            ),
+            patch.object(
+                nutrition_sources,
+                "lookup_published_nutrition",
+                AsyncMock(return_value=(usda, None)),
+            ) as published,
+        ):
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "McDonald's Quarter Pounder", identity_confirmed=True
+            )
+        assert detail.source == "McDonald's"
+        assert detail.carbs_low == 30  # the chain figure, not the USDA 12
+        assert detail.trust_tier == KnowledgeChunk.TIER_AUTHORITATIVE
+        # A restaurant hit short-circuits before the USDA/OFF HTTP round-trips.
+        published.assert_not_awaited()
+
+    async def test_corrected_own_history_beats_restaurant(self):
+        # Precedence: own-history corrected > restaurant. A corrected match
+        # short-circuits before the restaurant lookup even runs.
+        with (
+            patch.object(
+                meal_rag,
+                "recall_similar_meal",
+                AsyncMock(return_value=self._recall(corrected=True)),
+            ),
+            patch.object(
+                restaurant_nutrition, "lookup_restaurant", AsyncMock()
+            ) as restaurant,
+        ):
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "McDonald's Quarter Pounder", identity_confirmed=True
+            )
+        assert detail.source == "Your meal history"
+        restaurant.assert_not_awaited()
+
+    async def test_restaurant_falls_through_to_usda_when_unbranded(self):
+        # A generic food (restaurant lookup returns None) still grounds to USDA.
+        usda = self._fact(
+            "USDA FoodData Central", KnowledgeChunk.TIER_AUTHORITATIVE, 12
+        )
+        with (
+            patch.object(meal_rag, "recall_similar_meal", AsyncMock(return_value=None)),
+            patch.object(
+                restaurant_nutrition,
+                "lookup_restaurant",
+                AsyncMock(return_value=None),
+            ),
+            patch.object(
+                nutrition_sources,
+                "lookup_published_nutrition",
+                AsyncMock(return_value=(usda, None)),
+            ),
+        ):
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "oatmeal", identity_confirmed=True
+            )
+        assert detail.source == "USDA FoodData Central"
+        assert detail.carbs_low == 12
+
+    async def test_unconfirmed_identity_never_grounds_restaurant(self):
+        # AC8: the restaurant lookup is never even reached for an unconfirmed item.
+        with patch.object(
+            restaurant_nutrition, "lookup_restaurant", AsyncMock()
+        ) as restaurant:
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(),
+                "McDonald's Quarter Pounder",
+                identity_confirmed=False,
+            )
+        assert detail is None
+        restaurant.assert_not_awaited()
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/api/tests/test_restaurant_nutrition.py
+++ b/apps/api/tests/test_restaurant_nutrition.py
@@ -1,0 +1,668 @@
+"""Story 50.E2: restaurant / fast-food grounding -- fetchers, SSRF, owner-scoped
+cache, robots/rate-limit compliance, reference-data disclaimer, and the optional
+FatSecret BYO-key provider.
+
+Chain HTTP is always mocked (``_mock_httpx`` patches ``httpx.AsyncClient.stream`` /
+``.post`` -- never a live call, per the Test Plan). robots.txt is bypassed for the
+fetch tests (``_robots_allows`` patched True) and exercised directly in its own
+test. Behavioral assertions only -- never an exact published carb count from a real
+endpoint; the only hard numbers are inputs we control in the mocked payloads.
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import update
+
+from src.config import settings
+from src.database import get_session_maker
+from src.models.knowledge_chunk import KnowledgeChunk
+from src.models.user import User, UserRole
+from src.services import meal_rag
+from src.services import restaurant_nutrition as rn
+from src.vision.carb_contract import (
+    MEAL_ESTIMATE_QUALIFIER,
+    NEVER_DOSE_PROHIBITION,
+    find_dosing_violations,
+)
+
+# (asyncio_mode = "auto" in pyproject -- async tests need no explicit mark.)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers + fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _setup(monkeypatch):
+    monkeypatch.setattr(settings, "restaurant_grounding_enabled", True)
+    # No real sleeps in the rate limiter for the fetch tests.
+    monkeypatch.setattr(settings, "restaurant_min_seconds_between_fetches", 0.0)
+    # FatSecret off by default (no shared key); the FatSecret tests opt in.
+    monkeypatch.setattr(settings, "fatsecret_consumer_key", "")
+    monkeypatch.setattr(settings, "fatsecret_consumer_secret", "")
+    rn._reset_state_for_tests()
+    yield
+    rn._reset_state_for_tests()
+
+
+def _allow_robots():
+    """Bypass the robots.txt fetch so a test exercises only the data fetch."""
+    return patch.object(rn, "_robots_allows", AsyncMock(return_value=True))
+
+
+def _mock_httpx(payload, status=200, *, body=None, token=None):
+    """Patch ``httpx.AsyncClient`` so ``.stream("GET", ...)`` yields the data payload
+    and ``.stream("POST", ...)`` (the FatSecret OAuth token exchange) yields a token.
+
+    ``token=None`` makes the POST return 401 (a token failure). Mirrors
+    test_meal_grounding's streamed-mock idiom; ``stream()`` is method-aware so the
+    GET data fetch and the streamed POST token exchange get distinct responses.
+    """
+    search_raw = body if body is not None else json.dumps(payload).encode()
+    token_raw = json.dumps({"access_token": token}).encode() if token else b"{}"
+
+    def _make_cm(raw, st):
+        async def _aiter_bytes():
+            yield raw
+
+        resp = MagicMock()
+        resp.status_code = st
+        resp.aiter_bytes = _aiter_bytes
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    def _stream(method, *args, **kwargs):
+        if method == "POST":
+            return _make_cm(token_raw, 200 if token else 401)
+        return _make_cm(search_raw, status)
+
+    client = AsyncMock()
+    client.stream = MagicMock(side_effect=_stream)  # stream() is sync -> CM
+    ctx = patch("httpx.AsyncClient")
+    return ctx, client
+
+
+async def _new_user() -> User:
+    async with get_session_maker()() as db:
+        user = User(
+            email=f"restaurant_{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="x",
+            role=UserRole.DIABETIC,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        return user
+
+
+_MCD_PAYLOAD = {
+    "items": [
+        {
+            "item_name": "Quarter Pounder with Cheese",
+            "nutrient_facts": [
+                {"name": "Calories", "value": 520},
+                {"name": "Carbohydrates", "value": 42, "uom": "g"},
+            ],
+        }
+    ]
+}
+
+_CHIPOTLE_PAYLOAD = {
+    "items": [
+        {
+            "itemName": "Chicken Bowl",
+            "nutrition": [
+                {"name": "Protein", "value": 32},
+                {"name": "Total Carbohydrate", "value": 40, "unit": "g"},
+            ],
+        }
+    ]
+}
+
+# FatSecret v1 foods.search embeds nutrients in the description string.
+_FATSECRET_PAYLOAD = {
+    "foods": {
+        "food": {
+            "food_id": "33691",
+            "food_name": "Crunchwrap Supreme",
+            "food_description": "Per 1 wrap - Calories: 530kcal | Fat: 21.00g | "
+            "Carbs: 71.00g | Protein: 16.00g",
+        }
+    }
+}
+
+
+# --------------------------------------------------------------------------- #
+# Brand detection (the chain-from-identity step)
+# --------------------------------------------------------------------------- #
+class TestBrandDetection:
+    def test_identifies_dedicated_chains(self):
+        mcd = rn._identify_chain("McDonald's Quarter Pounder with cheese")
+        assert mcd is not None and mcd[0].chain_id == "mcdonalds"
+        assert "quarter pounder" in mcd[1]
+
+        chip = rn._identify_chain("Chipotle chicken bowl")
+        assert chip is not None and chip[0].chain_id == "chipotle"
+        assert "chicken bowl" in chip[1]
+
+    def test_generic_food_is_not_a_chain(self):
+        assert rn._identify_chain("a bowl of oatmeal with berries") is None
+        # No item after the brand -> nothing to look up.
+        assert rn._identify_chain("mcdonalds") is None
+
+    def test_known_brand_without_dedicated_fetcher(self):
+        # Routes to FatSecret, never to USDA/OFF.
+        assert rn._has_known_brand("Taco Bell crunchwrap supreme") is True
+        assert rn._has_known_brand("Starbucks caramel frappuccino") is True
+        # A plain food carries no brand.
+        assert rn._has_known_brand("homemade chili") is False
+
+    def test_brand_match_is_whole_token(self):
+        # "mcd" must not match inside "mcdonalds"; "taco" must not match a non-brand.
+        assert rn._contains_phrase(rn._canon("mcdonalds big mac"), "mcd") is False
+        assert rn._contains_phrase(rn._canon("tacopalooza dish"), "taco bell") is False
+
+    def test_canon_folds_accents(self):
+        # NFKD accent folding keeps an accented menu name comparable to its ASCII
+        # form (consistent with the hardened own-history matcher).
+        assert rn._canon("Crème Brûlée") == "creme brulee"
+        assert rn._canon("Açaí Bowl") == "acai bowl"
+
+
+# --------------------------------------------------------------------------- #
+# Happy path: fetch -> parse -> owner-scoped cache (GJ5 at the unit level)
+# --------------------------------------------------------------------------- #
+class TestChainFetch:
+    async def test_mcdonalds_parses_and_caches(self):
+        user = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            first = await rn.lookup_restaurant(user.id, "McDonald's Quarter Pounder")
+            second = await rn.lookup_restaurant(user.id, "McDonald's Quarter Pounder")
+
+        assert first is not None
+        assert first.source_name == "McDonald's"
+        assert first.trust_tier == KnowledgeChunk.TIER_AUTHORITATIVE
+        assert first.carbs_grams == 42
+        assert first.serving == "per item"
+        # Second call is served from the owner-scoped cache -- no second fetch.
+        assert client.stream.call_count == 1
+        assert second is not None and second.carbs_grams == 42
+
+    async def test_chipotle_parses(self):
+        user = await _new_user()
+        ctx, client = _mock_httpx(_CHIPOTLE_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "Chipotle chicken bowl")
+        assert fact is not None
+        assert fact.source_name == "Chipotle"
+        assert fact.carbs_grams == 40
+        assert fact.trust_tier == KnowledgeChunk.TIER_AUTHORITATIVE
+
+    async def test_no_brand_makes_no_request(self):
+        user = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "plain oatmeal")
+        assert fact is None
+        assert client.stream.call_count == 0  # generic food -> never a chain fetch
+
+    async def test_disabled_flag_skips_fetch(self, monkeypatch):
+        monkeypatch.setattr(settings, "restaurant_grounding_enabled", False)
+        user = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "McDonald's Big Mac")
+        assert fact is None
+        assert client.stream.call_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# FM7: owner-scoped cache isolation (the key difference from USDA/OFF caching)
+# --------------------------------------------------------------------------- #
+class TestOwnerScopedCache:
+    async def test_user_b_never_sees_user_a_cached_fetch(self):
+        user_a = await _new_user()
+        user_b = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            a1 = await rn.lookup_restaurant(user_a.id, "McDonald's Big Mac")
+            assert client.stream.call_count == 1
+            # A re-logs -> served from A's own cache (no new fetch).
+            await rn.lookup_restaurant(user_a.id, "McDonald's Big Mac")
+            assert client.stream.call_count == 1
+            # B logs the same item -> B does NOT read A's cache; it fetches itself.
+            b1 = await rn.lookup_restaurant(user_b.id, "McDonald's Big Mac")
+            assert client.stream.call_count == 2
+        assert a1 is not None and b1 is not None
+
+        # And the cache rows are genuinely per-user (distinct content_hash + user).
+        async with get_session_maker()() as db:
+            from sqlalchemy import func, select
+
+            a_rows = await db.scalar(
+                select(func.count())
+                .select_from(KnowledgeChunk)
+                .where(
+                    KnowledgeChunk.user_id == user_a.id,
+                    KnowledgeChunk.source_type == meal_rag.SOURCE_TYPE_RESTAURANT_CHAIN,
+                )
+            )
+            b_rows = await db.scalar(
+                select(func.count())
+                .select_from(KnowledgeChunk)
+                .where(
+                    KnowledgeChunk.user_id == user_b.id,
+                    KnowledgeChunk.source_type == meal_rag.SOURCE_TYPE_RESTAURANT_CHAIN,
+                )
+            )
+        assert a_rows == 1 and b_rows == 1
+
+    async def test_restaurant_cache_is_never_shared(self):
+        # A restaurant chunk must never be written shared (user_id IS NULL) like
+        # the redistributable USDA/OFF mirror.
+        user = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            await rn.lookup_restaurant(user.id, "McDonald's Big Mac")
+        async with get_session_maker()() as db:
+            from sqlalchemy import func, select
+
+            shared = await db.scalar(
+                select(func.count())
+                .select_from(KnowledgeChunk)
+                .where(
+                    KnowledgeChunk.user_id.is_(None),
+                    KnowledgeChunk.source_type == meal_rag.SOURCE_TYPE_RESTAURANT_CHAIN,
+                )
+            )
+        assert shared == 0
+
+
+# --------------------------------------------------------------------------- #
+# FM6 + fallbacks: every failure mode degrades to None (vision-only upstream)
+# --------------------------------------------------------------------------- #
+class TestFallbacks:
+    async def test_non_200_returns_none(self):
+        user = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD, status=500)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            assert await rn.lookup_restaurant(user.id, "McDonald's Big Mac") is None
+
+    async def test_fetch_exception_returns_none(self):
+        user = await _new_user()
+        with (
+            _allow_robots(),
+            patch.object(
+                rn._McDonalds,
+                "fetch_item",
+                AsyncMock(side_effect=RuntimeError("endpoint changed")),
+            ),
+        ):
+            assert await rn.lookup_restaurant(user.id, "McDonald's Big Mac") is None
+
+    async def test_empty_or_malformed_payload_returns_none(self):
+        user = await _new_user()
+        for payload in ({}, {"items": []}, {"items": [{"item_name": "x"}]}):
+            ctx, client = _mock_httpx(payload)
+            with _allow_robots(), ctx as ac:
+                ac.return_value.__aenter__.return_value = client
+                assert await rn.lookup_restaurant(user.id, "McDonald's thing") is None
+
+    async def test_out_of_range_carbs_dropped_not_clamped(self):
+        user = await _new_user()
+        payload = {
+            "items": [
+                {
+                    "item_name": "Impossible plate",
+                    "nutrient_facts": [{"name": "Carbohydrates", "value": 5000}],
+                }
+            ]
+        }
+        ctx, client = _mock_httpx(payload)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            # > CARB_GRAMS_MAX -> rejected, never a "published" wrong number.
+            assert await rn.lookup_restaurant(user.id, "McDonald's plate") is None
+
+    async def test_multi_item_no_match_does_not_cite_wrong_item(self):
+        # A search-style response with several items, none matching the confirmed
+        # identity, must NOT cite the first (a different food) as authoritative --
+        # it degrades to vision-only instead.
+        user = await _new_user()
+        payload = {
+            "items": [
+                {
+                    "item_name": "Big Mac",
+                    "nutrient_facts": [{"name": "Carbohydrates", "value": 45}],
+                },
+                {
+                    "item_name": "McFlurry",
+                    "nutrient_facts": [{"name": "Carbohydrates", "value": 80}],
+                },
+            ]
+        }
+        ctx, client = _mock_httpx(payload)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            assert (
+                await rn.lookup_restaurant(user.id, "McDonald's Quarter Pounder")
+                is None
+            )
+
+    async def test_single_item_response_is_trusted(self):
+        # A single-item endpoint response IS trusted even without a token match --
+        # it's the chain's one hit for our exact query param.
+        user = await _new_user()
+        payload = {
+            "items": [
+                {
+                    "item_name": "Some Combo",
+                    "nutrient_facts": [{"name": "Carbohydrates", "value": 50}],
+                }
+            ]
+        }
+        ctx, client = _mock_httpx(payload)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "McDonald's Quarter Pounder")
+        assert fact is not None and fact.carbs_grams == 50
+
+    async def test_dosing_language_item_name_is_dropped(self):
+        # Defence in depth: a source-controlled item name carrying dosing language
+        # drops the grounding rather than surface it in the citation note.
+        user = await _new_user()
+        payload = {
+            "items": [
+                {
+                    "item_name": "Quarter Pounder bolus 6u",
+                    "nutrient_facts": [{"name": "Carbohydrates", "value": 42}],
+                }
+            ]
+        }
+        ctx, client = _mock_httpx(payload)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            assert (
+                await rn.lookup_restaurant(user.id, "McDonald's Quarter Pounder")
+                is None
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Security: SSRF host allow-list / https-only / redirect-free / key handling
+# --------------------------------------------------------------------------- #
+class TestSsrf:
+    def test_host_allowlist(self):
+        hosts = frozenset({"www.mcdonalds.com"})
+        assert rn._host_allowed("https://www.mcdonalds.com/x", hosts)
+        # Plaintext, off-list, and metadata/internal targets are rejected.
+        assert not rn._host_allowed("http://www.mcdonalds.com/x", hosts)
+        assert not rn._host_allowed("https://169.254.169.254/x", hosts)
+        assert not rn._host_allowed("https://localhost/x", hosts)
+        assert not rn._host_allowed("https://evil.example.com/x", hosts)
+
+    async def test_off_list_host_makes_no_request(self):
+        ctx, client = _mock_httpx({"items": []})
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            out = await rn._fetch_json(
+                "https://169.254.169.254/itemNutrition",
+                {"name": "x"},
+                host="169.254.169.254",
+                allowed_hosts=frozenset({"www.mcdonalds.com"}),
+            )
+        assert out is None
+        # Guard short-circuits before any HTTP client stream is constructed.
+        assert client.stream.call_count == 0
+
+    async def test_redirect_free_and_query_rides_in_params(self):
+        user = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            await rn.lookup_restaurant(user.id, "McDonald's Quarter Pounder")
+        # AsyncClient configured to not follow redirects (no redirect-based SSRF).
+        _, kwargs = ac.call_args
+        assert kwargs.get("follow_redirects") is False
+        # The item travels as an encoded query param, never interpolated in a path.
+        _, stream_kwargs = client.stream.call_args
+        assert "quarter pounder" in stream_kwargs["params"]["name"].lower()
+
+    async def test_oversized_body_rejected(self, monkeypatch):
+        user = await _new_user()
+        monkeypatch.setattr(rn, "_MAX_RESPONSE_BYTES", 16)
+        ctx, client = _mock_httpx({}, body=b"x" * 64)  # 64 bytes > 16-byte cap
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            assert await rn.lookup_restaurant(user.id, "McDonald's Big Mac") is None
+
+
+# --------------------------------------------------------------------------- #
+# Compliance: robots.txt + rate-limit / back-off (AC2)
+# --------------------------------------------------------------------------- #
+class TestCompliance:
+    async def test_robots_disallow_skips_fetch(self):
+        user = await _new_user()
+        # The mocked response body is the robots.txt (disallow all) for the robots
+        # fetch; the data fetch must never run once robots forbids it.
+        ctx, client = _mock_httpx(None, body=b"User-agent: *\nDisallow: /")
+        with ctx as ac:  # NB: real _robots_allows (not bypassed) here
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "McDonald's Big Mac")
+        assert fact is None
+
+    async def test_robots_allow_permits_fetch(self):
+        allow = await self._robots_decision(b"User-agent: *\nAllow: /")
+        assert allow is True
+        disallow = await self._robots_decision(b"User-agent: *\nDisallow: /")
+        assert disallow is False
+
+    async def _robots_decision(self, robots_body: bytes) -> bool:
+        rn._reset_state_for_tests()
+        ctx, client = _mock_httpx(None, body=robots_body)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            return await rn._robots_allows(
+                "https://www.mcdonalds.com/dnaapp/itemNutrition",
+                frozenset({"www.mcdonalds.com"}),
+            )
+
+    async def test_backoff_skips_fetch_after_rate_limit(self):
+        host = "www.mcdonalds.com"
+        # A 429/503 arms back-off; while it holds, a fetch is skipped (no HTTP).
+        rn._note_backoff(host)
+        assert rn._in_backoff(host) is True
+        ctx, client = _mock_httpx(_MCD_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            out = await rn._fetch_json(
+                "https://www.mcdonalds.com/dnaapp/itemNutrition",
+                {"name": "x"},
+                host=host,
+                allowed_hosts=frozenset({host}),
+            )
+        assert out is None
+        assert client.stream.call_count == 0
+
+    async def test_503_response_arms_backoff(self):
+        user = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD, status=503)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            await rn.lookup_restaurant(user.id, "McDonald's Big Mac")
+        assert rn._in_backoff("www.mcdonalds.com") is True
+
+    async def test_rate_limit_sleeps_between_fetches(self, monkeypatch):
+        monkeypatch.setattr(settings, "restaurant_min_seconds_between_fetches", 5.0)
+        slept = []
+
+        async def _fake_sleep(seconds):
+            slept.append(seconds)
+
+        host = "www.mcdonalds.com"
+        rn._host_state[host] = {"last": __import__("time").monotonic()}
+        with patch.object(rn.asyncio, "sleep", _fake_sleep):
+            await rn._respect_rate_limit(host)
+        assert slept and slept[0] > 0  # waited for the min interval
+
+
+# --------------------------------------------------------------------------- #
+# Reference-data disclaimer (NOT an AI estimate) + no-dosing safety
+# --------------------------------------------------------------------------- #
+class TestDisclaimerAndSafety:
+    async def test_disclaimer_is_reference_data_not_ai_estimate(self):
+        user = await _new_user()
+        ctx, client = _mock_httpx(_MCD_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "McDonald's Quarter Pounder")
+        assert fact is not None and fact.disclaimer
+        # Carries the canonical dosing prohibition (single source of truth)...
+        assert NEVER_DOSE_PROHIBITION in fact.disclaimer
+        # ...but never the "AI estimate"/"AI guess" framing that would mislabel a
+        # chain's own published facts, nor the permissive "verify before dosing".
+        assert MEAL_ESTIMATE_QUALIFIER not in fact.disclaimer
+        assert "AI estimate" not in fact.disclaimer
+        assert "verify before dosing" not in fact.disclaimer.lower()
+        # The dosing scanner is applied to model-generated name/serving, NOT the
+        # disclaimer (which intentionally contains the word "bolus").
+        assert not find_dosing_violations(fact.name)
+        assert not find_dosing_violations(fact.serving or "")
+        assert "bolus" in fact.disclaimer
+
+
+# --------------------------------------------------------------------------- #
+# Optional FatSecret BYO-key provider (AC5)
+# --------------------------------------------------------------------------- #
+class TestFatSecret:
+    def _enable(self, monkeypatch):
+        monkeypatch.setattr(settings, "fatsecret_consumer_key", "KEY")
+        monkeypatch.setattr(settings, "fatsecret_consumer_secret", "SECRET")
+
+    async def test_without_key_silently_skipped(self):
+        # Default fixture leaves the key empty -> a known brand without a dedicated
+        # fetcher makes no FatSecret call.
+        user = await _new_user()
+        ctx, client = _mock_httpx(_FATSECRET_PAYLOAD, token="tok")
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "Taco Bell crunchwrap")
+        assert fact is None
+        assert client.stream.call_count == 0
+
+    async def test_with_key_fetches_and_caches(self, monkeypatch):
+        self._enable(monkeypatch)
+        user = await _new_user()
+        ctx, client = _mock_httpx(_FATSECRET_PAYLOAD, token="tok")
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            first = await rn.lookup_restaurant(user.id, "Taco Bell crunchwrap")
+            second = await rn.lookup_restaurant(user.id, "Taco Bell crunchwrap")
+        assert first is not None
+        assert first.source_name == "FatSecret"
+        assert first.carbs_grams == 71.0  # parsed from the description string
+        assert first.trust_tier == KnowledgeChunk.TIER_AUTHORITATIVE
+        assert NEVER_DOSE_PROHIBITION in (first.disclaimer or "")
+        # First lookup = token POST + search GET; second is served owner-scoped
+        # cache with no further token/search.
+        assert client.stream.call_count == 2
+        assert second is not None
+
+    async def test_token_failure_yields_no_search(self, monkeypatch):
+        self._enable(monkeypatch)
+        user = await _new_user()
+        # token=None -> the streamed token POST returns 401 -> no token -> no search.
+        ctx, client = _mock_httpx(_FATSECRET_PAYLOAD)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "Taco Bell crunchwrap")
+        assert fact is None
+        methods = [c.args[0] for c in client.stream.call_args_list]
+        assert "GET" not in methods  # the search GET was never reached
+
+    async def test_offlist_api_host_rejected(self, monkeypatch):
+        # The FatSecret SSRF allow-list is a fixed constant, not derived from the
+        # (operator) URL -- so a misconfigured api_url host is rejected.
+        self._enable(monkeypatch)
+        monkeypatch.setattr(
+            settings, "fatsecret_api_url", "https://evil.example.com/rest"
+        )
+        user = await _new_user()
+        ctx, client = _mock_httpx(_FATSECRET_PAYLOAD, token="tok")
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await rn.lookup_restaurant(user.id, "Taco Bell crunchwrap")
+        assert fact is None
+        methods = [c.args[0] for c in client.stream.call_args_list]
+        assert "GET" not in methods  # search to the off-list host never issued
+
+
+# --------------------------------------------------------------------------- #
+# Owner-scoped cache TTL (FatSecret's 24h ToS limit + lazy purge)
+# --------------------------------------------------------------------------- #
+class TestCacheTtl:
+    async def test_stale_entry_is_a_miss_and_is_purged(self):
+        user = await _new_user()
+        fact = rn.NutritionFact(
+            source_name="FatSecret",
+            source_url="https://www.fatsecret.com/x",
+            trust_tier=KnowledgeChunk.TIER_AUTHORITATIVE,
+            name="Crunchwrap",
+            carbs_grams=71.0,
+            serving="per 1 wrap",
+            disclaimer=rn._RESTAURANT_DISCLAIMER,
+        )
+        normalized = "taco bell crunchwrap"
+        await rn._cache_put(
+            user.id, meal_rag.SOURCE_TYPE_FATSECRET, normalized, fact, ttl_hours=24.0
+        )
+
+        # Fresh read within TTL -> hit.
+        hit = await rn._cache_get(
+            user.id, meal_rag.SOURCE_TYPE_FATSECRET, normalized, ttl_hours=24.0
+        )
+        assert hit is not None and hit.carbs_grams == 71.0
+
+        # Age the row beyond 24h: the value must not be served (FatSecret ToS) and
+        # the stale row is lazily purged.
+        async with get_session_maker()() as db:
+            await db.execute(
+                update(KnowledgeChunk)
+                .where(
+                    KnowledgeChunk.user_id == user.id,
+                    KnowledgeChunk.source_type == meal_rag.SOURCE_TYPE_FATSECRET,
+                )
+                .values(retrieved_at=datetime.now(UTC) - timedelta(hours=25))
+            )
+            await db.commit()
+
+        stale = await rn._cache_get(
+            user.id, meal_rag.SOURCE_TYPE_FATSECRET, normalized, ttl_hours=24.0
+        )
+        assert stale is None
+
+        async with get_session_maker()() as db:
+            from sqlalchemy import func, select
+
+            remaining = await db.scalar(
+                select(func.count())
+                .select_from(KnowledgeChunk)
+                .where(
+                    KnowledgeChunk.user_id == user.id,
+                    KnowledgeChunk.source_type == meal_rag.SOURCE_TYPE_FATSECRET,
+                )
+            )
+        assert remaining == 0  # lazily purged on the stale read

--- a/apps/api/tests/test_restaurant_nutrition.py
+++ b/apps/api/tests/test_restaurant_nutrition.py
@@ -9,6 +9,7 @@ test. Behavioral assertions only -- never an exact published carb count from a r
 endpoint; the only hard numbers are inputs we control in the mocked payloads.
 """
 
+import asyncio
 import json
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -161,6 +162,13 @@ class TestBrandDetection:
         assert rn._has_known_brand("Starbucks caramel frappuccino") is True
         # A plain food carries no brand.
         assert rn._has_known_brand("homemade chili") is False
+
+    def test_punctuation_free_brand_spellings_match(self):
+        # Common collapsed spellings must still be recognized as a brand, even
+        # though _canon turns "wendy's" -> "wendy s" / "chick-fil-a" -> "chick fil a".
+        assert rn._has_known_brand("wendys baconator") is True
+        assert rn._has_known_brand("chickfila sandwich") is True
+        assert rn._has_known_brand("innout double double") is True
 
     def test_brand_match_is_whole_token(self):
         # "mcd" must not match inside "mcdonalds"; "taco" must not match a non-brand.
@@ -517,6 +525,23 @@ class TestCompliance:
         with patch.object(rn.asyncio, "sleep", _fake_sleep):
             await rn._respect_rate_limit(host)
         assert slept and slept[0] > 0  # waited for the min interval
+
+    async def test_concurrent_same_host_calls_serialize(self, monkeypatch):
+        # The per-host lock serializes two concurrent fetches to the same host:
+        # exactly one waits for the other's slot (without it, both could read a
+        # stale `last` and skip the rate limit together).
+        monkeypatch.setattr(settings, "restaurant_min_seconds_between_fetches", 5.0)
+        slept = []
+
+        async def _fake_sleep(seconds):
+            slept.append(seconds)
+
+        host = "www.mcdonalds.com"
+        with patch.object(rn.asyncio, "sleep", _fake_sleep):
+            await asyncio.gather(
+                rn._respect_rate_limit(host), rn._respect_rate_limit(host)
+            )
+        assert len(slept) == 1 and slept[0] > 0
 
 
 # --------------------------------------------------------------------------- #

--- a/docs/daily-use/_meta.json
+++ b/docs/daily-use/_meta.json
@@ -10,6 +10,7 @@
     "ai-chat",
     "briefs",
     "meal-intelligence",
+    "restaurant-nutrition-grounding",
     "alerts",
     "data-export"
   ]

--- a/docs/daily-use/meal-intelligence.md
+++ b/docs/daily-use/meal-intelligence.md
@@ -22,7 +22,7 @@ The feature is designed so a guess can never quietly turn into a dose:
 
 - **A range, not a single confident number.** Real plates are uncertain; a single integer invites you to dose off it.
 - **Confidence comes from disagreement, not the model's self-rating.** The same photo is sampled several times; the spread between answers drives the confidence. (A model's own "I'm confident" score does not track accuracy and is never shown as a safety signal.) A wide spread is shown plainly — "this could be 40 g or 90 g, we're not sure."
-- **You confirm what the food is** before the app grounds it against nutrition data, so a misidentified food can't be "certified" with an authoritative-looking citation.
+- **You confirm what the food is** before the app grounds it against nutrition data, so a misidentified food can't be "certified" with an authoritative-looking citation. For branded restaurant items this can cite the chain's own published nutrition — see [Restaurant Nutrition Grounding](restaurant-nutrition-grounding.md).
 - **Carb estimates never flow into insulin-on-board, safety limits, or any dosing math.** They are descriptive notes, structurally isolated from the dosing engine.
 - **Every screen that shows a carb estimate carries a persistent reminder** — *"Rough estimate — an AI guess that's often wrong. Never use it to calculate an insulin dose or bolus."*
 

--- a/docs/daily-use/restaurant-nutrition-grounding.md
+++ b/docs/daily-use/restaurant-nutrition-grounding.md
@@ -1,0 +1,47 @@
+---
+title: Restaurant Nutrition Grounding
+description: How the app grounds a branded restaurant item against the chain's own published nutrition — reference facts with a citation, still never a dose.
+---
+
+When you log a meal from a **branded restaurant or fast-food chain** — say a McDonald's Quarter Pounder or a Chipotle chicken bowl — and you confirm what the food is, the app can ground its estimate against **that chain's own published nutrition** and show you the figure with a citation, instead of relying on a photo guess alone.
+
+> **A published carb figure is still descriptive reference data — never calculate an insulin dose or bolus from it.** Restaurant numbers vary by location, size, and preparation, the figure can be out of date, and the app might have matched the wrong menu item. Treat it as a better-sourced starting point to sanity-check against your own carb counting, and always verify before dosing.
+
+This builds on [Meal Intelligence](meal-intelligence.md) and follows the same alpha, off-by-default, never-a-dose posture.
+
+## Reference data, not an AI guess
+
+This is the one way the meal feature shows a number that is **not** an AI estimate. A chain's published nutrition is reference data for *its own* menu, so a grounded restaurant figure is labelled as a reference — *"Published nutrition from the restaurant's own menu data … never use it to dose or bolus"* — rather than the *"AI estimate, often wrong"* wording used for a pure photo guess.
+
+That distinction does **not** make it safe to dose from. It is more trustworthy than a photo guess, and still descriptive only.
+
+## You confirm the food first (identity gate)
+
+A restaurant figure is fetched **only after you confirm what the food is**. An unconfirmed photo, or a food the app misidentified, is never "certified" with a chain citation — confirming a misidentified dish with the chain's published facts would produce an authoritatively-cited *wrong* carb count, so the app refuses to do it. If you correct the identity, grounding re-runs against your corrected name.
+
+## How the fetch-and-cite policy works
+
+- **On demand, one item at a time.** The app fetches *that chain's* nutrition for *that one item*, only when you log and confirm it. There is **no** pre-crawling, no bulk mirroring, and no building of a redistributable restaurant database.
+- **Facts, not content.** Nutrition *facts* aren't copyrightable; the app uses the numbers, never copies a chain's page layout or images.
+- **Your fetches stay yours.** A restaurant figure the app fetches for you is cached **only for your account** (owner-scoped) on your self-hosted instance — it is never pooled into a shared, redistributable mirror, and another user never sees what you fetched. (Generic USDA / Open Food Facts facts *are* shared, because those licences allow it; restaurant data is treated more conservatively.)
+- **Polite by default.** The fetcher respects each site's `robots.txt`, rate-limits itself with back-off, and identifies itself with a descriptive User-Agent. A fetch only happens on your action.
+
+These mitigations are deliberate, non-negotiable design choices. Grounding against restaurant data is a maintainer policy decision for this self-hosted, open-source project; if you run your own instance you can turn it off entirely.
+
+## Supported chains
+
+Restaurant grounding ships with a small set of built-in chain fetchers and grows over time. Chain menu endpoints are undocumented and change without notice, so every fetcher is **failure-tolerant**: if a chain changes its page or can't be reached, the app silently falls back to the normal vision estimate — logging never breaks, and you always still get an estimate. A chain we don't recognize is simply treated as a normal food (grounded against generic USDA / Open Food Facts, or left as a photo estimate).
+
+> **Maintainers:** the built-in chain endpoint shapes are modelled, not continuously verified. Run the periodic live canary (see the developer runbook) to confirm each fetcher still parses real responses; a broken fetcher should degrade to vision-only, never break logging.
+
+## Optional: bring your own FatSecret key
+
+For broader commercial restaurant coverage, an operator can supply their **own** [FatSecret Platform](https://platform.fatsecret.com/) credentials (`fatsecret_consumer_key` / `fatsecret_consumer_secret`). This is entirely optional and **no shared key is ever shipped** — the app is blank until you add yours. To honour FatSecret's terms, a FatSecret-sourced value is cached for **at most 24 hours** and otherwise re-queried, and it is never shared across users.
+
+## Turning it off
+
+Restaurant grounding is on when Meal Intelligence is on, and can be disabled on its own with `restaurant_grounding_enabled=false` (it then falls back to vision-only for restaurant items). Because it makes an outbound request to the chain on your behalf, leave it off if you don't want that.
+
+## The bottom line
+
+Grounding a restaurant item gives you a **better-sourced number with a citation** — published reference data instead of a photo guess. It is still descriptive, can still be wrong for your specific order, and is still **never** a dose. Count your carbs and decide your insulin the way you and your healthcare provider do today.

--- a/docs/daily-use/restaurant-nutrition-grounding.md
+++ b/docs/daily-use/restaurant-nutrition-grounding.md
@@ -40,7 +40,7 @@ For broader commercial restaurant coverage, an operator can supply their **own**
 
 ## Turning it off
 
-Restaurant grounding is on when Meal Intelligence is on, and can be disabled on its own with `restaurant_grounding_enabled=false` (it then falls back to vision-only for restaurant items). Because it makes an outbound request to the chain on your behalf, leave it off if you don't want that.
+Restaurant grounding is on when Meal Intelligence is on, and can be disabled on its own with `restaurant_grounding_enabled=false` (restaurant-chain fetching is skipped, and grounding falls back to the normal USDA / Open Food Facts / vision path). Because it makes an outbound request to the chain on your behalf, leave it off if you don't want that.
 
 ## The bottom line
 


### PR DESCRIPTION
## Summary

Adds on-demand restaurant nutrition grounding. When a user logs and confirms a branded restaurant / fast-food item (e.g. a McDonald's Quarter Pounder), the app grounds its carb estimate against that chain's own published nutrition — fetched for that one item and cited as reference data. The grounded value slots into the existing grounding precedence as `AUTHORITATIVE`, above generic USDA and below the user's own corrected history.

A published figure is a better-sourced descriptive aid, and is still never a dose.

## How it works

- **Per-chain fetcher framework** with two built-in chains (McDonald's, Chipotle), plus an optional FatSecret BYO-key provider — the operator supplies their own key; none is ever shipped.
- **Identity-gated:** grounding fires only for a confirmed-identity item, and only when a known restaurant brand is present (a generic food is left to USDA / Open Food Facts). A multi-result response that does not match the confirmed item degrades to vision-only rather than cite a different menu item.
- **Compliance mitigations:** robots.txt honoring, per-host rate-limit with exponential back-off, a descriptive User-Agent, on-demand item-scoped fetches only (no bulk crawl), and owner-scoped caching — a fetched value is cached for the requesting user only, never pooled into the shared, redistributable mirror USDA/OFF use.
- **SSRF-guarded fetch:** fixed host allow-list, https-only, no redirects, hard timeout, streamed response-size cap, and no URL/credential logging — applied to every outbound request (chain fetch, robots.txt, and the FatSecret token + search).
- **Fail-open everywhere:** any fetch / parse / robots / cache failure degrades to the vision-only estimate; logging never breaks.
- **Reference-data framing:** the disclaimer carries the canonical never-dose prohibition, not the "AI estimate" qualifier. Nothing flows into IoB / treatment_safety.

## Testing

- New unit suite: per-chain parsing, owner-scoped cache isolation (user B never reads user A's fetch), SSRF, robots, rate-limit / back-off, reference-data framing, parser robustness, and the FatSecret BYO-key path (with-key works + 24h cache + without-key skipped).
- Extended the grounding precedence + identity-gate tests and the end-to-end journeys: a confirmed item gets an authoritative citation; a misidentified item grounds only the corrected identity; a fetch failure degrades to vision-only.
- Backend tests, ruff lint + format pass.

## Notes

- The built-in chain endpoint shapes are modelled, not continuously verified — chain menu APIs are undocumented and change. Each fetcher fails open to vision-only, and the user docs describe a periodic live canary for maintainers to confirm each fetcher still parses.
- No migration: restaurant facts are cached in the existing `knowledge_chunks` table, owner-scoped.
- User docs added: the fetch-and-cite policy and the freshness / accuracy caveat.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restaurant nutrition grounding: after confirming branded restaurant items, the app fetches chain nutrition for that specific item and surfaces it with authoritative citations/trust metadata.
  * Extended grounding sources and precedence to include restaurant nutrition (with corrected-identity handling) and graceful “vision-only” fallback on fetch failures.
  * Added operator controls for enabling/disabling restaurant grounding, per-host fetch pacing, and owner-scoped cache freshness; optional FatSecret integration for supported brands.

* **Bug Fixes**
  * Updated audit precedence recording to match the new restaurant nutrition grounding step.

* **Documentation**
  * Added and updated daily-use guidance explaining reference-only usage (never for dosing) and fetch/caching/failure behavior.

* **Tests**
  * Expanded end-to-end and unit coverage for restaurant grounding, caching isolation, and safety/compliance cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->