### PR TITLE
feat: web meal management view (list, detail, delete, photo upload + serving)

### DIFF
--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -12,6 +12,7 @@ treatment_safety / carb-ratio math.
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, status
+from fastapi.responses import FileResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -202,6 +203,48 @@ async def get_food_record(
     require_meal_intelligence()
     record = await _get_owned_record(record_id, current_user.id, db)
     return FoodRecordResponse.model_validate(record)
+
+
+@router.get(
+    "/{record_id}/photo",
+    responses={
+        200: {
+            "content": {"image/jpeg": {}, "image/png": {}, "image/webp": {}},
+            "description": "The stored meal photo",
+        },
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        404: {"model": ErrorResponse, "description": "Food record or photo not found"},
+    },
+)
+async def get_food_record_photo(
+    record_id: uuid.UUID,
+    current_user: DiabeticOrAdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> FileResponse:
+    """Serve the stored meal photo for one of the current user's records.
+
+    Owner-scoped (IDOR-safe): the record must belong to the caller, and the file
+    is served *by record id* -- the caller never supplies a path, and the path
+    read from the record is re-confined to the private uploads root before it is
+    served. The photo is the user's own PHI, so it is marked private (never a
+    shared-proxy cache).
+    """
+    require_meal_intelligence()
+    record = await _get_owned_record(record_id, current_user.id, db)
+    try:
+        path, media_type = food_image.resolve_stored_image(record.storage_path)
+    except food_image.StoredImageMissingError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Meal photo not available."
+        ) from exc
+    return FileResponse(
+        path,
+        media_type=media_type,
+        headers={
+            "Cache-Control": "private, max-age=300",
+            "Content-Disposition": "inline",
+        },
+    )
 
 
 @router.get(

--- a/apps/api/src/services/food_image.py
+++ b/apps/api/src/services/food_image.py
@@ -59,6 +59,15 @@ class ImageTooLargeError(FoodImageError):
     """The upload exceeds the configured size cap."""
 
 
+class StoredImageMissingError(FoodImageError):
+    """The stored image is absent, unreadable, or escapes the uploads root."""
+
+
+# Stored extension -> media type, derived from the same validated format map so a
+# served photo's Content-Type can never drift from what was accepted at upload.
+_EXTENSION_MEDIA_TYPES: dict[str, str] = dict(_ALLOWED_FORMATS.values())
+
+
 class ProcessedImage:
     """A validated, metadata-stripped image ready to store and send."""
 
@@ -149,6 +158,31 @@ def store_image(user_id: uuid.UUID, image: ProcessedImage) -> tuple[str, int]:
         path.unlink(missing_ok=True)
         raise
     return str(path), len(image.data)
+
+
+def resolve_stored_image(storage_path: str) -> tuple[Path, str]:
+    """Resolve a stored image to ``(path, media_type)``, confined to the uploads root.
+
+    Mirrors ``delete_stored_image``'s containment check so a malformed/poisoned
+    stored path can never read a file outside the uploads root. Raises
+    ``StoredImageMissingError`` if the path escapes the root or is not a readable
+    file. The media type is derived from the stored extension, never guessed from
+    the file's contents or any caller-supplied value.
+    """
+    base = Path(settings.upload_dir).resolve()
+    try:
+        target = Path(storage_path).resolve()
+    except OSError as exc:
+        raise StoredImageMissingError("invalid stored path") from exc
+    # Must be strictly *inside* the uploads root -- never the root itself.
+    if base not in target.parents:
+        raise StoredImageMissingError("stored path outside uploads root")
+    if not target.is_file():
+        raise StoredImageMissingError("stored image not found")
+    media_type = _EXTENSION_MEDIA_TYPES.get(target.suffix.lstrip(".").lower())
+    if media_type is None:
+        raise StoredImageMissingError("unsupported stored extension")
+    return target, media_type
 
 
 def delete_stored_image(storage_path: str) -> None:

--- a/apps/api/src/services/food_image.py
+++ b/apps/api/src/services/food_image.py
@@ -179,6 +179,13 @@ def resolve_stored_image(storage_path: str) -> tuple[Path, str]:
         raise StoredImageMissingError("stored path outside uploads root")
     if not target.is_file():
         raise StoredImageMissingError("stored image not found")
+    # Confirm the bytes are actually readable, so an existing-but-unreadable file
+    # surfaces as a clean 404 rather than a 500 mid-serve.
+    try:
+        with target.open("rb"):
+            pass
+    except OSError as exc:
+        raise StoredImageMissingError("stored image not readable") from exc
     media_type = _EXTENSION_MEDIA_TYPES.get(target.suffix.lstrip(".").lower())
     if media_type is None:
         raise StoredImageMissingError("unsupported stored extension")

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -236,6 +236,28 @@ class TestImageProcessing:
         food_image.delete_stored_image(str(outside))
         assert outside.exists()  # untouched -- containment check held
 
+    def test_resolve_stored_image_returns_path_and_media_type(self, _uploads_tmp):
+        user_id = uuid.uuid4()
+        processed = food_image.process_upload(_png_bytes())
+        path, _ = food_image.store_image(user_id, processed)
+        resolved, media_type = food_image.resolve_stored_image(path)
+        assert resolved == Path(path).resolve()
+        assert media_type == "image/png"
+
+    def test_resolve_refuses_path_outside_uploads_root(self, _uploads_tmp, tmp_path):
+        outside = tmp_path / "outside.png"
+        outside.write_bytes(_png_bytes())
+        with pytest.raises(food_image.StoredImageMissingError):
+            food_image.resolve_stored_image(str(outside))
+
+    def test_resolve_raises_for_missing_file(self, _uploads_tmp):
+        user_id = uuid.uuid4()
+        processed = food_image.process_upload(_png_bytes())
+        path, _ = food_image.store_image(user_id, processed)
+        Path(path).unlink()
+        with pytest.raises(food_image.StoredImageMissingError):
+            food_image.resolve_stored_image(path)
+
 
 # --------------------------------------------------------------------------- #
 # Vision request shape + sidecar contract mapping (AC3)
@@ -534,6 +556,42 @@ class TestFoodRecordsApi:
             cookie = await _register_login(other)
             other.cookies.set(settings.jwt_cookie_name, cookie)
             resp = await other.get(f"/api/food-records/{record_id}")
+        assert resp.status_code == 404
+
+    async def test_get_photo_returns_image_to_owner(self, auth_client):
+        client, _ = auth_client
+        record_id = (await _create_record(client))["id"]
+        resp = await client.get(f"/api/food-records/{record_id}/photo")
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "image/png"
+        assert resp.headers["cache-control"] == "private, max-age=300"
+        assert len(resp.content) > 0
+
+    async def test_get_photo_disabled_when_flag_off(self, auth_client, monkeypatch):
+        client, _ = auth_client
+        record_id = (await _create_record(client))["id"]
+        monkeypatch.setattr(settings, "meal_intelligence_enabled", False)
+        resp = await client.get(f"/api/food-records/{record_id}/photo")
+        assert resp.status_code == 404
+
+    async def test_cannot_access_other_users_photo(self, auth_client):
+        client, _ = auth_client
+        record_id = (await _create_record(client))["id"]
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as other:
+            cookie = await _register_login(other)
+            other.cookies.set(settings.jwt_cookie_name, cookie)
+            resp = await other.get(f"/api/food-records/{record_id}/photo")
+        assert resp.status_code == 404
+
+    async def test_get_photo_404_when_file_missing(self, auth_client, _uploads_tmp):
+        client, _ = auth_client
+        record_id = (await _create_record(client))["id"]
+        # Remove the stored file out from under the record; the row remains.
+        for stored in Path(_uploads_tmp).rglob("*"):
+            if stored.is_file():
+                stored.unlink()
+        resp = await client.get(f"/api/food-records/{record_id}/photo")
         assert resp.status_code == 404
 
 

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -7,6 +7,7 @@ food-record API endpoints.
 """
 
 import json
+import os
 import uuid
 from io import BytesIO
 from pathlib import Path
@@ -257,6 +258,19 @@ class TestImageProcessing:
         Path(path).unlink()
         with pytest.raises(food_image.StoredImageMissingError):
             food_image.resolve_stored_image(path)
+
+    def test_resolve_raises_for_unreadable_file(self, _uploads_tmp):
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            pytest.skip("root bypasses file permissions")
+        user_id = uuid.uuid4()
+        processed = food_image.process_upload(_png_bytes())
+        path, _ = food_image.store_image(user_id, processed)
+        Path(path).chmod(0o000)
+        try:
+            with pytest.raises(food_image.StoredImageMissingError):
+                food_image.resolve_stored_image(path)
+        finally:
+            Path(path).chmod(0o600)  # restore so tmp cleanup can remove it
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/web/__tests__/briefs-web-delivery.test.tsx
+++ b/apps/web/__tests__/briefs-web-delivery.test.tsx
@@ -43,6 +43,7 @@ jest.mock("next/image", () => {
 // Mock providers
 jest.mock("@/providers", () => ({
   useUserContext: () => ({ user: { role: "diabetic" } }),
+  useMealIntelligenceContext: () => ({ enabled: false, isLoading: false }),
 }));
 
 // Mock API functions

--- a/apps/web/__tests__/meals/meal-api.test.ts
+++ b/apps/web/__tests__/meals/meal-api.test.ts
@@ -113,6 +113,41 @@ describe("uploadFoodRecord", () => {
   });
 });
 
+describe("fetchFoodRecordPhotoObjectUrl", () => {
+  it("fetches the photo (credentialed) and returns an object URL", async () => {
+    const fakeBlob = new Blob(["bytes"], { type: "image/jpeg" });
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => fakeBlob,
+    });
+    global.fetch = mockFetch;
+    (URL as unknown as { createObjectURL: jest.Mock }).createObjectURL = jest.fn(
+      () => "blob:meal-photo"
+    );
+
+    const { fetchFoodRecordPhotoObjectUrl } = require("@/lib/api");
+    const url = await fetchFoodRecordPhotoObjectUrl("rec-1");
+
+    expect(url).toBe("blob:meal-photo");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/food-records/rec-1/photo",
+      expect.objectContaining({ credentials: "include" })
+    );
+    expect(URL.createObjectURL).toHaveBeenCalledWith(fakeBlob);
+  });
+
+  it("throws a MealApiError when the photo is unavailable (404)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Meal photo not available." }));
+    const { fetchFoodRecordPhotoObjectUrl, MealApiError } = require("@/lib/api");
+    await expect(fetchFoodRecordPhotoObjectUrl("rec-1")).rejects.toBeInstanceOf(
+      MealApiError
+    );
+  });
+});
+
 describe("deleteFoodRecord", () => {
   it("issues a DELETE and resolves on 204", async () => {
     const mockFetch = jest

--- a/apps/web/__tests__/meals/meal-api.test.ts
+++ b/apps/web/__tests__/meals/meal-api.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the food-records API client (api.ts), exercised through a mocked
+ * global.fetch (mirrors __tests__/api-fetch.test.ts). Covers list/detail/delete,
+ * the multipart upload, the meal-intelligence probe, and owner-scoped errors.
+ */
+
+function jsonResponse(status: number, body: unknown, ok?: boolean) {
+  return {
+    ok: ok ?? (status >= 200 && status < 300),
+    status,
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+describe("listFoodRecords", () => {
+  it("requests limit/offset and returns the wrapper", async () => {
+    const payload = { records: [{ id: "a" }], total: 1 };
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse(200, payload));
+    global.fetch = mockFetch;
+
+    const { listFoodRecords } = require("@/lib/api");
+    const result = await listFoodRecords(50, 0);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/food-records?limit=50&offset=0",
+      expect.objectContaining({ credentials: "include" })
+    );
+    expect(result).toEqual(payload);
+  });
+
+  it("throws a MealApiError carrying status + detail on a feature-off 404", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(404, { detail: "Meal intelligence is not enabled." })
+      );
+
+    const { listFoodRecords, MealApiError } = require("@/lib/api");
+    await expect(listFoodRecords()).rejects.toBeInstanceOf(MealApiError);
+    await expect(listFoodRecords()).rejects.toMatchObject({
+      status: 404,
+      detail: "Meal intelligence is not enabled.",
+    });
+  });
+});
+
+describe("getFoodRecord", () => {
+  it("fetches a single record by id", async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { id: "rec-1" }));
+    global.fetch = mockFetch;
+
+    const { getFoodRecord } = require("@/lib/api");
+    await getFoodRecord("rec-1");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/food-records/rec-1",
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+
+  it("rejects a cross-user / missing record with an owner-scoped 404", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Food record not found." }));
+
+    const { getFoodRecord, MealApiError } = require("@/lib/api");
+    await expect(getFoodRecord("someone-elses-id")).rejects.toMatchObject({
+      status: 404,
+      detail: "Food record not found.",
+    });
+    await expect(getFoodRecord("someone-elses-id")).rejects.toBeInstanceOf(
+      MealApiError
+    );
+  });
+});
+
+describe("uploadFoodRecord", () => {
+  it("POSTs a multipart 'file' part and returns the record", async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(201, { id: "new-rec" }));
+    global.fetch = mockFetch;
+
+    const { uploadFoodRecord } = require("@/lib/api");
+    const blob = new Blob(["jpeg-bytes"], { type: "image/jpeg" });
+    const result = await uploadFoodRecord(blob);
+
+    expect(result).toEqual({ id: "new-rec" });
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/food-records");
+    expect(options.method).toBe("POST");
+    expect(options.body).toBeInstanceOf(FormData);
+    expect((options.body as FormData).get("file")).toBeInstanceOf(Blob);
+    // The browser must set the multipart Content-Type (with boundary) itself.
+    const headers = new Headers(options.headers);
+    expect(headers.has("Content-Type")).toBe(false);
+  });
+
+  it("propagates a vision-unavailable 422 as a MealApiError", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse(422, {
+        detail: "Vision is not available on your current AI provider.",
+      })
+    );
+    const { uploadFoodRecord } = require("@/lib/api");
+    const blob = new Blob(["x"], { type: "image/jpeg" });
+    await expect(uploadFoodRecord(blob)).rejects.toMatchObject({ status: 422 });
+  });
+});
+
+describe("deleteFoodRecord", () => {
+  it("issues a DELETE and resolves on 204", async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, status: 204 });
+    global.fetch = mockFetch;
+
+    const { deleteFoodRecord } = require("@/lib/api");
+    await expect(deleteFoodRecord("rec-1")).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/food-records/rec-1",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+});
+
+describe("getMealIntelligenceStatus", () => {
+  it("reports enabled on a successful probe", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { records: [], total: 0 }));
+    const { getMealIntelligenceStatus } = require("@/lib/api");
+    expect(await getMealIntelligenceStatus()).toEqual({ enabled: true });
+  });
+
+  it("reports disabled only on a 404 whose detail says 'not enabled'", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(404, { detail: "Meal intelligence is not enabled." })
+      );
+    const { getMealIntelligenceStatus } = require("@/lib/api");
+    expect(await getMealIntelligenceStatus()).toEqual({ enabled: false });
+  });
+
+  it("treats a transient/other failure as available (degraded, never hides the feature)", async () => {
+    const { getMealIntelligenceStatus: viaServerError } = (() => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(jsonResponse(500, { detail: "boom" }));
+      return require("@/lib/api");
+    })();
+    expect(await viaServerError()).toEqual({ enabled: true });
+
+    jest.resetModules();
+    global.fetch = jest.fn().mockRejectedValue(new Error("network down"));
+    const { getMealIntelligenceStatus: viaNetwork } = require("@/lib/api");
+    expect(await viaNetwork()).toEqual({ enabled: true });
+  });
+});

--- a/apps/web/__tests__/meals/meal-detail.test.tsx
+++ b/apps/web/__tests__/meals/meal-detail.test.tsx
@@ -143,4 +143,16 @@ describe("Meal detail page", () => {
     expect(await screen.findByTestId("meal-not-found")).toBeInTheDocument();
     expect(screen.queryByTestId("meal-carb-range")).not.toBeInTheDocument();
   });
+
+  it("shows a fallback (no stale meal) on a retryable error", async () => {
+    mockGet.mockRejectedValue(
+      new MealApiError(502, "AI vision service is unreachable.")
+    );
+    render(<MealDetailPage />);
+    expect(
+      await screen.findByText(/temporarily unavailable/i)
+    ).toBeInTheDocument();
+    // The record state is cleared, so no stale meal content renders.
+    expect(screen.queryByTestId("meal-carb-range")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/__tests__/meals/meal-detail.test.tsx
+++ b/apps/web/__tests__/meals/meal-detail.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for the Meal detail page: renders range + empirical confidence + macros
+ * with no dose element, the delete-confirm flow, and the owner-scoped not-found
+ * state for a cross-user id.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+jest.mock("next/link", () => {
+  const Link = ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+  Link.displayName = "Link";
+  return Link;
+});
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ id: "rec-1" }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockGet = jest.fn();
+const mockDelete = jest.fn();
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  ...jest.requireActual("@/lib/api"),
+  getFoodRecord: (...args: unknown[]) => mockGet(...args),
+  deleteFoodRecord: (...args: unknown[]) => mockDelete(...args),
+}));
+
+import MealDetailPage from "../../src/app/dashboard/meals/[id]/page";
+import { MealApiError, type FoodRecord } from "@/lib/api";
+
+function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
+  return {
+    id: "rec-1",
+    meal_timestamp: "2026-06-19T12:00:00Z",
+    food_description: "Bowl of oatmeal",
+    carbs_low: 40,
+    carbs_high: 55,
+    confidence: "medium",
+    safety_qualifier: "Rough estimate — never dose from it.",
+    nutrition_json: { protein_grams: 12, fat_grams: 8 },
+    source: "ai_estimate",
+    corrected_carbs_low: null,
+    corrected_carbs_high: null,
+    corrected_nutrition_json: null,
+    corrected_at: null,
+    common_food_id: null,
+    ai_model: "claude-sonnet-4-5",
+    ai_provider: "anthropic",
+    confirmed_food_name: null,
+    identity_confirmed: false,
+    grounding_source: null,
+    grounding_source_url: null,
+    grounding_trust_tier: null,
+    created_at: "2026-06-19T12:00:01Z",
+    ...overrides,
+  };
+}
+
+describe("Meal detail page", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockDelete.mockReset();
+    mockPush.mockReset();
+  });
+
+  it("renders the carb range, empirical confidence band, and read-only macros with no dose element", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    render(<MealDetailPage />);
+
+    expect(await screen.findByTestId("meal-carb-range")).toHaveTextContent(
+      /g carbs/
+    );
+    expect(screen.getByTestId("meal-confidence")).toHaveTextContent(
+      "Medium confidence"
+    );
+    expect(screen.getAllByTestId("meal-macro").length).toBe(2);
+    // No dose/insulin element is ever presented (the safety qualifier warning aside).
+    expect(screen.queryByText(/recommended (dose|bolus)/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/units of insulin/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the corrected band and the original AI estimate when corrected", async () => {
+    mockGet.mockResolvedValue(
+      makeRecord({
+        source: "user_corrected",
+        corrected_carbs_low: 30,
+        corrected_carbs_high: 30,
+        corrected_at: "2026-06-19T13:00:00Z",
+      })
+    );
+    render(<MealDetailPage />);
+    await screen.findByTestId("meal-carb-range");
+    expect(screen.getByText(/You corrected this\. AI estimated/)).toBeInTheDocument();
+  });
+
+  it("deletes after confirmation and navigates back to the list", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    mockDelete.mockResolvedValue(undefined);
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<MealDetailPage />);
+    fireEvent.click(await screen.findByTestId("meal-delete"));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith("rec-1");
+    });
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/meals");
+    confirmSpy.mockRestore();
+  });
+
+  it("does not delete when the confirmation is cancelled", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(<MealDetailPage />);
+    fireEvent.click(await screen.findByTestId("meal-delete"));
+
+    expect(mockDelete).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("renders an owner-scoped not-found state for a cross-user / missing id", async () => {
+    mockGet.mockRejectedValue(new MealApiError(404, "Food record not found."));
+    render(<MealDetailPage />);
+    expect(await screen.findByTestId("meal-not-found")).toBeInTheDocument();
+    expect(screen.queryByTestId("meal-carb-range")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/meals/meal-detail.test.tsx
+++ b/apps/web/__tests__/meals/meal-detail.test.tsx
@@ -37,6 +37,10 @@ jest.mock("@/lib/api", () => ({
   ...jest.requireActual("@/lib/api"),
   getFoodRecord: (...args: unknown[]) => mockGet(...args),
   deleteFoodRecord: (...args: unknown[]) => mockDelete(...args),
+  // MealPhoto fetches the photo lazily; default to "no photo" -> placeholder.
+  fetchFoodRecordPhotoObjectUrl: jest.fn(() =>
+    Promise.reject(new Error("no photo"))
+  ),
 }));
 
 import MealDetailPage from "../../src/app/dashboard/meals/[id]/page";

--- a/apps/web/__tests__/meals/meal-errors.test.ts
+++ b/apps/web/__tests__/meals/meal-errors.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the meal API error -> UX-state mapping. Mirrors the mobile
+ * client's detail-substring contract.
+ */
+
+import { MealApiError } from "@/lib/api";
+import { classifyMealError } from "@/lib/meal-errors";
+
+describe("classifyMealError", () => {
+  it("maps a 404 'not enabled' to a non-retryable feature-off state", () => {
+    const info = classifyMealError(
+      new MealApiError(404, "Meal intelligence is not enabled.")
+    );
+    expect(info.kind).toBe("feature_off");
+    expect(info.retryable).toBe(false);
+  });
+
+  it("maps a 404 'AI provider' to a no-provider state pointing at Settings", () => {
+    const info = classifyMealError(
+      new MealApiError(404, "No AI provider configured.")
+    );
+    expect(info.kind).toBe("no_provider");
+    expect(info.retryable).toBe(false);
+    expect(info.settingsHref).toBe("/dashboard/settings/ai-provider");
+  });
+
+  it("maps a 422 'vision' to a vision-unavailable state", () => {
+    const info = classifyMealError(
+      new MealApiError(422, "Vision is not available on your current AI provider.")
+    );
+    expect(info.kind).toBe("vision_unavailable");
+    expect(info.retryable).toBe(false);
+    expect(info.settingsHref).toBe("/dashboard/settings/ai-provider");
+  });
+
+  it("maps an unverified-local-model 422 to a non-retryable model-not-certified state", () => {
+    const info = classifyMealError(
+      new MealApiError(
+        422,
+        "The local model 'llava' has not been verified to estimate meal carbs reliably enough, so photo estimates are turned off for it. Use a cloud AI provider."
+      )
+    );
+    expect(info.kind).toBe("model_not_certified");
+    expect(info.retryable).toBe(false);
+    expect(info.settingsHref).toBe("/dashboard/settings/ai-provider");
+    expect(info.message).toContain("has not been verified");
+  });
+
+  it("maps a generic 422 to a retryable estimate-failed state, surfacing the server detail", () => {
+    const info = classifyMealError(
+      new MealApiError(422, "Could not read a carbohydrate estimate from this photo.")
+    );
+    expect(info.kind).toBe("estimate_failed");
+    expect(info.retryable).toBe(true);
+    expect(info.message).toContain("carbohydrate estimate");
+  });
+
+  it("maps a plain 404 (record not found) to a non-retryable not-found state", () => {
+    const info = classifyMealError(
+      new MealApiError(404, "Food record not found.")
+    );
+    expect(info.kind).toBe("not_found");
+    expect(info.retryable).toBe(false);
+  });
+
+  it.each([
+    [413, "image_too_large"],
+    [415, "unsupported_image"],
+    [429, "rate_limited"],
+    [502, "service_unavailable"],
+    [400, "estimate_failed"],
+  ])("maps HTTP %s to %s", (status, kind) => {
+    expect(classifyMealError(new MealApiError(status, "")).kind).toBe(kind);
+  });
+
+  it("maps a non-API error to a retryable generic state", () => {
+    const info = classifyMealError(new Error("boom"));
+    expect(info.kind).toBe("generic");
+    expect(info.retryable).toBe(true);
+    expect(info.message).toBe("boom");
+  });
+});

--- a/apps/web/__tests__/meals/meal-format.test.ts
+++ b/apps/web/__tests__/meals/meal-format.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for meal display formatting/derivation helpers.
+ */
+
+import {
+  effectiveCarbRange,
+  formatCarbRange,
+  confidenceLabel,
+  sourceMeta,
+  mealTitle,
+  macroEntries,
+} from "@/lib/meal-format";
+import type { FoodRecord } from "@/lib/api";
+
+function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
+  return {
+    id: "rec-1",
+    meal_timestamp: "2026-06-19T12:00:00Z",
+    food_description: "Bowl of oatmeal",
+    carbs_low: 40,
+    carbs_high: 55,
+    confidence: "medium",
+    safety_qualifier: "Rough estimate — never dose.",
+    nutrition_json: null,
+    source: "ai_estimate",
+    corrected_carbs_low: null,
+    corrected_carbs_high: null,
+    corrected_nutrition_json: null,
+    corrected_at: null,
+    common_food_id: null,
+    ai_model: null,
+    ai_provider: null,
+    confirmed_food_name: null,
+    identity_confirmed: false,
+    grounding_source: null,
+    grounding_source_url: null,
+    grounding_trust_tier: null,
+    created_at: "2026-06-19T12:00:01Z",
+    ...overrides,
+  };
+}
+
+describe("formatCarbRange", () => {
+  it("renders a band as ≈ low–high g carbs", () => {
+    expect(formatCarbRange(40, 55)).toBe("≈ 40–55 g carbs");
+  });
+
+  it("collapses to a single value when the rounded endpoints coincide", () => {
+    expect(formatCarbRange(50.1, 50.4)).toBe("≈ 50 g carbs");
+  });
+
+  it("rounds to whole grams (no false precision)", () => {
+    expect(formatCarbRange(40.6, 54.5)).toBe("≈ 41–55 g carbs");
+  });
+});
+
+describe("effectiveCarbRange", () => {
+  it("uses the AI estimate when not corrected", () => {
+    expect(effectiveCarbRange(makeRecord())).toEqual({
+      low: 40,
+      high: 55,
+      corrected: false,
+    });
+  });
+
+  it("prefers the corrected band when both values are present", () => {
+    const record = makeRecord({
+      corrected_carbs_low: 30,
+      corrected_carbs_high: 45,
+      source: "user_corrected",
+    });
+    expect(effectiveCarbRange(record)).toEqual({
+      low: 30,
+      high: 45,
+      corrected: true,
+    });
+  });
+});
+
+describe("confidenceLabel", () => {
+  it.each([
+    ["low", "Low confidence"],
+    ["medium", "Medium confidence"],
+    ["high", "High confidence"],
+    ["HIGH", "High confidence"],
+  ])("labels %s as %s", (input, expected) => {
+    expect(confidenceLabel(input)).toBe(expected);
+  });
+
+  it("handles a null/unknown band", () => {
+    expect(confidenceLabel(null)).toBe("Confidence unavailable");
+    expect(confidenceLabel("garbage")).toBe("Confidence unavailable");
+  });
+});
+
+describe("sourceMeta", () => {
+  it("labels the known sources", () => {
+    expect(sourceMeta("ai_estimate").label).toBe("AI estimate");
+    expect(sourceMeta("user_corrected").label).toBe("You corrected this");
+    expect(sourceMeta("external_grounded").label).toBe("Grounded");
+  });
+
+  it("falls back to the raw value for an unknown source", () => {
+    expect(sourceMeta("mystery").label).toBe("mystery");
+  });
+});
+
+describe("mealTitle", () => {
+  it("prefers the confirmed identity", () => {
+    expect(
+      mealTitle(makeRecord({ confirmed_food_name: "Steel-cut oats" }))
+    ).toBe("Steel-cut oats");
+  });
+
+  it("falls back to the AI description then to a placeholder", () => {
+    expect(mealTitle(makeRecord({ food_description: "Pizza" }))).toBe("Pizza");
+    expect(
+      mealTitle(makeRecord({ food_description: null, confirmed_food_name: null }))
+    ).toBe("Unidentified meal");
+  });
+});
+
+describe("macroEntries", () => {
+  it("returns an empty list for null nutrition", () => {
+    expect(macroEntries(null)).toEqual([]);
+  });
+
+  it("orders known macros and gram-suffixes them (calories unit-less)", () => {
+    const entries = macroEntries({
+      calories: 250.6,
+      protein_grams: 12.4,
+      fat_grams: 8,
+    });
+    expect(entries.map((e) => e.key)).toEqual([
+      "protein_grams",
+      "fat_grams",
+      "calories",
+    ]);
+    expect(entries).toEqual([
+      { key: "protein_grams", label: "Protein", value: "12 g" },
+      { key: "fat_grams", label: "Fat", value: "8 g" },
+      { key: "calories", label: "Calories", value: "251" },
+    ]);
+  });
+
+  it("skips absent keys and passes unknown keys through with a humanised label", () => {
+    const entries = macroEntries({ sugar_grams: 5 });
+    expect(entries).toEqual([
+      { key: "sugar_grams", label: "Sugar", value: "5 g" },
+    ]);
+  });
+
+  it("title-cases each word of an unknown multi-word key", () => {
+    expect(macroEntries({ added_sugar_grams: 9 })).toEqual([
+      { key: "added_sugar_grams", label: "Added Sugar", value: "9 g" },
+    ]);
+  });
+});

--- a/apps/web/__tests__/meals/meal-photo.test.tsx
+++ b/apps/web/__tests__/meals/meal-photo.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Tests for MealPhoto: renders the fetched photo, falls back to the placeholder
+ * when it can't be loaded, and revokes the object URL on unmount.
+ */
+
+import { render, screen } from "@testing-library/react";
+
+const mockPhoto = jest.fn();
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  fetchFoodRecordPhotoObjectUrl: (...args: unknown[]) => mockPhoto(...args),
+}));
+
+import { MealPhoto } from "@/components/meals/meal-photo";
+
+describe("MealPhoto", () => {
+  beforeEach(() => {
+    mockPhoto.mockReset();
+    // jsdom doesn't implement these; the component revokes blobs on unmount.
+    (URL as unknown as { revokeObjectURL: jest.Mock }).revokeObjectURL =
+      jest.fn();
+  });
+
+  it("renders the fetched photo on success", async () => {
+    mockPhoto.mockResolvedValue("blob:abc123");
+    render(<MealPhoto recordId="rec-1" size="lg" />);
+    const img = await screen.findByTestId("meal-photo");
+    expect(img).toHaveAttribute("src", "blob:abc123");
+    expect(mockPhoto).toHaveBeenCalledWith("rec-1");
+  });
+
+  it("falls back to the placeholder when the photo can't be loaded", async () => {
+    mockPhoto.mockRejectedValue(new Error("404"));
+    render(<MealPhoto recordId="rec-1" size="sm" />);
+    expect(
+      await screen.findByTestId("meal-photo-placeholder")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("meal-photo")).not.toBeInTheDocument();
+  });
+
+  it("revokes the object URL on unmount", async () => {
+    mockPhoto.mockResolvedValue("blob:xyz");
+    const { unmount } = render(<MealPhoto recordId="rec-1" />);
+    await screen.findByTestId("meal-photo");
+    unmount();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:xyz");
+  });
+});

--- a/apps/web/__tests__/meals/meal-upload.test.tsx
+++ b/apps/web/__tests__/meals/meal-upload.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for the web meal upload control: happy path calls onUploaded, and the
+ * vision-unavailable / no-provider / feature-off responses surface the matching
+ * dead-end state and NEVER a fabricated estimate.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+jest.mock("next/link", () => {
+  const Link = ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+  Link.displayName = "Link";
+  return Link;
+});
+
+const mockUpload = jest.fn();
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  ...jest.requireActual("@/lib/api"),
+  uploadFoodRecord: (...args: unknown[]) => mockUpload(...args),
+}));
+
+const mockCompress = jest.fn();
+jest.mock("@/lib/image-compress", () => ({
+  __esModule: true,
+  ...jest.requireActual("@/lib/image-compress"),
+  compressImageToJpeg: (...args: unknown[]) => mockCompress(...args),
+}));
+
+import { MealUpload } from "@/components/meals/meal-upload";
+import { MealApiError } from "@/lib/api";
+
+function pickFile() {
+  const file = new File(["jpeg-bytes"], "meal.jpg", { type: "image/jpeg" });
+  fireEvent.change(screen.getByTestId("meal-file-input"), {
+    target: { files: [file] },
+  });
+}
+
+describe("MealUpload", () => {
+  beforeEach(() => {
+    mockUpload.mockReset();
+    mockCompress.mockReset();
+    mockCompress.mockResolvedValue(new Blob(["x"], { type: "image/jpeg" }));
+  });
+
+  it("compresses then uploads and calls onUploaded on success", async () => {
+    const record = { id: "new-rec" };
+    mockUpload.mockResolvedValue(record);
+    const onUploaded = jest.fn();
+
+    render(<MealUpload onUploaded={onUploaded} />);
+    pickFile();
+
+    await waitFor(() => expect(onUploaded).toHaveBeenCalledWith(record));
+    expect(mockCompress).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a vision-unavailable dead end and does not call onUploaded", async () => {
+    mockUpload.mockRejectedValue(
+      new MealApiError(422, "Vision is not available on your current AI provider.")
+    );
+    const onUploaded = jest.fn();
+
+    render(<MealUpload onUploaded={onUploaded} />);
+    pickFile();
+
+    expect(
+      await screen.findByTestId("meal-vision-unavailable")
+    ).toBeInTheDocument();
+    expect(onUploaded).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a no-provider dead end", async () => {
+    mockUpload.mockRejectedValue(
+      new MealApiError(404, "No AI provider configured.")
+    );
+    render(<MealUpload onUploaded={jest.fn()} />);
+    pickFile();
+    expect(await screen.findByTestId("meal-no-provider")).toBeInTheDocument();
+  });
+
+  it("calls onFeatureOff when the upload reveals the feature is disabled", async () => {
+    mockUpload.mockRejectedValue(
+      new MealApiError(404, "Meal intelligence is not enabled.")
+    );
+    const onFeatureOff = jest.fn();
+    render(<MealUpload onUploaded={jest.fn()} onFeatureOff={onFeatureOff} />);
+    pickFile();
+    await screen.findByTestId("meal-feature-off");
+    expect(onFeatureOff).toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/meals/meals-page.test.tsx
+++ b/apps/web/__tests__/meals/meals-page.test.tsx
@@ -30,6 +30,11 @@ jest.mock("@/lib/api", () => ({
   __esModule: true,
   ...jest.requireActual("@/lib/api"),
   listFoodRecords: (...args: unknown[]) => mockList(...args),
+  // The photo is fetched lazily by MealPhoto; default to "no photo" so the
+  // placeholder renders and these tests stay focused on the list behaviour.
+  fetchFoodRecordPhotoObjectUrl: jest.fn(() =>
+    Promise.reject(new Error("no photo"))
+  ),
 }));
 
 import MealsPage from "../../src/app/dashboard/meals/page";

--- a/apps/web/__tests__/meals/meals-page.test.tsx
+++ b/apps/web/__tests__/meals/meals-page.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests for the Meals list page: renders records (range + qualifier + source
+ * badge + identity indicator), empty state, the feature-off dead end (no raw
+ * 404), and pagination. Behavioural assertions only -- never pins exact carbs.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+jest.mock("next/link", () => {
+  const Link = ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+  Link.displayName = "Link";
+  return Link;
+});
+
+const mockList = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  ...jest.requireActual("@/lib/api"),
+  listFoodRecords: (...args: unknown[]) => mockList(...args),
+}));
+
+import MealsPage from "../../src/app/dashboard/meals/page";
+import { MealApiError, type FoodRecord } from "@/lib/api";
+
+function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
+  return {
+    id: "rec-1",
+    meal_timestamp: "2026-06-19T12:00:00Z",
+    food_description: "Bowl of oatmeal",
+    carbs_low: 40,
+    carbs_high: 55,
+    confidence: "medium",
+    safety_qualifier: "Rough estimate — an AI guess. Never dose from it.",
+    nutrition_json: null,
+    source: "ai_estimate",
+    corrected_carbs_low: null,
+    corrected_carbs_high: null,
+    corrected_nutrition_json: null,
+    corrected_at: null,
+    common_food_id: null,
+    ai_model: null,
+    ai_provider: null,
+    confirmed_food_name: null,
+    identity_confirmed: false,
+    grounding_source: null,
+    grounding_source_url: null,
+    grounding_trust_tier: null,
+    created_at: "2026-06-19T12:00:01Z",
+    ...overrides,
+  };
+}
+
+describe("Meals list page", () => {
+  beforeEach(() => {
+    mockList.mockReset();
+  });
+
+  it("renders a record with carb range, source badge, identity indicator, and the safety qualifier", async () => {
+    mockList.mockResolvedValue({
+      records: [makeRecord({ identity_confirmed: true })],
+      total: 1,
+    });
+
+    render(<MealsPage />);
+
+    const card = await screen.findByTestId("meal-card");
+    expect(card).toBeInTheDocument();
+    expect(screen.getByTestId("meal-carb-range")).toHaveTextContent(/g carbs/);
+    expect(screen.getByTestId("meal-source-badge")).toHaveTextContent(
+      "AI estimate"
+    );
+    expect(screen.getByTestId("meal-identity-confirmed")).toBeInTheDocument();
+    expect(screen.getByTestId("meal-safety-qualifier")).toHaveTextContent(
+      /never dose/i
+    );
+    expect(card).toHaveAttribute("href", "/dashboard/meals/rec-1");
+  });
+
+  it("shows an empty state when there are no records", async () => {
+    mockList.mockResolvedValue({ records: [], total: 0 });
+    render(<MealsPage />);
+    expect(await screen.findByTestId("meal-empty")).toBeInTheDocument();
+  });
+
+  it("renders a clear feature-off state (not a raw 404) when meal intelligence is disabled", async () => {
+    mockList.mockRejectedValue(
+      new MealApiError(404, "Meal intelligence is not enabled.")
+    );
+    render(<MealsPage />);
+    expect(await screen.findByTestId("meal-feature-off")).toBeInTheDocument();
+    expect(screen.queryByTestId("meal-card")).not.toBeInTheDocument();
+  });
+
+  it("paginates: Next requests the following offset", async () => {
+    mockList.mockResolvedValue({
+      records: [makeRecord()],
+      total: 120,
+    });
+    render(<MealsPage />);
+
+    await screen.findByTestId("meal-card");
+    expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => {
+      expect(mockList).toHaveBeenLastCalledWith(50, 50);
+    });
+  });
+});

--- a/apps/web/__tests__/meals/sidebar-meals.test.tsx
+++ b/apps/web/__tests__/meals/sidebar-meals.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests the flag-gated Meals nav item: present only when meal intelligence is
+ * enabled, hidden while the probe is loading or when disabled, and never for
+ * caregivers.
+ */
+
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+}));
+
+jest.mock("next/link", () => {
+  const Link = ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+  Link.displayName = "Link";
+  return Link;
+});
+
+jest.mock("next/image", () => {
+  const NextImage = (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />;
+  };
+  NextImage.displayName = "NextImage";
+  return { __esModule: true, default: NextImage };
+});
+
+const mockUser = jest.fn();
+const mockMeal = jest.fn();
+jest.mock("@/providers", () => ({
+  useUserContext: () => mockUser(),
+  useMealIntelligenceContext: () => mockMeal(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  getUnreadInsightsCount: jest.fn().mockResolvedValue(0),
+}));
+
+import { Sidebar } from "@/components/layout/sidebar";
+
+describe("Sidebar Meals nav gating", () => {
+  beforeEach(() => {
+    mockUser.mockReset();
+    mockMeal.mockReset();
+    mockUser.mockReturnValue({ user: { role: "diabetic" } });
+  });
+
+  it("shows the Meals item when meal intelligence is enabled", async () => {
+    mockMeal.mockReturnValue({ enabled: true, isLoading: false });
+    render(<Sidebar />);
+    const meals = await screen.findByText("Meals");
+    expect(meals.closest("a")).toHaveAttribute("href", "/dashboard/meals");
+  });
+
+  it("hides the Meals item while the flag probe is still loading", () => {
+    mockMeal.mockReturnValue({ enabled: null, isLoading: true });
+    render(<Sidebar />);
+    expect(screen.queryByText("Meals")).not.toBeInTheDocument();
+  });
+
+  it("hides the Meals item when meal intelligence is disabled", () => {
+    mockMeal.mockReturnValue({ enabled: false, isLoading: false });
+    render(<Sidebar />);
+    expect(screen.queryByText("Meals")).not.toBeInTheDocument();
+  });
+
+  it("never shows the Meals item for a caregiver", () => {
+    mockUser.mockReturnValue({ user: { role: "caregiver" } });
+    mockMeal.mockReturnValue({ enabled: true, isLoading: false });
+    render(<Sidebar />);
+    expect(screen.queryByText("Meals")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -48,6 +48,21 @@ const nextConfig: NextConfig = {
   output: "standalone",
   reactStrictMode: true,
   poweredByHeader: false,
+
+  /**
+   * Raise the rewrite-proxy timeout above Next's 30s default.
+   *
+   * Almost every /api/* call is sub-second, but the meal-photo upload
+   * (POST /api/food-records) runs multi-sample AI vision inference that can take
+   * tens of seconds. At the 30s default the proxy aborts the upstream
+   * (ECONNRESET / "socket hang up") and a meal that the API actually saved
+   * surfaces in the UI as a generic error. 120s comfortably covers it -- the
+   * mobile client uses a 90s read timeout on the same upload for this reason.
+   */
+  experimental: {
+    proxyTimeout: 120_000,
+  },
+
   async headers() {
     return [
       {

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -16,7 +16,11 @@
 
 import { DashboardLayout } from "@/components/layout";
 import { AuthDisclaimerGate } from "@/components/auth-disclaimer-gate";
-import { AlertNotificationProvider, UserProvider } from "@/providers";
+import {
+  AlertNotificationProvider,
+  MealIntelligenceProvider,
+  UserProvider,
+} from "@/providers";
 
 /**
  * Skip link component for keyboard navigation.
@@ -39,9 +43,11 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <SkipLink />
       <UserProvider>
         <AuthDisclaimerGate>
-          <AlertNotificationProvider>
-            <DashboardLayout>{children}</DashboardLayout>
-          </AlertNotificationProvider>
+          <MealIntelligenceProvider>
+            <AlertNotificationProvider>
+              <DashboardLayout>{children}</DashboardLayout>
+            </AlertNotificationProvider>
+          </MealIntelligenceProvider>
         </AuthDisclaimerGate>
       </UserProvider>
     </>

--- a/apps/web/src/app/dashboard/meals/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/meals/[id]/page.tsx
@@ -65,6 +65,9 @@ export default function MealDetailPage() {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    // Clear any prior meal so a stale record can't render under a new id.
+    setRecord(null);
+    setBlockedInfo(null);
     getFoodRecord(id)
       .then((data) => {
         if (cancelled) return;
@@ -76,6 +79,7 @@ export default function MealDetailPage() {
         const info = classifyMealError(err);
         if (info.retryable) {
           setError(info.message);
+          setRecord(null);
         } else {
           setBlockedInfo(info);
           setRecord(null);

--- a/apps/web/src/app/dashboard/meals/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/meals/[id]/page.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+/**
+ * Meal detail.
+ *
+ * Shows one food record: the (placeholder) photo, identity, carb range, the
+ * empirical-dispersion confidence band, read-only macros, and provenance. There
+ * is deliberately no dose/insulin element; the server-cleared safety qualifier
+ * carries the never-dose framing. Delete reuses the native-confirm UX.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, Loader2, Trash2 } from "lucide-react";
+import {
+  getFoodRecord,
+  deleteFoodRecord,
+  type FoodRecord,
+} from "@/lib/api";
+import { classifyMealError, type MealErrorInfo } from "@/lib/meal-errors";
+import {
+  effectiveCarbRange,
+  formatCarbRange,
+  confidenceLabel,
+  mealTitle,
+  macroEntries,
+} from "@/lib/meal-format";
+import { PageTransition } from "@/components/ui/page-transition";
+import { AnimatedCard } from "@/components/ui/animated-card";
+import {
+  SourceBadge,
+  IdentityConfirmedBadge,
+  MealSafetyQualifier,
+  MealPhotoPlaceholder,
+  MealErrorPanel,
+} from "@/components/meals/meal-ui";
+
+function BackLink() {
+  return (
+    <Link
+      href="/dashboard/meals"
+      className="inline-flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      Back to Meals
+    </Link>
+  );
+}
+
+export default function MealDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
+  const router = useRouter();
+
+  const [record, setRecord] = useState<FoodRecord | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [blockedInfo, setBlockedInfo] = useState<MealErrorInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    // Guard against a stale response applying after the id changes or unmount.
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getFoodRecord(id)
+      .then((data) => {
+        if (cancelled) return;
+        setRecord(data);
+        setBlockedInfo(null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const info = classifyMealError(err);
+        if (info.retryable) {
+          setError(info.message);
+        } else {
+          setBlockedInfo(info);
+          setRecord(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const handleDelete = useCallback(async () => {
+    if (!record || deleting) return;
+    if (
+      !window.confirm(
+        `Delete this meal log${
+          mealTitle(record) ? ` (${mealTitle(record)})` : ""
+        }? This also removes its photo and cannot be undone.`
+      )
+    ) {
+      return;
+    }
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteFoodRecord(record.id);
+      router.push("/dashboard/meals");
+    } catch (err) {
+      setError(classifyMealError(err).message);
+      setDeleting(false);
+    }
+  }, [record, deleting, router]);
+
+  if (loading) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex flex-col h-full items-center justify-center"
+      >
+        <Loader2 className="h-8 w-8 animate-spin text-blue-400" />
+        <p className="mt-4 text-slate-500 dark:text-slate-400">Loading meal...</p>
+      </div>
+    );
+  }
+
+  if (blockedInfo) {
+    return (
+      <PageTransition>
+        <div className="max-w-2xl mx-auto space-y-6 p-6">
+          <BackLink />
+          <MealErrorPanel info={blockedInfo} />
+        </div>
+      </PageTransition>
+    );
+  }
+
+  if (!record) {
+    return (
+      <PageTransition>
+        <div className="max-w-2xl mx-auto space-y-6 p-6">
+          <BackLink />
+          <p className="text-slate-500 dark:text-slate-400">
+            {error || "This meal could not be loaded."}
+          </p>
+        </div>
+      </PageTransition>
+    );
+  }
+
+  const range = effectiveCarbRange(record);
+  const macros = macroEntries(record.corrected_nutrition_json ?? record.nutrition_json);
+
+  return (
+    <PageTransition>
+      <div className="max-w-2xl mx-auto space-y-6 p-6">
+        <div className="flex items-center justify-between">
+          <BackLink />
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            data-testid="meal-delete"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg text-red-600 dark:text-red-400 hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {deleting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="h-4 w-4" />
+            )}
+            Delete
+          </button>
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="bg-red-500/10 border border-red-500/20 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg text-sm"
+          >
+            {error}
+          </div>
+        )}
+
+        <AnimatedCard>
+          <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 space-y-4">
+            <MealPhotoPlaceholder size="lg" />
+
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+                  {mealTitle(record)}
+                </h1>
+                {record.identity_confirmed && <IdentityConfirmedBadge />}
+              </div>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                {new Date(record.meal_timestamp).toLocaleString()}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                data-testid="meal-carb-range"
+                className="text-xl font-semibold text-slate-900 dark:text-white"
+              >
+                {formatCarbRange(range.low, range.high)}
+              </span>
+              <span
+                data-testid="meal-confidence"
+                className="text-sm text-slate-500 dark:text-slate-400"
+              >
+                {confidenceLabel(record.confidence)}
+              </span>
+              <SourceBadge source={record.source} />
+            </div>
+
+            {range.corrected && (
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                You corrected this. AI estimated{" "}
+                {formatCarbRange(record.carbs_low, record.carbs_high)}.
+              </p>
+            )}
+
+            <MealSafetyQualifier qualifier={record.safety_qualifier} />
+          </div>
+        </AnimatedCard>
+
+        {macros.length > 0 && (
+          <AnimatedCard delay={0.05}>
+            <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 space-y-3">
+              <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+                Estimated nutrition
+              </h2>
+              <dl className="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-4">
+                {macros.map((macro) => (
+                  <div key={macro.key} data-testid="meal-macro">
+                    <dt className="text-xs text-slate-500 dark:text-slate-400">
+                      {macro.label}
+                    </dt>
+                    <dd className="text-sm font-medium text-slate-900 dark:text-white">
+                      {macro.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </AnimatedCard>
+        )}
+
+        {(record.ai_model || record.ai_provider) && (
+          <p className="text-xs text-slate-400 dark:text-slate-500 text-center">
+            Estimated by {record.ai_model || "AI"}
+            {record.ai_provider ? ` · ${record.ai_provider}` : ""}
+          </p>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/apps/web/src/app/dashboard/meals/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/meals/[id]/page.tsx
@@ -28,11 +28,11 @@ import {
 } from "@/lib/meal-format";
 import { PageTransition } from "@/components/ui/page-transition";
 import { AnimatedCard } from "@/components/ui/animated-card";
+import { MealPhoto } from "@/components/meals/meal-photo";
 import {
   SourceBadge,
   IdentityConfirmedBadge,
   MealSafetyQualifier,
-  MealPhotoPlaceholder,
   MealErrorPanel,
 } from "@/components/meals/meal-ui";
 
@@ -183,7 +183,7 @@ export default function MealDetailPage() {
 
         <AnimatedCard>
           <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 space-y-4">
-            <MealPhotoPlaceholder size="lg" />
+            <MealPhoto recordId={record.id} size="lg" />
 
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/app/dashboard/meals/page.tsx
+++ b/apps/web/src/app/dashboard/meals/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+/**
+ * Meals list.
+ *
+ * Lists the user's food records (most recent first) and hosts the web meal
+ * upload. Modelled on the Knowledge Base page (list -> detail -> delete ->
+ * pagination). Owner-scoped + flag-gated server-side; a feature-off response is
+ * rendered as a clear state, never a raw 404.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
+import { UtensilsCrossed, Loader2, ChevronRight } from "lucide-react";
+import { listFoodRecords, type FoodRecord } from "@/lib/api";
+import { classifyMealError, type MealErrorInfo } from "@/lib/meal-errors";
+import {
+  effectiveCarbRange,
+  formatCarbRange,
+  confidenceLabel,
+  mealTitle,
+} from "@/lib/meal-format";
+import { PageTransition } from "@/components/ui/page-transition";
+import { AnimatedCard } from "@/components/ui/animated-card";
+import { MealUpload } from "@/components/meals/meal-upload";
+import {
+  SourceBadge,
+  IdentityConfirmedBadge,
+  MealSafetyQualifier,
+  MealPhotoPlaceholder,
+  MealErrorPanel,
+} from "@/components/meals/meal-ui";
+
+const PAGE_SIZE = 50;
+
+function MealRow({ record, delay }: { record: FoodRecord; delay: number }) {
+  const range = effectiveCarbRange(record);
+  return (
+    <AnimatedCard delay={delay}>
+      <Link
+        href={`/dashboard/meals/${record.id}`}
+        data-testid="meal-card"
+        className="flex gap-4 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4 hover:border-blue-400 dark:hover:border-blue-500/50 transition-colors"
+      >
+        <MealPhotoPlaceholder size="sm" />
+        <div className="flex-1 min-w-0 space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <h3 className="font-medium text-slate-900 dark:text-white truncate">
+                {mealTitle(record)}
+              </h3>
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                {new Date(record.meal_timestamp).toLocaleString()}
+              </p>
+            </div>
+            <ChevronRight className="h-4 w-4 flex-shrink-0 text-slate-400" />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              data-testid="meal-carb-range"
+              className="text-sm font-semibold text-slate-900 dark:text-white"
+            >
+              {formatCarbRange(range.low, range.high)}
+            </span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              {confidenceLabel(record.confidence)}
+            </span>
+            <SourceBadge source={record.source} />
+            {record.identity_confirmed && <IdentityConfirmedBadge />}
+          </div>
+
+          <MealSafetyQualifier qualifier={record.safety_qualifier} />
+        </div>
+      </Link>
+    </AnimatedCard>
+  );
+}
+
+export default function MealsPage() {
+  const [records, setRecords] = useState<FoodRecord[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  // A non-retryable dead end (feature off) replaces the list entirely.
+  const [blockedInfo, setBlockedInfo] = useState<MealErrorInfo | null>(null);
+  // Guards against out-of-order resolution: only the latest fetch may apply.
+  const requestIdRef = useRef(0);
+
+  const loadData = useCallback(async (pageNum: number) => {
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listFoodRecords(PAGE_SIZE, (pageNum - 1) * PAGE_SIZE);
+      if (requestId !== requestIdRef.current) return;
+      setRecords(data.records);
+      setTotal(data.total);
+      setBlockedInfo(null);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      const info = classifyMealError(err);
+      if (info.retryable) {
+        setError(info.message);
+      } else {
+        setBlockedInfo(info);
+        setRecords([]);
+        setTotal(0);
+      }
+    } finally {
+      if (requestId === requestIdRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData(page);
+  }, [loadData, page]);
+
+  // Auto-dismiss the upload success banner so it never lingers across reloads.
+  useEffect(() => {
+    if (!success) return;
+    const timer = setTimeout(() => setSuccess(null), 5000);
+    return () => clearTimeout(timer);
+  }, [success]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const handleUploaded = useCallback(
+    (record: FoodRecord) => {
+      setSuccess(`Logged: ${mealTitle(record)}`);
+      setBlockedInfo(null);
+      if (page === 1) {
+        loadData(1);
+      } else {
+        setPage(1);
+      }
+    },
+    [page, loadData]
+  );
+
+  if (loading && records.length === 0 && !blockedInfo) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex flex-col h-full items-center justify-center"
+      >
+        <Loader2 className="h-8 w-8 animate-spin text-blue-400" />
+        <p className="mt-4 text-slate-500 dark:text-slate-400">Loading meals...</p>
+      </div>
+    );
+  }
+
+  return (
+    <PageTransition>
+      <div className="max-w-4xl mx-auto space-y-6 p-6">
+        {/* Header */}
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <UtensilsCrossed className="h-7 w-7 text-blue-400" />
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+                Meals
+              </h1>
+              <p className="text-slate-500 dark:text-slate-400 text-sm">
+                {blockedInfo
+                  ? "Your meal photo log"
+                  : `${total} logged meal${total === 1 ? "" : "s"}`}
+              </p>
+            </div>
+          </div>
+          {!blockedInfo && (
+            <MealUpload
+              onUploaded={handleUploaded}
+              onFeatureOff={() => loadData(1)}
+            />
+          )}
+        </div>
+
+        {/* Status messages */}
+        {error && (
+          <div
+            role="alert"
+            className="bg-red-500/10 border border-red-500/20 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg text-sm"
+          >
+            {error}
+          </div>
+        )}
+        {success && (
+          <div
+            role="status"
+            className="bg-green-500/10 border border-green-500/20 text-green-700 dark:text-green-400 px-4 py-3 rounded-lg text-sm"
+          >
+            {success}
+          </div>
+        )}
+
+        {/* Feature-off (or other non-retryable) dead end */}
+        {blockedInfo ? (
+          <MealErrorPanel info={blockedInfo} />
+        ) : records.length === 0 ? (
+          <div
+            data-testid="meal-empty"
+            className="text-center py-16 bg-slate-100/50 dark:bg-slate-800/30 rounded-lg"
+          >
+            <UtensilsCrossed className="h-14 w-14 text-slate-400 dark:text-slate-600 mx-auto mb-4" />
+            <h2 className="text-lg font-medium text-slate-900 dark:text-white mb-2">
+              No meals logged yet
+            </h2>
+            <p className="text-slate-500 dark:text-slate-400 max-w-md mx-auto">
+              Use “Log a meal” to add a photo and get a rough AI carb estimate.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {records.map((record, i) => (
+              <MealRow
+                key={record.id}
+                record={record}
+                delay={Math.min(i * 0.03, 0.3)}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {!blockedInfo && totalPages > 1 && (
+          <div className="flex items-center justify-center gap-3 pt-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1 || loading}
+              className="px-3 py-1.5 bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-900 dark:text-white text-sm rounded disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Previous
+            </button>
+            <span className="text-sm text-slate-500 dark:text-slate-400">
+              Page {page} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page >= totalPages || loading}
+              className="px-3 py-1.5 bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-900 dark:text-white text-sm rounded disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/apps/web/src/app/dashboard/meals/page.tsx
+++ b/apps/web/src/app/dashboard/meals/page.tsx
@@ -23,11 +23,11 @@ import {
 import { PageTransition } from "@/components/ui/page-transition";
 import { AnimatedCard } from "@/components/ui/animated-card";
 import { MealUpload } from "@/components/meals/meal-upload";
+import { MealPhoto } from "@/components/meals/meal-photo";
 import {
   SourceBadge,
   IdentityConfirmedBadge,
   MealSafetyQualifier,
-  MealPhotoPlaceholder,
   MealErrorPanel,
 } from "@/components/meals/meal-ui";
 
@@ -42,7 +42,7 @@ function MealRow({ record, delay }: { record: FoodRecord; delay: number }) {
         data-testid="meal-card"
         className="flex gap-4 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4 hover:border-blue-400 dark:hover:border-blue-500/50 transition-colors"
       >
-        <MealPhotoPlaceholder size="sm" />
+        <MealPhoto recordId={record.id} size="sm" />
         <div className="flex-1 min-w-0 space-y-2">
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0">

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -23,11 +23,12 @@ import {
   Bell,
   MessageSquare,
   BookOpen,
+  UtensilsCrossed,
   Settings,
   Menu,
   X,
 } from "lucide-react";
-import { useUserContext } from "@/providers";
+import { useUserContext, useMealIntelligenceContext } from "@/providers";
 import { getUnreadInsightsCount } from "@/lib/api";
 
 interface NavItem {
@@ -49,6 +50,28 @@ const diabeticNavigation: NavItem[] = [
 const caregiverNavigation: NavItem[] = [
   { name: "Dashboard", href: "/dashboard/caregiver", icon: LayoutDashboard },
 ];
+
+// Meals is gated on the deployment-wide meal-intelligence flag (resolved via a
+// probe in MealIntelligenceProvider). When off, the nav item is hidden; the
+// route itself renders a clear feature-off state (never a raw 404), mirroring
+// the mobile client. Inserted just before the trailing Settings item.
+const mealsNavItem: NavItem = {
+  name: "Meals",
+  href: "/dashboard/meals",
+  icon: UtensilsCrossed,
+};
+
+function navItemsFor(isCaregiver: boolean, mealsEnabled: boolean): NavItem[] {
+  if (isCaregiver) return caregiverNavigation;
+  if (!mealsEnabled) return diabeticNavigation;
+  // Settings is the trailing item; keep it last with Meals just before it.
+  const lastIndex = diabeticNavigation.length - 1;
+  return [
+    ...diabeticNavigation.slice(0, lastIndex),
+    mealsNavItem,
+    ...diabeticNavigation.slice(lastIndex),
+  ];
+}
 
 interface SidebarProps {
   className?: string;
@@ -94,8 +117,9 @@ function UnreadBadge({ count }: { count: number }) {
 export function Sidebar({ className }: SidebarProps) {
   const pathname = usePathname();
   const { user } = useUserContext();
+  const { enabled: mealsEnabled } = useMealIntelligenceContext();
   const isCaregiver = user?.role === "caregiver";
-  const navigation = isCaregiver ? caregiverNavigation : diabeticNavigation;
+  const navigation = navItemsFor(isCaregiver, mealsEnabled === true);
   const unreadCount = useUnreadCount(!isCaregiver);
 
   return (
@@ -162,8 +186,9 @@ export function MobileNav() {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
   const { user } = useUserContext();
+  const { enabled: mealsEnabled } = useMealIntelligenceContext();
   const isCaregiver = user?.role === "caregiver";
-  const navigation = isCaregiver ? caregiverNavigation : diabeticNavigation;
+  const navigation = navItemsFor(isCaregiver, mealsEnabled === true);
   const unreadCount = useUnreadCount(!isCaregiver);
 
   return (

--- a/apps/web/src/components/meals/meal-photo.tsx
+++ b/apps/web/src/components/meals/meal-photo.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { fetchFoodRecordPhotoObjectUrl } from "@/lib/api";
+import { MealPhotoPlaceholder } from "@/components/meals/meal-ui";
+
+/**
+ * Renders a record's stored meal photo, fetched as a credentialed `blob:` URL
+ * (the endpoint is cookie-protected and next/image can't carry the cookie).
+ * Shows the neutral placeholder while loading or if the photo can't be loaded
+ * (e.g. an older record without a served photo), and revokes the object URL on
+ * unmount / id change so blobs aren't leaked.
+ */
+export function MealPhoto({
+  recordId,
+  size = "sm",
+}: {
+  recordId: string;
+  size?: "sm" | "lg";
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    let objectUrl: string | null = null;
+    setUrl(null);
+    fetchFoodRecordPhotoObjectUrl(recordId)
+      .then((resolved) => {
+        if (active) {
+          objectUrl = resolved;
+          setUrl(resolved);
+        } else {
+          URL.revokeObjectURL(resolved);
+        }
+      })
+      .catch(() => {
+        // Leave the placeholder shown -- no broken-image flash.
+      });
+    return () => {
+      active = false;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [recordId]);
+
+  if (!url) {
+    return <MealPhotoPlaceholder size={size} />;
+  }
+
+  const dimensions = size === "lg" ? "h-48 w-full" : "h-14 w-14";
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- credentialed blob URL; next/image can't carry the auth cookie.
+    <img
+      src={url}
+      alt="Meal photo"
+      data-testid="meal-photo"
+      className={`${dimensions} flex-shrink-0 rounded-lg object-cover bg-slate-100 dark:bg-slate-800`}
+    />
+  );
+}

--- a/apps/web/src/components/meals/meal-ui.tsx
+++ b/apps/web/src/components/meals/meal-ui.tsx
@@ -1,0 +1,153 @@
+/**
+ * Shared presentational pieces for the meal-management surfaces (list + detail).
+ *
+ * Descriptive only: the safety qualifier is rendered verbatim from the server
+ * `safety_qualifier` field, and nothing here renders a dose or insulin value.
+ */
+
+import Link from "next/link";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ImageOff,
+  Settings as SettingsIcon,
+  X,
+} from "lucide-react";
+import { sourceMeta } from "@/lib/meal-format";
+import type { FoodRecordSource } from "@/lib/api";
+import type { MealErrorInfo } from "@/lib/meal-errors";
+
+/** Provenance badge (AI estimate / corrected / grounded). */
+export function SourceBadge({ source }: { source: FoodRecordSource | string }) {
+  const meta = sourceMeta(source);
+  return (
+    <span
+      data-testid="meal-source-badge"
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${meta.bg} ${meta.text}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+/** "Identity confirmed" marker -- only shown once the user has confirmed the food. */
+export function IdentityConfirmedBadge() {
+  return (
+    <span
+      data-testid="meal-identity-confirmed"
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-emerald-500/15 text-emerald-700 dark:text-emerald-400"
+    >
+      <CheckCircle2 className="h-3 w-3" />
+      Identity confirmed
+    </span>
+  );
+}
+
+/**
+ * The always-present, server-cleared safety qualifier. Rendered verbatim from
+ * the record's `safety_qualifier` so the never-dose framing can never drift or
+ * be omitted on a carb surface.
+ */
+export function MealSafetyQualifier({
+  qualifier,
+  className = "",
+}: {
+  qualifier: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="note"
+      data-testid="meal-safety-qualifier"
+      className={`flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-300 ${className}`}
+    >
+      <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+      <span>{qualifier}</span>
+    </div>
+  );
+}
+
+/**
+ * Placeholder for the meal photo. The current API stores the photo for analysis
+ * but never serves it back to clients (no photo URL / endpoint), so there is
+ * nothing to render; this shows a neutral placeholder rather than a broken image.
+ */
+export function MealPhotoPlaceholder({
+  size = "sm",
+}: {
+  size?: "sm" | "lg";
+}) {
+  const dimensions = size === "lg" ? "h-48 w-full" : "h-14 w-14";
+  const iconSize = size === "lg" ? "h-8 w-8" : "h-5 w-5";
+  return (
+    <div
+      data-testid="meal-photo-placeholder"
+      aria-hidden="true"
+      className={`${dimensions} flex-shrink-0 flex items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500`}
+    >
+      <ImageOff className={iconSize} />
+    </div>
+  );
+}
+
+/**
+ * Renders a classified meal error. Non-retryable failures (feature off, no
+ * provider, vision unavailable) become a blocking card that points the user at
+ * Settings; retryable ones become a dismissible inline banner.
+ */
+export function MealErrorPanel({
+  info,
+  onDismiss,
+}: {
+  info: MealErrorInfo;
+  onDismiss?: () => void;
+}) {
+  if (info.retryable) {
+    return (
+      <div
+        role="alert"
+        data-testid="meal-error"
+        className="flex items-start justify-between gap-3 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-700 dark:text-red-400"
+      >
+        <span>
+          <span className="font-medium">{info.title}.</span> {info.message}
+        </span>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="text-red-700 dark:text-red-400 hover:opacity-70"
+            aria-label="Dismiss"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="alert"
+      data-testid={`meal-${info.kind.replace(/_/g, "-")}`}
+      className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-4 text-sm"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+        <div className="space-y-2">
+          <p className="font-medium text-slate-900 dark:text-white">{info.title}</p>
+          <p className="text-slate-600 dark:text-slate-300">{info.message}</p>
+          {info.settingsHref && (
+            <Link
+              href={info.settingsHref}
+              className="inline-flex items-center gap-1.5 text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              <SettingsIcon className="h-4 w-4" />
+              Open Settings
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/meals/meal-upload.tsx
+++ b/apps/web/src/components/meals/meal-upload.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * Web meal-photo upload: pick -> validate/compress -> POST multipart.
+ *
+ * Mirrors the mobile compress-then-multipart flow (1280px / quality ladder /
+ * 5 MiB JPEG). On a vision-unavailable / no-provider / feature-off response it
+ * surfaces the matching dead-end state and NEVER a fabricated estimate.
+ */
+
+import { useRef, useState } from "react";
+import { Camera, Loader2 } from "lucide-react";
+import { uploadFoodRecord, type FoodRecord } from "@/lib/api";
+import { compressImageToJpeg, ImageCompressionError } from "@/lib/image-compress";
+import { classifyMealError, type MealErrorInfo } from "@/lib/meal-errors";
+import { MealErrorPanel } from "@/components/meals/meal-ui";
+
+const ACCEPT = "image/jpeg,image/png,image/webp";
+
+export function MealUpload({
+  onUploaded,
+  onFeatureOff,
+}: {
+  onUploaded: (record: FoodRecord) => void;
+  /** Called when an upload reveals the feature is off, so the page can switch state. */
+  onFeatureOff?: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [errorInfo, setErrorInfo] = useState<MealErrorInfo | null>(null);
+
+  async function handleFile(file: File) {
+    setErrorInfo(null);
+    setBusy(true);
+    try {
+      const blob = await compressImageToJpeg(file);
+      const record = await uploadFoodRecord(blob);
+      onUploaded(record);
+    } catch (err) {
+      if (err instanceof ImageCompressionError) {
+        setErrorInfo({
+          kind: "unsupported_image",
+          title: "Couldn't use that photo",
+          message: err.message,
+          retryable: true,
+        });
+      } else {
+        const info = classifyMealError(err);
+        setErrorInfo(info);
+        if (info.kind === "feature_off") onFeatureOff?.();
+      }
+    } finally {
+      setBusy(false);
+      // Reset so re-picking the same file fires onChange again.
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPT}
+        className="hidden"
+        data-testid="meal-file-input"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleFile(file);
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={busy}
+        data-testid="meal-upload-button"
+        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+      >
+        {busy ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" data-testid="meal-uploading" />
+            Estimating carbs…
+          </>
+        ) : (
+          <>
+            <Camera className="h-4 w-4" />
+            Log a meal
+          </>
+        )}
+      </button>
+
+      {errorInfo && (
+        <MealErrorPanel
+          info={errorInfo}
+          onDismiss={
+            errorInfo.retryable ? () => setErrorInfo(null) : undefined
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-meal-intelligence.ts
+++ b/apps/web/src/hooks/use-meal-intelligence.ts
@@ -1,0 +1,49 @@
+/**
+ * useMealIntelligence -- resolves whether the meal-photo feature is enabled.
+ *
+ * There is no server flag endpoint, so this probes the food-records list once on
+ * mount (see `getMealIntelligenceStatus`). `enabled` is `null` while resolving,
+ * then `false` only when the server explicitly reports the feature is off, else
+ * `true`. Mirrors the mobile client's reactive availability probe.
+ */
+
+"use client";
+
+import { useState, useEffect } from "react";
+import { getMealIntelligenceStatus } from "@/lib/api";
+
+export interface UseMealIntelligenceReturn {
+  /** null while the probe is in flight; true/false once resolved. */
+  enabled: boolean | null;
+  isLoading: boolean;
+}
+
+export function useMealIntelligence(): UseMealIntelligenceReturn {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function probe() {
+      // getMealIntelligenceStatus never rejects (it degrades to enabled on a
+      // transient failure), so a throw here would be unexpected; keep the guard
+      // so the nav simply stays hidden rather than crashing.
+      try {
+        const { enabled: isEnabled } = await getMealIntelligenceStatus();
+        if (!cancelled) setEnabled(isEnabled);
+      } catch {
+        if (!cancelled) setEnabled(false);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    probe();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { enabled, isLoading };
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4309,6 +4309,27 @@ export async function getFoodRecord(recordId: string): Promise<FoodRecord> {
 }
 
 /**
+ * Fetch a record's stored meal photo as a `blob:` object URL.
+ *
+ * The photo endpoint is same-origin and cookie-protected, and next/image's
+ * optimizer can't carry the auth cookie, so we fetch the bytes through apiFetch
+ * (which sends credentials) and wrap them in a `blob:` URL the CSP allows. The
+ * caller MUST revoke the URL (URL.revokeObjectURL) once it is no longer shown.
+ */
+export async function fetchFoodRecordPhotoObjectUrl(
+  recordId: string
+): Promise<string> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}/photo`
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+}
+
+/**
  * Upload a meal photo for AI carb estimation. The caller compresses to a JPEG
  * blob first (see `@/lib/image-compress`); this mirrors the mobile client's
  * single-part `file` upload. Returns the persisted record (with the create-time

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4150,3 +4150,216 @@ export async function importGlookoHistory(): Promise<GlookoSyncResult> {
   }
   return response.json();
 }
+
+// ============================================================================
+// Meal management (food records)
+//
+// Wires the existing, owner-scoped, flag-gated food-records API into the web
+// app. Descriptive nutrition observations only -- there is deliberately no
+// dose/insulin field anywhere in these types. The server attaches the cleared
+// safety qualifier as `safety_qualifier`; the web renders that field verbatim
+// rather than re-stating any carb/dosing copy of its own.
+// ============================================================================
+
+/** Record provenance, as the API emits it (snake_case enum value). */
+export type FoodRecordSource =
+  | "ai_estimate"
+  | "user_corrected"
+  | "external_grounded";
+
+/**
+ * Macro nutrition for a meal. Only visually-estimable macros are present; any
+ * subset of the known keys may appear. Carbs are NOT here -- they live in the
+ * dedicated carbs_low/carbs_high columns.
+ */
+export interface FoodRecordNutrition {
+  protein_grams?: number;
+  fat_grams?: number;
+  fiber_grams?: number;
+  calories?: number;
+  [key: string]: number | undefined;
+}
+
+/**
+ * A persisted food record. Mirrors `FoodRecordResponse`
+ * (apps/api/src/schemas/food_record.py). `carbs_low`/`carbs_high` are the
+ * original AI estimate; when corrected, `corrected_carbs_*` carry the user's
+ * values and `source` is `user_corrected`. `confidence` is the EMPIRICAL
+ * dispersion band ("low"|"medium"|"high"), not the model's self-reported
+ * confidence. The create (upload) response additionally carries transient
+ * dispersion detail; reads of an existing record do not, so it is omitted here.
+ */
+export interface FoodRecord {
+  id: string;
+  meal_timestamp: string;
+  food_description: string | null;
+  carbs_low: number;
+  carbs_high: number;
+  confidence: string | null;
+  /** Server-cleared "this is a guess, never dose from it" qualifier. Render verbatim. */
+  safety_qualifier: string;
+  nutrition_json: FoodRecordNutrition | null;
+  source: FoodRecordSource;
+  corrected_carbs_low: number | null;
+  corrected_carbs_high: number | null;
+  corrected_nutrition_json: FoodRecordNutrition | null;
+  corrected_at: string | null;
+  common_food_id: string | null;
+  ai_model: string | null;
+  ai_provider: string | null;
+  confirmed_food_name: string | null;
+  identity_confirmed: boolean;
+  grounding_source: string | null;
+  grounding_source_url: string | null;
+  grounding_trust_tier: string | null;
+  created_at: string;
+}
+
+export interface FoodRecordListResponse {
+  records: FoodRecord[];
+  total: number;
+}
+
+/**
+ * A food-records API failure that preserves the HTTP status and the server's
+ * `detail` string, so callers can map it to the right UX state (feature off,
+ * no provider, vision unavailable, ...) -- mirroring the mobile client's
+ * detail-substring contract. See `classifyMealError` in `@/lib/meal-errors`.
+ */
+export class MealApiError extends Error {
+  readonly status: number;
+  readonly detail: string;
+
+  constructor(status: number, detail: string) {
+    super(detail || `Food-records request failed: ${status}`);
+    this.name = "MealApiError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+/**
+ * Read a FastAPI error envelope's `detail` as a bare string for substring
+ * matching. Tolerates both the common string form and the 422 list-of-objects
+ * form; returns "" when no usable detail is present.
+ *
+ * Distinct from `_readErrorDetail` (above) on purpose: that helper formats a
+ * ready-to-throw Error *message* (folding in a fallback + the status and
+ * JSON-stringifying a non-string detail), whereas the meal path needs the raw
+ * detail string preserved verbatim so callers can substring-match the
+ * cross-client contract (e.g. "not enabled", "vision") and carry the status
+ * separately on `MealApiError`. Keep the two in sync if the envelope changes.
+ */
+async function _readMealDetail(response: Response): Promise<string> {
+  try {
+    const body = await response.json();
+    const detail = (body as { detail?: unknown })?.detail;
+    if (typeof detail === "string") return detail;
+    if (Array.isArray(detail)) {
+      return detail
+        .map((e) =>
+          e && typeof e === "object" && "msg" in e
+            ? String((e as { msg: unknown }).msg)
+            : ""
+        )
+        .filter(Boolean)
+        .join("; ");
+    }
+  } catch {
+    // Non-JSON / empty body.
+  }
+  return "";
+}
+
+async function _throwMealError(response: Response): Promise<never> {
+  throw new MealApiError(response.status, await _readMealDetail(response));
+}
+
+/**
+ * List the current user's food records, most recent meal first.
+ * Owner-scoped + flag-gated server-side; a 404 whose detail says the feature is
+ * "not enabled" means the global flag is off (see `getMealIntelligenceStatus`).
+ */
+export async function listFoodRecords(
+  limit = 50,
+  offset = 0
+): Promise<FoodRecordListResponse> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records?${params.toString()}`
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/** Fetch a single owner-scoped food record (404 for missing or cross-user). */
+export async function getFoodRecord(recordId: string): Promise<FoodRecord> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}`
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/**
+ * Upload a meal photo for AI carb estimation. The caller compresses to a JPEG
+ * blob first (see `@/lib/image-compress`); this mirrors the mobile client's
+ * single-part `file` upload. Returns the persisted record (with the create-time
+ * estimate). Throws `MealApiError` on failure for UX-state mapping.
+ */
+export async function uploadFoodRecord(image: Blob): Promise<FoodRecord> {
+  const formData = new FormData();
+  // Field name `file` and filename `meal.jpg` mirror the mobile multipart part.
+  formData.append("file", image, "meal.jpg");
+  // Do NOT set Content-Type -- the browser sets multipart/form-data + boundary.
+  const response = await apiFetch(`${API_BASE_URL}/api/food-records`, {
+    method: "POST",
+    body: formData,
+  });
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/** Delete a food record and unlink its stored photo (204 No Content). */
+export async function deleteFoodRecord(recordId: string): Promise<void> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}`,
+    { method: "DELETE" }
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+}
+
+/**
+ * Resolve whether meal intelligence is enabled for the current user.
+ *
+ * There is no server flag endpoint: `meal_intelligence_enabled` is a global
+ * deployment flag, and every meal route is hidden behind a 404 when it is off.
+ * So we mirror the mobile cross-client contract and probe the list endpoint: a
+ * 404 whose detail contains "not enabled" means the flag is off; success (or
+ * any transient/other error) is treated as available, so a network blip never
+ * hides a real feature.
+ */
+export async function getMealIntelligenceStatus(): Promise<{ enabled: boolean }> {
+  try {
+    const response = await apiFetch(`${API_BASE_URL}/api/food-records?limit=1`);
+    if (response.status === 404) {
+      const detail = (await _readMealDetail(response)).toLowerCase();
+      if (detail.includes("not enabled")) return { enabled: false };
+    }
+    return { enabled: true };
+  } catch {
+    // Network/other failure: degrade to available, matching the mobile client.
+    return { enabled: true };
+  }
+}

--- a/apps/web/src/lib/image-compress.ts
+++ b/apps/web/src/lib/image-compress.ts
@@ -1,0 +1,90 @@
+/**
+ * Client-side meal-photo compression, mirroring the mobile `ImageCompressor`:
+ * downscale so the longest edge is <= 1280px, re-encode to JPEG, and step the
+ * quality down (90 -> 40) until the result is under the server's 5 MiB cap.
+ *
+ * Re-encoding through a canvas also strips EXIF/GPS metadata (defence in depth
+ * on top of the server's EXIF stripping) while `imageOrientation: "from-image"`
+ * bakes the EXIF rotation into the pixels so the upload is upright.
+ */
+
+const MAX_DIMENSION = 1280;
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MiB -- matches the API's food_image_max_bytes.
+const QUALITY_LADDER = [0.9, 0.8, 0.7, 0.6, 0.5, 0.4];
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+/** A user-actionable failure while preparing a photo for upload. */
+export class ImageCompressionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImageCompressionError";
+  }
+}
+
+/** Fit (w, h) within a square of `max`, preserving aspect ratio. */
+function fitWithin(
+  width: number,
+  height: number,
+  max: number
+): { width: number; height: number } {
+  const longest = Math.max(width, height);
+  if (longest <= max) return { width, height };
+  const scale = max / longest;
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number
+): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, type, quality));
+}
+
+/**
+ * Validate, downscale, and JPEG-compress a picked image to an upload-ready blob.
+ * Throws `ImageCompressionError` with a user-facing message on any failure.
+ */
+export async function compressImageToJpeg(file: File): Promise<Blob> {
+  if (file.type && !ACCEPTED_TYPES.includes(file.type)) {
+    throw new ImageCompressionError("Use a JPEG, PNG, or WebP photo.");
+  }
+
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file, { imageOrientation: "from-image" });
+  } catch {
+    throw new ImageCompressionError("Couldn't read that photo. Try another one.");
+  }
+
+  try {
+    const { width, height } = fitWithin(
+      bitmap.width,
+      bitmap.height,
+      MAX_DIMENSION
+    );
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      throw new ImageCompressionError("Couldn't process that photo.");
+    }
+    ctx.drawImage(bitmap, 0, 0, width, height);
+
+    for (const quality of QUALITY_LADDER) {
+      const blob = await canvasToBlob(canvas, "image/jpeg", quality);
+      if (blob && blob.size <= MAX_BYTES) {
+        return blob;
+      }
+    }
+    throw new ImageCompressionError(
+      "That photo is too large to upload. Try a smaller one."
+    );
+  } finally {
+    bitmap.close?.();
+  }
+}

--- a/apps/web/src/lib/meal-errors.ts
+++ b/apps/web/src/lib/meal-errors.ts
@@ -1,0 +1,168 @@
+/**
+ * Map a food-records API failure to a user-facing UX state.
+ *
+ * Mirrors the mobile client's detail-substring contract (MealRepository.mapError)
+ * so the web surfaces the same distinctions: a missing-provider / vision-
+ * unavailable / feature-off response is a non-retryable "dead end" that points
+ * the user at Settings, while transient failures are retryable. None of these
+ * strings are carb/nutrition descriptive copy -- they steer the user away from
+ * (never toward) acting on a number.
+ */
+
+import { MealApiError } from "./api";
+
+export type MealErrorKind =
+  | "feature_off"
+  | "no_provider"
+  | "vision_unavailable"
+  | "model_not_certified"
+  | "estimate_failed"
+  | "image_too_large"
+  | "unsupported_image"
+  | "rate_limited"
+  | "service_unavailable"
+  | "not_found"
+  | "generic";
+
+export interface MealErrorInfo {
+  kind: MealErrorKind;
+  title: string;
+  message: string;
+  /**
+   * Retryable failures render as a dismissible inline banner; non-retryable
+   * ones (feature off, no provider, vision unavailable) render as a blocking
+   * card that points the user to Settings.
+   */
+  retryable: boolean;
+  /** When set, the card offers a link to this settings route. */
+  settingsHref?: string;
+}
+
+const AI_PROVIDER_HREF = "/dashboard/settings/ai-provider";
+
+export function classifyMealError(err: unknown): MealErrorInfo {
+  if (err instanceof MealApiError) {
+    const { status } = err;
+    const detail = err.detail.toLowerCase();
+
+    if (status === 404) {
+      if (detail.includes("not enabled")) {
+        return {
+          kind: "feature_off",
+          title: "Meal logging isn't turned on",
+          message:
+            "Meal intelligence is turned off for this server. Ask your server admin to enable it.",
+          retryable: false,
+        };
+      }
+      if (detail.includes("ai provider")) {
+        return {
+          kind: "no_provider",
+          title: "No AI provider configured",
+          message:
+            "Set up an AI provider in Settings to estimate carbs from a photo.",
+          retryable: false,
+          settingsHref: AI_PROVIDER_HREF,
+        };
+      }
+      return {
+        kind: "not_found",
+        title: "Meal not found",
+        message: err.detail || "That meal could not be found.",
+        retryable: false,
+      };
+    }
+
+    if (status === 422) {
+      if (detail.includes("vision")) {
+        return {
+          kind: "vision_unavailable",
+          title: "Vision isn't available on your AI provider",
+          message:
+            "Carb estimates from photos need a vision-capable AI provider. Switch to one in Settings, then try again.",
+          retryable: false,
+          settingsHref: AI_PROVIDER_HREF,
+        };
+      }
+      // An unverified local vision model is refused outright (the model is gated
+      // off, so retrying can't succeed). Surface the server's actionable message
+      // and point at Settings rather than implying a clearer photo would help.
+      if (detail.includes("not been verified") || detail.includes("turned off for it")) {
+        return {
+          kind: "model_not_certified",
+          title: "This model can't estimate meal carbs",
+          message:
+            err.detail ||
+            "The configured local AI model isn't verified for meal photos. Switch to a cloud AI provider in Settings.",
+          retryable: false,
+          settingsHref: AI_PROVIDER_HREF,
+        };
+      }
+      // Estimate rejected, out-of-range, etc. -- a different photo may succeed.
+      return {
+        kind: "estimate_failed",
+        title: "Couldn't estimate carbs",
+        message:
+          err.detail ||
+          "We couldn't read a carb estimate from that photo. Try a clearer one.",
+        retryable: true,
+      };
+    }
+
+    if (status === 413) {
+      return {
+        kind: "image_too_large",
+        title: "That photo is too large",
+        message: "Try a smaller photo.",
+        retryable: true,
+      };
+    }
+    if (status === 415) {
+      return {
+        kind: "unsupported_image",
+        title: "Unsupported image type",
+        message: "Use a JPEG, PNG, or WebP photo.",
+        retryable: true,
+      };
+    }
+    if (status === 429) {
+      return {
+        kind: "rate_limited",
+        title: "Too many uploads",
+        message: "You're uploading too fast. Wait a moment and try again.",
+        retryable: true,
+      };
+    }
+    if (status === 502) {
+      return {
+        kind: "service_unavailable",
+        title: "AI vision service unavailable",
+        message:
+          "The AI vision service is temporarily unavailable. Try again shortly.",
+        retryable: true,
+      };
+    }
+    if (status === 400) {
+      return {
+        kind: "estimate_failed",
+        title: "Couldn't estimate carbs",
+        message: "We couldn't process that photo. Try a different one.",
+        retryable: true,
+      };
+    }
+
+    return {
+      kind: "generic",
+      title: "Something went wrong",
+      message: err.detail || "Please try again.",
+      retryable: true,
+    };
+  }
+
+  return {
+    kind: "generic",
+    title: "Something went wrong",
+    message: err instanceof Error ? err.message : "Please try again.",
+    retryable: true,
+  };
+}

--- a/apps/web/src/lib/meal-format.ts
+++ b/apps/web/src/lib/meal-format.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure formatting/derivation helpers for meal (food-record) display.
+ *
+ * Kept free of JSX so they can be unit-tested directly. All carb rendering is
+ * descriptive ("≈ N g carbs") and never a dose -- the server-cleared
+ * `safety_qualifier` field carries the never-dose framing on the surface.
+ */
+
+import type { FoodRecord, FoodRecordNutrition, FoodRecordSource } from "./api";
+
+/** Round to whole grams; avoids false precision on a float estimate. */
+function grams(value: number): string {
+  return String(Math.round(value));
+}
+
+export interface CarbRange {
+  low: number;
+  high: number;
+  /** True when these are the user's corrected values rather than the AI estimate. */
+  corrected: boolean;
+}
+
+/**
+ * The carb band to display: the user's corrected values when both are present,
+ * otherwise the original AI estimate.
+ */
+export function effectiveCarbRange(record: FoodRecord): CarbRange {
+  if (
+    record.corrected_carbs_low != null &&
+    record.corrected_carbs_high != null
+  ) {
+    return {
+      low: record.corrected_carbs_low,
+      high: record.corrected_carbs_high,
+      corrected: true,
+    };
+  }
+  return { low: record.carbs_low, high: record.carbs_high, corrected: false };
+}
+
+/**
+ * Render a carb band as "≈ 40–55 g carbs" (or "≈ 50 g carbs" when the rounded
+ * endpoints coincide). Mirrors the mobile `formatCarbRange`. Carbs only.
+ */
+export function formatCarbRange(low: number, high: number): string {
+  const lo = grams(low);
+  const hi = grams(high);
+  return lo === hi ? `≈ ${lo} g carbs` : `≈ ${lo}–${hi} g carbs`;
+}
+
+/**
+ * Human label for the EMPIRICAL dispersion confidence band. Mirrors the mobile
+ * `confidenceLabel`. Low dispersion is NOT "safe to dose" -- consistency is not
+ * correctness -- so the never-dose qualifier stays dominant regardless of this.
+ */
+export function confidenceLabel(confidence: string | null): string {
+  switch ((confidence ?? "").toLowerCase()) {
+    case "low":
+      return "Low confidence";
+    case "medium":
+      return "Medium confidence";
+    case "high":
+      return "High confidence";
+    default:
+      return "Confidence unavailable";
+  }
+}
+
+export interface SourceMeta {
+  label: string;
+  /** Tailwind background + text classes for the badge (dual light/dark). */
+  bg: string;
+  text: string;
+}
+
+const SOURCE_META: Record<FoodRecordSource, SourceMeta> = {
+  ai_estimate: {
+    label: "AI estimate",
+    bg: "bg-amber-500/15",
+    text: "text-amber-700 dark:text-amber-400",
+  },
+  user_corrected: {
+    label: "You corrected this",
+    bg: "bg-emerald-500/15",
+    text: "text-emerald-700 dark:text-emerald-400",
+  },
+  external_grounded: {
+    label: "Grounded",
+    bg: "bg-blue-500/15",
+    text: "text-blue-700 dark:text-blue-400",
+  },
+};
+
+/** Badge styling/label for a record source; falls back gracefully for unknowns. */
+export function sourceMeta(source: FoodRecordSource | string): SourceMeta {
+  return (
+    SOURCE_META[source as FoodRecordSource] ?? {
+      label: String(source),
+      bg: "bg-slate-500/15",
+      text: "text-slate-600 dark:text-slate-400",
+    }
+  );
+}
+
+/** The display name for a record: confirmed identity, else the AI description. */
+export function mealTitle(record: FoodRecord): string {
+  return (
+    record.confirmed_food_name?.trim() ||
+    record.food_description?.trim() ||
+    "Unidentified meal"
+  );
+}
+
+const MACRO_LABELS: Record<string, string> = {
+  protein_grams: "Protein",
+  fat_grams: "Fat",
+  fiber_grams: "Fiber",
+  calories: "Calories",
+};
+
+export interface MacroEntry {
+  key: string;
+  label: string;
+  value: string;
+}
+
+/**
+ * Normalise a nutrition_json object into labelled, display-ready macro entries.
+ * Known macros are ordered and gram-suffixed; calories are unit-less; unknown
+ * keys are passed through with a humanised label. Read-only -- never a dose.
+ */
+export function macroEntries(
+  nutrition: FoodRecordNutrition | null | undefined
+): MacroEntry[] {
+  if (!nutrition) return [];
+  const ordered = ["protein_grams", "fat_grams", "fiber_grams", "calories"];
+  const keys = [
+    ...ordered.filter((k) => nutrition[k] != null),
+    ...Object.keys(nutrition).filter(
+      (k) => !ordered.includes(k) && nutrition[k] != null
+    ),
+  ];
+  return keys.map((key) => {
+    const raw = nutrition[key] as number;
+    const isCalories = key === "calories";
+    const label =
+      MACRO_LABELS[key] ??
+      // Best-effort label for an unknown key: drop the _grams suffix and
+      // title-case each word ("added_sugar_grams" -> "Added Sugar").
+      key
+        .replace(/_grams$/, "")
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+    const value = isCalories ? String(Math.round(raw)) : `${Math.round(raw)} g`;
+    return { key, label, value };
+  });
+}

--- a/apps/web/src/providers/index.ts
+++ b/apps/web/src/providers/index.ts
@@ -21,4 +21,9 @@ export {
 
 export { UserProvider, useUserContext } from "./user-provider";
 
+export {
+  MealIntelligenceProvider,
+  useMealIntelligenceContext,
+} from "./meal-intelligence-provider";
+
 export { ThemeProvider, useTheme } from "./theme-provider";

--- a/apps/web/src/providers/meal-intelligence-provider.tsx
+++ b/apps/web/src/providers/meal-intelligence-provider.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/**
+ * MealIntelligenceProvider -- shares a single meal-feature availability probe.
+ *
+ * Wraps `useMealIntelligence` in a context so the sidebar (desktop + mobile) and
+ * the meals pages read one probe instead of each firing their own. Modelled on
+ * `user-provider.tsx`: a non-null default + a no-throw hook.
+ */
+
+import { createContext, useContext } from "react";
+import {
+  useMealIntelligence,
+  type UseMealIntelligenceReturn,
+} from "@/hooks/use-meal-intelligence";
+
+const MealIntelligenceContext = createContext<UseMealIntelligenceReturn>({
+  enabled: null,
+  isLoading: true,
+});
+
+export function MealIntelligenceProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const value = useMealIntelligence();
+
+  return (
+    <MealIntelligenceContext.Provider value={value}>
+      {children}
+    </MealIntelligenceContext.Provider>
+  );
+}
+
+export function useMealIntelligenceContext(): UseMealIntelligenceReturn {
+  return useContext(MealIntelligenceContext);
+}


### PR DESCRIPTION
## Summary

First web surface for the meal feature: a flag-gated **Meals** tab with a list, detail view, delete, and photo upload — wiring the existing owner-scoped, flag-gated food-records API into the dashboard. Also adds an owner-scoped endpoint to serve the stored meal photo, and raises the rewrite-proxy timeout so slow vision uploads aren't aborted.

## What's included

- **Flag-gated nav + route** — a Meals item appears only when meal intelligence is enabled (resolved via a probe that mirrors the mobile cross-client contract). When off, the route renders a clear feature-off state, never a raw 404.
- **List** (`/dashboard/meals`) — most-recent-first, paginated; each card shows the photo thumbnail, carb range, the empirical-dispersion confidence band, source badge, identity indicator, and the server-cleared safety qualifier.
- **Detail** (`/dashboard/meals/[id]`) — photo, carb range + confidence, read-only macros, source/model provenance. No dose or insulin element anywhere.
- **Photo upload** — client-side validate/compress (1280px, quality ladder, 5 MiB JPEG — mirrors the mobile client) then multipart POST. Vision-unavailable / no-provider / unverified-local-model responses surface clear dead ends pointing at Settings, never a fabricated estimate.
- **Delete** — native confirm; removes the record and its photo.
- **Photo serving** — new owner-scoped `GET /api/food-records/{id}/photo` (flag-gated, IDOR-safe, serves by record id, path re-confined to the uploads root, content-type from the validated stored extension, PHI-private cache headers). The web renders it via a credentialed blob URL since `next/image` can't carry the auth cookie.
- **Proxy-timeout fix** — `experimental.proxyTimeout: 120000` so a multi-sample vision upload (tens of seconds) isn't aborted by Next's 30s default rewrite-proxy timeout.

## Safety

All carb/nutrition copy is descriptive; the only safety wording is the server `safety_qualifier` field, rendered verbatim. No new dosing-adjacent copy is introduced, and no error path renders a fabricated estimate. Everything is owner-scoped and nothing renders a dose or recommendation.

## Testing

- Web: full Jest suite green (913 tests; new meal + photo coverage). Backend: new photo-endpoint and path-containment tests.
- Lint (`next lint`, `ruff`) and build green. Independent security review of the file-serving surface came back clean (no traversal / IDOR / XSS / unbounded read).
- Validated end-to-end against a real provider: photo upload → AI vision estimate → list and detail rendering the photo, carb range, confidence band, and macros.

## Known limitation

`items` / `assumptions` / `portion` are not shown — the vision parser drops them, so they are not present in any API response.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added meal management UI for uploading, viewing, and deleting meal photos and records.
  * Added Meals navigation to the dashboard, plus new meals list and meal detail pages with carb/confidence and macro display.
  * Introduced meal-intelligence availability detection to dynamically enable or disable the photo experience.
  * Added client-side image compression to optimize uploads.
* **Bug Fixes**
  * Added safer stored-photo serving with ownership checks and correct 404 behavior when photos are missing.
* **Tests**
  * Expanded API and UI test coverage for photo handling, error states, and meal formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->