### PR TITLE
feat: web common-foods management and save/link from a meal

### DIFF
--- a/apps/web/__tests__/meals/common-food-actions.test.tsx
+++ b/apps/web/__tests__/meals/common-food-actions.test.tsx
@@ -201,6 +201,17 @@ describe("MealCommonFoodSection", () => {
     expect(screen.queryByTestId("meal-link-select")).not.toBeInTheDocument();
   });
 
+  it("shows an error (not the empty state) when the baseline list fails to load", async () => {
+    mockListCommon.mockRejectedValue(new MealApiError(502, "transient"));
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId("meal-link-common-food"));
+    expect(await screen.findByTestId("meal-link-error")).toBeInTheDocument();
+    // A load failure must not masquerade as "you have no common foods".
+    expect(screen.queryByTestId("meal-link-empty")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("meal-link-select")).not.toBeInTheDocument();
+  });
+
   it("handles a link 404 (cross-user baseline) gracefully (IDOR)", async () => {
     mockListCommon.mockResolvedValue({
       common_foods: [makeFood({ id: "cf-1", name: "Oatmeal" })],

--- a/apps/web/__tests__/meals/common-food-actions.test.tsx
+++ b/apps/web/__tests__/meals/common-food-actions.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for the meal detail save-as / link-to common-food actions
+ * (MealCommonFoodSection). Behavioural: save-as forwards the record + name to the
+ * promotion endpoint (which uses corrected values + dedupes server-side) and
+ * reflects the link locally; link attaches to a chosen baseline; both handle the
+ * owner-scoped 404 gracefully. The never-dose baseline note is always present.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockSaveAs = jest.fn();
+const mockLink = jest.fn();
+const mockListCommon = jest.fn();
+const mockGetRecord = jest.fn();
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  ...jest.requireActual("@/lib/api"),
+  saveRecordAsCommonFood: (...args: unknown[]) => mockSaveAs(...args),
+  linkRecordToCommonFood: (...args: unknown[]) => mockLink(...args),
+  listCommonFoods: (...args: unknown[]) => mockListCommon(...args),
+  getFoodRecord: (...args: unknown[]) => mockGetRecord(...args),
+}));
+
+import { MealCommonFoodSection } from "../../src/components/meals/common-food-actions";
+import { MealApiError, type CommonFood, type FoodRecord } from "@/lib/api";
+
+function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
+  return {
+    id: "rec-1",
+    meal_timestamp: "2026-06-19T12:00:00Z",
+    food_description: "Bowl of oatmeal",
+    carbs_low: 40,
+    carbs_high: 55,
+    confidence: "medium",
+    safety_qualifier: "Rough estimate — never dose from it.",
+    nutrition_json: null,
+    assumptions: null,
+    source: "ai_estimate",
+    corrected_carbs_low: null,
+    corrected_carbs_high: null,
+    corrected_nutrition_json: null,
+    corrected_at: null,
+    common_food_id: null,
+    ai_model: null,
+    ai_provider: null,
+    confirmed_food_name: null,
+    identity_confirmed: false,
+    suggested_identity: null,
+    grounding_source: null,
+    grounding_source_url: null,
+    grounding_trust_tier: null,
+    nutrition_facts: null,
+    created_at: "2026-06-19T12:00:01Z",
+    ...overrides,
+  };
+}
+
+function makeFood(overrides: Partial<CommonFood> = {}): CommonFood {
+  return {
+    id: "cf-1",
+    name: "Oatmeal",
+    carbs_low: 40,
+    carbs_high: 55,
+    nutrition_json: null,
+    created_at: "2026-06-19T12:00:00Z",
+    updated_at: "2026-06-19T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("MealCommonFoodSection", () => {
+  beforeEach(() => {
+    mockSaveAs.mockReset();
+    mockLink.mockReset();
+    mockListCommon.mockReset();
+    mockGetRecord.mockReset();
+  });
+
+  it("always shows the never-dose baseline note", () => {
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={jest.fn()} />);
+    expect(screen.getByTestId("meal-common-food-note")).toHaveTextContent(
+      /not a dose target/i
+    );
+  });
+
+  it("saves the record as a common food, prefilling the meal title", async () => {
+    const onUpdated = jest.fn();
+    mockSaveAs.mockResolvedValue(makeFood({ id: "cf-9", name: "Bowl of oatmeal" }));
+    // The promotion links the record server-side; the section re-fetches it.
+    mockGetRecord.mockResolvedValue(makeRecord({ common_food_id: "cf-9" }));
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={onUpdated} />);
+
+    fireEvent.click(screen.getByTestId("meal-save-as-common-food"));
+    // Prefilled with the record's display title.
+    expect((screen.getByTestId("meal-save-as-name") as HTMLInputElement).value).toBe(
+      "Bowl of oatmeal"
+    );
+    fireEvent.click(screen.getByTestId("meal-save-as-submit"));
+
+    await waitFor(() =>
+      expect(mockSaveAs).toHaveBeenCalledWith("rec-1", "Bowl of oatmeal")
+    );
+    // Re-fetches from the source of truth and swaps in the now-linked record.
+    await waitFor(() => expect(mockGetRecord).toHaveBeenCalledWith("rec-1"));
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "rec-1", common_food_id: "cf-9" })
+    );
+    expect(screen.getByTestId("meal-common-food-success")).toHaveTextContent(
+      /Bowl of oatmeal/
+    );
+  });
+
+  it("clamps the save-as name prefill to the server's 120-char cap", () => {
+    const longDescription = "Grilled ".repeat(40).trim(); // well over 120 chars
+    render(
+      <MealCommonFoodSection
+        record={makeRecord({ food_description: longDescription })}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("meal-save-as-common-food"));
+    const input = screen.getByTestId("meal-save-as-name") as HTMLInputElement;
+    expect(input.value.length).toBe(120);
+  });
+
+  it("still shows success even if the post-save refresh blips", async () => {
+    const onUpdated = jest.fn();
+    mockSaveAs.mockResolvedValue(makeFood({ id: "cf-9", name: "Oatmeal" }));
+    mockGetRecord.mockRejectedValue(new MealApiError(502, "transient"));
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={onUpdated} />);
+
+    fireEvent.click(screen.getByTestId("meal-save-as-common-food"));
+    fireEvent.click(screen.getByTestId("meal-save-as-submit"));
+
+    expect(
+      await screen.findByTestId("meal-common-food-success")
+    ).toBeInTheDocument();
+    // No stale snapshot written back when the refresh failed.
+    expect(onUpdated).not.toHaveBeenCalled();
+  });
+
+  it("disables save-as for a blank name, so no empty-name request is sent", async () => {
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId("meal-save-as-common-food"));
+    fireEvent.change(screen.getByTestId("meal-save-as-name"), {
+      target: { value: "   " },
+    });
+
+    expect(screen.getByTestId("meal-save-as-submit")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("meal-save-as-submit"));
+    expect(mockSaveAs).not.toHaveBeenCalled();
+  });
+
+  it("handles a save-as 404 (deleted / cross-user record) gracefully (IDOR)", async () => {
+    mockSaveAs.mockRejectedValue(new MealApiError(404, "Food record not found."));
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId("meal-save-as-common-food"));
+    fireEvent.click(screen.getByTestId("meal-save-as-submit"));
+
+    expect(await screen.findByTestId("meal-save-as-error")).toHaveTextContent(
+      /no longer exists/i
+    );
+  });
+
+  it("links the record to a chosen existing baseline", async () => {
+    const onUpdated = jest.fn();
+    mockListCommon.mockResolvedValue({
+      common_foods: [
+        makeFood({ id: "cf-1", name: "Oatmeal" }),
+        makeFood({ id: "cf-2", name: "Greek yogurt" }),
+      ],
+      total: 2,
+    });
+    mockLink.mockResolvedValue(makeRecord({ common_food_id: "cf-2" }));
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={onUpdated} />);
+
+    fireEvent.click(screen.getByTestId("meal-link-common-food"));
+    const select = (await screen.findByTestId(
+      "meal-link-select"
+    )) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "cf-2" } });
+    fireEvent.click(screen.getByTestId("meal-link-submit"));
+
+    await waitFor(() =>
+      expect(mockLink).toHaveBeenCalledWith("rec-1", "cf-2")
+    );
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ common_food_id: "cf-2" })
+    );
+  });
+
+  it("shows an empty state in the link picker when there are no baselines", async () => {
+    mockListCommon.mockResolvedValue({ common_foods: [], total: 0 });
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId("meal-link-common-food"));
+    expect(await screen.findByTestId("meal-link-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("meal-link-select")).not.toBeInTheDocument();
+  });
+
+  it("handles a link 404 (cross-user baseline) gracefully (IDOR)", async () => {
+    mockListCommon.mockResolvedValue({
+      common_foods: [makeFood({ id: "cf-1", name: "Oatmeal" })],
+      total: 1,
+    });
+    mockLink.mockRejectedValue(new MealApiError(404, "Common food not found."));
+    render(<MealCommonFoodSection record={makeRecord()} onUpdated={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId("meal-link-common-food"));
+    await screen.findByTestId("meal-link-select");
+    fireEvent.click(screen.getByTestId("meal-link-submit"));
+
+    expect(await screen.findByTestId("meal-link-error")).toHaveTextContent(
+      /no longer exists/i
+    );
+  });
+
+  it("shows the linked note when the record is already linked to a baseline", () => {
+    render(
+      <MealCommonFoodSection
+        record={makeRecord({ common_food_id: "cf-1" })}
+        onUpdated={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId("meal-common-food-linked")).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/meals/common-food-actions.test.tsx
+++ b/apps/web/__tests__/meals/common-food-actions.test.tsx
@@ -229,6 +229,29 @@ describe("MealCommonFoodSection", () => {
     );
   });
 
+  it("clears a stale success message when the detail view switches to another meal", async () => {
+    mockSaveAs.mockResolvedValue(makeFood({ id: "cf-9", name: "Oatmeal" }));
+    mockGetRecord.mockResolvedValue(makeRecord({ common_food_id: "cf-9" }));
+    const { rerender } = render(
+      <MealCommonFoodSection record={makeRecord({ id: "rec-1" })} onUpdated={jest.fn()} />
+    );
+
+    fireEvent.click(screen.getByTestId("meal-save-as-common-food"));
+    fireEvent.click(screen.getByTestId("meal-save-as-submit"));
+    expect(
+      await screen.findByTestId("meal-common-food-success")
+    ).toBeInTheDocument();
+
+    // The route re-runs its loader on navigation without remounting the section;
+    // a new record id must reset the prior meal's success message.
+    rerender(
+      <MealCommonFoodSection record={makeRecord({ id: "rec-2" })} onUpdated={jest.fn()} />
+    );
+    expect(
+      screen.queryByTestId("meal-common-food-success")
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the linked note when the record is already linked to a baseline", () => {
     render(
       <MealCommonFoodSection

--- a/apps/web/__tests__/meals/common-foods-api.test.ts
+++ b/apps/web/__tests__/meals/common-foods-api.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the common-foods + save/link API client (api.ts), exercised through
+ * a mocked global.fetch (mirrors meal-api.test.ts). Covers list/update/delete,
+ * save-as + link, and the owner-scoped 404 / 409 / 422 error contract.
+ */
+
+function jsonResponse(status: number, body: unknown, ok?: boolean) {
+  return {
+    ok: ok ?? (status >= 200 && status < 300),
+    status,
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+describe("listCommonFoods", () => {
+  it("requests limit/offset and returns the wrapper", async () => {
+    const payload = {
+      common_foods: [{ id: "cf-1", name: "Oatmeal" }],
+      total: 1,
+    };
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse(200, payload));
+    global.fetch = mockFetch;
+
+    const { listCommonFoods } = require("@/lib/api");
+    const result = await listCommonFoods(50, 0);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/common-foods?limit=50&offset=0",
+      expect.objectContaining({ credentials: "include" })
+    );
+    expect(result).toEqual(payload);
+  });
+
+  it("throws a MealApiError on a feature-off 404", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(404, { detail: "Meal intelligence is not enabled." })
+      );
+
+    const { listCommonFoods, MealApiError } = require("@/lib/api");
+    await expect(listCommonFoods()).rejects.toBeInstanceOf(MealApiError);
+    await expect(listCommonFoods()).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("updateCommonFood", () => {
+  it("PATCHes the name + carb range and returns the baseline", async () => {
+    const updated = { id: "cf-1", name: "Steel-cut oats" };
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse(200, updated));
+    global.fetch = mockFetch;
+
+    const { updateCommonFood } = require("@/lib/api");
+    const result = await updateCommonFood("cf-1", {
+      name: "Steel-cut oats",
+      carbs_low: 30,
+      carbs_high: 45,
+    });
+
+    expect(result).toEqual(updated);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/common-foods/cf-1");
+    expect(options.method).toBe("PATCH");
+    expect(JSON.parse(options.body)).toEqual({
+      name: "Steel-cut oats",
+      carbs_low: 30,
+      carbs_high: 45,
+    });
+    expect(options.credentials).toBe("include");
+  });
+
+  it("surfaces a name-in-use 409 as a MealApiError", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse(409, {
+        detail: "A common food with that name already exists.",
+      })
+    );
+    const { updateCommonFood, MealApiError } = require("@/lib/api");
+    await expect(
+      updateCommonFood("cf-1", { name: "Oatmeal" })
+    ).rejects.toBeInstanceOf(MealApiError);
+    await expect(
+      updateCommonFood("cf-1", { name: "Oatmeal" })
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("surfaces an out-of-range 422 as a MealApiError", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(422, { detail: "carbs_low must not exceed carbs_high" })
+      );
+    const { updateCommonFood, MealApiError } = require("@/lib/api");
+    await expect(
+      updateCommonFood("cf-1", { carbs_low: 50, carbs_high: 10 })
+    ).rejects.toBeInstanceOf(MealApiError);
+    await expect(
+      updateCommonFood("cf-1", { carbs_low: 50, carbs_high: 10 })
+    ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("rejects a cross-user id with an owner-scoped 404 (IDOR)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Common food not found." }));
+    const { updateCommonFood, MealApiError } = require("@/lib/api");
+    await expect(
+      updateCommonFood("someone-elses-id", { name: "x" })
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      updateCommonFood("someone-elses-id", { name: "x" })
+    ).rejects.toBeInstanceOf(MealApiError);
+  });
+});
+
+describe("deleteCommonFood", () => {
+  it("issues a DELETE and resolves on 204", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true, status: 204 });
+    global.fetch = mockFetch;
+
+    const { deleteCommonFood } = require("@/lib/api");
+    await expect(deleteCommonFood("cf-1")).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/common-foods/cf-1",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  it("rejects a cross-user id with an owner-scoped 404 (IDOR)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Common food not found." }));
+    const { deleteCommonFood, MealApiError } = require("@/lib/api");
+    await expect(deleteCommonFood("someone-elses-id")).rejects.toBeInstanceOf(
+      MealApiError
+    );
+    await expect(deleteCommonFood("someone-elses-id")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe("saveRecordAsCommonFood", () => {
+  it("POSTs the name and returns the saved baseline", async () => {
+    const saved = { id: "cf-9", name: "Oatmeal" };
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse(201, saved));
+    global.fetch = mockFetch;
+
+    const { saveRecordAsCommonFood } = require("@/lib/api");
+    const result = await saveRecordAsCommonFood("rec-1", "Oatmeal");
+
+    expect(result).toEqual(saved);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/food-records/rec-1/save-as-common-food");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual({ name: "Oatmeal" });
+    expect(options.credentials).toBe("include");
+  });
+
+  it("rejects a cross-user record id with an owner-scoped 404 (IDOR)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Food record not found." }));
+    const { saveRecordAsCommonFood, MealApiError } = require("@/lib/api");
+    await expect(
+      saveRecordAsCommonFood("someone-elses-id", "x")
+    ).rejects.toBeInstanceOf(MealApiError);
+    await expect(
+      saveRecordAsCommonFood("someone-elses-id", "x")
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("linkRecordToCommonFood", () => {
+  it("POSTs the common_food_id and returns the refreshed record", async () => {
+    const updated = { id: "rec-1", common_food_id: "cf-1" };
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse(200, updated));
+    global.fetch = mockFetch;
+
+    const { linkRecordToCommonFood } = require("@/lib/api");
+    const result = await linkRecordToCommonFood("rec-1", "cf-1");
+
+    expect(result).toEqual(updated);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/food-records/rec-1/link-common-food");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual({ common_food_id: "cf-1" });
+    expect(options.credentials).toBe("include");
+  });
+
+  it("rejects a cross-user common-food id with an owner-scoped 404 (IDOR)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Common food not found." }));
+    const { linkRecordToCommonFood, MealApiError } = require("@/lib/api");
+    await expect(
+      linkRecordToCommonFood("rec-1", "someone-elses-common-food")
+    ).rejects.toBeInstanceOf(MealApiError);
+    await expect(
+      linkRecordToCommonFood("rec-1", "someone-elses-common-food")
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/apps/web/__tests__/meals/common-foods-page.test.tsx
+++ b/apps/web/__tests__/meals/common-foods-page.test.tsx
@@ -194,6 +194,20 @@ describe("Common foods page", () => {
     confirmSpy.mockRestore();
   });
 
+  it("surfaces a delete failure inline and leaves the delete button usable", async () => {
+    mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
+    mockDelete.mockRejectedValue(new MealApiError(502, "transient"));
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+    render(<CommonFoodsPage />);
+
+    fireEvent.click(await screen.findByTestId("common-food-delete"));
+
+    expect(await screen.findByTestId("common-food-row-error")).toBeInTheDocument();
+    // Not left stuck in the deleting (disabled) state after a failure.
+    expect(screen.getByTestId("common-food-delete")).not.toBeDisabled();
+    confirmSpy.mockRestore();
+  });
+
   it("does not delete when the confirmation is cancelled", async () => {
     mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
     const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(false);

--- a/apps/web/__tests__/meals/common-foods-page.test.tsx
+++ b/apps/web/__tests__/meals/common-foods-page.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * Tests for the Common foods management page: lists baselines (most-recently-
+ * updated-first), the never-dose baseline note, inline rename + re-baseline with
+ * 409/422 handled gracefully, the delete-confirm flow (linked records unlink, not
+ * deleted), the feature-off dead end (no raw 404), and the empty state.
+ * Behavioural assertions only.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+jest.mock("next/link", () => {
+  const Link = ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+  Link.displayName = "Link";
+  return Link;
+});
+
+const mockList = jest.fn();
+const mockUpdate = jest.fn();
+const mockDelete = jest.fn();
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  ...jest.requireActual("@/lib/api"),
+  listCommonFoods: (...args: unknown[]) => mockList(...args),
+  updateCommonFood: (...args: unknown[]) => mockUpdate(...args),
+  deleteCommonFood: (...args: unknown[]) => mockDelete(...args),
+}));
+
+import CommonFoodsPage from "../../src/app/dashboard/meals/common-foods/page";
+import { MealApiError, type CommonFood } from "@/lib/api";
+
+function makeFood(overrides: Partial<CommonFood> = {}): CommonFood {
+  return {
+    id: "cf-1",
+    name: "Oatmeal",
+    carbs_low: 40,
+    carbs_high: 55,
+    nutrition_json: null,
+    created_at: "2026-06-19T12:00:00Z",
+    updated_at: "2026-06-19T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("Common foods page", () => {
+  beforeEach(() => {
+    mockList.mockReset();
+    mockUpdate.mockReset();
+    mockDelete.mockReset();
+  });
+
+  it("lists baselines in the server order (most recently updated first)", async () => {
+    mockList.mockResolvedValue({
+      common_foods: [
+        makeFood({ id: "cf-1", name: "Greek yogurt" }),
+        makeFood({ id: "cf-2", name: "Oatmeal" }),
+      ],
+      total: 2,
+    });
+    render(<CommonFoodsPage />);
+
+    const names = await screen.findAllByTestId("common-food-name");
+    expect(names.map((n) => n.textContent)).toEqual(["Greek yogurt", "Oatmeal"]);
+    expect(mockList).toHaveBeenCalledWith(50, 0);
+  });
+
+  it("renders the never-dose baseline note", async () => {
+    mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
+    render(<CommonFoodsPage />);
+
+    const note = await screen.findByTestId("meal-safety-qualifier");
+    expect(note).toHaveTextContent(/not a dose target/i);
+    expect(note).toHaveTextContent(/never dose/i);
+  });
+
+  it("renders the empty state when there are no baselines", async () => {
+    mockList.mockResolvedValue({ common_foods: [], total: 0 });
+    render(<CommonFoodsPage />);
+
+    expect(await screen.findByTestId("common-food-empty")).toBeInTheDocument();
+  });
+
+  it("renames + re-baselines a common food via PATCH", async () => {
+    mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
+    mockUpdate.mockResolvedValue(
+      makeFood({ name: "Steel-cut oats", carbs_low: 30, carbs_high: 45 })
+    );
+    render(<CommonFoodsPage />);
+
+    fireEvent.click(await screen.findByTestId("common-food-edit"));
+    fireEvent.change(screen.getByTestId("common-food-edit-name"), {
+      target: { value: "Steel-cut oats" },
+    });
+    fireEvent.change(screen.getByTestId("common-food-edit-low"), {
+      target: { value: "30" },
+    });
+    fireEvent.change(screen.getByTestId("common-food-edit-high"), {
+      target: { value: "45" },
+    });
+    fireEvent.click(screen.getByTestId("common-food-edit-save"));
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith("cf-1", {
+        name: "Steel-cut oats",
+        carbs_low: 30,
+        carbs_high: 45,
+      })
+    );
+  });
+
+  it("handles a 409 name collision gracefully (inline error, no crash)", async () => {
+    mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
+    mockUpdate.mockRejectedValue(
+      new MealApiError(409, "A common food with that name already exists.")
+    );
+    render(<CommonFoodsPage />);
+
+    fireEvent.click(await screen.findByTestId("common-food-edit"));
+    fireEvent.change(screen.getByTestId("common-food-edit-name"), {
+      target: { value: "Greek yogurt" },
+    });
+    fireEvent.click(screen.getByTestId("common-food-edit-save"));
+
+    expect(await screen.findByTestId("common-food-edit-error")).toHaveTextContent(
+      /already have a common food with that name/i
+    );
+  });
+
+  it("handles a 422 out-of-range from the server gracefully", async () => {
+    mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
+    mockUpdate.mockRejectedValue(
+      new MealApiError(422, "carbohydrate bound above 1000 g")
+    );
+    render(<CommonFoodsPage />);
+
+    fireEvent.click(await screen.findByTestId("common-food-edit"));
+    // A valid client-side range so the request reaches the server (which rejects).
+    fireEvent.change(screen.getByTestId("common-food-edit-low"), {
+      target: { value: "30" },
+    });
+    fireEvent.change(screen.getByTestId("common-food-edit-high"), {
+      target: { value: "40" },
+    });
+    fireEvent.click(screen.getByTestId("common-food-edit-save"));
+
+    expect(await screen.findByTestId("common-food-edit-error")).toHaveTextContent(
+      /between 0 and 1000/i
+    );
+  });
+
+  it("rejects an inverted range client-side without any network call", async () => {
+    mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
+    render(<CommonFoodsPage />);
+
+    fireEvent.click(await screen.findByTestId("common-food-edit"));
+    fireEvent.change(screen.getByTestId("common-food-edit-low"), {
+      target: { value: "50" },
+    });
+    fireEvent.change(screen.getByTestId("common-food-edit-high"), {
+      target: { value: "10" },
+    });
+    fireEvent.click(screen.getByTestId("common-food-edit-save"));
+
+    expect(await screen.findByTestId("common-food-edit-error")).toHaveTextContent(
+      /low value must not exceed/i
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("deletes after confirmation, telling the user linked meals are unlinked, not deleted", async () => {
+    mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
+    mockDelete.mockResolvedValue(undefined);
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<CommonFoodsPage />);
+    fireEvent.click(await screen.findByTestId("common-food-delete"));
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith("cf-1"));
+    // The confirm copy must not imply the linked meals themselves are deleted.
+    const prompt = confirmSpy.mock.calls[0][0] as string;
+    expect(prompt).toMatch(/unlinked/i);
+    expect(prompt).toMatch(/stay logged/i);
+    confirmSpy.mockRestore();
+  });
+
+  it("does not delete when the confirmation is cancelled", async () => {
+    mockList.mockResolvedValue({ common_foods: [makeFood()], total: 1 });
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(<CommonFoodsPage />);
+    fireEvent.click(await screen.findByTestId("common-food-delete"));
+
+    expect(mockDelete).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("paginates: Next requests the next offset and reflects the page count", async () => {
+    const pageOne = Array.from({ length: 50 }, (_, i) =>
+      makeFood({ id: `cf-${i}`, name: `Food ${i}` })
+    );
+    const pageTwo = [makeFood({ id: "cf-50", name: "Food 50" })];
+    mockList.mockImplementation((_limit: number, offset: number) =>
+      Promise.resolve({
+        common_foods: offset === 0 ? pageOne : pageTwo,
+        total: 51,
+      })
+    );
+    render(<CommonFoodsPage />);
+
+    // Page 1 fully loaded, two pages total (51 rows / 50 per page).
+    await waitFor(() =>
+      expect(screen.getAllByTestId("common-food-row")).toHaveLength(50)
+    );
+    expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => expect(mockList).toHaveBeenCalledWith(50, 50));
+    expect(await screen.findByText("Page 2 of 2")).toBeInTheDocument();
+  });
+
+  it("steps back a page when the last row on a non-first page is deleted", async () => {
+    const pageOne = Array.from({ length: 50 }, (_, i) =>
+      makeFood({ id: `cf-${i}`, name: `Food ${i}` })
+    );
+    const pageTwo = [makeFood({ id: "cf-50", name: "Food 50" })];
+    mockList.mockImplementation((_limit: number, offset: number) =>
+      Promise.resolve({
+        common_foods: offset === 0 ? pageOne : pageTwo,
+        total: 51,
+      })
+    );
+    mockDelete.mockResolvedValue(undefined);
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+    render(<CommonFoodsPage />);
+
+    await screen.findByText("Page 1 of 2");
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await screen.findByText("Page 2 of 2");
+
+    // Delete the only row on page 2 -> should reload page 1 (offset 0).
+    fireEvent.click(screen.getByTestId("common-food-delete"));
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith("cf-50"));
+    await waitFor(() =>
+      expect(mockList).toHaveBeenLastCalledWith(50, 0)
+    );
+    confirmSpy.mockRestore();
+  });
+
+  it("renders a feature-off dead end (no raw 404) when meal intelligence is off", async () => {
+    mockList.mockRejectedValue(
+      new MealApiError(404, "Meal intelligence is not enabled.")
+    );
+    render(<CommonFoodsPage />);
+
+    expect(await screen.findByTestId("meal-feature-off")).toBeInTheDocument();
+    expect(screen.queryByTestId("common-food-row")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/dashboard/meals/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/meals/[id]/page.tsx
@@ -42,6 +42,7 @@ import {
   MealCorrectionSection,
   MealIdentitySection,
 } from "@/components/meals/meal-edit";
+import { MealCommonFoodSection } from "@/components/meals/common-food-actions";
 
 function BackLink() {
   return (
@@ -262,6 +263,27 @@ export default function MealDetailPage() {
               What is this?
             </h2>
             <MealIdentitySection record={record} onUpdated={handleUpdated} />
+          </div>
+        </AnimatedCard>
+
+        {/* Personalize: save this meal as a reusable baseline, or link it to one
+            you already keep. A baseline is the user's curated truth, but still a
+            description of the food — never a dose. */}
+        <AnimatedCard delay={0.075}>
+          <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 space-y-3">
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+                Common foods
+              </h2>
+              <Link
+                href="/dashboard/meals/common-foods"
+                data-testid="meal-manage-common-foods"
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Manage
+              </Link>
+            </div>
+            <MealCommonFoodSection record={record} onUpdated={handleUpdated} />
           </div>
         </AnimatedCard>
 

--- a/apps/web/src/app/dashboard/meals/common-foods/page.tsx
+++ b/apps/web/src/app/dashboard/meals/common-foods/page.tsx
@@ -129,6 +129,10 @@ function CommonFoodRow({
       onDeleted();
     } catch (err) {
       setError(describeCommonFoodError(err));
+    } finally {
+      // Clear the loading state on success too: a successful delete usually
+      // unmounts this row (the list reloads without it), but a failed reload can
+      // leave the row mounted — without this it would stay stuck disabled.
       setDeleting(false);
     }
   }, [food.id, food.name, onDeleted]);

--- a/apps/web/src/app/dashboard/meals/common-foods/page.tsx
+++ b/apps/web/src/app/dashboard/meals/common-foods/page.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+/**
+ * Common foods management.
+ *
+ * Lists the user's saved carb/nutrition baselines (most recently updated first),
+ * and lets them rename, re-baseline the carb range, or delete a baseline -- web
+ * parity with mobile. Modelled on the Settings multi-page structure (back link +
+ * card + inline edit form) and the Meals list (pagination + feature-off state).
+ *
+ * Owner-scoped + flag-gated server-side; the whole surface is hidden behind a
+ * clear feature-off state when meal intelligence is off (never a raw 404). A
+ * baseline is the user's curated truth, but still a description of a food, never
+ * a dose -- the never-dose qualifier stays attached.
+ */
+
+import { useState, useEffect, useCallback, useId, useRef } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  BookMarked,
+  Loader2,
+  Pencil,
+  Trash2,
+  Check,
+} from "lucide-react";
+import {
+  listCommonFoods,
+  updateCommonFood,
+  deleteCommonFood,
+  type CommonFood,
+} from "@/lib/api";
+import { classifyMealError, type MealErrorInfo } from "@/lib/meal-errors";
+import {
+  describeCommonFoodError,
+  NEVER_DOSE_BASELINE_NOTE,
+} from "@/lib/common-food-format";
+import {
+  formatCarbRange,
+  parseCarbInputs,
+  CARB_GRAMS_MIN,
+  CARB_GRAMS_MAX,
+} from "@/lib/meal-format";
+import { PageTransition } from "@/components/ui/page-transition";
+import { AnimatedCard } from "@/components/ui/animated-card";
+import { MealSafetyQualifier, MealErrorPanel } from "@/components/meals/meal-ui";
+
+const PAGE_SIZE = 50;
+
+interface EditState {
+  name: string;
+  low: string;
+  high: string;
+}
+
+function CommonFoodRow({
+  food,
+  delay,
+  onEdited,
+  onDeleted,
+}: {
+  food: CommonFood;
+  delay: number;
+  onEdited: () => void;
+  onDeleted: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<EditState>({ name: "", low: "", high: "" });
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const errorId = useId();
+
+  const open = useCallback(() => {
+    setDraft({
+      name: food.name,
+      low: String(Math.round(food.carbs_low)),
+      high: String(Math.round(food.carbs_high)),
+    });
+    setError(null);
+    setEditing(true);
+  }, [food.name, food.carbs_low, food.carbs_high]);
+
+  const cancel = useCallback(() => {
+    setEditing(false);
+    setError(null);
+  }, []);
+
+  const save = useCallback(async () => {
+    const trimmedName = draft.name.trim();
+    if (!trimmedName) {
+      setError("Enter a name for this common food.");
+      return;
+    }
+    const parsed = parseCarbInputs(draft.low, draft.high);
+    if (!parsed.ok) {
+      setError(parsed.reason);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await updateCommonFood(food.id, {
+        name: trimmedName,
+        carbs_low: parsed.low,
+        carbs_high: parsed.high,
+      });
+      setEditing(false);
+      onEdited();
+    } catch (err) {
+      setError(describeCommonFoodError(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, food.id, onEdited]);
+
+  const remove = useCallback(async () => {
+    if (
+      !window.confirm(
+        `Delete the common food “${food.name}”? Meals linked to it stay logged — they’re just unlinked from this baseline.`
+      )
+    ) {
+      return;
+    }
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteCommonFood(food.id);
+      onDeleted();
+    } catch (err) {
+      setError(describeCommonFoodError(err));
+      setDeleting(false);
+    }
+  }, [food.id, food.name, onDeleted]);
+
+  if (editing) {
+    return (
+      <AnimatedCard delay={delay}>
+        <div
+          data-testid="common-food-editor"
+          className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/40 p-5 space-y-4"
+        >
+          <label className="block text-xs text-slate-500 dark:text-slate-400">
+            Name
+            <input
+              type="text"
+              value={draft.name}
+              maxLength={120}
+              onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+              data-testid="common-food-edit-name"
+              aria-invalid={!!error}
+              aria-describedby={error ? errorId : undefined}
+              className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
+            />
+          </label>
+          <div className="flex gap-3">
+            <label className="flex-1 text-xs text-slate-500 dark:text-slate-400">
+              Low (g)
+              <input
+                type="number"
+                inputMode="numeric"
+                min={CARB_GRAMS_MIN}
+                max={CARB_GRAMS_MAX}
+                value={draft.low}
+                onChange={(e) => setDraft((d) => ({ ...d, low: e.target.value }))}
+                data-testid="common-food-edit-low"
+                aria-invalid={!!error}
+                aria-describedby={error ? errorId : undefined}
+                className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex-1 text-xs text-slate-500 dark:text-slate-400">
+              High (g)
+              <input
+                type="number"
+                inputMode="numeric"
+                min={CARB_GRAMS_MIN}
+                max={CARB_GRAMS_MAX}
+                value={draft.high}
+                onChange={(e) => setDraft((d) => ({ ...d, high: e.target.value }))}
+                data-testid="common-food-edit-high"
+                aria-invalid={!!error}
+                aria-describedby={error ? errorId : undefined}
+                className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
+              />
+            </label>
+          </div>
+          {error && (
+            <p
+              role="alert"
+              id={errorId}
+              data-testid="common-food-edit-error"
+              className="text-xs text-red-600 dark:text-red-400"
+            >
+              {error}
+            </p>
+          )}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={cancel}
+              disabled={saving}
+              data-testid="common-food-edit-cancel"
+              className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              data-testid="common-food-edit-save"
+              className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      </AnimatedCard>
+    );
+  }
+
+  return (
+    <AnimatedCard delay={delay}>
+      <div
+        data-testid="common-food-row"
+        className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4"
+      >
+        <div className="min-w-0">
+          <h3
+            data-testid="common-food-name"
+            className="font-medium text-slate-900 dark:text-white truncate"
+          >
+            {food.name}
+          </h3>
+          <p className="flex flex-wrap items-center gap-2 text-sm">
+            <span
+              data-testid="common-food-range"
+              className="font-semibold text-slate-900 dark:text-white"
+            >
+              {formatCarbRange(food.carbs_low, food.carbs_high)}
+            </span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              Updated {new Date(food.updated_at).toLocaleDateString()}
+            </span>
+          </p>
+          {error && (
+            <p
+              role="alert"
+              data-testid="common-food-row-error"
+              className="mt-1 text-xs text-red-600 dark:text-red-400"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            onClick={open}
+            data-testid="common-food-edit"
+            aria-label={`Edit ${food.name}`}
+            className="p-2 rounded-lg text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            <Pencil className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={remove}
+            disabled={deleting}
+            data-testid="common-food-delete"
+            aria-label={`Delete ${food.name}`}
+            className="p-2 rounded-lg text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-500/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {deleting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      </div>
+    </AnimatedCard>
+  );
+}
+
+export default function CommonFoodsPage() {
+  const [foods, setFoods] = useState<CommonFood[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  // A non-retryable dead end (feature off) replaces the list entirely.
+  const [blockedInfo, setBlockedInfo] = useState<MealErrorInfo | null>(null);
+  // Guards against out-of-order resolution: only the latest fetch may apply.
+  const requestIdRef = useRef(0);
+
+  const loadData = useCallback(async (pageNum: number) => {
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listCommonFoods(PAGE_SIZE, (pageNum - 1) * PAGE_SIZE);
+      if (requestId !== requestIdRef.current) return;
+      setFoods(data.common_foods);
+      setTotal(data.total);
+      setBlockedInfo(null);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      const info = classifyMealError(err);
+      if (info.retryable) {
+        setError(info.message);
+      } else {
+        setBlockedInfo(info);
+        setFoods([]);
+        setTotal(0);
+      }
+    } finally {
+      if (requestId === requestIdRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData(page);
+  }, [loadData, page]);
+
+  // Auto-dismiss the success banner so it never lingers across reloads.
+  useEffect(() => {
+    if (!success) return;
+    const timer = setTimeout(() => setSuccess(null), 5000);
+    return () => clearTimeout(timer);
+  }, [success]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const handleEdited = useCallback(() => {
+    setSuccess("Common food updated.");
+    loadData(page);
+  }, [loadData, page]);
+
+  const handleDeleted = useCallback(() => {
+    setSuccess("Common food deleted. Any meals linked to it stay logged.");
+    // Stepping back a page when the last row on a non-first page is removed lets
+    // the page effect reload; otherwise reload the current page in place.
+    if (foods.length === 1 && page > 1) {
+      setPage((p) => p - 1);
+    } else {
+      loadData(page);
+    }
+  }, [foods.length, page, loadData]);
+
+  if (loading && foods.length === 0 && !blockedInfo) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex flex-col h-full items-center justify-center"
+      >
+        <Loader2 className="h-8 w-8 animate-spin text-blue-400" />
+        <p className="mt-4 text-slate-500 dark:text-slate-400">
+          Loading common foods...
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <PageTransition>
+      <div className="max-w-2xl mx-auto space-y-6 p-6">
+        {/* Header */}
+        <div>
+          <Link
+            href="/dashboard/meals"
+            className="inline-flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white mb-2"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Meals
+          </Link>
+          <div className="flex items-center gap-3">
+            <BookMarked className="h-7 w-7 text-blue-400" />
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+                Common foods
+              </h1>
+              <p className="text-slate-500 dark:text-slate-400 text-sm">
+                {blockedInfo
+                  ? "Your saved food baselines"
+                  : `${total} saved baseline${total === 1 ? "" : "s"}`}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Status messages */}
+        {error && (
+          <div
+            role="alert"
+            className="bg-red-500/10 border border-red-500/20 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg text-sm"
+          >
+            {error}
+          </div>
+        )}
+        {success && (
+          <div
+            role="status"
+            className="bg-green-500/10 border border-green-500/20 text-green-700 dark:text-green-400 px-4 py-3 rounded-lg text-sm"
+          >
+            {success}
+          </div>
+        )}
+
+        {blockedInfo ? (
+          <MealErrorPanel info={blockedInfo} />
+        ) : (
+          <>
+            {/* AC6: a baseline is the user's curated truth, but still descriptive
+                — never a dose target. */}
+            <MealSafetyQualifier
+              qualifier={NEVER_DOSE_BASELINE_NOTE}
+            />
+
+            {foods.length === 0 ? (
+              <div
+                data-testid="common-food-empty"
+                className="text-center py-16 bg-slate-100/50 dark:bg-slate-800/30 rounded-lg"
+              >
+                <BookMarked className="h-14 w-14 text-slate-400 dark:text-slate-600 mx-auto mb-4" />
+                <h2 className="text-lg font-medium text-slate-900 dark:text-white mb-2">
+                  No common foods yet
+                </h2>
+                <p className="text-slate-500 dark:text-slate-400 max-w-md mx-auto">
+                  Open a logged meal and choose “Save as common food” to create a
+                  reusable baseline.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {foods.map((food, i) => (
+                  <CommonFoodRow
+                    key={food.id}
+                    food={food}
+                    delay={Math.min(i * 0.03, 0.3)}
+                    onEdited={handleEdited}
+                    onDeleted={handleDeleted}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-3 pt-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1 || loading}
+                  className="px-3 py-1.5 bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-900 dark:text-white text-sm rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Previous
+                </button>
+                <span className="text-sm text-slate-500 dark:text-slate-400">
+                  Page {page} of {totalPages}
+                </span>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={page >= totalPages || loading}
+                  className="px-3 py-1.5 bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-900 dark:text-white text-sm rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Next
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/apps/web/src/app/dashboard/meals/page.tsx
+++ b/apps/web/src/app/dashboard/meals/page.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
-import { UtensilsCrossed, Loader2, ChevronRight } from "lucide-react";
+import { UtensilsCrossed, Loader2, ChevronRight, BookMarked } from "lucide-react";
 import { listFoodRecords, type FoodRecord } from "@/lib/api";
 import { classifyMealError, type MealErrorInfo } from "@/lib/meal-errors";
 import {
@@ -172,10 +172,20 @@ export default function MealsPage() {
             </div>
           </div>
           {!blockedInfo && (
-            <MealUpload
-              onUploaded={handleUploaded}
-              onFeatureOff={() => loadData(1)}
-            />
+            <div className="flex flex-col items-end gap-2">
+              <MealUpload
+                onUploaded={handleUploaded}
+                onFeatureOff={() => loadData(1)}
+              />
+              <Link
+                href="/dashboard/meals/common-foods"
+                data-testid="meals-common-foods-link"
+                className="inline-flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
+              >
+                <BookMarked className="h-4 w-4" />
+                Common foods
+              </Link>
+            </div>
           )}
         </div>
 

--- a/apps/web/src/components/meals/common-food-actions.tsx
+++ b/apps/web/src/components/meals/common-food-actions.tsx
@@ -76,6 +76,17 @@ export function MealCommonFoodSection({ record, onUpdated }: SectionProps) {
     setMode("link");
   }, []);
 
+  // Reset the section's transient state when the detail view switches to a
+  // different meal. This route re-runs its loader on navigation rather than
+  // remounting, so a success/error/open editor from a prior meal must not linger
+  // on the next one. Re-rendering with the same record (e.g. after a save) keeps
+  // record.id stable, so the success message it just set survives.
+  useEffect(() => {
+    setMode("idle");
+    setSuccess(null);
+    setError(null);
+  }, [record.id]);
+
   // Load the baselines for the link picker on demand. Re-runs if the mode toggles
   // back to "link", so a baseline saved meanwhile shows up without a full reload.
   useEffect(() => {

--- a/apps/web/src/components/meals/common-food-actions.tsx
+++ b/apps/web/src/components/meals/common-food-actions.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+/**
+ * Save-as / link-to common-food actions for the meal detail view, bringing the
+ * web app to mobile parity with the personalization loop:
+ *
+ *  - "Save as common food" promotes this record to a named baseline (the server
+ *    uses the record's corrected values when present, else the AI estimate, and
+ *    dedupes by name) and links the record to it.
+ *  - "Link to common food" attaches this record to one of the user's existing
+ *    baselines.
+ *
+ * A common food is the user's curated truth for a food they eat often, but it is
+ * still a *description* of the food, never a dose: nothing here is fed to IoB /
+ * treatment_safety / carb-ratio math, and the never-dose framing stays attached.
+ */
+
+import { useCallback, useEffect, useId, useState } from "react";
+import { BookmarkPlus, Check, Link2, Loader2 } from "lucide-react";
+import {
+  type CommonFood,
+  type FoodRecord,
+  getFoodRecord,
+  linkRecordToCommonFood,
+  listCommonFoods,
+  saveRecordAsCommonFood,
+} from "@/lib/api";
+import { describeCommonFoodError, NEVER_DOSE_BASELINE_NOTE } from "@/lib/common-food-format";
+import { mealTitle } from "@/lib/meal-format";
+
+interface SectionProps {
+  record: FoodRecord;
+  /** Called with the refreshed record so the detail view re-renders the link state. */
+  onUpdated: (record: FoodRecord) => void;
+}
+
+type Mode = "idle" | "save" | "link";
+
+/**
+ * Promote/link a record to a common-food baseline. Two distinct actions behind
+ * one card; both leave the carb estimate untouched and never imply a dose.
+ */
+export function MealCommonFoodSection({ record, onUpdated }: SectionProps) {
+  const [mode, setMode] = useState<Mode>("idle");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const errorId = useId();
+
+  // Save-as state.
+  const [name, setName] = useState("");
+
+  // Link state: the user's existing baselines, loaded lazily when the picker opens.
+  const [baselines, setBaselines] = useState<CommonFood[] | null>(null);
+  const [loadingBaselines, setLoadingBaselines] = useState(false);
+  const [selectedId, setSelectedId] = useState("");
+
+  const reset = useCallback(() => {
+    setMode("idle");
+    setError(null);
+  }, []);
+
+  const openSave = useCallback(() => {
+    // The AI food_description is unbounded; clamp the prefill to the server's
+    // 120-char name cap (which the input's maxLength only enforces for typing).
+    setName(mealTitle(record).slice(0, 120));
+    setError(null);
+    setSuccess(null);
+    setMode("save");
+  }, [record]);
+
+  const openLink = useCallback(() => {
+    setError(null);
+    setSuccess(null);
+    setSelectedId("");
+    setMode("link");
+  }, []);
+
+  // Load the baselines for the link picker on demand. Re-runs if the mode toggles
+  // back to "link", so a baseline saved meanwhile shows up without a full reload.
+  useEffect(() => {
+    if (mode !== "link") return;
+    let cancelled = false;
+    setLoadingBaselines(true);
+    setError(null);
+    listCommonFoods(200, 0)
+      .then((data) => {
+        if (cancelled) return;
+        setBaselines(data.common_foods);
+        // Default the picker to the currently-linked baseline when present.
+        const current = data.common_foods.find((f) => f.id === record.common_food_id);
+        setSelectedId(current?.id ?? data.common_foods[0]?.id ?? "");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setBaselines([]);
+        setError(describeCommonFoodError(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingBaselines(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, record.common_food_id]);
+
+  const submitSave = useCallback(async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Enter a name for this common food.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const saved = await saveRecordAsCommonFood(record.id, trimmed);
+      // The promotion links the record server-side. Re-fetch so the detail view
+      // reflects the link from the source of truth — uniform with the correction
+      // and identity flows, which also swap in a server-returned record (and so
+      // never write a stale closure snapshot back over a concurrent edit). A
+      // refresh blip is non-fatal: the save already succeeded.
+      try {
+        onUpdated(await getFoodRecord(record.id));
+      } catch {
+        /* keep the success state; the link shows on the next load */
+      }
+      setSuccess(`Saved “${saved.name}” to your common foods.`);
+      setMode("idle");
+    } catch (err) {
+      setError(describeCommonFoodError(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [name, record.id, onUpdated]);
+
+  const submitLink = useCallback(async () => {
+    if (!selectedId) {
+      setError("Pick a common food to link to.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await linkRecordToCommonFood(record.id, selectedId);
+      onUpdated(updated);
+      const linked = baselines?.find((f) => f.id === selectedId);
+      setSuccess(`Linked to “${linked?.name ?? "your common food"}”.`);
+      setMode("idle");
+    } catch (err) {
+      setError(describeCommonFoodError(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [selectedId, record.id, onUpdated, baselines]);
+
+  return (
+    <div data-testid="meal-common-food-section" className="space-y-3">
+      {record.common_food_id && (
+        <p
+          data-testid="meal-common-food-linked"
+          className="flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-300"
+        >
+          <Check className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+          Linked to one of your common foods.
+        </p>
+      )}
+
+      {success && (
+        <p
+          role="status"
+          data-testid="meal-common-food-success"
+          className="text-sm text-emerald-700 dark:text-emerald-400"
+        >
+          {success}
+        </p>
+      )}
+
+      {mode === "idle" && (
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={openSave}
+            data-testid="meal-save-as-common-food"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+          >
+            <BookmarkPlus className="h-4 w-4" />
+            Save as common food
+          </button>
+          <button
+            type="button"
+            onClick={openLink}
+            data-testid="meal-link-common-food"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+          >
+            <Link2 className="h-4 w-4" />
+            Link to common food
+          </button>
+        </div>
+      )}
+
+      {mode === "save" && (
+        <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/40 p-5 space-y-4">
+          <label className="block text-xs text-slate-500 dark:text-slate-400">
+            Common food name
+            <input
+              type="text"
+              value={name}
+              maxLength={120}
+              onChange={(e) => setName(e.target.value)}
+              data-testid="meal-save-as-name"
+              aria-invalid={!!error}
+              aria-describedby={error ? errorId : undefined}
+              className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
+            />
+          </label>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Saves this meal’s carbs as a reusable baseline. Saving under a name you
+            already use updates that baseline instead of adding a duplicate.
+          </p>
+          {error && (
+            <p
+              role="alert"
+              id={errorId}
+              data-testid="meal-save-as-error"
+              className="text-xs text-red-600 dark:text-red-400"
+            >
+              {error}
+            </p>
+          )}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={reset}
+              disabled={saving}
+              data-testid="meal-save-as-cancel"
+              className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={submitSave}
+              disabled={saving || !name.trim()}
+              data-testid="meal-save-as-submit"
+              className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors"
+            >
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {mode === "link" && (
+        <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/40 p-5 space-y-4">
+          {loadingBaselines ? (
+            <p
+              role="status"
+              data-testid="meal-link-loading"
+              className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400"
+            >
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading your common foods…
+            </p>
+          ) : baselines && baselines.length === 0 ? (
+            <p
+              data-testid="meal-link-empty"
+              className="text-sm text-slate-500 dark:text-slate-400"
+            >
+              You don’t have any common foods yet. Use “Save as common food” to
+              create one.
+            </p>
+          ) : (
+            <label className="block text-xs text-slate-500 dark:text-slate-400">
+              Link to
+              <select
+                value={selectedId}
+                onChange={(e) => setSelectedId(e.target.value)}
+                data-testid="meal-link-select"
+                aria-invalid={!!error}
+                aria-describedby={error ? errorId : undefined}
+                className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
+              >
+                {(baselines ?? []).map((food) => (
+                  <option key={food.id} value={food.id}>
+                    {food.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          {error && (
+            <p
+              role="alert"
+              id={errorId}
+              data-testid="meal-link-error"
+              className="text-xs text-red-600 dark:text-red-400"
+            >
+              {error}
+            </p>
+          )}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={reset}
+              disabled={saving}
+              data-testid="meal-link-cancel"
+              className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={submitLink}
+              disabled={saving || loadingBaselines || !selectedId}
+              data-testid="meal-link-submit"
+              className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors"
+            >
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {saving ? "Linking…" : "Link"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <p
+        data-testid="meal-common-food-note"
+        className="text-xs text-slate-400 dark:text-slate-500"
+      >
+        {NEVER_DOSE_BASELINE_NOTE}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/meals/common-food-actions.tsx
+++ b/apps/web/src/components/meals/common-food-actions.tsx
@@ -93,7 +93,8 @@ export function MealCommonFoodSection({ record, onUpdated }: SectionProps) {
       })
       .catch((err) => {
         if (cancelled) return;
-        setBaselines([]);
+        // Leave baselines null on error so the picker shows the error message,
+        // not the misleading "no common foods yet" empty state.
         setError(describeCommonFoodError(err));
       })
       .finally(() => {
@@ -262,15 +263,7 @@ export function MealCommonFoodSection({ record, onUpdated }: SectionProps) {
               <Loader2 className="h-4 w-4 animate-spin" />
               Loading your common foods…
             </p>
-          ) : baselines && baselines.length === 0 ? (
-            <p
-              data-testid="meal-link-empty"
-              className="text-sm text-slate-500 dark:text-slate-400"
-            >
-              You don’t have any common foods yet. Use “Save as common food” to
-              create one.
-            </p>
-          ) : (
+          ) : baselines && baselines.length > 0 ? (
             <label className="block text-xs text-slate-500 dark:text-slate-400">
               Link to
               <select
@@ -281,14 +274,22 @@ export function MealCommonFoodSection({ record, onUpdated }: SectionProps) {
                 aria-describedby={error ? errorId : undefined}
                 className="mt-1 w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-white focus:border-blue-400 focus:outline-none"
               >
-                {(baselines ?? []).map((food) => (
+                {baselines.map((food) => (
                   <option key={food.id} value={food.id}>
                     {food.name}
                   </option>
                 ))}
               </select>
             </label>
-          )}
+          ) : baselines && baselines.length === 0 ? (
+            <p
+              data-testid="meal-link-empty"
+              className="text-sm text-slate-500 dark:text-slate-400"
+            >
+              You don’t have any common foods yet. Use “Save as common food” to
+              create one.
+            </p>
+          ) : null}
           {error && (
             <p
               role="alert"

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4484,3 +4484,148 @@ export async function getMealIntelligenceStatus(): Promise<{ enabled: boolean }>
     return { enabled: true };
   }
 }
+
+// ============================================================================
+// Common-foods management + save/link
+//
+// A common food is a user-named carb/nutrition baseline for a food eaten often.
+// Mirrors `CommonFoodResponse` (apps/api/src/schemas/common_food.py). It is a
+// descriptive baseline only: there is deliberately no dose/insulin field, and
+// these values never flow into IoB / treatment_safety / carb-ratio math. Every
+// endpoint is owner-scoped + flag-gated server-side (a 404 whose detail says the
+// feature is "not enabled" means the global flag is off). Failures throw
+// `MealApiError` so callers can map status to UX (409 name-in-use, 422 range).
+// ============================================================================
+
+/** A saved common-food baseline. The `nutrition_json` macros mirror a record's. */
+export interface CommonFood {
+  id: string;
+  name: string;
+  carbs_low: number;
+  carbs_high: number;
+  nutrition_json: FoodRecordNutrition | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommonFoodListResponse {
+  common_foods: CommonFood[];
+  total: number;
+}
+
+/** Fields a user can edit on a baseline. Carb bounds are sent together (the
+ *  server rejects one without the other), matching the carb-correction contract. */
+export interface CommonFoodUpdate {
+  name?: string;
+  carbs_low?: number;
+  carbs_high?: number;
+}
+
+/**
+ * List the current user's common foods, most recently updated first. Paginated
+ * (server caps limit at 200). Flag-gated + owner-scoped server-side.
+ */
+export async function listCommonFoods(
+  limit = 50,
+  offset = 0
+): Promise<CommonFoodListResponse> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/common-foods?${params.toString()}`
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/**
+ * Rename and/or re-baseline a common food. Throws `MealApiError`: 404 for a
+ * missing/cross-user id (IDOR-safe, no existence leak), 409 when the new name
+ * collides with another of the user's baselines, 422 for an out-of-range or
+ * inverted carb band. The baseline is a description of a food, never a dose.
+ */
+export async function updateCommonFood(
+  commonFoodId: string,
+  update: CommonFoodUpdate
+): Promise<CommonFood> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/common-foods/${encodeURIComponent(commonFoodId)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(update),
+    }
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/**
+ * Delete a common food (204 No Content). Records linked to it are unlinked
+ * (FK ON DELETE SET NULL), never deleted. Throws `MealApiError` 404 for a
+ * missing/cross-user id.
+ */
+export async function deleteCommonFood(commonFoodId: string): Promise<void> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/common-foods/${encodeURIComponent(commonFoodId)}`,
+    { method: "DELETE" }
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+}
+
+/**
+ * Promote a food record to a named common-food baseline and link it. The server
+ * uses the record's corrected values when present, else the AI estimate, and
+ * dedupes by name (saving under an existing name updates that baseline). Returns
+ * the saved/updated baseline. Throws `MealApiError` (404 missing/cross-user
+ * record, 422 out-of-range).
+ */
+export async function saveRecordAsCommonFood(
+  recordId: string,
+  name: string
+): Promise<CommonFood> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}/save-as-common-food`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    }
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/**
+ * Link an existing food record to one of the user's existing common foods.
+ * Both sides are owner-scoped: a missing or cross-user record OR baseline 404s
+ * with no existence leak. Returns the refreshed record (now carrying
+ * `common_food_id`). Throws `MealApiError` 404.
+ */
+export async function linkRecordToCommonFood(
+  recordId: string,
+  commonFoodId: string
+): Promise<FoodRecord> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}/link-common-food`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ common_food_id: commonFoodId }),
+    }
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}

--- a/apps/web/src/lib/common-food-format.ts
+++ b/apps/web/src/lib/common-food-format.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure helpers for the common-food (baseline) management surface.
+ *
+ * A common food is the user's curated truth for a food they eat often, but it is
+ * still a *description* of that food, never a dose target. Kept free of JSX so it
+ * is unit-testable; carb display reuses `formatCarbRange` from `meal-format`.
+ */
+
+import { MealApiError } from "./api";
+
+/**
+ * The always-present never-dose framing for baselines. A baseline is the user's
+ * own number, so it reads as more trustworthy than an AI estimate -- which is
+ * exactly why the never-dose qualifier must stay attached: consistency is not a
+ * dose. Mirrors the voice of the record `safety_qualifier` ("never dose from
+ * it") rather than introducing new dosing-adjacent copy.
+ */
+export const NEVER_DOSE_BASELINE_NOTE =
+  "A baseline describes a food you eat often — it's still an estimate, not a dose target. Never dose from it.";
+
+/**
+ * Map a common-food API failure to friendly copy, preserving the server detail
+ * where it is safe to show. Handles the three states the baseline endpoints
+ * raise: 409 name-in-use, 422 out-of-range carbs, and the owner-scoped 404
+ * (a missing or cross-user id). Anything else falls back to a generic retry.
+ */
+export function describeCommonFoodError(err: unknown): string {
+  if (err instanceof MealApiError) {
+    if (err.status === 404) {
+      return "That common food no longer exists.";
+    }
+    if (err.status === 409) {
+      return "You already have a common food with that name.";
+    }
+    if (err.status === 422) {
+      const detail = err.detail.toLowerCase();
+      if (detail.includes("exceed")) {
+        return "The low value must not exceed the high value.";
+      }
+      // A name length violation (server caps the name at 120 chars) surfaces as a
+      // Pydantic "String should have at most/least N characters" message — map it
+      // to a name-specific hint so it never falls through to the carb default.
+      if (
+        detail.includes("at most") ||
+        detail.includes("at least") ||
+        detail.includes("character")
+      ) {
+        return "Choose a name between 1 and 120 characters.";
+      }
+      if (detail.includes("empty") || detail.includes("name")) {
+        return "Enter a name for this common food.";
+      }
+      return "Enter carb values between 0 and 1000 grams.";
+    }
+    return err.detail || "Couldn't save that change. Try again.";
+  }
+  return "Couldn't save that change. Try again.";
+}


### PR DESCRIPTION
## Summary

Adds a web surface to manage common-food baselines and to save/link meal records to them, bringing the web app to parity with mobile. No backend change — uses the existing owner-scoped, flag-gated `/api/common-foods` and food-record save-as/link endpoints.

## What's included

- **Common foods page** (`/dashboard/meals/common-foods`): lists baselines (most recently updated first) with pagination; inline rename + carb-range edit with graceful handling of a name collision (409) and out-of-range carbs (422); delete with a confirmation that makes clear linked meals are unlinked (FK SET NULL), not deleted.
- **Meal detail**: "Save as common food" (the server uses the record's corrected values when present and dedupes by name) and "Link to common food" (attach to an existing baseline). Both re-render from the server record.
- API client + friendly error mapping. Baseline carbs always carry the never-dose qualifier — a baseline is the user's curated truth, but still an estimate, not a dose target.
- Owner-scoped throughout; the whole surface is hidden behind a clear feature-off state when meal intelligence is disabled.

## Testing

- `npm run lint`, `npm run build`, and the full Jest suite (977 tests; 130 meal-specific) pass.
- New tests cover list/edit/delete (including 409 and 422), save-as, link, pagination and page step-back, the feature-off dead end, and the owner-scoped 404 (IDOR) on every endpoint.
- Visual verification with Playwright: list, edit (and 409 conflict), save-as, and link exercised end-to-end.
- Security review (IDOR on every endpoint, never-dose copy, CSRF, XSS): pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Common foods” actions on meal detail to **save as** a baseline or **link** to one, including the always-visible “never dose” safety note.
  * Introduced a “Common foods” management dashboard with paginated listing, rename/re-baselining, and delete/unlink controls.
* **Bug Fixes**
  * Improved validation and messaging across save/link/rename/delete flows, including feature-off handling, error mapping, and correct pagination/offset behavior.
* **Tests**
  * Added/extended Jest + React Testing Library coverage for the UI flows and common-foods API request/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->