### PR TITLE
feat: web meal estimate provenance panel (how this was estimated)

### DIFF
--- a/apps/web/__tests__/meals/meal-api.test.ts
+++ b/apps/web/__tests__/meals/meal-api.test.ts
@@ -79,6 +79,58 @@ describe("getFoodRecord", () => {
   });
 });
 
+describe("getFoodRecordAudit", () => {
+  it("fetches the owner-scoped audit trail for a record", async () => {
+    const payload = {
+      food_record_id: "rec-1",
+      samples: [{ carbs_low: 40, carbs_high: 55, identity: "oatmeal", parse_ok: true }],
+      dispersion: { confidence: "medium", coefficient_of_variation: 0.12 },
+      precedence: { outcome: "vision_only", ladder: [] },
+      created_at: "2026-06-19T12:00:00Z",
+      updated_at: "2026-06-19T12:00:00Z",
+    };
+    const mockFetch = jest.fn().mockResolvedValue(jsonResponse(200, payload));
+    global.fetch = mockFetch;
+
+    const { getFoodRecordAudit } = require("@/lib/api");
+    const result = await getFoodRecordAudit("rec-1");
+
+    expect(result).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/food-records/rec-1/audit",
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+
+  it("rejects a cross-user / no-audit id with an owner-scoped 404 (IDOR)", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { detail: "Audit trail not found" }));
+
+    const { getFoodRecordAudit, MealApiError } = require("@/lib/api");
+    await expect(getFoodRecordAudit("someone-elses-id")).rejects.toMatchObject({
+      status: 404,
+    });
+    await expect(getFoodRecordAudit("someone-elses-id")).rejects.toBeInstanceOf(
+      MealApiError
+    );
+  });
+
+  it("encodes the record id in the path", async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { food_record_id: "a/b" }));
+    global.fetch = mockFetch;
+
+    const { getFoodRecordAudit } = require("@/lib/api");
+    await getFoodRecordAudit("a/b");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/food-records/a%2Fb/audit",
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+});
+
 describe("uploadFoodRecord", () => {
   it("POSTs a multipart 'file' part and returns the record", async () => {
     const mockFetch = jest

--- a/apps/web/__tests__/meals/meal-audit.test.tsx
+++ b/apps/web/__tests__/meals/meal-audit.test.tsx
@@ -281,4 +281,49 @@ describe("MealAuditPanel", () => {
     expect(await screen.findByTestId("meal-audit-details")).toBeInTheDocument();
     expect(mockGetAudit).toHaveBeenCalledTimes(1);
   });
+
+  it("invalidates the cached audit when the record is swapped in place (e.g. identity confirmed)", async () => {
+    mockGetAudit
+      .mockResolvedValueOnce(makeAudit()) // vision-only trail
+      .mockResolvedValueOnce(
+        makeAudit({
+          precedence: {
+            outcome: "grounded",
+            chosen_source: "USDA FoodData Central",
+            trust_tier: "AUTHORITATIVE",
+            source_url: "https://fdc.nal.usda.gov/",
+            identity_used: "Bowl of oatmeal",
+            identity_confirmed: true,
+            reason: null,
+            ladder: ["own-history corrected", "USDA FoodData Central", "vision-only"],
+          },
+        })
+      );
+    const { rerender } = render(<MealAuditPanel record={makeRecord()} />);
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+    expect(await screen.findByTestId("meal-audit-precedence")).toHaveTextContent(
+      /Vision-only estimate/i
+    );
+
+    // The detail view confirms identity and swaps the record in place.
+    rerender(
+      <MealAuditPanel
+        record={makeRecord({
+          identity_confirmed: true,
+          confirmed_food_name: "Bowl of oatmeal",
+          source: "external_grounded",
+          grounding_source: "USDA FoodData Central",
+        })}
+      />
+    );
+
+    // Stale trail dropped + collapsed; re-opening refetches the current decision.
+    expect(screen.queryByTestId("meal-audit-details")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+    expect(await screen.findByTestId("meal-audit-precedence")).toHaveTextContent(
+      /Grounded against USDA FoodData Central/i
+    );
+    expect(mockGetAudit).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/__tests__/meals/meal-audit.test.tsx
+++ b/apps/web/__tests__/meals/meal-audit.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * Tests for the "How this was estimated" audit / provenance panel.
+ *
+ * Behavioral assertions only: the panel surfaces the per-sample reads, the
+ * EMPIRICAL dispersion, and the precedence decision; renders the grounding
+ * citation only when the record is grounded (identity-gated, per Story 50.W2);
+ * never shows the model's self-reported confidence; carries the never-dose
+ * qualifier; presents no dose/recommendation; and degrades gracefully on a 404
+ * (no audit / cross-user) without leaking another record's data.
+ */
+
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+const mockGetAudit = jest.fn();
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  ...jest.requireActual("@/lib/api"),
+  getFoodRecordAudit: (...args: unknown[]) => mockGetAudit(...args),
+}));
+
+import { MealAuditPanel } from "@/components/meals/meal-audit";
+import {
+  MealApiError,
+  type FoodRecord,
+  type FoodRecordAudit,
+} from "@/lib/api";
+
+function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
+  return {
+    id: "rec-1",
+    meal_timestamp: "2026-06-19T12:00:00Z",
+    food_description: "Bowl of oatmeal",
+    carbs_low: 40,
+    carbs_high: 55,
+    confidence: "medium",
+    safety_qualifier: "Rough estimate — never dose from it.",
+    nutrition_json: null,
+    assumptions: null,
+    source: "ai_estimate",
+    corrected_carbs_low: null,
+    corrected_carbs_high: null,
+    corrected_nutrition_json: null,
+    corrected_at: null,
+    common_food_id: null,
+    ai_model: "claude-sonnet-4-5",
+    ai_provider: "anthropic",
+    confirmed_food_name: null,
+    identity_confirmed: false,
+    suggested_identity: null,
+    grounding_source: null,
+    grounding_source_url: null,
+    grounding_trust_tier: null,
+    nutrition_facts: null,
+    created_at: "2026-06-19T12:00:01Z",
+    ...overrides,
+  };
+}
+
+function makeAudit(overrides: Partial<FoodRecordAudit> = {}): FoodRecordAudit {
+  return {
+    food_record_id: "rec-1",
+    samples: [
+      { carbs_low: 40, carbs_high: 50, identity: "oatmeal with berries", parse_ok: true },
+      { carbs_low: 45, carbs_high: 60, identity: "porridge", parse_ok: true },
+      { carbs_low: null, carbs_high: null, identity: null, parse_ok: false },
+    ],
+    dispersion: {
+      confidence: "medium",
+      coefficient_of_variation: 0.12,
+      samples_requested: 3,
+      samples_used: 2,
+      identity_agreement: true,
+      distinct_identities: ["oatmeal with berries", "porridge"],
+      wide_spread: false,
+    },
+    precedence: {
+      outcome: "vision_only",
+      chosen_source: "vision-only",
+      trust_tier: null,
+      source_url: null,
+      identity_used: null,
+      identity_confirmed: false,
+      reason: "Identity not yet confirmed; estimate is vision-only.",
+      ladder: [
+        "own-history corrected",
+        "USDA FoodData Central",
+        "Open Food Facts",
+        "vision-only",
+      ],
+    },
+    created_at: "2026-06-19T12:00:00Z",
+    updated_at: "2026-06-19T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("MealAuditPanel", () => {
+  beforeEach(() => {
+    mockGetAudit.mockReset();
+  });
+
+  it("renders collapsed with the never-dose qualifier and no detail until expanded", () => {
+    render(<MealAuditPanel record={makeRecord()} />);
+
+    expect(screen.getByTestId("meal-audit-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("meal-audit-safety-qualifier")).toHaveTextContent(
+      /never dose/i
+    );
+    // Lazy: nothing is fetched or shown until the user opens it.
+    expect(mockGetAudit).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("meal-audit-details")).not.toBeInTheDocument();
+  });
+
+  it("expands to show per-sample reads, empirical dispersion, and the precedence decision", async () => {
+    mockGetAudit.mockResolvedValue(makeAudit());
+    render(<MealAuditPanel record={makeRecord()} />);
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+
+    await waitFor(() => expect(mockGetAudit).toHaveBeenCalledWith("rec-1"));
+
+    // Per-sample reads (one row per sample, including the unreadable one).
+    const samples = await screen.findAllByTestId("meal-audit-sample");
+    expect(samples).toHaveLength(3);
+    expect(samples[0]).toHaveTextContent("oatmeal with berries");
+    expect(samples[0]).toHaveTextContent("≈ 40–50 g carbs");
+    expect(samples[2]).toHaveTextContent(/unreadable/i);
+
+    // Empirical dispersion (the confidence is the dispersion-derived band).
+    const dispersion = screen.getByTestId("meal-audit-dispersion");
+    expect(dispersion).toHaveTextContent("Medium confidence");
+    expect(dispersion).toHaveTextContent("12%");
+    expect(dispersion).toHaveTextContent("2 of 3");
+
+    // Precedence decision + the ladder as it stood.
+    const precedence = screen.getByTestId("meal-audit-precedence");
+    expect(precedence).toHaveTextContent(/Vision-only estimate/i);
+    expect(precedence).toHaveTextContent("USDA FoodData Central");
+  });
+
+  it("renders the grounding citation (with a safe outbound link) only when grounded", async () => {
+    mockGetAudit.mockResolvedValue(
+      makeAudit({
+        precedence: {
+          outcome: "grounded",
+          chosen_source: "USDA FoodData Central",
+          trust_tier: "AUTHORITATIVE",
+          source_url: "https://fdc.nal.usda.gov/",
+          identity_used: "Bowl of oatmeal",
+          identity_confirmed: true,
+          reason: null,
+          ladder: ["own-history corrected", "USDA FoodData Central", "vision-only"],
+        },
+      })
+    );
+    render(
+      <MealAuditPanel
+        record={makeRecord({
+          identity_confirmed: true,
+          confirmed_food_name: "Bowl of oatmeal",
+          source: "external_grounded",
+          grounding_source: "USDA FoodData Central",
+          grounding_source_url: "https://fdc.nal.usda.gov/",
+          grounding_trust_tier: "AUTHORITATIVE",
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+
+    const citation = await screen.findByTestId("meal-audit-grounding");
+    expect(citation).toHaveTextContent("USDA FoodData Central");
+    const link = within(citation).getByTestId("meal-audit-grounding-link");
+    expect(link).toHaveAttribute("href", "https://fdc.nal.usda.gov/");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveAttribute("target", "_blank");
+    // The ladder marks the chosen source as used.
+    expect(screen.getByTestId("meal-audit-precedence")).toHaveTextContent(
+      /USDA FoodData Central — used/i
+    );
+  });
+
+  it("withholds the grounding citation for an unconfirmed identity even if a source is present (W2 gate)", async () => {
+    mockGetAudit.mockResolvedValue(makeAudit());
+    render(
+      <MealAuditPanel
+        record={makeRecord({
+          identity_confirmed: false,
+          grounding_source: "USDA FoodData Central",
+          grounding_source_url: "https://fdc.nal.usda.gov/",
+          grounding_trust_tier: "AUTHORITATIVE",
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+    await screen.findByTestId("meal-audit-details");
+    // Not identity-confirmed -> no authoritative citation, no outbound link.
+    expect(screen.queryByTestId("meal-audit-grounding")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meal-audit-grounding-link")
+    ).not.toBeInTheDocument();
+  });
+
+  it("never surfaces the model's self-reported confidence (only the empirical band)", async () => {
+    // A stray self-reported field on the wire must never reach the UI.
+    const auditWithLeak = makeAudit();
+    (auditWithLeak.samples[0] as unknown as Record<string, unknown>)[
+      "self_reported_confidence"
+    ] = "model-says-99-percent";
+    mockGetAudit.mockResolvedValue(auditWithLeak);
+    render(<MealAuditPanel record={makeRecord()} />);
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+    await screen.findByTestId("meal-audit-details");
+
+    expect(screen.queryByText(/model-says-99-percent/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/self-reported/i)).not.toBeInTheDocument();
+    // The empirical dispersion confidence is what's shown.
+    expect(screen.getByTestId("meal-audit-dispersion")).toHaveTextContent(
+      "Medium confidence"
+    );
+  });
+
+  it("presents no dose or recommendation element", async () => {
+    mockGetAudit.mockResolvedValue(makeAudit());
+    render(<MealAuditPanel record={makeRecord()} />);
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+    await screen.findByTestId("meal-audit-details");
+
+    expect(screen.queryByText(/units of insulin/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/recommended (dose|bolus)/i)
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/take \d/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a benign unavailable state on a 404 (no audit / cross-user) without leaking", async () => {
+    mockGetAudit.mockRejectedValue(new MealApiError(404, "Audit trail not found"));
+    render(<MealAuditPanel record={makeRecord()} />);
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+
+    expect(
+      await screen.findByTestId("meal-audit-unavailable")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("meal-audit-details")).not.toBeInTheDocument();
+    // No scary error banner for the benign "no trail recorded" case.
+    expect(screen.queryByTestId("meal-audit-error")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a transient failure and retries on a second click", async () => {
+    mockGetAudit
+      .mockRejectedValueOnce(new MealApiError(502, "upstream down"))
+      .mockResolvedValueOnce(makeAudit());
+    render(<MealAuditPanel record={makeRecord()} />);
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+    expect(await screen.findByTestId("meal-audit-error")).toBeInTheDocument();
+    // Stays collapsed so the button can retry.
+    expect(screen.queryByTestId("meal-audit-details")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+    expect(await screen.findByTestId("meal-audit-details")).toBeInTheDocument();
+    expect(screen.queryByTestId("meal-audit-error")).not.toBeInTheDocument();
+    expect(mockGetAudit).toHaveBeenCalledTimes(2);
+  });
+
+  it("collapses without refetching once loaded", async () => {
+    mockGetAudit.mockResolvedValue(makeAudit());
+    render(<MealAuditPanel record={makeRecord()} />);
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle"));
+    await screen.findByTestId("meal-audit-details");
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle")); // collapse
+    expect(screen.queryByTestId("meal-audit-details")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("meal-audit-toggle")); // re-open
+    expect(await screen.findByTestId("meal-audit-details")).toBeInTheDocument();
+    expect(mockGetAudit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/__tests__/meals/meal-detail.test.tsx
+++ b/apps/web/__tests__/meals/meal-detail.test.tsx
@@ -127,6 +127,19 @@ describe("Meal detail page", () => {
     expect(screen.queryByText(/units of insulin/i)).not.toBeInTheDocument();
   });
 
+  it("wires the 'how this was estimated' provenance panel onto the detail view", async () => {
+    mockGet.mockResolvedValue(makeRecord());
+    render(<MealDetailPage />);
+
+    // Present (collapsed) once the record loads; it lazily fetches only on open,
+    // so no audit request fires just from rendering the detail page.
+    expect(await screen.findByTestId("meal-audit-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("meal-audit-toggle")).toHaveTextContent(
+      /view details/i
+    );
+    expect(screen.queryByTestId("meal-audit-details")).not.toBeInTheDocument();
+  });
+
   it("surfaces the assumed portion prominently as the primary sanity-check", async () => {
     mockGet.mockResolvedValue(makeRecord());
     render(<MealDetailPage />);

--- a/apps/web/__tests__/meals/meal-format.test.ts
+++ b/apps/web/__tests__/meals/meal-format.test.ts
@@ -82,6 +82,11 @@ describe("formatCoefficientOfVariation", () => {
     expect(formatCoefficientOfVariation(undefined)).toBeNull();
     expect(formatCoefficientOfVariation(NaN)).toBeNull();
   });
+
+  it("returns null for a non-finite CV (zero-mean degenerate case)", () => {
+    expect(formatCoefficientOfVariation(Infinity)).toBeNull();
+    expect(formatCoefficientOfVariation(-Infinity)).toBeNull();
+  });
 });
 
 describe("effectiveCarbRange", () => {

--- a/apps/web/__tests__/meals/meal-format.test.ts
+++ b/apps/web/__tests__/meals/meal-format.test.ts
@@ -5,6 +5,7 @@
 import {
   effectiveCarbRange,
   formatCarbRange,
+  formatCoefficientOfVariation,
   confidenceLabel,
   sourceMeta,
   mealTitle,
@@ -60,6 +61,26 @@ describe("formatCarbRange", () => {
 
   it("rounds to whole grams (no false precision)", () => {
     expect(formatCarbRange(40.6, 54.5)).toBe("≈ 41–55 g carbs");
+  });
+});
+
+describe("formatCoefficientOfVariation", () => {
+  it("renders a fraction as a whole-percent spread", () => {
+    expect(formatCoefficientOfVariation(0.123)).toBe("12%");
+  });
+
+  it("rounds to the nearest whole percent (no false precision)", () => {
+    expect(formatCoefficientOfVariation(0.156)).toBe("16%");
+  });
+
+  it("renders zero spread as 0%", () => {
+    expect(formatCoefficientOfVariation(0)).toBe("0%");
+  });
+
+  it("returns null when no CV was recorded", () => {
+    expect(formatCoefficientOfVariation(null)).toBeNull();
+    expect(formatCoefficientOfVariation(undefined)).toBeNull();
+    expect(formatCoefficientOfVariation(NaN)).toBeNull();
   });
 });
 

--- a/apps/web/src/app/dashboard/meals/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/meals/[id]/page.tsx
@@ -43,6 +43,7 @@ import {
   MealIdentitySection,
 } from "@/components/meals/meal-edit";
 import { MealCommonFoodSection } from "@/components/meals/common-food-actions";
+import { MealAuditPanel } from "@/components/meals/meal-audit";
 
 function BackLink() {
   return (
@@ -287,8 +288,16 @@ export default function MealDetailPage() {
           </div>
         </AnimatedCard>
 
+        {/* "How this was estimated": the deterministic provenance trail (Story
+            50.H3) — per-sample reads, empirical dispersion, and the precedence
+            decision. Descriptive only; it hides itself when meal intelligence is
+            off (a flag-off server hides the record above, so we never get here). */}
+        <AnimatedCard delay={0.1}>
+          <MealAuditPanel record={record} />
+        </AnimatedCard>
+
         {facts?.portion && (
-          <AnimatedCard delay={0.1}>
+          <AnimatedCard delay={0.125}>
             <MealAssumedPortion portion={facts.portion} />
           </AnimatedCard>
         )}

--- a/apps/web/src/app/dashboard/meals/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/meals/[id]/page.tsx
@@ -288,10 +288,11 @@ export default function MealDetailPage() {
           </div>
         </AnimatedCard>
 
-        {/* "How this was estimated": the deterministic provenance trail (Story
-            50.H3) — per-sample reads, empirical dispersion, and the precedence
-            decision. Descriptive only; it hides itself when meal intelligence is
-            off (a flag-off server hides the record above, so we never get here). */}
+        {/* "How this was estimated": the deterministic provenance trail the audit
+            endpoint records — per-sample reads, empirical dispersion, and the
+            precedence decision. Descriptive only; it hides itself when meal
+            intelligence is off (a flag-off server hides the record above, so we
+            never get here). */}
         <AnimatedCard delay={0.1}>
           <MealAuditPanel record={record} />
         </AnimatedCard>

--- a/apps/web/src/components/meals/meal-audit.tsx
+++ b/apps/web/src/components/meals/meal-audit.tsx
@@ -23,13 +23,11 @@
  * shows a blocked state and never reaches this panel).
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   AlertTriangle,
-  BadgeCheck,
   ChevronDown,
   ChevronUp,
-  ExternalLink,
   FileSearch,
   Loader2,
   ScanLine,
@@ -48,9 +46,11 @@ import {
   formatCarbRange,
   formatCoefficientOfVariation,
   isGrounded,
-  isSafeHttpUrl,
 } from "@/lib/meal-format";
-import { MealSafetyQualifier } from "@/components/meals/meal-ui";
+import {
+  GroundedSourceNote,
+  MealSafetyQualifier,
+} from "@/components/meals/meal-ui";
 
 /** A labelled key/value provenance row. */
 function DetailRow({ label, value }: { label: string; value: string }) {
@@ -75,50 +75,26 @@ function SectionHeading({ children }: { children: React.ReactNode }) {
 
 /**
  * The grounding citation (AC2): renders the record's grounding attribution as a
- * "how this was grounded" line, distinct from the raw vision estimate. Gated on
- * `isGrounded` -- the same identity-confirmed gate the detail view uses (Story
- * 50.W2) -- so a stale/regressed source can never render an authoritative
- * citation before the user has confirmed what the food is. The outbound link is
- * defended by the shared safe-URL guard.
+ * "how this was grounded" line (with the trust tier), distinct from the raw
+ * vision estimate. Gated on `isGrounded` -- the same identity-confirmed gate the
+ * detail view uses (Story 50.W2) -- so a stale/regressed source can never render
+ * an authoritative citation before the user has confirmed what the food is. The
+ * citation box itself is the shared `GroundedSourceNote`, so its safe-URL guard
+ * and outbound-link attributes stay in lockstep with the detail card's.
  */
 function GroundingCitation({ record }: { record: FoodRecord }) {
   if (!isGrounded(record)) return null;
   return (
     <div className="space-y-2">
       <SectionHeading>How this was grounded</SectionHeading>
-      <div
-        role="note"
-        data-testid="meal-audit-grounding"
-        className="flex items-start gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 dark:bg-blue-500/10 px-3 py-2 text-xs text-slate-600 dark:text-slate-300"
-      >
-        <BadgeCheck className="h-4 w-4 flex-shrink-0 mt-0.5 text-blue-600 dark:text-blue-400" />
-        <span>
-          Checked against{" "}
-          <span className="font-medium text-slate-900 dark:text-white">
-            {record.grounding_source}
-          </span>
-          {record.grounding_trust_tier && (
-            <> ({record.grounding_trust_tier.toLowerCase()} source)</>
-          )}
-          {isSafeHttpUrl(record.grounding_source_url) && (
-            <>
-              {" — "}
-              <a
-                href={record.grounding_source_url!}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-testid="meal-audit-grounding-link"
-                aria-label={`View ${record.grounding_source} source (opens in a new window)`}
-                className="inline-flex items-center gap-0.5 text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                view source
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            </>
-          )}
-          .
-        </span>
-      </div>
+      <GroundedSourceNote
+        record={record}
+        label="Checked against"
+        linkLabel="view source"
+        showTrustTier
+        testId="meal-audit-grounding"
+        linkTestId="meal-audit-grounding-link"
+      />
     </div>
   );
 }
@@ -209,9 +185,15 @@ function precedenceDecision(precedence: AuditPrecedence): string {
 /**
  * The precedence decision (AC1): which source won and the ladder AS IT STOOD when
  * the decision was made. The recorded ladder is shown rather than a live constant
- * so the trail reads the ordering that actually applied.
+ * so the trail reads the ordering that actually applied. The grounding citation
+ * (above) carries the trust tier and outbound link; this section is just the
+ * decision + the ordered ladder.
+ *
+ * The server documents the precedence payload as schema-loose (still settling),
+ * so the ladder is coerced to an array before iterating rather than trusted blind.
  */
 function PrecedenceSection({ precedence }: { precedence: AuditPrecedence }) {
+  const ladder = Array.isArray(precedence.ladder) ? precedence.ladder : [];
   return (
     <div className="space-y-2" data-testid="meal-audit-precedence">
       <SectionHeading>Which source was used</SectionHeading>
@@ -225,19 +207,21 @@ function PrecedenceSection({ precedence }: { precedence: AuditPrecedence }) {
             {precedence.reason}
           </p>
         )}
-        {precedence.ladder.length > 0 && (
+        {ladder.length > 0 && (
           <div className="pt-1">
             <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">
               Sources considered, in order:
             </p>
             <ol className="list-decimal list-inside space-y-0.5">
-              {precedence.ladder.map((rung) => {
+              {ladder.map((rung, i) => {
                 const used =
                   !!precedence.chosen_source &&
                   rung.toLowerCase() === precedence.chosen_source.toLowerCase();
                 return (
+                  // Index-keyed: the ladder is render-only and never reordered, and
+                  // a malformed payload could repeat a rung.
                   <li
-                    key={rung}
+                    key={`${i}-${rung}`}
                     className={
                       used
                         ? "text-xs font-medium text-slate-900 dark:text-white"
@@ -297,6 +281,17 @@ export function MealAuditPanel({ record }: { record: FoodRecord }) {
   // A 404 means the record simply has no stored audit trail (benign) rather than
   // a failure to surface for retry.
   const [unavailable, setUnavailable] = useState(false);
+
+  // The detail view swaps the record in place when the user corrects carbs or
+  // confirms identity (which re-runs the grounding decision), so a cached audit
+  // can go stale. Drop it and collapse on those changes; the next open refetches
+  // the current trail. Mirrors AIInsightCard invalidating its cached detail.
+  useEffect(() => {
+    setAudit(null);
+    setUnavailable(false);
+    setError(null);
+    setExpanded(false);
+  }, [record.id, record.identity_confirmed, record.source, record.corrected_at]);
 
   const toggle = useCallback(async () => {
     if (expanded) {

--- a/apps/web/src/components/meals/meal-audit.tsx
+++ b/apps/web/src/components/meals/meal-audit.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+/**
+ * "How this was estimated" audit / provenance panel for the meal detail view.
+ *
+ * Surfaces the deterministic audit trail the API records for a vision estimate
+ * (the merged `GET /api/food-records/{id}/audit`, Story 50.H3): the raw per-sample
+ * vision reads, the empirical dispersion summary, and the precedence decision.
+ * The point is the same one a deterministic healthcare tool gives you -- let the
+ * user judge how much to trust a number by showing how it was produced.
+ *
+ * Strictly descriptive provenance: it carries the server-cleared never-dose
+ * qualifier and never presents a dose or recommendation. It deliberately does NOT
+ * surface the model's self-reported confidence -- the server strips that before
+ * responding (it stays internal, per Story 50.H1), and only the EMPIRICAL
+ * dispersion-derived confidence is shown.
+ *
+ * Reuses `AIInsightCard`'s shape: a card with an amber safety note and a lazy
+ * expand/collapse that fetches the detail only on first open.
+ *
+ * Hidden when meal intelligence is off: this only renders inside the loaded-record
+ * detail view, and a flag-off server hides the record itself (the detail page
+ * shows a blocked state and never reaches this panel).
+ */
+
+import { useCallback, useState } from "react";
+import {
+  AlertTriangle,
+  BadgeCheck,
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  FileSearch,
+  Loader2,
+  ScanLine,
+} from "lucide-react";
+import {
+  getFoodRecordAudit,
+  MealApiError,
+  type AuditDispersion,
+  type AuditPrecedence,
+  type AuditSample,
+  type FoodRecord,
+  type FoodRecordAudit,
+} from "@/lib/api";
+import {
+  confidenceLabel,
+  formatCarbRange,
+  formatCoefficientOfVariation,
+  isGrounded,
+  isSafeHttpUrl,
+} from "@/lib/meal-format";
+import { MealSafetyQualifier } from "@/components/meals/meal-ui";
+
+/** A labelled key/value provenance row. */
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <dt className="text-xs text-slate-500 dark:text-slate-400">{label}</dt>
+      <dd className="text-xs font-medium text-slate-700 dark:text-slate-200 text-right">
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+/** Section heading inside the expanded audit trail. */
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h4 className="text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
+      {children}
+    </h4>
+  );
+}
+
+/**
+ * The grounding citation (AC2): renders the record's grounding attribution as a
+ * "how this was grounded" line, distinct from the raw vision estimate. Gated on
+ * `isGrounded` -- the same identity-confirmed gate the detail view uses (Story
+ * 50.W2) -- so a stale/regressed source can never render an authoritative
+ * citation before the user has confirmed what the food is. The outbound link is
+ * defended by the shared safe-URL guard.
+ */
+function GroundingCitation({ record }: { record: FoodRecord }) {
+  if (!isGrounded(record)) return null;
+  return (
+    <div className="space-y-2">
+      <SectionHeading>How this was grounded</SectionHeading>
+      <div
+        role="note"
+        data-testid="meal-audit-grounding"
+        className="flex items-start gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 dark:bg-blue-500/10 px-3 py-2 text-xs text-slate-600 dark:text-slate-300"
+      >
+        <BadgeCheck className="h-4 w-4 flex-shrink-0 mt-0.5 text-blue-600 dark:text-blue-400" />
+        <span>
+          Checked against{" "}
+          <span className="font-medium text-slate-900 dark:text-white">
+            {record.grounding_source}
+          </span>
+          {record.grounding_trust_tier && (
+            <> ({record.grounding_trust_tier.toLowerCase()} source)</>
+          )}
+          {isSafeHttpUrl(record.grounding_source_url) && (
+            <>
+              {" — "}
+              <a
+                href={record.grounding_source_url!}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid="meal-audit-grounding-link"
+                aria-label={`View ${record.grounding_source} source (opens in a new window)`}
+                className="inline-flex items-center gap-0.5 text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                view source
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </>
+          )}
+          .
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** The raw per-sample vision reads (AC1). One row per sample; no self-reported confidence. */
+function SamplesSection({ samples }: { samples: AuditSample[] }) {
+  if (samples.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      <SectionHeading>Photo reads ({samples.length})</SectionHeading>
+      <ul className="space-y-1.5">
+        {samples.map((sample, i) => {
+          const carbs =
+            sample.carbs_low != null && sample.carbs_high != null
+              ? formatCarbRange(sample.carbs_low, sample.carbs_high)
+              : "no carb read";
+          return (
+            <li
+              key={i}
+              data-testid="meal-audit-sample"
+              className="flex items-baseline justify-between gap-3 text-xs"
+            >
+              <span className="text-slate-600 dark:text-slate-300 min-w-0 truncate">
+                {sample.identity?.trim() || "Unlabelled read"}
+              </span>
+              <span className="flex-shrink-0 font-medium text-slate-700 dark:text-slate-200">
+                {sample.parse_ok ? carbs : "unreadable"}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * The empirical dispersion summary (AC1 + AC3): how much the photo reads
+ * disagreed. The confidence here is the EMPIRICAL dispersion band, never the
+ * model's self-reported confidence.
+ */
+function DispersionSection({ dispersion }: { dispersion: AuditDispersion }) {
+  const cv = formatCoefficientOfVariation(dispersion.coefficient_of_variation);
+  const sampleCount =
+    dispersion.samples_used != null && dispersion.samples_requested != null
+      ? `${dispersion.samples_used} of ${dispersion.samples_requested}`
+      : dispersion.samples_used != null
+        ? String(dispersion.samples_used)
+        : null;
+  return (
+    <div className="space-y-2">
+      <SectionHeading>How much the reads agreed</SectionHeading>
+      <dl
+        data-testid="meal-audit-dispersion"
+        className="space-y-1.5 rounded-lg border border-slate-200 dark:border-slate-800 px-3 py-2"
+      >
+        <DetailRow
+          label="Confidence (from spread)"
+          value={confidenceLabel(dispersion.confidence)}
+        />
+        {cv && <DetailRow label="Spread between reads" value={cv} />}
+        {sampleCount && <DetailRow label="Usable reads" value={sampleCount} />}
+        {dispersion.identity_agreement != null && (
+          <DetailRow
+            label="Reads agreed on the food"
+            value={dispersion.identity_agreement ? "Yes" : "No"}
+          />
+        )}
+        {dispersion.distinct_identities.length > 1 && (
+          <DetailRow
+            label="Identities seen"
+            value={dispersion.distinct_identities.join(", ")}
+          />
+        )}
+      </dl>
+    </div>
+  );
+}
+
+/** Humanize the precedence outcome into a short decision line. */
+function precedenceDecision(precedence: AuditPrecedence): string {
+  if (precedence.outcome === "grounded" && precedence.chosen_source) {
+    return `Grounded against ${precedence.chosen_source}`;
+  }
+  return "Vision-only estimate";
+}
+
+/**
+ * The precedence decision (AC1): which source won and the ladder AS IT STOOD when
+ * the decision was made. The recorded ladder is shown rather than a live constant
+ * so the trail reads the ordering that actually applied.
+ */
+function PrecedenceSection({ precedence }: { precedence: AuditPrecedence }) {
+  return (
+    <div className="space-y-2" data-testid="meal-audit-precedence">
+      <SectionHeading>Which source was used</SectionHeading>
+      <div className="space-y-1.5 rounded-lg border border-slate-200 dark:border-slate-800 px-3 py-2">
+        <DetailRow label="Decision" value={precedenceDecision(precedence)} />
+        {precedence.identity_used && (
+          <DetailRow label="Keyed on" value={precedence.identity_used} />
+        )}
+        {precedence.reason && (
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            {precedence.reason}
+          </p>
+        )}
+        {precedence.ladder.length > 0 && (
+          <div className="pt-1">
+            <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">
+              Sources considered, in order:
+            </p>
+            <ol className="list-decimal list-inside space-y-0.5">
+              {precedence.ladder.map((rung) => {
+                const used =
+                  !!precedence.chosen_source &&
+                  rung.toLowerCase() === precedence.chosen_source.toLowerCase();
+                return (
+                  <li
+                    key={rung}
+                    className={
+                      used
+                        ? "text-xs font-medium text-slate-900 dark:text-white"
+                        : "text-xs text-slate-500 dark:text-slate-400"
+                    }
+                  >
+                    {rung}
+                    {used && " — used"}
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** The expanded provenance body, once the audit has loaded. */
+function AuditDetails({
+  record,
+  audit,
+}: {
+  record: FoodRecord;
+  audit: FoodRecordAudit;
+}) {
+  return (
+    <div
+      data-testid="meal-audit-details"
+      role="region"
+      aria-label="How this estimate was produced"
+      className="mt-3 pt-3 border-t border-slate-200 dark:border-slate-800 space-y-4"
+    >
+      <GroundingCitation record={record} />
+      <SamplesSection samples={audit.samples} />
+      {audit.dispersion && (
+        <DispersionSection dispersion={audit.dispersion} />
+      )}
+      {audit.precedence && (
+        <PrecedenceSection precedence={audit.precedence} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * The audit / provenance panel. Closed, it is a compact "How this was estimated"
+ * card with the never-dose qualifier; opening it lazily fetches and renders the
+ * full audit trail.
+ */
+export function MealAuditPanel({ record }: { record: FoodRecord }) {
+  const [expanded, setExpanded] = useState(false);
+  const [audit, setAudit] = useState<FoodRecordAudit | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // A 404 means the record simply has no stored audit trail (benign) rather than
+  // a failure to surface for retry.
+  const [unavailable, setUnavailable] = useState(false);
+
+  const toggle = useCallback(async () => {
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+    // Already resolved once (loaded, or known-unavailable): just re-open.
+    if (audit || unavailable) {
+      setExpanded(true);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getFoodRecordAudit(record.id);
+      setAudit(result);
+      setExpanded(true);
+    } catch (err) {
+      if (err instanceof MealApiError && err.status === 404) {
+        setUnavailable(true);
+        setExpanded(true);
+      } else {
+        // Transient: leave the panel collapsed so the button retries on re-click.
+        setError("Couldn’t load how this was estimated. Try again.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [expanded, audit, unavailable, record.id]);
+
+  return (
+    <article
+      data-testid="meal-audit-panel"
+      aria-label="How this was estimated"
+      className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 space-y-3 focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 focus-within:ring-offset-white dark:focus-within:ring-offset-slate-950"
+    >
+      <div className="flex items-start gap-3">
+        <div className="p-2 rounded-lg shrink-0 bg-slate-100 dark:bg-slate-800" aria-hidden="true">
+          <FileSearch className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+            How this was estimated
+          </h2>
+          <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+            The photo reads, how much they agreed, and what grounded the number —
+            so you can judge how much to trust it.
+          </p>
+        </div>
+      </div>
+
+      {/* The never-dose qualifier travels with this provenance surface (AC4),
+          rendered verbatim from the server-cleared field. */}
+      <MealSafetyQualifier
+        qualifier={record.safety_qualifier}
+        testId="meal-audit-safety-qualifier"
+      />
+
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={loading}
+        data-testid="meal-audit-toggle"
+        aria-expanded={expanded}
+        className="inline-flex items-center gap-1.5 text-xs font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {loading ? (
+          <>
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            Loading…
+          </>
+        ) : (
+          <>
+            <ScanLine className="h-3.5 w-3.5" aria-hidden="true" />
+            {expanded ? "Hide details" : "View details"}
+            {expanded ? (
+              <ChevronUp className="h-3 w-3" />
+            ) : (
+              <ChevronDown className="h-3 w-3" />
+            )}
+          </>
+        )}
+      </button>
+
+      {error && (
+        <p
+          role="alert"
+          data-testid="meal-audit-error"
+          className="text-xs text-red-600 dark:text-red-400"
+        >
+          {error}
+        </p>
+      )}
+
+      {expanded && unavailable && (
+        <div
+          role="note"
+          data-testid="meal-audit-unavailable"
+          className="flex items-start gap-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 px-3 py-2 text-xs text-slate-500 dark:text-slate-400"
+        >
+          <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+          <span>No estimation trail was recorded for this meal.</span>
+        </div>
+      )}
+
+      {expanded && audit && <AuditDetails record={record} audit={audit} />}
+    </article>
+  );
+}

--- a/apps/web/src/components/meals/meal-ui.tsx
+++ b/apps/web/src/components/meals/meal-ui.tsx
@@ -60,14 +60,17 @@ export function IdentityConfirmedBadge() {
 export function MealSafetyQualifier({
   qualifier,
   className = "",
+  testId = "meal-safety-qualifier",
 }: {
   qualifier: string;
   className?: string;
+  /** Override when more than one qualifier can render on a page (avoids a duplicate testid). */
+  testId?: string;
 }) {
   return (
     <div
       role="note"
-      data-testid="meal-safety-qualifier"
+      data-testid={testId}
       className={`flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-300 ${className}`}
     >
       <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5" />

--- a/apps/web/src/components/meals/meal-ui.tsx
+++ b/apps/web/src/components/meals/meal-ui.tsx
@@ -194,6 +194,70 @@ export function MealNutritionDisclaimer({ disclaimer }: { disclaimer: string }) 
 }
 
 /**
+ * The blue "grounded against {source}" attribution note: the bold source name,
+ * an optional trust tier, and a safe outbound link to the source. The single
+ * source of truth for this citation markup -- both the detail card's grounding
+ * status and the audit panel's "how this was grounded" line render through it, so
+ * the safe-URL guard, the outbound-link attributes, and the accessible label can
+ * never drift between the two surfaces. The lead-in `label` and `linkLabel` vary
+ * by surface; the box itself does not. Only ever rendered for a grounded record.
+ */
+export function GroundedSourceNote({
+  record,
+  label,
+  linkLabel = "source",
+  showTrustTier = false,
+  testId,
+  linkTestId,
+}: {
+  record: FoodRecord;
+  /** Lead-in before the source name, e.g. "Grounded against" / "Checked against". */
+  label: string;
+  /** Visible text of the outbound link. */
+  linkLabel?: string;
+  /** Append the (cleared) trust tier as "(authoritative source)". */
+  showTrustTier?: boolean;
+  testId: string;
+  linkTestId: string;
+}) {
+  return (
+    <div
+      role="note"
+      data-testid={testId}
+      className="flex items-start gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 dark:bg-blue-500/10 px-3 py-2 text-xs text-slate-600 dark:text-slate-300"
+    >
+      <BadgeCheck className="h-4 w-4 flex-shrink-0 mt-0.5 text-blue-600 dark:text-blue-400" />
+      <span>
+        {label}{" "}
+        <span className="font-medium text-slate-900 dark:text-white">
+          {record.grounding_source}
+        </span>
+        {showTrustTier && record.grounding_trust_tier && (
+          <> ({record.grounding_trust_tier.toLowerCase()} source)</>
+        )}
+        {isSafeHttpUrl(record.grounding_source_url) && (
+          <>
+            {" — "}
+            <a
+              href={record.grounding_source_url!}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid={linkTestId}
+              aria-label={`View ${record.grounding_source} source (opens in a new window)`}
+              className="inline-flex items-center gap-0.5 text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {linkLabel}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </>
+        )}
+        .
+      </span>
+    </div>
+  );
+}
+
+/**
  * Grounding status for the carb estimate (Story 50.H2/E1). Confirming the food's
  * identity opens the grounding gate, so an unconfirmed record is "vision-only --
  * not checked against an external source"; once a source grounds it, the
@@ -203,36 +267,12 @@ export function MealNutritionDisclaimer({ disclaimer }: { disclaimer: string }) 
 export function MealGroundingStatus({ record }: { record: FoodRecord }) {
   if (isGrounded(record)) {
     return (
-      <div
-        role="note"
-        data-testid="meal-grounding-grounded"
-        className="flex items-start gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 dark:bg-blue-500/10 px-3 py-2 text-xs text-slate-600 dark:text-slate-300"
-      >
-        <BadgeCheck className="h-4 w-4 flex-shrink-0 mt-0.5 text-blue-600 dark:text-blue-400" />
-        <span>
-          Grounded against{" "}
-          <span className="font-medium text-slate-900 dark:text-white">
-            {record.grounding_source}
-          </span>
-          {isSafeHttpUrl(record.grounding_source_url) && (
-            <>
-              {" "}
-              <a
-                href={record.grounding_source_url!}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-testid="meal-grounding-link"
-                aria-label={`View ${record.grounding_source} source (opens in a new window)`}
-                className="inline-flex items-center gap-0.5 text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                source
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            </>
-          )}
-          .
-        </span>
-      </div>
+      <GroundedSourceNote
+        record={record}
+        label="Grounded against"
+        testId="meal-grounding-grounded"
+        linkTestId="meal-grounding-link"
+      />
     );
   }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4268,6 +4268,68 @@ export interface FoodRecordListResponse {
 }
 
 /**
+ * One raw vision sample as surfaced in the audit trail (Story 50.H3). Mirrors
+ * the server `AuditSample`. The model's self-reported confidence is deliberately
+ * NOT part of this shape: the server strips it before responding (it is retained
+ * internally for eval/triage only, per 50.H1), so it can never reach the UI.
+ */
+export interface AuditSample {
+  carbs_low: number | null;
+  carbs_high: number | null;
+  identity: string | null;
+  parse_ok: boolean;
+}
+
+/**
+ * The empirical dispersion summary in the audit trail (Story 50.H3). Mirrors the
+ * server `AuditDispersion`. `confidence` is the EMPIRICAL dispersion band, never
+ * the model's self-reported confidence -- low dispersion is consistency, not
+ * correctness, so it is provenance, not a dose signal.
+ */
+export interface AuditDispersion {
+  confidence: string | null;
+  coefficient_of_variation: number | null;
+  samples_requested: number | null;
+  samples_used: number | null;
+  identity_agreement: boolean | null;
+  distinct_identities: string[];
+  wide_spread: boolean | null;
+}
+
+/**
+ * The precedence decision recorded for an estimate (Story 50.H2/H3). Mirrors the
+ * server precedence payload built by `services.meal_audit`: which source won (or
+ * vision-only), the identity it was keyed on, and the ladder AS IT STOOD when the
+ * decision was made (recorded per-row so the audit reads the ordering that
+ * actually applied). Descriptive provenance only -- never a dose.
+ */
+export interface AuditPrecedence {
+  outcome: string;
+  chosen_source: string | null;
+  trust_tier: string | null;
+  source_url: string | null;
+  identity_used: string | null;
+  identity_confirmed: boolean;
+  reason: string | null;
+  ladder: string[];
+}
+
+/**
+ * The "how was this estimated" provenance trail for a food record (Story 50.H3).
+ * Mirrors the server `FoodRecordAuditResponse`: the raw per-sample vision reads,
+ * the empirical dispersion summary, and the precedence decision. Descriptive
+ * only; nothing here is read by dosing math.
+ */
+export interface FoodRecordAudit {
+  food_record_id: string;
+  samples: AuditSample[];
+  dispersion: AuditDispersion | null;
+  precedence: AuditPrecedence | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
  * A food-records API failure that preserves the HTTP status and the server's
  * `detail` string, so callers can map it to the right UX state (feature off,
  * no provider, vision unavailable, ...) -- mirroring the mobile client's
@@ -4348,6 +4410,29 @@ export async function listFoodRecords(
 export async function getFoodRecord(recordId: string): Promise<FoodRecord> {
   const response = await apiFetch(
     `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}`
+  );
+  if (!response.ok) {
+    await _throwMealError(response);
+  }
+  return response.json();
+}
+
+/**
+ * Fetch a record's "how was this estimated" provenance trail (Story 50.H3).
+ *
+ * Owner-scoped and IDOR-safe server-side: the record must belong to the caller
+ * and the audit row is itself scoped by user id, so a cross-user id yields a 404
+ * (never another user's samples). A 404 can also mean a record simply has no
+ * stored audit (e.g. created before retention), which the caller renders as a
+ * benign "provenance unavailable" state rather than an error. Throws
+ * `MealApiError` carrying the status so callers can tell 404 from a transient
+ * failure.
+ */
+export async function getFoodRecordAudit(
+  recordId: string
+): Promise<FoodRecordAudit> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/food-records/${encodeURIComponent(recordId)}/audit`
   );
   if (!response.ok) {
     await _throwMealError(response);

--- a/apps/web/src/lib/meal-format.ts
+++ b/apps/web/src/lib/meal-format.ts
@@ -75,7 +75,9 @@ export function confidenceLabel(confidence: string | null): string {
 export function formatCoefficientOfVariation(
   cv: number | null | undefined
 ): string | null {
-  if (cv == null || Number.isNaN(cv)) return null;
+  // `Number.isFinite` also rejects an Infinity CV (a zero-mean degenerate case),
+  // which would otherwise render as "Infinity%".
+  if (cv == null || !Number.isFinite(cv)) return null;
   return `${Math.round(cv * 100)}%`;
 }
 

--- a/apps/web/src/lib/meal-format.ts
+++ b/apps/web/src/lib/meal-format.ts
@@ -66,6 +66,19 @@ export function confidenceLabel(confidence: string | null): string {
   }
 }
 
+/**
+ * Render the empirical coefficient of variation (a fraction, `stdev / mean`) as a
+ * whole-percent spread for the audit trail -- e.g. `0.123` -> "12%". This is a
+ * descriptive dispersion measure (how much the vision samples disagreed), never a
+ * dose signal. Returns null when no CV was recorded (e.g. a single usable sample).
+ */
+export function formatCoefficientOfVariation(
+  cv: number | null | undefined
+): string | null {
+  if (cv == null || Number.isNaN(cv)) return null;
+  return `${Math.round(cv * 100)}%`;
+}
+
 export interface SourceMeta {
   label: string;
   /** Tailwind background + text classes for the badge (dual light/dark). */


### PR DESCRIPTION
## Summary

Adds a "How this was estimated" audit / provenance panel to the web meal detail view, so a user can judge how much to trust a carb figure by seeing how it was produced — the way deterministic healthcare tools let you. Reads the existing owner-scoped `GET /api/food-records/{id}/audit`; client-only, no backend change.

## What it shows

- **Per-sample vision reads** — each photo read's carb range and identity (unreadable reads marked).
- **Empirical dispersion** — the dispersion-derived confidence band, the spread between reads (coefficient of variation as a percent), usable reads, and whether the reads agreed on the food.
- **Precedence decision** — which source won (or vision-only), the identity it was keyed on, and the precedence ladder as it stood when the decision was made.
- **Grounding citation** — when a record is grounded, a distinct "how this was grounded" line with the source, its trust tier, and a safe outbound link.

## Safety posture

- Strictly descriptive provenance: reuses the existing card's never-dose safety qualifier (rendered verbatim) and never presents a dose or recommendation.
- The model's self-reported confidence is never shown — only the empirical dispersion-derived confidence. The web audit type is a field allow-list that mirrors the server response, which strips the self-reported field.
- The grounding citation stays identity-gated, so a stale or regressed source can never render an authoritative citation before the user confirms what the food is. The outbound link is guarded against non-http(s) schemes.
- Both the record and audit fetches are owner-scoped; a cross-user or no-trail id degrades to a benign "no estimation trail" state. The panel is hidden when meal intelligence is off.

## Implementation

- `getFoodRecordAudit` + audit DTOs in the API client; a new `MealAuditPanel` (lazy fetch on expand) reusing the insight-card expand/collapse + safety-disclaimer shape.
- The blue grounded-citation note is factored into one shared `GroundedSourceNote`, consumed by both the detail card's grounding status and the audit panel, so the safe-URL guard and link attributes can't drift between the two surfaces.

## Testing

- Unit/component tests cover the per-sample/dispersion/precedence render, the identity-gated grounding citation, the self-reported-confidence non-leak, the no-dose guarantee, the 404/retry paths, and cached-audit invalidation on an in-place record swap. Full web suite green.
- Lint + build clean. Playwright visual verification of the vision-only panel, the grounded panel, and the flag-off hidden state. Security review (IDOR + safe-URL), CodeRabbit, and a Sentry validation run all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "How this was estimated" audit panel to meal records, displaying confidence levels, empirical spreads, and provenance information.
  * Added formatting support for displaying confidence spreads as percentages.

* **Tests**
  * Added comprehensive test coverage for the new audit panel, API endpoints, and formatting functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->