### PR TITLE
feat: web meal carb correction and food-identity confirmation

### DIFF
--- a/apps/web/__tests__/meals/meal-api.test.ts
+++ b/apps/web/__tests__/meals/meal-api.test.ts
@@ -247,10 +247,13 @@ describe("confirmFoodIdentity", () => {
     global.fetch = jest
       .fn()
       .mockResolvedValue(jsonResponse(404, { detail: "Food record not found." }));
-    const { confirmFoodIdentity } = require("@/lib/api");
+    const { confirmFoodIdentity, MealApiError } = require("@/lib/api");
     await expect(
       confirmFoodIdentity("someone-elses-id", "Pizza")
     ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      confirmFoodIdentity("someone-elses-id", "Pizza")
+    ).rejects.toBeInstanceOf(MealApiError);
   });
 });
 

--- a/apps/web/__tests__/meals/meal-api.test.ts
+++ b/apps/web/__tests__/meals/meal-api.test.ts
@@ -148,6 +148,112 @@ describe("fetchFoodRecordPhotoObjectUrl", () => {
   });
 });
 
+describe("correctFoodRecord", () => {
+  it("POSTs the corrected carb range and returns the refreshed record", async () => {
+    const updated = { id: "rec-1", source: "user_corrected" };
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse(200, updated));
+    global.fetch = mockFetch;
+
+    const { correctFoodRecord } = require("@/lib/api");
+    const result = await correctFoodRecord("rec-1", {
+      corrected_carbs_low: 30,
+      corrected_carbs_high: 40,
+    });
+
+    expect(result).toEqual(updated);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/food-records/rec-1/correct");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual({
+      corrected_carbs_low: 30,
+      corrected_carbs_high: 40,
+    });
+    expect(options.credentials).toBe("include");
+  });
+
+  it("surfaces an out-of-range / inverted 422 as a MealApiError (graceful, GJ2)", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse(422, {
+        detail: "corrected_carbs_low must not exceed corrected_carbs_high",
+      })
+    );
+    const { correctFoodRecord, MealApiError } = require("@/lib/api");
+    await expect(
+      correctFoodRecord("rec-1", {
+        corrected_carbs_low: 50,
+        corrected_carbs_high: 10,
+      })
+    ).rejects.toBeInstanceOf(MealApiError);
+    await expect(
+      correctFoodRecord("rec-1", {
+        corrected_carbs_low: 50,
+        corrected_carbs_high: 10,
+      })
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("rejects a cross-user id with an owner-scoped 404 (IDOR)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Food record not found." }));
+    const { correctFoodRecord, MealApiError } = require("@/lib/api");
+    await expect(
+      correctFoodRecord("someone-elses-id", {
+        corrected_carbs_low: 30,
+        corrected_carbs_high: 40,
+      })
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      correctFoodRecord("someone-elses-id", {
+        corrected_carbs_low: 30,
+        corrected_carbs_high: 40,
+      })
+    ).rejects.toBeInstanceOf(MealApiError);
+  });
+});
+
+describe("confirmFoodIdentity", () => {
+  it("POSTs the confirmed name and returns the refreshed record", async () => {
+    const updated = { id: "rec-1", identity_confirmed: true };
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse(200, updated));
+    global.fetch = mockFetch;
+
+    const { confirmFoodIdentity } = require("@/lib/api");
+    const result = await confirmFoodIdentity("rec-1", "Steel-cut oats");
+
+    expect(result).toEqual(updated);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/food-records/rec-1/confirm-identity");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual({
+      confirmed_food_name: "Steel-cut oats",
+    });
+    expect(options.credentials).toBe("include");
+  });
+
+  it("surfaces a blank/invalid-name 422 as a MealApiError", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(422, { detail: "confirmed_food_name must not be blank" })
+      );
+    const { confirmFoodIdentity, MealApiError } = require("@/lib/api");
+    await expect(confirmFoodIdentity("rec-1", " ")).rejects.toBeInstanceOf(
+      MealApiError
+    );
+  });
+
+  it("rejects a cross-user id with an owner-scoped 404 (IDOR)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Food record not found." }));
+    const { confirmFoodIdentity } = require("@/lib/api");
+    await expect(
+      confirmFoodIdentity("someone-elses-id", "Pizza")
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
 describe("deleteFoodRecord", () => {
   it("issues a DELETE and resolves on 204", async () => {
     const mockFetch = jest

--- a/apps/web/__tests__/meals/meal-detail.test.tsx
+++ b/apps/web/__tests__/meals/meal-detail.test.tsx
@@ -32,11 +32,15 @@ jest.mock("next/navigation", () => ({
 
 const mockGet = jest.fn();
 const mockDelete = jest.fn();
+const mockCorrect = jest.fn();
+const mockConfirm = jest.fn();
 jest.mock("@/lib/api", () => ({
   __esModule: true,
   ...jest.requireActual("@/lib/api"),
   getFoodRecord: (...args: unknown[]) => mockGet(...args),
   deleteFoodRecord: (...args: unknown[]) => mockDelete(...args),
+  correctFoodRecord: (...args: unknown[]) => mockCorrect(...args),
+  confirmFoodIdentity: (...args: unknown[]) => mockConfirm(...args),
   // MealPhoto fetches the photo lazily; default to "no photo" -> placeholder.
   fetchFoodRecordPhotoObjectUrl: jest.fn(() =>
     Promise.reject(new Error("no photo"))
@@ -67,6 +71,7 @@ function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
     ai_provider: "anthropic",
     confirmed_food_name: null,
     identity_confirmed: false,
+    suggested_identity: null,
     grounding_source: null,
     grounding_source_url: null,
     grounding_trust_tier: null,
@@ -101,6 +106,8 @@ describe("Meal detail page", () => {
   beforeEach(() => {
     mockGet.mockReset();
     mockDelete.mockReset();
+    mockCorrect.mockReset();
+    mockConfirm.mockReset();
     mockPush.mockReset();
   });
 
@@ -259,5 +266,216 @@ describe("Meal detail page", () => {
     ).toBeInTheDocument();
     // The record state is cleared, so no stale meal content renders.
     expect(screen.queryByTestId("meal-carb-range")).not.toBeInTheDocument();
+  });
+
+  // --- carb correction ---
+
+  it("corrects the carb range: shows the corrected band, retains the original, flips the source", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    mockCorrect.mockResolvedValue(
+      makeRecord({
+        source: "user_corrected",
+        corrected_carbs_low: 30,
+        corrected_carbs_high: 30,
+        corrected_at: "2026-06-19T13:00:00Z",
+      })
+    );
+    render(<MealDetailPage />);
+
+    fireEvent.click(await screen.findByTestId("meal-correct-button"));
+    // AC2: the editor states the corrected values never feed dosing math.
+    expect(screen.getByTestId("meal-correct-decoupling")).toHaveTextContent(
+      /never fed to IoB, treatment safety, or carb-ratio/i
+    );
+    fireEvent.change(screen.getByTestId("meal-correct-low"), {
+      target: { value: "30" },
+    });
+    fireEvent.change(screen.getByTestId("meal-correct-high"), {
+      target: { value: "30" },
+    });
+    fireEvent.click(screen.getByTestId("meal-correct-save"));
+
+    await waitFor(() =>
+      expect(mockCorrect).toHaveBeenCalledWith("rec-1", {
+        corrected_carbs_low: 30,
+        corrected_carbs_high: 30,
+      })
+    );
+    // Refreshed in place: corrected band shown, source flipped, original retained.
+    expect(await screen.findByTestId("meal-carb-range")).toHaveTextContent(
+      "≈ 30 g carbs"
+    );
+    expect(screen.getByTestId("meal-source-badge")).toHaveTextContent(
+      "You corrected this"
+    );
+    expect(screen.getByText(/AI estimated/)).toHaveTextContent(
+      "≈ 40–55 g carbs"
+    );
+    // Two distinct actions: correcting carbs never confirms identity.
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it("rejects an inverted correction client-side, without any network call", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    render(<MealDetailPage />);
+
+    fireEvent.click(await screen.findByTestId("meal-correct-button"));
+    fireEvent.change(screen.getByTestId("meal-correct-low"), {
+      target: { value: "50" },
+    });
+    fireEvent.change(screen.getByTestId("meal-correct-high"), {
+      target: { value: "10" },
+    });
+    fireEvent.click(screen.getByTestId("meal-correct-save"));
+
+    expect(await screen.findByTestId("meal-correct-error")).toHaveTextContent(
+      /low value must not exceed/i
+    );
+    expect(mockCorrect).not.toHaveBeenCalled();
+  });
+
+  it("handles a server-side out-of-range 422 gracefully and does not mutate the record", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    mockCorrect.mockRejectedValue(
+      new MealApiError(422, "carbohydrate bound above 1000 g")
+    );
+    render(<MealDetailPage />);
+
+    fireEvent.click(await screen.findByTestId("meal-correct-button"));
+    fireEvent.change(screen.getByTestId("meal-correct-low"), {
+      target: { value: "30" },
+    });
+    fireEvent.change(screen.getByTestId("meal-correct-high"), {
+      target: { value: "40" },
+    });
+    fireEvent.click(screen.getByTestId("meal-correct-save"));
+
+    expect(await screen.findByTestId("meal-correct-error")).toHaveTextContent(
+      /between 0 and 1000/i
+    );
+    // A rejected correction never mutates the displayed estimate or its source.
+    expect(screen.getByTestId("meal-carb-range")).toHaveTextContent(
+      "≈ 40–55 g carbs"
+    );
+    expect(screen.getByTestId("meal-source-badge")).toHaveTextContent(
+      "AI estimate"
+    );
+  });
+
+  it("surfaces a 404 (deleted / cross-user) on correction without mutating the record (IDOR)", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    mockCorrect.mockRejectedValue(new MealApiError(404, "Food record not found."));
+    render(<MealDetailPage />);
+
+    fireEvent.click(await screen.findByTestId("meal-correct-button"));
+    fireEvent.change(screen.getByTestId("meal-correct-low"), {
+      target: { value: "30" },
+    });
+    fireEvent.change(screen.getByTestId("meal-correct-high"), {
+      target: { value: "40" },
+    });
+    fireEvent.click(screen.getByTestId("meal-correct-save"));
+
+    expect(await screen.findByTestId("meal-correct-error")).toHaveTextContent(
+      /no longer exists/i
+    );
+    expect(screen.getByTestId("meal-carb-range")).toHaveTextContent(
+      "≈ 40–55 g carbs"
+    );
+  });
+
+  // --- identity confirmation + grounding gate ---
+
+  it("keeps an unconfirmed record vision-only with no authoritative citation", async () => {
+    mockGet.mockResolvedValue(
+      makeRecord({ identity_confirmed: false, grounding_source: null })
+    );
+    render(<MealDetailPage />);
+
+    expect(
+      await screen.findByTestId("meal-grounding-vision-only")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meal-grounding-grounded")
+    ).not.toBeInTheDocument();
+    // Confirm-identity and correct-carbs are two distinct actions on the surface.
+    expect(screen.getByTestId("meal-identity-confirm")).toBeInTheDocument();
+    expect(screen.getByTestId("meal-correct-button")).toBeInTheDocument();
+  });
+
+  it("confirm-identity opens grounding: vision-only before, attribution after", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    mockConfirm.mockResolvedValue(
+      makeRecord({
+        identity_confirmed: true,
+        confirmed_food_name: "Bowl of oatmeal",
+        source: "external_grounded",
+        grounding_source: "USDA FoodData Central",
+        grounding_source_url: "https://fdc.nal.usda.gov/",
+        grounding_trust_tier: "AUTHORITATIVE",
+      })
+    );
+    render(<MealDetailPage />);
+
+    // Before: vision-only, no authoritative citation.
+    expect(
+      await screen.findByTestId("meal-grounding-vision-only")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meal-grounding-grounded")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("meal-identity-confirm"));
+
+    await waitFor(() =>
+      expect(mockConfirm).toHaveBeenCalledWith("rec-1", "Bowl of oatmeal")
+    );
+    // After: refreshes to show the grounding attribution + a safe outbound link.
+    expect(
+      await screen.findByTestId("meal-grounding-grounded")
+    ).toHaveTextContent("USDA FoodData Central");
+    const link = screen.getByTestId("meal-grounding-link");
+    expect(link).toHaveAttribute("href", "https://fdc.nal.usda.gov/");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(
+      screen.queryByTestId("meal-grounding-vision-only")
+    ).not.toBeInTheDocument();
+    // Two distinct actions: confirming identity never corrects carbs.
+    expect(mockCorrect).not.toHaveBeenCalled();
+  });
+
+  it("corrects the identity to a different name via the editor", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    mockConfirm.mockResolvedValue(
+      makeRecord({ identity_confirmed: true, confirmed_food_name: "Steel-cut oats" })
+    );
+    render(<MealDetailPage />);
+
+    fireEvent.click(await screen.findByTestId("meal-identity-correct"));
+    fireEvent.change(screen.getByTestId("meal-identity-input"), {
+      target: { value: "Steel-cut oats" },
+    });
+    fireEvent.click(screen.getByTestId("meal-identity-save"));
+
+    await waitFor(() =>
+      expect(mockConfirm).toHaveBeenCalledWith("rec-1", "Steel-cut oats")
+    );
+  });
+
+  it("pre-fills and surfaces an own-history suggested identity", async () => {
+    mockGet.mockResolvedValue(makeRecord({ suggested_identity: "Saved oatmeal" }));
+    mockConfirm.mockResolvedValue(
+      makeRecord({ identity_confirmed: true, confirmed_food_name: "Saved oatmeal" })
+    );
+    render(<MealDetailPage />);
+
+    expect(await screen.findByTestId("meal-identity-prompt")).toHaveTextContent(
+      /Saved oatmeal/
+    );
+    fireEvent.click(screen.getByTestId("meal-identity-confirm"));
+    await waitFor(() =>
+      expect(mockConfirm).toHaveBeenCalledWith("rec-1", "Saved oatmeal")
+    );
   });
 });

--- a/apps/web/__tests__/meals/meal-format.test.ts
+++ b/apps/web/__tests__/meals/meal-format.test.ts
@@ -235,14 +235,34 @@ describe("prefillIdentity", () => {
 
 describe("isGrounded", () => {
   it("is false for a vision-only record (no grounding source)", () => {
-    expect(isGrounded(makeRecord({ grounding_source: null }))).toBe(false);
-    expect(isGrounded(makeRecord({ grounding_source: "  " }))).toBe(false);
+    expect(
+      isGrounded(makeRecord({ identity_confirmed: true, grounding_source: null }))
+    ).toBe(false);
+    expect(
+      isGrounded(makeRecord({ identity_confirmed: true, grounding_source: "  " }))
+    ).toBe(false);
   });
 
-  it("is true once an external source has grounded it", () => {
+  it("is true once a confirmed identity has been grounded by an external source", () => {
     expect(
-      isGrounded(makeRecord({ grounding_source: "USDA FoodData Central" }))
+      isGrounded(
+        makeRecord({
+          identity_confirmed: true,
+          grounding_source: "USDA FoodData Central",
+        })
+      )
     ).toBe(true);
+  });
+
+  it("requires identity confirmation: a stale source without confirmation is not grounded", () => {
+    expect(
+      isGrounded(
+        makeRecord({
+          identity_confirmed: false,
+          grounding_source: "USDA FoodData Central",
+        })
+      )
+    ).toBe(false);
   });
 });
 

--- a/apps/web/__tests__/meals/meal-format.test.ts
+++ b/apps/web/__tests__/meals/meal-format.test.ts
@@ -10,6 +10,10 @@ import {
   mealTitle,
   formatMacroValue,
   formatNetCarbs,
+  parseCarbInputs,
+  validateCarbBounds,
+  prefillIdentity,
+  isGrounded,
 } from "@/lib/meal-format";
 import type { FoodRecord } from "@/lib/api";
 
@@ -33,6 +37,7 @@ function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
     ai_provider: null,
     confirmed_food_name: null,
     identity_confirmed: false,
+    suggested_identity: null,
     assumptions: null,
     grounding_source: null,
     grounding_source_url: null,
@@ -137,5 +142,105 @@ describe("formatNetCarbs", () => {
 
   it("collapses to a single value when the rounded endpoints coincide", () => {
     expect(formatNetCarbs(26, 26)).toBe("≈ 26 g");
+  });
+});
+
+describe("validateCarbBounds", () => {
+  it("accepts an in-range, well-ordered band", () => {
+    expect(validateCarbBounds(30, 45)).toBeNull();
+    expect(validateCarbBounds(0, 1000)).toBeNull();
+  });
+
+  it("rejects an inverted band", () => {
+    expect(validateCarbBounds(50, 10)).toMatch(/low value must not exceed/i);
+  });
+
+  it("rejects negative and over-cap values", () => {
+    expect(validateCarbBounds(-1, 10)).toMatch(/can't be negative/i);
+    expect(validateCarbBounds(10, 1001)).toMatch(/can't exceed 1000/i);
+  });
+
+  it("rejects NaN input", () => {
+    expect(validateCarbBounds(NaN, 10)).toMatch(/enter a number/i);
+  });
+});
+
+describe("parseCarbInputs", () => {
+  it("parses two numeric strings into an ordered range", () => {
+    expect(parseCarbInputs("30", "45")).toEqual({ ok: true, low: 30, high: 45 });
+  });
+
+  it("rejects blank input before any network call", () => {
+    expect(parseCarbInputs("", "45")).toEqual({
+      ok: false,
+      reason: "Enter both carb values in grams.",
+    });
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(parseCarbInputs("abc", "45")).toMatchObject({ ok: false });
+  });
+
+  it("rejects an inverted range with the shared bounds copy", () => {
+    expect(parseCarbInputs("50", "10")).toMatchObject({
+      ok: false,
+      reason: expect.stringMatching(/low value must not exceed/i),
+    });
+  });
+});
+
+describe("prefillIdentity", () => {
+  it("prefers a fresh own-history suggestion", () => {
+    expect(
+      prefillIdentity(
+        makeRecord({
+          suggested_identity: "Saved oatmeal",
+          confirmed_food_name: "Confirmed thing",
+          food_description: "AI desc",
+        })
+      )
+    ).toBe("Saved oatmeal");
+  });
+
+  it("falls back to the confirmed name, then the AI description", () => {
+    expect(
+      prefillIdentity(
+        makeRecord({ suggested_identity: null, confirmed_food_name: "Confirmed thing" })
+      )
+    ).toBe("Confirmed thing");
+    expect(
+      prefillIdentity(
+        makeRecord({
+          suggested_identity: null,
+          confirmed_food_name: null,
+          food_description: "AI desc",
+        })
+      )
+    ).toBe("AI desc");
+  });
+
+  it("is empty when nothing is known", () => {
+    expect(
+      prefillIdentity(
+        makeRecord({
+          suggested_identity: null,
+          confirmed_food_name: null,
+          food_description: null,
+        })
+      )
+    ).toBe("");
+  });
+});
+
+describe("isGrounded", () => {
+  it("is false for a vision-only record (no grounding source)", () => {
+    expect(isGrounded(makeRecord({ grounding_source: null }))).toBe(false);
+    expect(isGrounded(makeRecord({ grounding_source: "  " }))).toBe(false);
+  });
+
+  it("is true once an external source has grounded it", () => {
+    expect(
+      isGrounded(makeRecord({ grounding_source: "USDA FoodData Central" }))
+    ).toBe(true);
   });
 });

--- a/apps/web/__tests__/meals/meal-format.test.ts
+++ b/apps/web/__tests__/meals/meal-format.test.ts
@@ -14,6 +14,7 @@ import {
   validateCarbBounds,
   prefillIdentity,
   isGrounded,
+  isSafeHttpUrl,
 } from "@/lib/meal-format";
 import type { FoodRecord } from "@/lib/api";
 
@@ -242,5 +243,20 @@ describe("isGrounded", () => {
     expect(
       isGrounded(makeRecord({ grounding_source: "USDA FoodData Central" }))
     ).toBe(true);
+  });
+});
+
+describe("isSafeHttpUrl", () => {
+  it("accepts http(s) URLs", () => {
+    expect(isSafeHttpUrl("https://fdc.nal.usda.gov/")).toBe(true);
+    expect(isSafeHttpUrl("http://example.com")).toBe(true);
+  });
+
+  it("rejects non-http schemes and junk", () => {
+    expect(isSafeHttpUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeHttpUrl("data:text/html,<script>")).toBe(false);
+    expect(isSafeHttpUrl("not a url")).toBe(false);
+    expect(isSafeHttpUrl(null)).toBe(false);
+    expect(isSafeHttpUrl("")).toBe(false);
   });
 });

--- a/apps/web/__tests__/meals/meals-page.test.tsx
+++ b/apps/web/__tests__/meals/meals-page.test.tsx
@@ -61,6 +61,7 @@ function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
     ai_provider: null,
     confirmed_food_name: null,
     identity_confirmed: false,
+    suggested_identity: null,
     grounding_source: null,
     grounding_source_url: null,
     grounding_trust_tier: null,

--- a/apps/web/src/app/dashboard/meals/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/meals/[id]/page.tsx
@@ -32,11 +32,16 @@ import {
   SourceBadge,
   IdentityConfirmedBadge,
   MealSafetyQualifier,
+  MealGroundingStatus,
   MealAssumedPortion,
   MealNutritionFacts,
   MealNutritionDisclaimer,
   MealErrorPanel,
 } from "@/components/meals/meal-ui";
+import {
+  MealCorrectionSection,
+  MealIdentitySection,
+} from "@/components/meals/meal-edit";
 
 function BackLink() {
   return (
@@ -116,6 +121,20 @@ export default function MealDetailPage() {
       setDeleting(false);
     }
   }, [record, deleting, router]);
+
+  // A correction / identity-confirmation returns the refreshed record; swap it in
+  // so the carb band, source badge, and grounding attribution re-render in place.
+  // Guard on the route id: this route segment re-runs its loader on navigation
+  // without remounting, so a response that resolves after the user moved to a
+  // different meal must not overwrite the now-active record with stale data.
+  const handleUpdated = useCallback(
+    (updated: FoodRecord) => {
+      if (updated.id !== id) return;
+      setRecord(updated);
+      setError(null);
+    },
+    [id]
+  );
 
   if (loading) {
     return (
@@ -228,17 +247,32 @@ export default function MealDetailPage() {
             )}
 
             <MealSafetyQualifier qualifier={record.safety_qualifier} />
+            <MealGroundingStatus record={record} />
+            <MealCorrectionSection record={record} onUpdated={handleUpdated} />
+          </div>
+        </AnimatedCard>
+
+        {/* Confirming/correcting *what the food is* is a distinct action from
+            carb correction (the Story 50.H2 split between fixing carbs and
+            confirming identity): it is what opens external authoritative
+            grounding, so a misidentification is never certified. */}
+        <AnimatedCard delay={0.05}>
+          <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 space-y-3">
+            <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+              What is this?
+            </h2>
+            <MealIdentitySection record={record} onUpdated={handleUpdated} />
           </div>
         </AnimatedCard>
 
         {facts?.portion && (
-          <AnimatedCard delay={0.05}>
+          <AnimatedCard delay={0.1}>
             <MealAssumedPortion portion={facts.portion} />
           </AnimatedCard>
         )}
 
         {hasNutrition && facts && (
-          <AnimatedCard delay={0.1}>
+          <AnimatedCard delay={0.15}>
             <MealNutritionFacts facts={facts} />
           </AnimatedCard>
         )}

--- a/apps/web/src/components/meals/meal-edit.tsx
+++ b/apps/web/src/components/meals/meal-edit.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+/**
+ * Interactive meal-correction surfaces for the detail view, bringing the web app
+ * to mobile parity with the two things a user does when the AI is wrong:
+ *
+ *  - {@link MealCorrectionSection} corrects the carb *range*.
+ *  - {@link MealIdentitySection} confirms/corrects *what the food is*.
+ *
+ * These are deliberately TWO separate actions (the Story 50.H2 split between
+ * fixing carbs and confirming identity): correcting carbs never touches identity,
+ * and confirming identity is what opens external grounding. Both fix a
+ * description of the food, never a dose -- the corrected values are never fed to
+ * IoB / treatment_safety / carb-ratio math, and the never-dose framing is the
+ * server-cleared `safety_qualifier`, rendered verbatim.
+ */
+
+import { useCallback, useId, useState } from "react";
+import { Check, Loader2, Pencil, X } from "lucide-react";
+import {
+  confirmFoodIdentity,
+  correctFoodRecord,
+  MealApiError,
+  type FoodRecord,
+} from "@/lib/api";
+import {
+  CARB_GRAMS_MAX,
+  CARB_GRAMS_MIN,
+  effectiveCarbRange,
+  parseCarbInputs,
+  prefillIdentity,
+} from "@/lib/meal-format";
+import { MealSafetyQualifier } from "@/components/meals/meal-ui";
+
+/**
+ * The shared explainer that confirming a food's identity opens external
+ * grounding. Rendered identically by the prompt and the editor, so it lives in
+ * one place rather than being copy-pasted across the two branches.
+ */
+function IdentityGroundingExplainer() {
+  return (
+    <p
+      data-testid="meal-identity-grounding-explainer"
+      className="text-xs text-slate-500 dark:text-slate-400"
+    >
+      Confirming opens a lookup against authoritative nutrition data (USDA, Open
+      Food Facts, or a restaurant’s published facts).
+    </p>
+  );
+}
+
+/** Map a correction failure to friendly copy; surfaces the server detail otherwise. */
+function describeCorrectionError(err: unknown): string {
+  if (err instanceof MealApiError) {
+    if (err.status === 404) return "This meal no longer exists.";
+    const detail = err.detail.toLowerCase();
+    if (detail.includes("exceed")) {
+      return "The low value must not exceed the high value.";
+    }
+    if (
+      detail.includes("less than or equal") ||
+      detail.includes("greater than or equal") ||
+      detail.includes("bound above") ||
+      detail.includes("bound below") ||
+      detail.includes("range")
+    ) {
+      return "Enter carb values between 0 and 1000 grams.";
+    }
+    return err.detail || "Couldn't save that correction. Try again.";
+  }
+  return "Couldn't save that correction. Try again.";
+}
+
+/** Map an identity failure to friendly copy; surfaces the server detail otherwise. */
+function describeIdentityError(err: unknown): string {
+  if (err instanceof MealApiError) {
+    if (err.status === 404) return "This meal no longer exists.";
+    return err.detail || "Couldn't confirm that. Try again.";
+  }
+  return "Couldn't confirm that. Try again.";
+}
+
+interface SectionProps {
+  record: FoodRecord;
+  /** Called with the refreshed record so the detail view re-renders in place. */
+  onUpdated: (record: FoodRecord) => void;
+}
+
+/**
+ * Correct the carb range. Closed, it is a single "Correct carbs" button; open,
+ * it is a low/high editor seeded from the current range. States plainly that the
+ * correction never feeds dosing math and carries the server never-dose qualifier.
+ */
+export function MealCorrectionSection({ record, onUpdated }: SectionProps) {
+  const range = effectiveCarbRange(record);
+  const [editing, setEditing] = useState(false);
+  const [low, setLow] = useState("");
+  const [high, setHigh] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const errorId = useId();
+
+  const open = useCallback(() => {
+    // Seed from the currently-displayed range so a small fix is a couple of taps.
+    setLow(String(Math.round(range.low)));
+    setHigh(String(Math.round(range.high)));
+    setError(null);
+    setEditing(true);
+  }, [range.low, range.high]);
+
+  const cancel = useCallback(() => {
+    setEditing(false);
+    setError(null);
+  }, []);
+
+  const submit = useCallback(async () => {
+    const parsed = parseCarbInputs(low, high);
+    if (!parsed.ok) {
+      setError(parsed.reason);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await correctFoodRecord(record.id, {
+        corrected_carbs_low: parsed.low,
+        corrected_carbs_high: parsed.high,
+      });
+      onUpdated(updated);
+      setEditing(false);
+    } catch (err) {
+      setError(describeCorrectionError(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [low, high, record.id, onUpdated]);
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={open}
+        data-testid="meal-correct-button"
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+      >
+        <Pencil className="h-4 w-4" />
+        Correct carbs
+      </button>
+    );
+  }
+
+  return (
+    <div
+      data-testid="meal-correction-editor"
+      className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/40 p-5 space-y-4"
+    >
+      <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+        Correct the carb estimate (grams)
+      </h2>
+      <div className="flex gap-3">
+        <label className="flex-1 text-xs text-slate-500 dark:text-slate-400">
+          Low (g)
+          <input
+            type="number"
+            inputMode="numeric"
+            min={CARB_GRAMS_MIN}
+            max={CARB_GRAMS_MAX}
+            value={low}
+            onChange={(e) => setLow(e.target.value)}
+            data-testid="meal-correct-low"
+            aria-invalid={!!error}
+            aria-describedby={error ? errorId : undefined}
+            className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
+          />
+        </label>
+        <label className="flex-1 text-xs text-slate-500 dark:text-slate-400">
+          High (g)
+          <input
+            type="number"
+            inputMode="numeric"
+            min={CARB_GRAMS_MIN}
+            max={CARB_GRAMS_MAX}
+            value={high}
+            onChange={(e) => setHigh(e.target.value)}
+            data-testid="meal-correct-high"
+            aria-invalid={!!error}
+            aria-describedby={error ? errorId : undefined}
+            className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
+          />
+        </label>
+      </div>
+
+      {/* AC2: corrected values fix the record only -- they are decoupled from all
+          dosing math, and the never-dose framing is the server-cleared qualifier. */}
+      <p
+        data-testid="meal-correct-decoupling"
+        className="text-xs text-slate-500 dark:text-slate-400"
+      >
+        Correcting only updates this record — corrected values are never fed to
+        IoB, treatment safety, or carb-ratio math.
+      </p>
+      <MealSafetyQualifier qualifier={record.safety_qualifier} />
+
+      {error && (
+        <p
+          role="alert"
+          id={errorId}
+          data-testid="meal-correct-error"
+          className="text-xs text-red-600 dark:text-red-400"
+        >
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={cancel}
+          disabled={saving}
+          data-testid="meal-correct-cancel"
+          className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={saving}
+          data-testid="meal-correct-save"
+          className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors"
+        >
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Confirm or correct what the food is. Distinct from carb correction: this is
+ * what opens external authoritative grounding (USDA / Open Food Facts /
+ * restaurant facts) server-side, so a confident misidentification is never
+ * certified with a citation. An own-history suggestion (when present) pre-fills
+ * a one-click confirm.
+ */
+export function MealIdentitySection({ record, onUpdated }: SectionProps) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const errorId = useId();
+
+  const candidate = prefillIdentity(record);
+
+  const openEditor = useCallback(() => {
+    setName(candidate);
+    setError(null);
+    setEditing(true);
+  }, [candidate]);
+
+  const cancelEditor = useCallback(() => {
+    setEditing(false);
+    setError(null);
+  }, []);
+
+  const submit = useCallback(
+    async (value: string) => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        setError("Tell us what this food is.");
+        return;
+      }
+      setSaving(true);
+      setError(null);
+      try {
+        const updated = await confirmFoodIdentity(record.id, trimmed);
+        onUpdated(updated);
+        setEditing(false);
+      } catch (err) {
+        setError(describeIdentityError(err));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [record.id, onUpdated]
+  );
+
+  // Editing the free-text name (used for both "Correct" and "Change what this is").
+  if (editing) {
+    return (
+      <div
+        data-testid="meal-identity-editor"
+        className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/40 p-5 space-y-4"
+      >
+        <label className="block text-xs text-slate-500 dark:text-slate-400">
+          Food name
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            data-testid="meal-identity-input"
+            aria-invalid={!!error}
+            aria-describedby={error ? errorId : undefined}
+            className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
+          />
+        </label>
+        <IdentityGroundingExplainer />
+        {error && (
+          <p
+            role="alert"
+            id={errorId}
+            data-testid="meal-identity-error"
+            className="text-xs text-red-600 dark:text-red-400"
+          >
+            {error}
+          </p>
+        )}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={cancelEditor}
+            disabled={saving}
+            data-testid="meal-identity-cancel"
+            className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => submit(name)}
+            disabled={saving || !name.trim()}
+            data-testid="meal-identity-save"
+            className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            {saving ? "Confirming…" : "Confirm"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Already confirmed: let the user change what it is (which re-opens grounding).
+  if (record.identity_confirmed) {
+    return (
+      <div className="space-y-2">
+        <p
+          data-testid="meal-identity-confirmed-note"
+          className="text-sm text-slate-600 dark:text-slate-300"
+        >
+          <Check className="inline h-4 w-4 text-emerald-600 dark:text-emerald-400" />{" "}
+          You confirmed this food.
+        </p>
+        <button
+          type="button"
+          onClick={openEditor}
+          data-testid="meal-identity-change"
+          className="inline-flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          <Pencil className="h-4 w-4" />
+          Change what this is
+        </button>
+      </div>
+    );
+  }
+
+  // Not yet confirmed: prompt to confirm (opens grounding) or correct the name.
+  return (
+    <div
+      data-testid="meal-identity-prompt"
+      className="rounded-xl border border-blue-500/30 bg-blue-500/5 dark:bg-blue-500/10 p-5 space-y-3"
+    >
+      <p className="text-sm text-slate-900 dark:text-white">
+        {record.suggested_identity ? (
+          <>
+            Looks like your saved “{record.suggested_identity}” — confirm?
+          </>
+        ) : (
+          <>Confirm what this food is so we can ground it against real nutrition data.</>
+        )}
+      </p>
+      <IdentityGroundingExplainer />
+      {error && (
+        <p
+          role="alert"
+          id={errorId}
+          data-testid="meal-identity-error"
+          className="text-xs text-red-600 dark:text-red-400"
+        >
+          {error}
+        </p>
+      )}
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={() => submit(candidate)}
+          disabled={saving || !candidate}
+          data-testid="meal-identity-confirm"
+          className="inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors"
+        >
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          {saving ? "Confirming…" : "Confirm"}
+        </button>
+        <button
+          type="button"
+          onClick={openEditor}
+          disabled={saving}
+          data-testid="meal-identity-correct"
+          className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 transition-colors"
+        >
+          <X className="h-4 w-4" />
+          That’s not it
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/meals/meal-ui.tsx
+++ b/apps/web/src/components/meals/meal-ui.tsx
@@ -8,13 +8,21 @@
 import Link from "next/link";
 import {
   AlertTriangle,
+  BadgeCheck,
   CheckCircle2,
+  ExternalLink,
   ImageOff,
+  ScanLine,
   Settings as SettingsIcon,
   X,
 } from "lucide-react";
-import { formatMacroValue, formatNetCarbs, sourceMeta } from "@/lib/meal-format";
-import type { FoodRecordSource, NutritionFacts } from "@/lib/api";
+import {
+  formatMacroValue,
+  formatNetCarbs,
+  isGrounded,
+  sourceMeta,
+} from "@/lib/meal-format";
+import type { FoodRecord, FoodRecordSource, NutritionFacts } from "@/lib/api";
 import type { MealErrorInfo } from "@/lib/meal-errors";
 
 /** Provenance badge (AI estimate / corrected / grounded). */
@@ -178,6 +186,75 @@ export function MealNutritionDisclaimer({ disclaimer }: { disclaimer: string }) 
     >
       {disclaimer}
     </p>
+  );
+}
+
+/**
+ * Grounding status for the carb estimate (Story 50.H2/E1). Confirming the food's
+ * identity opens the grounding gate, so an unconfirmed record is "vision-only --
+ * not checked against an external source"; once a source grounds it, the
+ * attribution (and an optional outbound link) is shown. Descriptive provenance
+ * only -- nothing here is a dose.
+ */
+export function MealGroundingStatus({ record }: { record: FoodRecord }) {
+  if (isGrounded(record)) {
+    return (
+      <div
+        role="note"
+        data-testid="meal-grounding-grounded"
+        className="flex items-start gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 dark:bg-blue-500/10 px-3 py-2 text-xs text-slate-600 dark:text-slate-300"
+      >
+        <BadgeCheck className="h-4 w-4 flex-shrink-0 mt-0.5 text-blue-600 dark:text-blue-400" />
+        <span>
+          Grounded against{" "}
+          <span className="font-medium text-slate-900 dark:text-white">
+            {record.grounding_source}
+          </span>
+          {record.grounding_source_url && (
+            <>
+              {" "}
+              <a
+                href={record.grounding_source_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid="meal-grounding-link"
+                className="inline-flex items-center gap-0.5 text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                source
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </>
+          )}
+          .
+        </span>
+      </div>
+    );
+  }
+
+  // Not grounded: be precise about *why*, since provenance accuracy is the whole
+  // point of the grounding gate. A corrected band is the user's own number; a
+  // confirmed-but-unmatched record was checked and nothing authoritative matched;
+  // otherwise it is a pure vision estimate that hasn't been checked at all.
+  let copy: string;
+  if (record.source === "user_corrected") {
+    copy =
+      "Your corrected estimate — not checked against an external nutrition source.";
+  } else if (record.identity_confirmed) {
+    copy =
+      "Confirmed, but no authoritative nutrition source matched this food.";
+  } else {
+    copy =
+      "Vision-only — this estimate hasn’t been checked against an external nutrition source.";
+  }
+  return (
+    <div
+      role="note"
+      data-testid="meal-grounding-vision-only"
+      className="flex items-start gap-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 px-3 py-2 text-xs text-slate-500 dark:text-slate-400"
+    >
+      <ScanLine className="h-4 w-4 flex-shrink-0 mt-0.5" />
+      <span>{copy}</span>
+    </div>
   );
 }
 

--- a/apps/web/src/components/meals/meal-ui.tsx
+++ b/apps/web/src/components/meals/meal-ui.tsx
@@ -20,6 +20,7 @@ import {
   formatMacroValue,
   formatNetCarbs,
   isGrounded,
+  isSafeHttpUrl,
   sourceMeta,
 } from "@/lib/meal-format";
 import type { FoodRecord, FoodRecordSource, NutritionFacts } from "@/lib/api";
@@ -210,14 +211,15 @@ export function MealGroundingStatus({ record }: { record: FoodRecord }) {
           <span className="font-medium text-slate-900 dark:text-white">
             {record.grounding_source}
           </span>
-          {record.grounding_source_url && (
+          {isSafeHttpUrl(record.grounding_source_url) && (
             <>
               {" "}
               <a
-                href={record.grounding_source_url}
+                href={record.grounding_source_url!}
                 target="_blank"
                 rel="noopener noreferrer"
                 data-testid="meal-grounding-link"
+                aria-label={`View ${record.grounding_source} source (opens in a new window)`}
                 className="inline-flex items-center gap-0.5 text-blue-600 dark:text-blue-400 hover:underline"
               >
                 source

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4248,6 +4248,12 @@ export interface FoodRecord {
   ai_provider: string | null;
   confirmed_food_name: string | null;
   identity_confirmed: boolean;
+  /**
+   * Transient create-time own-history pre-fill ("looks like your saved X"); the
+   * server emits it on the upload response and it is absent (null) on later reads
+   * of a persisted record. Used to pre-fill the identity-confirmation input.
+   */
+  suggested_identity: string | null;
   grounding_source: string | null;
   grounding_source_url: string | null;
   grounding_trust_tier: string | null;
@@ -4385,6 +4391,59 @@ export async function uploadFoodRecord(image: Blob): Promise<FoodRecord> {
     method: "POST",
     body: formData,
   });
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/**
+ * Correct a food record's carb range (Story 50.C). Fixes a *description of the
+ * food*, never a dose: the corrected values land in the record's correction
+ * columns and provenance flips to `user_corrected`; the original AI estimate is
+ * preserved, and corrected values are never read by IoB / treatment_safety /
+ * carb-ratio math. Returns the refreshed record. Throws `MealApiError` (404 for
+ * a missing/cross-user id, 422 for out-of-range/inverted) for UX-state mapping.
+ */
+export async function correctFoodRecord(
+  recordId: string,
+  correction: { corrected_carbs_low: number; corrected_carbs_high: number }
+): Promise<FoodRecord> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}/correct`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(correction),
+    }
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/**
+ * Confirm or correct *what the food is* (Story 50.H2) -- a distinct action from
+ * carb correction. The confirmed name opens the grounding gate: only now does
+ * the server look up external authoritative nutrition (USDA / Open Food Facts;
+ * restaurant facts) keyed on the confirmed name, so a misidentified label is
+ * never certified with a citation. Returns the refreshed record (which may now
+ * carry grounding attribution). Throws `MealApiError` (404 missing/cross-user,
+ * 422 blank/oversized name) for UX-state mapping.
+ */
+export async function confirmFoodIdentity(
+  recordId: string,
+  confirmedFoodName: string
+): Promise<FoodRecord> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}/confirm-identity`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ confirmed_food_name: confirmedFoodName }),
+    }
+  );
   if (!response.ok) {
     await _throwMealError(response);
   }

--- a/apps/web/src/lib/meal-format.ts
+++ b/apps/web/src/lib/meal-format.ts
@@ -127,3 +127,80 @@ export function formatNetCarbs(low: number, high: number): string {
   const hi = grams(high);
   return lo === hi ? `≈ ${lo} g` : `≈ ${lo}–${hi} g`;
 }
+
+/**
+ * Carb-correction input bounds, identical to the server's reject-not-clamp range
+ * (`CARB_GRAMS_MIN`/`CARB_GRAMS_MAX`) and the mobile `CarbBounds`. These describe
+ * food, never a dose; a client-side check just spares an obvious round-trip, the
+ * server re-validates regardless.
+ */
+export const CARB_GRAMS_MIN = 0;
+export const CARB_GRAMS_MAX = 1000;
+
+export type CarbInputResult =
+  | { ok: true; low: number; high: number }
+  | { ok: false; reason: string };
+
+/**
+ * Return a human-readable reason a low/high carb range is invalid, or null when
+ * it is acceptable. Copy mirrors the mobile `CarbBounds.validate` so the two
+ * clients never drift.
+ */
+export function validateCarbBounds(low: number, high: number): string | null {
+  if (Number.isNaN(low) || Number.isNaN(high)) {
+    return "Enter a number of carbs in grams.";
+  }
+  if (low < CARB_GRAMS_MIN || high < CARB_GRAMS_MIN) {
+    return "Carbs can't be negative.";
+  }
+  if (low > CARB_GRAMS_MAX || high > CARB_GRAMS_MAX) {
+    return `Carbs can't exceed ${CARB_GRAMS_MAX} g.`;
+  }
+  if (low > high) {
+    return "The low value must not exceed the high value.";
+  }
+  return null;
+}
+
+/**
+ * Parse two free-text gram inputs into a validated range, mirroring the mobile
+ * `CarbBounds.parse`. Returns the parsed numbers on success, else a reason to
+ * show inline. Blank / non-numeric input is rejected before any network call.
+ */
+export function parseCarbInputs(
+  lowText: string,
+  highText: string
+): CarbInputResult {
+  const low = Number(lowText.trim());
+  const high = Number(highText.trim());
+  if (lowText.trim() === "" || highText.trim() === "" || Number.isNaN(low) || Number.isNaN(high)) {
+    return { ok: false, reason: "Enter both carb values in grams." };
+  }
+  const reason = validateCarbBounds(low, high);
+  if (reason) return { ok: false, reason };
+  return { ok: true, low, high };
+}
+
+/**
+ * The identity to pre-fill the confirm/correct input with: a fresh own-history
+ * suggestion when the server offered one, else the current display identity
+ * (confirmed name or AI description). Trimmed; "" when nothing is known. Mirrors
+ * the mobile candidate (`suggestedIdentity ?? displayIdentity`).
+ */
+export function prefillIdentity(record: FoodRecord): string {
+  return (
+    record.suggested_identity?.trim() ||
+    record.confirmed_food_name?.trim() ||
+    record.food_description?.trim() ||
+    ""
+  );
+}
+
+/**
+ * Whether a record has been grounded against an external nutrition source. The
+ * grounding gate only opens once an identity is confirmed, so an unconfirmed
+ * record is always vision-only here.
+ */
+export function isGrounded(record: FoodRecord): boolean {
+  return !!record.grounding_source?.trim();
+}

--- a/apps/web/src/lib/meal-format.ts
+++ b/apps/web/src/lib/meal-format.ts
@@ -198,11 +198,14 @@ export function prefillIdentity(record: FoodRecord): string {
 
 /**
  * Whether a record has been grounded against an external nutrition source. The
- * grounding gate only opens once an identity is confirmed, so an unconfirmed
- * record is always vision-only here.
+ * grounding gate only opens once an identity is confirmed, so we require BOTH a
+ * confirmed identity and a grounding source: the server only populates
+ * `grounding_source` after confirmation, and gating the client on
+ * `identity_confirmed` too means a regressed/stale source can never render
+ * authoritative attribution before the user has confirmed what the food is.
  */
 export function isGrounded(record: FoodRecord): boolean {
-  return !!record.grounding_source?.trim();
+  return record.identity_confirmed && !!record.grounding_source?.trim();
 }
 
 /**

--- a/apps/web/src/lib/meal-format.ts
+++ b/apps/web/src/lib/meal-format.ts
@@ -204,3 +204,19 @@ export function prefillIdentity(record: FoodRecord): string {
 export function isGrounded(record: FoodRecord): boolean {
   return !!record.grounding_source?.trim();
 }
+
+/**
+ * Whether a string is a safe http(s) URL to render as an outbound link. The
+ * grounding attribution URL is server-provided (from a fixed source allow-list),
+ * but this is defense-in-depth so a non-http scheme (`javascript:` / `data:`)
+ * can never be turned into a clickable link on a medical surface.
+ */
+export function isSafeHttpUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Brings the web meal detail view to mobile parity for the two corrections a user makes when an AI carb estimate is wrong. Both actions run against existing, owner-scoped endpoints — no backend change.

- **Correct carbs** — a correction form on the detail view posts the corrected low/high range, preserves the original AI estimate, flips the source to "you corrected this", and refreshes the detail in place. The UI states corrected values are never fed to IoB / treatment-safety / carb-ratio math, and shows the server-cleared never-dose qualifier verbatim. Out-of-range / inverted input is rejected client-side; a server `422` is surfaced gracefully without mutating the record.
- **Confirm / correct what the food is** — a *separate* action, distinct from carb correction. Confirming opens external authoritative grounding (USDA / Open Food Facts / restaurant facts): before confirmation the estimate is shown as vision-only / not grounded, and after it refreshes to show any grounding attribution (with a safe, http(s)-only outbound link). An own-history suggestion pre-fills the input.

Both actions are owner-scoped, and the whole surface stays hidden when meal intelligence is disabled.

## Testing

- **Unit / component:** API client (request shape, 422/404 handling, cross-user IDOR), pure helpers (carb parse/validate, identity pre-fill, grounding + URL-safety guards), and detail-page flows — correction persists + original retained + source flips, graceful server 422 with no mutation, confirm opens grounding (vision-only before / attribution after), correct vs confirm as two distinct actions, IDOR no-mutation. Full web test suite green.
- **Visual (Playwright):** vision-only, correction editor, validation error, corrected, identity-confirmed, and grounded-attribution states.
- **Reviews:** adversarial + senior code-quality + medical-safety review, CodeRabbit CLI, and a security review (IDOR / CSRF / secrets — clean). Sentry validation gate passed with no real issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Carb correction: Add an editor for updating carb low/high estimates with client-side range validation, plus server-backed refresh after saving.
  * Food identity confirmation: Add an identity editor and confirmation flow that updates the page with the refreshed record.
  * Grounding status: Display grounded vs. vision-only status, show an authority indicator, and safely render external source links when allowed.
* **Improvements**
  * Meal detail page now updates in place after correction/identity actions.
* **Tests**
  * Expanded API and UI coverage for correction, identity confirmation, and grounding behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->