### PR TITLE
feat: web + mobile meal comorbidity nutrition (saturated fat, sugars, sodium)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Run lint
         run: npm run lint
 

--- a/apps/api/migrations/versions/074_food_record_comorbidity.py
+++ b/apps/api/migrations/versions/074_food_record_comorbidity.py
@@ -1,0 +1,38 @@
+"""Add the grounding-backed comorbidity nutrition column to food_records.
+
+Saturated fat, sugars/added sugars, and sodium aren't reliably estimable from a
+plated-food photo and their value is comorbidity (blood-pressure / cardiovascular)
+awareness, so they are grounding-only: populated from an authoritative published
+source (USDA / Open Food Facts / restaurant) ONLY after identity confirmation,
+never asserted from the photo. This stores those grounded values in their own
+JSONB column, kept deliberately separate from the AI's ``nutrition_json`` (the
+photo-estimated macros) so a photo can never assert a comorbidity value.
+
+One nullable JSONB column: NULL for every existing row (no backfill needed) and
+for any record that has no grounded comorbidity data. Descriptive comorbidity
+awareness only -- never read by IoB / treatment_safety / carb-ratio math.
+
+Revision ID: 074_food_record_comorbidity
+Revises: 073_food_record_assumptions
+Create Date: 2026-06-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "074_food_record_comorbidity"
+down_revision = "073_food_record_assumptions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "food_records",
+        sa.Column("grounding_nutrition_json", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("food_records", "grounding_nutrition_json")

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -13,7 +13,9 @@ dependencies = [
     "starlette>=1.3.1",
     "uvicorn[standard]>=0.27.0",
     "pydantic[email]>=2.6.0",
-    "pydantic-settings>=2.1.0",
+    # Security floor: <2.14.2 is vulnerable to GHSA-4xgf-cpjx-pc3j (5.3, fixed
+    # 2.14.2); we floor at the fix and let uv take the latest compatible release.
+    "pydantic-settings>=2.14.2",
     "sqlalchemy[asyncio]>=2.0.25",
     "asyncpg>=0.29.0",
     "alembic>=1.13.0",

--- a/apps/api/src/models/food_record.py
+++ b/apps/api/src/models/food_record.py
@@ -189,6 +189,15 @@ class FoodRecord(Base):
     # Trust-tier marker mirroring knowledge_chunks.trust_tier: USER_PROVIDED
     # (own history) / RESEARCHED / AUTHORITATIVE (published nutrition facts).
     grounding_trust_tier: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # --- Grounding-backed comorbidity / label nutrition ---
+    # Saturated fat / sugars / added sugars / sodium, populated ONLY from the
+    # authoritative grounding source (USDA / OFF / restaurant) once identity is
+    # confirmed -- never asserted from the photo. Kept SEPARATE from the AI's
+    # ``nutrition_json`` (photo-estimated macros) so the photo can never assert a
+    # comorbidity value, and reset whenever grounding is re-run. NULL = no grounded
+    # comorbidity data. Comorbidity awareness only; never read by IoB /
+    # treatment_safety / carb-ratio math.
+    grounding_nutrition_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     # NOTE: the estimation pipeline (food_vision) attaches a transient, non-mapped
     # ``grounding`` attribute (a schemas.food_record.GroundingDetail) to a freshly
     # created instance so the create response can carry the grounded range + note +

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -17,10 +17,13 @@ from src.models.food_record import FoodRecordSource
 from src.vision.carb_contract import (
     CARB_GRAMS_MAX,
     CARB_GRAMS_MIN,
+    COMORBIDITY_NUTRITION_DISCLAIMER,
+    COMORBIDITY_NUTRITION_NOTES,
     MACRO_GLUCOSE_NOTES,
     NET_CARBS_CAVEAT,
     NUTRITION_DOSE_DISCLAIMER,
     SAFETY_QUALIFIER,
+    SUGAR_FREE_NOTE,
 )
 
 if TYPE_CHECKING:
@@ -55,6 +58,30 @@ class GroundingDetail(BaseModel):
     note: str | None = None
     # Source licence / non-medical disclaimer to surface (e.g. Open Food Facts).
     disclaimer: str | None = None
+    # --- Grounding-backed comorbidity nutrition ---
+    # Saturated fat / sugars / added sugars / sodium from the same grounded source,
+    # when published. Only present on a published-fact grounding (USDA / OFF /
+    # restaurant); an own-history recall leaves them None (no label). Persisted via
+    # ``comorbidity_dict()`` into the record's ``grounding_nutrition_json``.
+    saturated_fat_grams: float | None = Field(default=None, ge=0)
+    sugars_grams: float | None = Field(default=None, ge=0)
+    added_sugars_grams: float | None = Field(default=None, ge=0)
+    sodium_mg: float | None = Field(default=None, ge=0)
+
+    def comorbidity_dict(self) -> dict | None:
+        """The grounded comorbidity values as a dict for persistence, or None.
+
+        Only the present (non-None) keys are kept, so a source that publishes no
+        comorbidity data persists nothing rather than a dict of nulls.
+        """
+        values = {
+            "saturated_fat_grams": self.saturated_fat_grams,
+            "sugars_grams": self.sugars_grams,
+            "added_sugars_grams": self.added_sugars_grams,
+            "sodium_mg": self.sodium_mg,
+        }
+        present = {k: v for k, v in values.items() if v is not None}
+        return present or None
 
     @model_validator(mode="after")
     def validate_carb_ordering(self) -> "GroundingDetail":
@@ -254,6 +281,117 @@ def build_nutrition_facts(
     return NutritionFacts(portion=portion_text, macros=macros, net_carbs=net_carbs)
 
 
+# --- Grounding-backed comorbidity / label nutrition ------------ #
+# The comorbidity (blood-pressure / cardiovascular) label fields, in display
+# order, paired with a user label and unit. Unlike the N1 macros (photo-estimated)
+# these are GROUNDING-ONLY: surfaced solely from an authoritative grounded source
+# after identity confirmation. The descriptive awareness framing per field lives in
+# ``carb_contract.COMORBIDITY_NUTRITION_NOTES`` so all the safety-adjacent copy sits
+# in one scrubber-checked place.
+_COMORBIDITY_DISPLAY: dict[str, tuple[str, str]] = {
+    "saturated_fat_grams": ("Saturated fat", "g"),
+    "sugars_grams": ("Sugars", "g"),
+    "added_sugars_grams": ("Added sugars", "g"),
+    "sodium_mg": ("Sodium", "mg"),
+}
+
+# Sane upper bounds so a single off-contract garbage value can't render an absurd
+# card. Reject-not-clamp (like the macro/carb bounds): an over-ceiling value is
+# dropped, never shown. Grams mirror the carb ceiling; sodium (mg) allows a large
+# but finite amount (100 g of sodium per portion is already implausible).
+_COMORBIDITY_MAX: dict[str, float] = {
+    "saturated_fat_grams": CARB_GRAMS_MAX,
+    "sugars_grams": CARB_GRAMS_MAX,
+    "added_sugars_grams": CARB_GRAMS_MAX,
+    "sodium_mg": 100_000.0,
+}
+
+# Whether a surfaced field is a sugars field (drives the "sugar-free is not
+# carb-free" reminder).
+_SUGAR_KEYS = frozenset({"sugars_grams", "added_sugars_grams"})
+
+
+class ComorbidityFact(BaseModel):
+    """One grounding-backed comorbidity nutrient with awareness framing.
+
+    Read-only and descriptive: ``note`` explains why the figure matters for
+    comorbidity (blood-pressure / cardiovascular) awareness, never a clinical
+    limit or a dose. The value never feeds dosing math.
+    """
+
+    key: str
+    label: str
+    value: float = Field(ge=0)
+    unit: str
+    note: str = ""
+
+
+class ComorbidityNutrition(BaseModel):
+    """Grounding-backed comorbidity / label nutrition block.
+
+    GROUNDING-ONLY and identity-gated: populated solely from an authoritative
+    grounded source (USDA / Open Food Facts / restaurant) once the user has
+    confirmed identity -- never asserted from the photo. Framed as blood-pressure /
+    cardiovascular awareness, never a directive. Carries its OWN attribution
+    (``source`` / ``source_url`` / ``trust_tier``), distinct from the vision
+    estimate, and a ``disclaimer`` carrying the never-dose prohibition.
+    """
+
+    facts: list[ComorbidityFact] = Field(default_factory=list)
+    # The "sugar-free is not carb-free" reminder; present only when a sugars
+    # figure is surfaced.
+    sugar_note: str | None = None
+    # Grounding attribution for these figures (the single source they came from).
+    source: str | None = None
+    source_url: str | None = None
+    trust_tier: str | None = None
+    disclaimer: str = COMORBIDITY_NUTRITION_DISCLAIMER
+
+
+def build_comorbidity_nutrition(
+    *,
+    grounding_nutrition: dict | None,
+    source: str | None,
+    source_url: str | None,
+    trust_tier: str | None,
+) -> ComorbidityNutrition | None:
+    """Assemble the grounding-backed comorbidity block.
+
+    Reads ONLY the grounded comorbidity values (never the photo's
+    ``nutrition_json``), so a comorbidity figure can structurally never originate
+    from the vision estimate. Returns ``None`` when there is nothing grounded to
+    show. Everything here is descriptive awareness -- nothing is a dose, and the
+    block is never persisted (only the flat ``grounding_nutrition_json`` is).
+    """
+    grounding_nutrition = grounding_nutrition or {}
+    facts: list[ComorbidityFact] = []
+    for key, (label, unit) in _COMORBIDITY_DISPLAY.items():
+        value = _macro_value(grounding_nutrition.get(key), _COMORBIDITY_MAX.get(key))
+        if value is None:
+            continue
+        facts.append(
+            ComorbidityFact(
+                key=key,
+                label=label,
+                value=value,
+                unit=unit,
+                note=COMORBIDITY_NUTRITION_NOTES.get(key, ""),
+            )
+        )
+
+    if not facts:
+        return None
+
+    sugar_note = SUGAR_FREE_NOTE if any(f.key in _SUGAR_KEYS for f in facts) else None
+    return ComorbidityNutrition(
+        facts=facts,
+        sugar_note=sugar_note,
+        source=source,
+        source_url=source_url,
+        trust_tier=trust_tier,
+    )
+
+
 class FoodRecordResponse(BaseModel):
     """A persisted food record returned to the client.
 
@@ -308,6 +446,14 @@ class FoodRecordResponse(BaseModel):
     grounding_source: str | None = None
     grounding_source_url: str | None = None
     grounding_trust_tier: str | None = None
+    # Grounding-backed comorbidity nutrition. ``grounding_nutrition_json`` is the
+    # raw persisted column (saturated fat / sugars / added sugars / sodium) mapped
+    # off the ORM; it is read internally to build ``comorbidity_nutrition`` -- the
+    # display-ready, awareness-framed, attributed block clients actually consume --
+    # and is itself excluded from the response (an internal column, not a client
+    # field). Both are absent (null) on a record with no grounded comorbidity data.
+    grounding_nutrition_json: dict | None = Field(default=None, exclude=True)
+    comorbidity_nutrition: "ComorbidityNutrition | None" = None
     grounding: GroundingDetail | None = None
     # Multi-sample dispersion (Story 50.H1). Transient create-time detail
     # (empirical confidence + observed spread); absent on later reads.
@@ -357,6 +503,23 @@ class FoodRecordResponse(BaseModel):
             carbs_low=eff_low,
             carbs_high=eff_high,
             portion=self.assumptions,
+        )
+        return self
+
+    @model_validator(mode="after")
+    def build_comorbidity_block(self) -> "FoodRecordResponse":
+        """Compute the grounding-backed comorbidity block.
+
+        Built here -- not stored -- ONLY from the grounded comorbidity values and
+        the record's grounding attribution, so a comorbidity figure can never
+        originate from the photo's ``nutrition_json``. Absent on a record with no
+        grounded comorbidity data.
+        """
+        self.comorbidity_nutrition = build_comorbidity_nutrition(
+            grounding_nutrition=self.grounding_nutrition_json,
+            source=self.grounding_source,
+            source_url=self.grounding_source_url,
+            trust_tier=self.grounding_trust_tier,
         )
         return self
 

--- a/apps/api/src/schemas/food_record.py
+++ b/apps/api/src/schemas/food_record.py
@@ -363,7 +363,11 @@ def build_comorbidity_nutrition(
     show. Everything here is descriptive awareness -- nothing is a dose, and the
     block is never persisted (only the flat ``grounding_nutrition_json`` is).
     """
-    grounding_nutrition = grounding_nutrition or {}
+    # JSONB can hold any JSON value; a non-object payload (a corrupted or
+    # hand-edited row) would raise on ``.get`` and 500 the whole record read, so
+    # treat anything that isn't an object as "no grounded comorbidity data".
+    if not isinstance(grounding_nutrition, dict):
+        return None
     facts: list[ComorbidityFact] = []
     for key, (label, unit) in _COMORBIDITY_DISPLAY.items():
         value = _macro_value(grounding_nutrition.get(key), _COMORBIDITY_MAX.get(key))

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -146,6 +146,13 @@ async def confirm_food_identity(
     record.grounding_source = grounding.source if grounding else None
     record.grounding_source_url = grounding.source_url if grounding else None
     record.grounding_trust_tier = grounding.trust_tier if grounding else None
+    # Persist any grounding-backed comorbidity values (saturated fat /
+    # sugars / added sugars / sodium) from the chosen source. Reset to None when a
+    # re-confirmation grounds to a source without them (e.g. own-history), so a
+    # stale comorbidity block can never outlive its grounding.
+    record.grounding_nutrition_json = (
+        grounding.comorbidity_dict() if grounding else None
+    )
 
     await db.commit()
     await db.refresh(record)

--- a/apps/api/src/services/meal_grounding.py
+++ b/apps/api/src/services/meal_grounding.py
@@ -57,6 +57,13 @@ def _fact_detail(fact: nutrition_sources.NutritionFact) -> GroundingDetail:
         serving=fact.serving,
         note=f"{fact.name}: ~{fact.carbs_grams:g}g carbohydrate {fact.serving}.",
         disclaimer=fact.disclaimer,
+        # Carry any published comorbidity values (saturated fat /
+        # sugars / added sugars / sodium) so the confirm path can persist them. An
+        # own-history recall has no label, so ``_recall_detail`` leaves them None.
+        saturated_fat_grams=fact.saturated_fat_grams,
+        sugars_grams=fact.sugars_grams,
+        added_sugars_grams=fact.added_sugars_grams,
+        sodium_mg=fact.sodium_mg,
     )
 
 

--- a/apps/api/src/services/nutrition_sources.py
+++ b/apps/api/src/services/nutrition_sources.py
@@ -208,7 +208,12 @@ def _usda_comorbidity(food_nutrients: object) -> dict[str, float]:
         number = str(nutrient.get("nutrientNumber") or "")
         name = str(nutrient.get("nutrientName") or "").lower()
         raw = nutrient.get("value")
-        if number == _USDA_SATURATED_FAT_NUMBER or "saturated" in name:
+        if number == _USDA_SATURATED_FAT_NUMBER or (
+            # "saturated" is a substring of mono-/poly-unsaturated, which are
+            # distinct nutrients; exclude them so an unsaturated row isn't stored
+            # as saturated fat.
+            "saturated" in name and "unsaturated" not in name
+        ):
             value = _bounded(raw, maximum=_MAX_GRAMS_PER_100G)
             if value is not None:
                 result.setdefault("saturated_fat_grams", value)

--- a/apps/api/src/services/nutrition_sources.py
+++ b/apps/api/src/services/nutrition_sources.py
@@ -83,7 +83,12 @@ _SERVING_PER_100G = "per 100 g"
 
 @dataclass(frozen=True)
 class NutritionFact:
-    """A grounded nutrition fact from a published source."""
+    """A grounded nutrition fact from a published source.
+
+    The comorbidity fields -- saturated fat / sugars / added sugars /
+    sodium -- are optional: present only when the source publishes them. They are
+    blood-pressure / cardiovascular awareness data, never a dosing input.
+    """
 
     source_name: str
     source_url: str | None
@@ -92,6 +97,25 @@ class NutritionFact:
     carbs_grams: float
     serving: str
     disclaimer: str | None
+    # Grounding-backed comorbidity nutrition; None when unpublished.
+    saturated_fat_grams: float | None = None
+    sugars_grams: float | None = None
+    added_sugars_grams: float | None = None
+    sodium_mg: float | None = None
+
+    def comorbidity_dict(self) -> dict | None:
+        """The present comorbidity values as a dict, or None when there are none."""
+        present = {
+            k: v
+            for k, v in (
+                ("saturated_fat_grams", self.saturated_fat_grams),
+                ("sugars_grams", self.sugars_grams),
+                ("added_sugars_grams", self.added_sugars_grams),
+                ("sodium_mg", self.sodium_mg),
+            )
+            if v is not None
+        }
+        return present or None
 
 
 def _normalize_query(query: str) -> str:
@@ -141,6 +165,119 @@ def _valid_carbs(value: object) -> float | None:
     return carbs
 
 
+# --- Comorbidity nutrition extraction -------------------------- #
+# Per-100 g grams (saturated fat / sugars) can't exceed 100 g; sodium per 100 g
+# is in mg and bounded by an implausible-but-finite ceiling (pure salt is ~38.8 g
+# sodium / 100 g). Reject-not-clamp: a value past the ceiling signals bad/mis-parsed
+# source data, so it is dropped rather than grounded on.
+_MAX_GRAMS_PER_100G = 100.0
+_MAX_SODIUM_MG_PER_100G = 100_000.0
+
+# USDA FoodData Central nutrient numbers for the comorbidity fields.
+_USDA_SATURATED_FAT_NUMBER = "606"
+_USDA_ADDED_SUGARS_NUMBER = "539"
+_USDA_SODIUM_NUMBER = "307"
+# Total sugars shifted nutrient number between USDA datasets (269 / 269.3).
+_USDA_TOTAL_SUGARS_NUMBERS = frozenset({"269", "269.3"})
+
+
+def _bounded(value: object, *, maximum: float) -> float | None:
+    """A finite, non-negative number within ``maximum``, else None (reject-not-clamp)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    if not (0.0 <= number <= maximum):
+        return None
+    return number
+
+
+def _usda_comorbidity(food_nutrients: object) -> dict[str, float]:
+    """Pull the comorbidity nutrients out of a USDA ``foodNutrients`` list.
+
+    Returns only the fields the source actually published, each bounded per 100 g.
+    Matched by USDA nutrient number first (stable), falling back to the nutrient
+    name -- and added sugars is matched separately from total sugars so the two are
+    never conflated.
+    """
+    result: dict[str, float] = {}
+    if not isinstance(food_nutrients, list):
+        return result
+    for nutrient in food_nutrients:
+        if not isinstance(nutrient, dict):
+            continue
+        number = str(nutrient.get("nutrientNumber") or "")
+        name = str(nutrient.get("nutrientName") or "").lower()
+        raw = nutrient.get("value")
+        if number == _USDA_SATURATED_FAT_NUMBER or "saturated" in name:
+            value = _bounded(raw, maximum=_MAX_GRAMS_PER_100G)
+            if value is not None:
+                result.setdefault("saturated_fat_grams", value)
+        elif number == _USDA_ADDED_SUGARS_NUMBER or (
+            # USDA names this "Sugars, added", so match both word orders rather than
+            # the (never-matching) "added sugar" substring.
+            "added" in name and "sugar" in name
+        ):
+            value = _bounded(raw, maximum=_MAX_GRAMS_PER_100G)
+            if value is not None:
+                result.setdefault("added_sugars_grams", value)
+        elif number in _USDA_TOTAL_SUGARS_NUMBERS or (
+            "sugars" in name and "added" not in name
+        ):
+            value = _bounded(raw, maximum=_MAX_GRAMS_PER_100G)
+            if value is not None:
+                result.setdefault("sugars_grams", value)
+        elif number == _USDA_SODIUM_NUMBER or name == "sodium, na":
+            value = _bounded(raw, maximum=_MAX_SODIUM_MG_PER_100G)
+            if value is not None:
+                result.setdefault("sodium_mg", value)
+    return result
+
+
+def comorbidity_from_meta(
+    meta: dict, *, grams_max: float = _MAX_GRAMS_PER_100G
+) -> dict[str, float]:
+    """Reconstruct a cached fact's comorbidity values, each re-bounded.
+
+    Defence in depth: although the cache is written by us, re-validate every value
+    on read so a hand-edited / corrupted ``metadata_json`` can never resurrect an
+    out-of-range comorbidity figure. Shared by the USDA/OFF (per-100 g) and
+    restaurant (per-item) caches; ``grams_max`` is the gram ceiling for that basis.
+    """
+    result: dict[str, float] = {}
+    for key in ("saturated_fat_grams", "sugars_grams", "added_sugars_grams"):
+        value = _bounded(meta.get(key), maximum=grams_max)
+        if value is not None:
+            result[key] = value
+    sodium = _bounded(meta.get("sodium_mg"), maximum=_MAX_SODIUM_MG_PER_100G)
+    if sodium is not None:
+        result["sodium_mg"] = sodium
+    return result
+
+
+def _off_comorbidity(product: dict) -> dict[str, float]:
+    """Pull the comorbidity nutrients out of an Open Food Facts product.
+
+    OFF reports per 100 g; sodium is in grams there, so it is converted to mg. When
+    only salt is given, sodium is derived as ``salt / 2.5`` (the standard factor).
+    OFF has no reliable added-sugars field, so that key is left unset.
+    """
+    result: dict[str, float] = {}
+    sat = _bounded(product.get("saturated-fat_100g"), maximum=_MAX_GRAMS_PER_100G)
+    if sat is not None:
+        result["saturated_fat_grams"] = sat
+    sugars = _bounded(product.get("sugars_100g"), maximum=_MAX_GRAMS_PER_100G)
+    if sugars is not None:
+        result["sugars_grams"] = sugars
+    sodium_g = _bounded(product.get("sodium_100g"), maximum=_MAX_GRAMS_PER_100G)
+    if sodium_g is not None:
+        result["sodium_mg"] = sodium_g * 1000.0
+    else:
+        salt_g = _bounded(product.get("salt_100g"), maximum=_MAX_GRAMS_PER_100G)
+        if salt_g is not None:
+            result["sodium_mg"] = salt_g / 2.5 * 1000.0
+    return result
+
+
 async def _cache_get(
     db: AsyncSession, source_type: str, normalized_query: str
 ) -> NutritionFact | None:
@@ -172,6 +309,7 @@ async def _cache_get(
         carbs_grams=carbs,
         serving=meta.get("serving") or _SERVING_PER_100G,
         disclaimer=meta.get("disclaimer"),
+        **comorbidity_from_meta(meta),
     )
 
 
@@ -205,6 +343,9 @@ async def _cache_put(
         "carbs_grams": fact.carbs_grams,
         "serving": fact.serving,
         "disclaimer": fact.disclaimer,
+        # Persist any grounded comorbidity values so a cache hit
+        # surfaces them too (only the present keys are written).
+        **(fact.comorbidity_dict() or {}),
     }
     stmt = pg_insert(KnowledgeChunk).values(
         user_id=None,
@@ -334,6 +475,7 @@ async def lookup_usda(query: str) -> NutritionFact | None:
         return None
 
     fdc_id = food.get("fdcId")
+    comorbidity = _usda_comorbidity(food.get("foodNutrients"))
     fact = NutritionFact(
         source_name="USDA FoodData Central",
         source_url=(
@@ -346,6 +488,7 @@ async def lookup_usda(query: str) -> NutritionFact | None:
         carbs_grams=carbs,
         serving=_SERVING_PER_100G,
         disclaimer=None,
+        **comorbidity,
     )
     async with get_session_maker()() as db:
         await _cache_put(
@@ -380,7 +523,11 @@ async def lookup_open_food_facts(query: str) -> NutritionFact | None:
             "action": "process",
             "json": 1,
             "page_size": 1,
-            "fields": "product_name,carbohydrates_100g,code,url",
+            "fields": (
+                "product_name,carbohydrates_100g,code,url,"
+                # Comorbidity fields (per 100 g; sodium in grams here).
+                "saturated-fat_100g,sugars_100g,sodium_100g,salt_100g"
+            ),
         },
     )
     if data is None:
@@ -400,6 +547,7 @@ async def lookup_open_food_facts(query: str) -> NutritionFact | None:
     if not name:
         name = query[:120]
     source_url = _safe_off_citation_url(product.get("url"), product.get("code"))
+    comorbidity = _off_comorbidity(product)
     fact = NutritionFact(
         source_name="Open Food Facts",
         source_url=source_url,
@@ -408,6 +556,7 @@ async def lookup_open_food_facts(query: str) -> NutritionFact | None:
         carbs_grams=carbs,
         serving=_SERVING_PER_100G,
         disclaimer=_OFF_DISCLAIMER,
+        **comorbidity,
     )
     async with get_session_maker()() as db:
         await _cache_put(

--- a/apps/api/src/services/restaurant_nutrition.py
+++ b/apps/api/src/services/restaurant_nutrition.py
@@ -55,7 +55,7 @@ from src.database import get_session_maker
 from src.logging_config import get_logger
 from src.models.knowledge_chunk import KnowledgeChunk
 from src.services.meal_rag import SOURCE_TYPE_FATSECRET, SOURCE_TYPE_RESTAURANT_CHAIN
-from src.services.nutrition_sources import NutritionFact
+from src.services.nutrition_sources import NutritionFact, comorbidity_from_meta
 from src.vision.carb_contract import (
     CARB_GRAMS_MAX,
     CARB_GRAMS_MIN,
@@ -322,6 +322,24 @@ async def _fetch_json(
 # --------------------------------------------------------------------------- #
 # Carb + response parsing helpers
 # --------------------------------------------------------------------------- #
+def _coerce_number(value: object) -> float | None:
+    """Coerce a number or numeric string to a float, else None (no bounds applied).
+
+    Shared by the carb and comorbidity parsers so their numeric coercion (reject
+    bool; pull the first signed decimal out of a string) can never drift apart;
+    each caller applies its own reject-not-clamp bound on top.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        match = re.search(r"-?\d+(?:\.\d+)?", value)
+        if match:
+            return float(match.group(0))
+    return None
+
+
 def _valid_item_carbs(value: object) -> float | None:
     """Per-item carbs within the absolute single-meal bounds, or None.
 
@@ -330,15 +348,7 @@ def _valid_item_carbs(value: object) -> float | None:
     rather than cite a wrong "published" number. ``GroundingDetail`` enforces the
     same bound at construction, so an out-of-range value would otherwise raise.
     """
-    if isinstance(value, bool):
-        return None
-    carbs: float | None = None
-    if isinstance(value, (int, float)):
-        carbs = float(value)
-    elif isinstance(value, str):
-        match = re.search(r"-?\d+(?:\.\d+)?", value)
-        if match:
-            carbs = float(match.group(0))
+    carbs = _coerce_number(value)
     if carbs is None or not (CARB_GRAMS_MIN <= carbs <= CARB_GRAMS_MAX):
         return None
     return carbs
@@ -357,6 +367,46 @@ def _carb_from_nutrients(
         if "carbohydrate" in name or name in ("carbs", "total carbs"):
             return _valid_item_carbs(nutrient.get(value_key))
     return None
+
+
+# A per-item meal's sodium (mg) is bounded by an implausible-but-finite ceiling
+# (reject-not-clamp), distinct from the per-item gram bound the macros use.
+_MAX_ITEM_SODIUM_MG = 100_000.0
+
+
+def _comorbidity_from_nutrients(
+    nutrients: object, *, name_key: str, value_key: str
+) -> dict[str, float]:
+    """Scan a [{name, value}, ...] nutrient list for the comorbidity fields.
+
+    Per-item grams are bounded by the absolute single-meal carb range; sodium (mg)
+    by its own ceiling. Added sugars is matched before total sugars so the two are
+    never conflated, and total sugars excludes "sugar alcohol" / polyols (a distinct
+    field that is not a sugar). Returns only the fields the chain actually published.
+    """
+    result: dict[str, float] = {}
+    if not isinstance(nutrients, list):
+        return result
+    for nutrient in nutrients:
+        if not isinstance(nutrient, dict):
+            continue
+        name = str(nutrient.get(name_key) or "").lower()
+        amount = _coerce_number(nutrient.get(value_key))
+        if amount is None:
+            continue
+        if "saturated" in name:
+            if CARB_GRAMS_MIN <= amount <= CARB_GRAMS_MAX:
+                result.setdefault("saturated_fat_grams", amount)
+        elif "added" in name and "sugar" in name:
+            if CARB_GRAMS_MIN <= amount <= CARB_GRAMS_MAX:
+                result.setdefault("added_sugars_grams", amount)
+        elif "sugar" in name and "alcohol" not in name and "polyol" not in name:
+            if CARB_GRAMS_MIN <= amount <= CARB_GRAMS_MAX:
+                result.setdefault("sugars_grams", amount)
+        elif "sodium" in name:
+            if 0.0 <= amount <= _MAX_ITEM_SODIUM_MG:
+                result.setdefault("sodium_mg", amount)
+    return result
 
 
 def _best_item(items: object, *, name_key: str, item_query: str) -> dict | None:
@@ -460,6 +510,9 @@ class _McDonalds(RestaurantChain):
         )
         if carbs is None:
             return None
+        comorbidity = _comorbidity_from_nutrients(
+            item.get("nutrient_facts"), name_key="name", value_key="value"
+        )
         name = (
             str(item.get("item_name") or item_query).strip()[:120] or item_query[:120]
         )
@@ -468,6 +521,7 @@ class _McDonalds(RestaurantChain):
             source_url=self.citation_url,
             name=name,
             carbs=carbs,
+            comorbidity=comorbidity,
         )
 
 
@@ -497,12 +551,16 @@ class _Chipotle(RestaurantChain):
         )
         if carbs is None:
             return None
+        comorbidity = _comorbidity_from_nutrients(
+            item.get("nutrition"), name_key="name", value_key="value"
+        )
         name = str(item.get("itemName") or item_query).strip()[:120] or item_query[:120]
         return _build_fact(
             source_name=self.display_name,
             source_url=self.citation_url,
             name=name,
             carbs=carbs,
+            comorbidity=comorbidity,
         )
 
 
@@ -552,6 +610,7 @@ def _build_fact(
     name: str,
     carbs: float,
     serving: str = _SERVING_PER_ITEM,
+    comorbidity: dict | None = None,
 ) -> NutritionFact | None:
     """Build an AUTHORITATIVE reference fact, or None if the (source-controlled)
     item name carries dosing language.
@@ -562,6 +621,9 @@ def _build_fact(
     entirely rather than surface that text in the citation note returned to the
     client -- the same no-dosing-language boundary the rest of the meal pipeline
     enforces on generated/source text.
+
+    ``comorbidity`` carries the optional comorbidity fields (saturated fat /
+    sugars / added sugars / sodium) the chain published for this item.
     """
     if find_dosing_violations(name):
         logger.warning("Restaurant item name carried dosing language; dropping")
@@ -574,6 +636,7 @@ def _build_fact(
         carbs_grams=carbs,
         serving=serving,
         disclaimer=_RESTAURANT_DISCLAIMER,
+        **(comorbidity or {}),
     )
 
 
@@ -796,6 +859,8 @@ async def _cache_get(
                 carbs_grams=carbs,
                 serving=meta.get("serving") or _SERVING_PER_ITEM,
                 disclaimer=meta.get("disclaimer"),
+                # Per-item basis, so grams are bounded by the absolute carb ceiling.
+                **comorbidity_from_meta(meta, grams_max=CARB_GRAMS_MAX),
             )
     except Exception:
         logger.warning("Restaurant cache lookup failed", source=source_type)
@@ -838,6 +903,8 @@ async def _cache_put(
         "source_name": fact.source_name,
         "source_url": fact.source_url,
         "trust_tier": fact.trust_tier,
+        # Persist any grounded comorbidity values (present keys only).
+        **(fact.comorbidity_dict() or {}),
     }
     stmt = pg_insert(KnowledgeChunk).values(
         user_id=user_id,

--- a/apps/api/src/services/restaurant_nutrition.py
+++ b/apps/api/src/services/restaurant_nutrition.py
@@ -394,7 +394,9 @@ def _comorbidity_from_nutrients(
         amount = _coerce_number(nutrient.get(value_key))
         if amount is None:
             continue
-        if "saturated" in name:
+        if "saturated" in name and "unsaturated" not in name:
+            # "saturated" is a substring of mono-/poly-unsaturated; exclude those
+            # so an unsaturated-fat row isn't stored as saturated fat.
             if CARB_GRAMS_MIN <= amount <= CARB_GRAMS_MAX:
                 result.setdefault("saturated_fat_grams", amount)
         elif "added" in name and "sugar" in name:

--- a/apps/api/src/vision/carb_contract.py
+++ b/apps/api/src/vision/carb_contract.py
@@ -203,6 +203,56 @@ NUTRITION_DOSE_DISCLAIMER = (
     f"{NEVER_DOSE_PROHIBITION}."
 )
 
+# --- Grounding-backed comorbidity / label nutrition framing -----
+# Saturated fat, sugars/added sugars, and sodium aren't reliably estimable from a
+# plated-food photo, and their value is comorbidity (blood-pressure / cardiovascular)
+# awareness -- so they are GROUNDING-ONLY (looked up from a published source after
+# identity confirmation) and framed as awareness, never a directive. Each note is
+# deliberately:
+#   * free of any dosing language (each passes ``find_dosing_violations``), and
+#   * descriptive of why the figure matters, not a clinical limit or a dose input.
+# Adversarially verified: total fat (not its saturation) drives the acute glucose
+# effect, so saturated fat is framed as cardiovascular awareness only; sodium has
+# no acute glucose link but real blood-pressure value. Keyed by the grounding
+# nutrition key so the framing travels with the value.
+COMORBIDITY_NUTRITION_NOTES = {
+    "saturated_fat_grams": (
+        "Saturated fat is a heart-health signal, not a glucose one — it doesn't "
+        "change your sugar rise, but it's worth knowing for cardiovascular health."
+    ),
+    "sugars_grams": (
+        "Sugars are carbohydrates that tend to spike glucose sooner than starches do."
+    ),
+    "added_sugars_grams": (
+        "Added sugars are put in during processing — like other sugars, they tend "
+        "to spike glucose sooner."
+    ),
+    "sodium_mg": (
+        "Sodium matters for blood pressure — it doesn't affect glucose, but it's "
+        "worth keeping an eye on for cardiovascular health."
+    ),
+}
+
+# The "sugar-free is not carb-free" note that travels with a surfaced sugars
+# figure: a reminder that the absence of sugar does not mean the food won't raise
+# glucose. Descriptive and dosing-language-free (passes ``find_dosing_violations``);
+# it points back to total carbs, never to a dose.
+SUGAR_FREE_NOTE = (
+    "Sugar-free doesn't mean carb-free — sugar alcohols and starches still raise "
+    "glucose, so count total carbohydrates."
+)
+
+# Section-level disclaimer for the comorbidity block. These are PUBLISHED reference
+# figures (not AI estimates), shown for blood-pressure / heart-health awareness, so
+# -- like the OFF / restaurant disclaimers -- this avoids the "AI guess" framing and
+# reuses only the canonical ``NEVER_DOSE_PROHIBITION``. By naming the prohibited
+# action ("bolus") it intentionally does NOT itself pass ``find_dosing_violations``:
+# it is a prohibition, not a description of food.
+COMORBIDITY_NUTRITION_DISCLAIMER = (
+    "These figures come from published nutrition data, shown for blood-pressure "
+    f"and heart-health awareness — a descriptive reference only; {NEVER_DOSE_PROHIBITION}."
+)
+
 
 @dataclass
 class ParsedEstimate:

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -445,6 +445,13 @@ class TestNoTherapyCoupling:
             # math either -- they are descriptive read-side figures only.
             assert "net_carb" not in text.lower(), f"{path} references net carbs"
             assert "nutrition_facts" not in text, f"{path} references nutrition_facts"
+            # Grounded comorbidity nutrition is descriptive-only too.
+            assert "comorbidity" not in text.lower(), (
+                f"{path} references comorbidity nutrition"
+            )
+            assert "grounding_nutrition" not in text.lower(), (
+                f"{path} references grounding nutrition"
+            )
 
     async def test_food_record_does_not_change_iob(self):
         """A logged meal must not produce or alter insulin-on-board."""
@@ -851,6 +858,127 @@ class TestIdentityConfirmation:
         # Carbs are untouched by an identity confirmation (never a dose).
         assert body["carbs_low"] == created["carbs_low"]
         assert body["carbs_high"] == created["carbs_high"]
+
+    async def test_confirm_persists_grounded_comorbidity_and_read_surfaces_it(
+        self, auth_client
+    ):
+        # When identity confirmation grounds against a published source
+        # that has comorbidity data, those values persist and the read response
+        # surfaces an attributed, awareness-framed comorbidity block. AC2 (gated on
+        # confirmation) + AC4 (attribution surfaced).
+        from src.schemas.food_record import GroundingDetail
+        from src.vision.carb_contract import NEVER_DOSE_PROHIBITION
+
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        # A fresh (unconfirmed) record has no comorbidity block (AC1/AC2).
+        assert created["comorbidity_nutrition"] is None
+
+        detail = GroundingDetail(
+            source="USDA FoodData Central",
+            source_url="https://fdc.nal.usda.gov/x",
+            trust_tier="AUTHORITATIVE",
+            carbs_low=45,
+            carbs_high=45,
+            saturated_fat_grams=12.0,
+            sugars_grams=8.0,
+            sodium_mg=1100.0,
+        )
+        with patch(
+            "src.services.common_food.meal_grounding.ground_estimate",
+            AsyncMock(return_value=detail),
+        ):
+            resp = await client.post(
+                f"/api/food-records/{record_id}/confirm-identity",
+                json={"confirmed_food_name": "cheeseburger"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        comorbidity = body["comorbidity_nutrition"]
+        assert comorbidity is not None
+        keys = {f["key"] for f in comorbidity["facts"]}
+        assert keys == {"saturated_fat_grams", "sugars_grams", "sodium_mg"}
+        # Attribution distinct from the vision estimate + the never-dose prohibition.
+        assert comorbidity["source"] == "USDA FoodData Central"
+        assert comorbidity["sugar_note"] and "carb-free" in comorbidity["sugar_note"]
+        assert NEVER_DOSE_PROHIBITION in comorbidity["disclaimer"]
+        # The comorbidity facts are descriptive figures, never a dose: no fact key
+        # carries dosing/insulin wording.
+        assert not any(
+            tok in f["key"]
+            for f in comorbidity["facts"]
+            for tok in ("dose", "insulin", "bolus")
+        )
+
+        # Persisted: a later read still carries the comorbidity block (not transient).
+        read = await client.get(f"/api/food-records/{record_id}")
+        assert read.status_code == 200
+        reread = read.json()["comorbidity_nutrition"]
+        assert reread is not None
+        assert {f["key"] for f in reread["facts"]} == keys
+
+    async def test_confirm_without_grounded_comorbidity_surfaces_nothing(
+        self, auth_client
+    ):
+        # Confirming an identity that grounds to nothing (or to own-history, which
+        # has no label) leaves the comorbidity block absent -- never fabricated.
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+        with patch(
+            "src.services.common_food.meal_grounding.ground_estimate",
+            AsyncMock(return_value=None),
+        ):
+            resp = await client.post(
+                f"/api/food-records/{record_id}/confirm-identity",
+                json={"confirmed_food_name": "homemade stew"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["comorbidity_nutrition"] is None
+
+    async def test_reconfirm_to_ungrounded_identity_clears_stale_comorbidity(
+        self, auth_client
+    ):
+        # A re-confirmation that grounds to a source without comorbidity (e.g.
+        # own-history, or nothing) must clear a previously-grounded block, so a
+        # stale comorbidity card can never outlive its grounding.
+        from src.schemas.food_record import GroundingDetail
+
+        client, _ = auth_client
+        created = await _create_record(client)
+        record_id = created["id"]
+
+        grounded = GroundingDetail(
+            source="USDA FoodData Central",
+            trust_tier="AUTHORITATIVE",
+            sodium_mg=900.0,
+        )
+        with patch(
+            "src.services.common_food.meal_grounding.ground_estimate",
+            AsyncMock(return_value=grounded),
+        ):
+            first = await client.post(
+                f"/api/food-records/{record_id}/confirm-identity",
+                json={"confirmed_food_name": "branded soup"},
+            )
+        assert first.status_code == 200
+        assert first.json()["comorbidity_nutrition"] is not None
+
+        # Re-confirm to a name that grounds to nothing -> the block is cleared.
+        with patch(
+            "src.services.common_food.meal_grounding.ground_estimate",
+            AsyncMock(return_value=None),
+        ):
+            second = await client.post(
+                f"/api/food-records/{record_id}/confirm-identity",
+                json={"confirmed_food_name": "my homemade soup"},
+            )
+        assert second.status_code == 200
+        assert second.json()["comorbidity_nutrition"] is None
+        # And a fresh read confirms the cleared state is persisted.
+        read = await client.get(f"/api/food-records/{record_id}")
+        assert read.json()["comorbidity_nutrition"] is None
 
     async def test_confirm_identity_rejects_blank(self, auth_client):
         client, _ = auth_client

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -672,6 +672,19 @@ class TestComorbidityCapture:
         )
         assert result == {"sugars_grams": 9.0, "added_sugars_grams": 3.0}
 
+    def test_usda_unsaturated_fat_not_stored_as_saturated(self):
+        # "saturated" is a substring of mono-/poly-unsaturated; those distinct
+        # nutrients (which appear first here, without a number) must not be stored
+        # as saturated fat -- only the real saturated row is.
+        result = nutrition_sources._usda_comorbidity(
+            [
+                {"nutrientName": "Fatty acids, total monounsaturated", "value": 6.0},
+                {"nutrientName": "Fatty acids, total polyunsaturated", "value": 4.0},
+                {"nutrientName": "Fatty acids, total saturated", "value": 3.0},
+            ]
+        )
+        assert result == {"saturated_fat_grams": 3.0}
+
     async def test_off_converts_sodium_grams_to_mg(self, monkeypatch):
         monkeypatch.setattr(settings, "open_food_facts_enabled", True)
         payload = {

--- a/apps/api/tests/test_meal_grounding.py
+++ b/apps/api/tests/test_meal_grounding.py
@@ -602,6 +602,135 @@ class TestOpenFoodFacts:
 
 
 # --------------------------------------------------------------------------- #
+# Grounding-backed comorbidity capture + propagation
+# --------------------------------------------------------------------------- #
+class TestComorbidityCapture:
+    _USDA_PAYLOAD = {
+        "foods": [
+            {
+                "description": "Cheeseburger",
+                "fdcId": 7777,
+                "foodNutrients": [
+                    {"nutrientNumber": "205", "value": 30.0},
+                    {
+                        "nutrientNumber": "606",
+                        "nutrientName": "Fatty acids, total saturated",
+                        "value": 11.0,
+                    },
+                    {
+                        "nutrientNumber": "269.3",
+                        "nutrientName": "Sugars, total including NLEA",
+                        "value": 7.0,
+                    },
+                    {
+                        "nutrientNumber": "539",
+                        "nutrientName": "Sugars, added",
+                        "value": 4.0,
+                    },
+                    {
+                        "nutrientNumber": "307",
+                        "nutrientName": "Sodium, Na",
+                        "value": 990.0,
+                    },
+                ],
+            }
+        ]
+    }
+
+    async def test_usda_captures_comorbidity_and_cache_round_trips(self, monkeypatch):
+        monkeypatch.setattr(settings, "usda_fdc_api_key", "TESTKEY")
+        query = _uniq("burger")
+        ctx, client = _mock_httpx(self._USDA_PAYLOAD)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            first = await nutrition_sources.lookup_usda(query)
+            second = await nutrition_sources.lookup_usda(query)  # cache hit
+
+        assert first is not None
+        assert first.saturated_fat_grams == 11.0
+        assert first.sugars_grams == 7.0
+        assert first.added_sugars_grams == 4.0
+        assert first.sodium_mg == 990.0
+        # The cached fact preserves the comorbidity values (no second HTTP call).
+        assert client.stream.call_count == 1
+        assert second is not None
+        assert second.comorbidity_dict() == {
+            "saturated_fat_grams": 11.0,
+            "sugars_grams": 7.0,
+            "added_sugars_grams": 4.0,
+            "sodium_mg": 990.0,
+        }
+
+    def test_usda_added_sugars_matched_by_name_when_number_absent(self):
+        # USDA names this "Sugars, added"; the name fallback must match it (and not
+        # mis-bucket it as total sugars) even when no nutrient number is supplied.
+        result = nutrition_sources._usda_comorbidity(
+            [
+                {"nutrientName": "Sugars, total including NLEA", "value": 9.0},
+                {"nutrientName": "Sugars, added", "value": 3.0},
+            ]
+        )
+        assert result == {"sugars_grams": 9.0, "added_sugars_grams": 3.0}
+
+    async def test_off_converts_sodium_grams_to_mg(self, monkeypatch):
+        monkeypatch.setattr(settings, "open_food_facts_enabled", True)
+        payload = {
+            "products": [
+                {
+                    "product_name": "Cereal",
+                    "carbohydrates_100g": 70.0,
+                    "code": "1",
+                    "saturated-fat_100g": 2.0,
+                    "sugars_100g": 30.0,
+                    "sodium_100g": 0.5,  # grams -> 500 mg
+                }
+            ]
+        }
+        ctx, client = _mock_httpx(payload)
+        with ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            fact = await nutrition_sources.lookup_open_food_facts(_uniq("cereal"))
+        assert fact is not None
+        assert fact.saturated_fat_grams == 2.0
+        assert fact.sugars_grams == 30.0
+        assert fact.sodium_mg == 500.0
+        # OFF has no reliable added-sugars field.
+        assert fact.added_sugars_grams is None
+
+    async def test_grounding_detail_propagates_comorbidity(self):
+        # A published fact's comorbidity values flow into the GroundingDetail so the
+        # confirm path can persist them; an own-history recall carries none.
+        fact = nutrition_sources.NutritionFact(
+            source_name="USDA FoodData Central",
+            source_url="https://fdc.nal.usda.gov/x",
+            trust_tier=KnowledgeChunk.TIER_AUTHORITATIVE,
+            name="burger",
+            carbs_grams=30.0,
+            serving="per 100 g",
+            disclaimer=None,
+            saturated_fat_grams=11.0,
+            sodium_mg=990.0,
+        )
+        with (
+            patch.object(meal_rag, "recall_similar_meal", AsyncMock(return_value=None)),
+            patch.object(
+                nutrition_sources,
+                "lookup_published_nutrition",
+                AsyncMock(return_value=(fact, None)),
+            ),
+            patch.object(settings, "meal_intelligence_enabled", True),
+        ):
+            detail = await meal_grounding.ground_estimate(
+                uuid.uuid4(), "cheeseburger", identity_confirmed=True
+            )
+        assert detail is not None
+        assert detail.comorbidity_dict() == {
+            "saturated_fat_grams": 11.0,
+            "sodium_mg": 990.0,
+        }
+
+
+# --------------------------------------------------------------------------- #
 # Security: SSRF / host allow-list on the external fetch
 # --------------------------------------------------------------------------- #
 class TestExternalFetchSecurity:

--- a/apps/api/tests/test_meal_nutrition_facts.py
+++ b/apps/api/tests/test_meal_nutrition_facts.py
@@ -420,6 +420,20 @@ class TestBuildComorbidityNutrition:
         assert block is not None
         assert [f.key for f in block.facts] == ["added_sugars_grams"]
 
+    def test_non_object_grounding_payload_returns_none(self):
+        # JSONB can hold any JSON value; a non-object (corrupted / hand-edited row)
+        # must not raise on .get and 500 the record read -- it yields no block.
+        for payload in ("just a string", 42, ["a", "list"], True):
+            assert (
+                build_comorbidity_nutrition(
+                    grounding_nutrition=payload,
+                    source="x",
+                    source_url=None,
+                    trust_tier=None,
+                )
+                is None
+            )
+
 
 class TestComorbidityExcludesOutOfScopeFields:
     def test_vision_contract_never_asks_for_comorbidity_fields(self):

--- a/apps/api/tests/test_meal_nutrition_facts.py
+++ b/apps/api/tests/test_meal_nutrition_facts.py
@@ -21,13 +21,17 @@ import pytest
 
 from src.schemas.food_record import (
     NetCarbsEstimate,
+    build_comorbidity_nutrition,
     build_nutrition_facts,
 )
 from src.vision.carb_contract import (
+    COMORBIDITY_NUTRITION_DISCLAIMER,
+    COMORBIDITY_NUTRITION_NOTES,
     MACRO_GLUCOSE_NOTES,
     NET_CARBS_CAVEAT,
     NEVER_DOSE_PROHIBITION,
     NUTRITION_DOSE_DISCLAIMER,
+    SUGAR_FREE_NOTE,
     find_dosing_violations,
 )
 
@@ -288,3 +292,169 @@ class TestNetCarbsNeverCouples:
             assert "net_carb" not in text, f"{path} references net carbs"
             assert "nutrition_facts" not in text, f"{path} references nutrition_facts"
             assert "macrofact" not in text, f"{path} references MacroFact"
+            # Grounded comorbidity nutrition is descriptive-only too.
+            assert "comorbidity" not in text, f"{path} references comorbidity"
+            assert "grounding_nutrition" not in text, (
+                f"{path} references grounding nutrition"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Grounding-backed comorbidity nutrition -- framing + build + safety
+# --------------------------------------------------------------------------- #
+class TestComorbidityFraming:
+    def test_the_four_comorbidity_fields_are_framed(self):
+        assert set(COMORBIDITY_NUTRITION_NOTES) == {
+            "saturated_fat_grams",
+            "sugars_grams",
+            "added_sugars_grams",
+            "sodium_mg",
+        }
+
+    def test_every_comorbidity_note_is_free_of_dosing_language(self):
+        # AC3: the awareness framing must pass the scrubber (it describes the food,
+        # never a dose).
+        for key, note in COMORBIDITY_NUTRITION_NOTES.items():
+            assert find_dosing_violations(note) == [], f"{key} note reads as dosing"
+
+    def test_sodium_and_sat_fat_frame_bp_cardiovascular_awareness(self):
+        # AC3: sodium -> blood pressure; saturated fat -> cardiovascular.
+        assert "blood pressure" in COMORBIDITY_NUTRITION_NOTES["sodium_mg"].lower()
+        assert (
+            "cardiovascular"
+            in COMORBIDITY_NUTRITION_NOTES["saturated_fat_grams"].lower()
+        )
+
+    def test_sugars_frame_an_earlier_spike(self):
+        # AC3: sugars -> "tends to spike sooner".
+        for key in ("sugars_grams", "added_sugars_grams"):
+            note = COMORBIDITY_NUTRITION_NOTES[key].lower()
+            assert "spike" in note and "sooner" in note, key
+
+    def test_sugar_free_note_is_descriptive_and_points_to_total_carbs(self):
+        # AC3: the "sugar-free is not carb-free" note passes the scrubber and points
+        # the user back to total carbs (never a dose).
+        assert find_dosing_violations(SUGAR_FREE_NOTE) == []
+        lowered = SUGAR_FREE_NOTE.lower()
+        assert "sugar-free" in lowered and "carb-free" in lowered
+        assert "total carb" in lowered
+
+    def test_section_disclaimer_carries_the_prohibition_not_ai_framing(self):
+        # The figures are published reference data, so the disclaimer carries the
+        # never-dose prohibition but must NOT mislabel them as an "AI estimate".
+        assert NEVER_DOSE_PROHIBITION in COMORBIDITY_NUTRITION_DISCLAIMER
+        assert "ai estimate" not in COMORBIDITY_NUTRITION_DISCLAIMER.lower()
+
+
+class TestBuildComorbidityNutrition:
+    _GROUNDED = {
+        "saturated_fat_grams": 12.0,
+        "sugars_grams": 8.0,
+        "added_sugars_grams": 5.0,
+        "sodium_mg": 1100.0,
+    }
+
+    def test_builds_attributed_facts_from_grounded_values(self):
+        block = build_comorbidity_nutrition(
+            grounding_nutrition=self._GROUNDED,
+            source="USDA FoodData Central",
+            source_url="https://fdc.nal.usda.gov/x",
+            trust_tier="AUTHORITATIVE",
+        )
+        assert block is not None
+        labels = [f.label for f in block.facts]
+        assert labels == ["Saturated fat", "Sugars", "Added sugars", "Sodium"]
+        units = {f.key: f.unit for f in block.facts}
+        assert units["sodium_mg"] == "mg" and units["saturated_fat_grams"] == "g"
+        # Each fact carries its descriptive awareness note.
+        for fact in block.facts:
+            assert fact.note == COMORBIDITY_NUTRITION_NOTES[fact.key]
+        # Attribution is distinct from the vision estimate.
+        assert block.source == "USDA FoodData Central"
+        assert block.source_url == "https://fdc.nal.usda.gov/x"
+        assert block.trust_tier == "AUTHORITATIVE"
+        assert block.disclaimer == COMORBIDITY_NUTRITION_DISCLAIMER
+
+    def test_sugar_note_only_when_a_sugars_field_is_present(self):
+        with_sugar = build_comorbidity_nutrition(
+            grounding_nutrition={"sugars_grams": 9.0},
+            source="x",
+            source_url=None,
+            trust_tier=None,
+        )
+        assert with_sugar is not None and with_sugar.sugar_note == SUGAR_FREE_NOTE
+        without_sugar = build_comorbidity_nutrition(
+            grounding_nutrition={"sodium_mg": 500.0},
+            source="x",
+            source_url=None,
+            trust_tier=None,
+        )
+        assert without_sugar is not None and without_sugar.sugar_note is None
+
+    def test_returns_none_without_grounded_values(self):
+        assert (
+            build_comorbidity_nutrition(
+                grounding_nutrition=None, source=None, source_url=None, trust_tier=None
+            )
+            is None
+        )
+        assert (
+            build_comorbidity_nutrition(
+                grounding_nutrition={}, source="x", source_url=None, trust_tier=None
+            )
+            is None
+        )
+
+    def test_absurd_and_invalid_values_are_dropped_reject_not_clamp(self):
+        block = build_comorbidity_nutrition(
+            grounding_nutrition={
+                "sodium_mg": 10**9,  # over ceiling -> dropped
+                "sugars_grams": -3,  # negative -> dropped
+                "saturated_fat_grams": "lots",  # non-numeric -> dropped
+                "added_sugars_grams": 4.0,  # kept
+            },
+            source="x",
+            source_url=None,
+            trust_tier=None,
+        )
+        assert block is not None
+        assert [f.key for f in block.facts] == ["added_sugars_grams"]
+
+
+class TestComorbidityExcludesOutOfScopeFields:
+    def test_vision_contract_never_asks_for_comorbidity_fields(self):
+        # AC1: the comorbidity fields are grounding-only -- the photo is never asked
+        # for them, so they can't be asserted from a plated-food image.
+        from src.vision.carb_contract import ESTIMATE_JSON_SHAPE, SYSTEM_PROMPT
+
+        nutrition_spec = ESTIMATE_JSON_SHAPE["nutrition"].lower()
+        for term in ("saturated", "sugar", "sodium", "salt"):
+            assert term not in nutrition_spec, f"vision contract solicits {term}"
+        prompt = SYSTEM_PROMPT.lower()
+        for term in ("saturated fat", "sodium", "added sugar"):
+            assert term not in prompt, f"system prompt solicits {term}"
+
+    def test_no_gi_gl_or_fpu_field_is_surfaced(self):
+        # AC5: GI / GL / FPU stay out of scope -- a block fed those keys surfaces
+        # only the four allowed comorbidity fields (here: none), never them.
+        block = build_comorbidity_nutrition(
+            grounding_nutrition={
+                "glycemic_index": 70,
+                "glycemic_load": 25,
+                "fat_protein_units": 2,
+            },
+            source="x",
+            source_url=None,
+            trust_tier=None,
+        )
+        assert block is None
+
+    def test_comorbidity_is_not_a_food_record_dosing_column(self):
+        # The grounded comorbidity values live in their own JSONB column, never a
+        # carb/dose column the therapy math could read.
+        from src.models.food_record import FoodRecord
+
+        cols = set(FoodRecord.__table__.columns.keys())
+        assert "grounding_nutrition_json" in cols
+        for forbidden in ("dose", "insulin", "bolus", "sodium", "saturated"):
+            assert not any(forbidden in c for c in cols), forbidden

--- a/apps/api/tests/test_restaurant_nutrition.py
+++ b/apps/api/tests/test_restaurant_nutrition.py
@@ -262,6 +262,20 @@ class TestChainFetch:
         )
         assert result == {"sugars_grams": 9.0}
 
+    def test_unsaturated_fat_is_not_bucketed_as_saturated(self):
+        # "saturated" is a substring of mono-/poly-unsaturated; an unsaturated row
+        # (appearing first) must not be stored as the saturated-fat figure.
+        result = rn._comorbidity_from_nutrients(
+            [
+                {"name": "Monounsaturated Fat", "value": 7},
+                {"name": "Polyunsaturated Fat", "value": 5},
+                {"name": "Saturated Fat", "value": 3},
+            ],
+            name_key="name",
+            value_key="value",
+        )
+        assert result == {"saturated_fat_grams": 3.0}
+
     async def test_no_brand_makes_no_request(self):
         user = await _new_user()
         ctx, client = _mock_httpx(_MCD_PAYLOAD)

--- a/apps/api/tests/test_restaurant_nutrition.py
+++ b/apps/api/tests/test_restaurant_nutrition.py
@@ -214,6 +214,54 @@ class TestChainFetch:
         assert fact.carbs_grams == 40
         assert fact.trust_tier == KnowledgeChunk.TIER_AUTHORITATIVE
 
+    async def test_captures_comorbidity_and_cache_round_trips(self):
+        # A chain's published saturated fat / sugars / sodium flow into
+        # the fact (per-item) and survive the owner-scoped cache round-trip.
+        user = await _new_user()
+        payload = {
+            "items": [
+                {
+                    "item_name": "Big Mac",
+                    "nutrient_facts": [
+                        {"name": "Carbohydrates", "value": 45},
+                        {"name": "Saturated Fat", "value": 10},
+                        {"name": "Total Sugars", "value": 9},
+                        {"name": "Added Sugars", "value": 7},
+                        {"name": "Sodium", "value": 1010},
+                    ],
+                }
+            ]
+        }
+        ctx, client = _mock_httpx(payload)
+        with _allow_robots(), ctx as ac:
+            ac.return_value.__aenter__.return_value = client
+            first = await rn.lookup_restaurant(user.id, "McDonald's Big Mac")
+            second = await rn.lookup_restaurant(user.id, "McDonald's Big Mac")
+        assert first is not None
+        assert first.comorbidity_dict() == {
+            "saturated_fat_grams": 10.0,
+            "sugars_grams": 9.0,
+            "added_sugars_grams": 7.0,
+            "sodium_mg": 1010.0,
+        }
+        # Served from the owner-scoped cache with comorbidity intact (no 2nd fetch).
+        assert client.stream.call_count == 1
+        assert second is not None
+        assert second.comorbidity_dict() == first.comorbidity_dict()
+
+    def test_sugar_alcohol_is_not_bucketed_as_total_sugars(self):
+        # "Sugar Alcohol" (polyols) contains "sugar" but is a distinct field; it must
+        # not be surfaced as the meal's total Sugars figure.
+        result = rn._comorbidity_from_nutrients(
+            [
+                {"name": "Total Sugars", "value": 9},
+                {"name": "Sugar Alcohol", "value": 4},
+            ],
+            name_key="name",
+            value_key="value",
+        )
+        assert result == {"sugars_grams": 9.0}
+
     async def test_no_brand_makes_no_request(self):
         user = await _new_user()
         ctx, client = _mock_httpx(_MCD_PAYLOAD)

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -772,7 +772,7 @@ requires-dist = [
     { name = "pgvector", specifier = ">=0.3.0" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.6.0" },
-    { name = "pydantic-settings", specifier = ">=2.1.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pydexcom", specifier = ">=0.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
@@ -1833,16 +1833,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/meal/MealModels.kt
@@ -1,5 +1,6 @@
 package com.glycemicgpt.mobile.data.meal
 
+import com.glycemicgpt.mobile.data.remote.dto.ComorbidityNutritionResponse
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordAuditResponse
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordResponse
@@ -140,6 +141,31 @@ data class MealNetCarbs(
     val caveat: String,
 )
 
+/**
+ * Grounding-backed comorbidity / label nutrition. GROUNDING-ONLY and
+ * identity-gated: published reference figures (saturated fat / sugars / sodium)
+ * framed as blood-pressure / cardiovascular awareness, never a dose. Attributed to
+ * [source] (distinct from the vision estimate); [disclaimer] carries the never-dose
+ * framing; [sugarNote] (the "sugar-free isn't carb-free" reminder) is present only
+ * when a sugars figure is surfaced. All copy is server-cleared and rendered verbatim.
+ */
+data class MealComorbidityNutrition(
+    val facts: List<MealComorbidityFact>,
+    val sugarNote: String?,
+    val source: String?,
+    val trustTier: String?,
+    val disclaimer: String?,
+)
+
+/** One grounding-backed comorbidity nutrient with its awareness-framing note. */
+data class MealComorbidityFact(
+    val key: String,
+    val label: String,
+    val value: Double,
+    val unit: String,
+    val note: String?,
+)
+
 /** A persisted meal photo + carb estimate, optionally corrected by the user. */
 data class FoodRecord(
     val id: String,
@@ -167,6 +193,12 @@ data class FoodRecord(
     val suggestedIdentity: String? = null,
     /** Glucose-framed nutrition (Story 50.N1): portion + macros + net carbs. */
     val nutritionFacts: MealNutritionFacts? = null,
+    /**
+     * Grounding-backed comorbidity nutrition: saturated fat / sugars /
+     * sodium when an authoritative source published them. Null when nothing was
+     * grounded; only ever present on a confirmed, grounded record.
+     */
+    val comorbidityNutrition: MealComorbidityNutrition? = null,
 ) {
     /** Whether the user has corrected the AI estimate. */
     val isCorrected: Boolean get() = correction != null
@@ -234,6 +266,38 @@ fun FoodRecordResponse.toDomain(): FoodRecord {
         identityConfirmed = identityConfirmed,
         suggestedIdentity = suggestedIdentity?.takeIf { it.isNotBlank() },
         nutritionFacts = nutritionFacts?.toDomain(),
+        comorbidityNutrition = comorbidityNutrition?.toDomain(),
+    )
+}
+
+private fun ComorbidityNutritionResponse.toDomain(): MealComorbidityNutrition? {
+    // Drop any non-finite / negative value defensively (the server already rejects
+    // these); a comorbidity block with no usable fact is treated as absent so an
+    // empty card never renders.
+    val mapped = facts.mapNotNull { fact ->
+        fact.takeIf { it.value.isFinite() && it.value >= 0.0 }?.let {
+            MealComorbidityFact(
+                key = it.key,
+                label = it.label,
+                value = it.value,
+                unit = it.unit,
+                note = it.note?.takeIf { note -> note.isNotBlank() },
+            )
+        }
+    }
+    if (mapped.isEmpty()) return null
+    // Keep the "sugar-free isn't carb-free" note only when a sugars fact actually
+    // survived, mirroring the server's _SUGAR_KEYS gating, so a dropped/non-finite
+    // sugars value can't leave an orphaned reminder on the card.
+    val sugarSurvived = mapped.any {
+        it.key == "sugars_grams" || it.key == "added_sugars_grams"
+    }
+    return MealComorbidityNutrition(
+        facts = mapped,
+        sugarNote = if (sugarSurvived) sugarNote?.takeIf { it.isNotBlank() } else null,
+        source = source?.takeIf { it.isNotBlank() },
+        trustTier = trustTier?.takeIf { it.isNotBlank() },
+        disclaimer = disclaimer?.takeIf { it.isNotBlank() },
     )
 }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/FoodModels.kt
@@ -44,7 +44,38 @@ data class FoodRecordResponse(
     // with their "how this affects glucose" notes, and caveated net carbs. All
     // copy is server-cleared and rendered verbatim. Descriptive only -- never a dose.
     @Json(name = "nutrition_facts") val nutritionFacts: NutritionFactsResponse? = null,
+    // Grounding-backed comorbidity nutrition: saturated fat / sugars /
+    // sodium when an authoritative source published them. GROUNDING-ONLY and
+    // identity-gated; absent on a record with no grounded comorbidity data.
+    @Json(name = "comorbidity_nutrition")
+    val comorbidityNutrition: ComorbidityNutritionResponse? = null,
     @Json(name = "created_at") val createdAt: String,
+)
+
+/**
+ * Grounding-backed comorbidity / label nutrition. GROUNDING-ONLY and
+ * identity-gated: published reference figures for blood-pressure / cardiovascular
+ * awareness, attributed to their [source] (distinct from the vision estimate), with
+ * a [disclaimer] carrying the never-dose framing. [sugarNote] (the "sugar-free isn't
+ * carb-free" reminder) is present only when a sugars figure is surfaced. Descriptive
+ * only -- never a dose. Only consumed fields are declared.
+ */
+@JsonClass(generateAdapter = true)
+data class ComorbidityNutritionResponse(
+    val facts: List<ComorbidityFactResponse> = emptyList(),
+    @Json(name = "sugar_note") val sugarNote: String? = null,
+    val source: String? = null,
+    @Json(name = "trust_tier") val trustTier: String? = null,
+    val disclaimer: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ComorbidityFactResponse(
+    val key: String,
+    val label: String,
+    val value: Double,
+    val unit: String,
+    val note: String? = null,
 )
 
 /**

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.glycemicgpt.mobile.data.meal.CarbConfidence
 import com.glycemicgpt.mobile.data.meal.CarbRange
+import com.glycemicgpt.mobile.data.meal.MealComorbidityFact
+import com.glycemicgpt.mobile.data.meal.MealComorbidityNutrition
 import com.glycemicgpt.mobile.data.meal.MealDispersion
 import com.glycemicgpt.mobile.data.meal.MealMacro
 import com.glycemicgpt.mobile.data.meal.MealNetCarbs
@@ -399,7 +401,6 @@ private fun MacroRow(macro: MealMacro) {
 
 @Composable
 private fun NetCarbsRow(netCarbs: MealNetCarbs) {
-    val palette = safetyPalette()
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -424,26 +425,7 @@ private fun NetCarbsRow(netCarbs: MealNetCarbs) {
         }
         // The net-carbs caveat rides a calm-caution strip (not error red): named
         // as inexact, pointing back to total carbs, carrying the never-dose line.
-        Surface(color = palette.background, shape = RoundedCornerShape(8.dp)) {
-            Row(
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Info,
-                    contentDescription = null,
-                    tint = palette.icon,
-                    modifier = Modifier.size(18.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = netCarbs.caveat,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = palette.foreground,
-                    modifier = Modifier.testTag("meal_net_carbs_caveat"),
-                )
-            }
-        }
+        CautionStrip(text = netCarbs.caveat, testTag = "meal_net_carbs_caveat")
     }
 }
 
@@ -463,6 +445,135 @@ fun formatNetCarbs(low: Double, high: Double): String {
     val lo = low.roundToInt()
     val hi = high.roundToInt()
     return if (lo == hi) "≈ $lo g" else "≈ $lo–$hi g"
+}
+
+/**
+ * Grounding-backed comorbidity / label nutrition: saturated fat,
+ * sugars, and sodium when an authoritative source published them. GROUNDING-ONLY
+ * (never from the photo) and identity-gated, so the caller renders this only for a
+ * grounded record. Framed as blood-pressure / cardiovascular awareness, never a
+ * directive: each figure carries its descriptive note, sugars carry the "sugar-free
+ * isn't carb-free" reminder, the block is attributed to its source (distinct from
+ * the vision estimate), and the never-dose disclaimer closes it. All copy is
+ * server-cleared and rendered verbatim. Read-only -- nothing here is a dose.
+ */
+@Composable
+fun MealComorbidityContent(
+    comorbidity: MealComorbidityNutrition,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("meal_comorbidity"),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Heart & blood-pressure awareness",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            comorbidity.facts.forEach { fact -> ComorbidityRow(fact) }
+            comorbidity.sugarNote?.let { note -> ComorbidityCaution(note) }
+            // Attribution: these are published reference figures, distinct from the
+            // photo estimate, so name the source (and its trust tier when present).
+            comorbidity.source?.let { source ->
+                val tier = comorbidity.trustTier?.lowercase(Locale.US)
+                Text(
+                    text = if (tier != null) "From $source ($tier source)" else "From $source",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("meal_comorbidity_source"),
+                )
+            }
+            comorbidity.disclaimer?.takeIf { it.isNotBlank() }?.let { disclaimer ->
+                Text(
+                    text = disclaimer,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("meal_comorbidity_disclaimer"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ComorbidityRow(fact: MealComorbidityFact) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("meal_comorbidity_fact"),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = fact.label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = formatMacroValue(fact.value, fact.unit),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        fact.note?.let { note ->
+            Text(
+                text = note,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("meal_comorbidity_note"),
+            )
+        }
+    }
+}
+
+/** The "sugar-free isn't carb-free" reminder, on the shared calm-caution strip. */
+@Composable
+private fun ComorbidityCaution(note: String) {
+    CautionStrip(text = note, testTag = "meal_comorbidity_sugar_note")
+}
+
+/**
+ * A calm-caution strip (info icon + text on the safety palette, NOT error red):
+ * the single source of truth for the never-dose-adjacent caveats so the net-carbs
+ * caveat and the comorbidity sugar note can't drift apart visually. The caller
+ * supplies the verbatim server text and the test tag for that surface.
+ */
+@Composable
+private fun CautionStrip(text: String, testTag: String) {
+    val palette = safetyPalette()
+    Surface(color = palette.background, shape = RoundedCornerShape(8.dp)) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Info,
+                contentDescription = null,
+                tint = palette.icon,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodySmall,
+                color = palette.foreground,
+                modifier = Modifier.testTag(testTag),
+            )
+        }
+    }
 }
 
 /** Full-screen centered spinner with an optional caption, shared across the meal screens. */

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -400,6 +400,12 @@ private fun ResultContent(
     // before the user corrects. Descriptive only -- never a dose.
     record.nutritionFacts?.let { MealNutritionContent(it) }
 
+    // Grounding-backed comorbidity nutrition: saturated fat, sugars,
+    // and sodium when an authoritative source published them. Only present on a
+    // grounded record; framed as blood-pressure / cardiovascular awareness and
+    // attributed to its source -- distinct from the photo-estimated macros above.
+    record.comorbidityNutrition?.let { MealComorbidityContent(it) }
+
     if (uiState.isCorrecting) {
         CorrectionEditor(
             initialLow = record.displayRange.lowGrams,

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/MealModelsTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/meal/MealModelsTest.kt
@@ -3,6 +3,8 @@ package com.glycemicgpt.mobile.data.meal
 import com.glycemicgpt.mobile.data.remote.dto.AuditDispersionResponse
 import com.glycemicgpt.mobile.data.remote.dto.AuditPrecedenceResponse
 import com.glycemicgpt.mobile.data.remote.dto.AuditSampleResponse
+import com.glycemicgpt.mobile.data.remote.dto.ComorbidityFactResponse
+import com.glycemicgpt.mobile.data.remote.dto.ComorbidityNutritionResponse
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
 import com.glycemicgpt.mobile.data.remote.dto.EstimateDispersionResponse
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordAuditResponse
@@ -287,6 +289,98 @@ class MealModelsTest {
         val facts = domain.nutritionFacts!!
         assertEquals(listOf("Calories"), facts.macros.map { it.label })
         assertNull(facts.netCarbs)
+    }
+
+    @Test
+    fun `comorbidity nutrition maps grounded facts, sugar note, and attribution`() {
+        val domain = record().copy(
+            comorbidityNutrition = ComorbidityNutritionResponse(
+                facts = listOf(
+                    ComorbidityFactResponse(
+                        key = "saturated_fat_grams",
+                        label = "Saturated fat",
+                        value = 12.0,
+                        unit = "g",
+                        note = "Saturated fat ... worth knowing for cardiovascular health.",
+                    ),
+                    ComorbidityFactResponse(
+                        key = "sugars_grams",
+                        label = "Sugars",
+                        value = 8.0,
+                        unit = "g",
+                        note = "Sugars ... tend to spike glucose sooner ...",
+                    ),
+                    ComorbidityFactResponse(
+                        key = "sodium_mg",
+                        label = "Sodium",
+                        value = 1100.0,
+                        unit = "mg",
+                        note = "Sodium matters for blood pressure ...",
+                    ),
+                ),
+                sugarNote = "Sugar-free doesn't mean carb-free ...",
+                source = "USDA FoodData Central",
+                trustTier = "AUTHORITATIVE",
+                disclaimer = "These figures come from published nutrition data ... never use it to dose or bolus.",
+            ),
+        ).toDomain()
+
+        val comorbidity = domain.comorbidityNutrition
+        assertTrue("comorbidity should be mapped", comorbidity != null)
+        assertEquals(
+            listOf("Saturated fat", "Sugars", "Sodium"),
+            comorbidity?.facts?.map { it.label },
+        )
+        assertEquals("mg", comorbidity?.facts?.get(2)?.unit)
+        assertTrue(comorbidity?.facts?.get(2)?.note?.contains("blood pressure") == true)
+        assertEquals("USDA FoodData Central", comorbidity?.source)
+        assertEquals("AUTHORITATIVE", comorbidity?.trustTier)
+        // The sugar note is retained because a sugars fact survived.
+        assertTrue(comorbidity?.sugarNote?.contains("carb-free") == true)
+        assertTrue(comorbidity?.disclaimer?.contains("dose or bolus") == true)
+    }
+
+    @Test
+    fun `comorbidity nutrition is null on a read that omits it`() {
+        assertNull(record().toDomain().comorbidityNutrition)
+    }
+
+    @Test
+    fun `a comorbidity block with only non-finite values maps to null`() {
+        // Defensive client mirror of the server bounds: a NaN/Infinity figure must
+        // never render, and a block left with no usable fact is treated as absent.
+        val domain = record().copy(
+            comorbidityNutrition = ComorbidityNutritionResponse(
+                facts = listOf(
+                    ComorbidityFactResponse("sodium_mg", "Sodium", Double.NaN, "mg", null),
+                    ComorbidityFactResponse(
+                        "sugars_grams", "Sugars", Double.POSITIVE_INFINITY, "g", null,
+                    ),
+                ),
+                source = "USDA FoodData Central",
+            ),
+        ).toDomain()
+        assertNull(domain.comorbidityNutrition)
+    }
+
+    @Test
+    fun `sugar note is dropped when its sugars fact does not survive`() {
+        // A non-finite sugars value is dropped but a finite sodium fact survives;
+        // the "sugar-free isn't carb-free" note must not be left orphaned.
+        val domain = record().copy(
+            comorbidityNutrition = ComorbidityNutritionResponse(
+                facts = listOf(
+                    ComorbidityFactResponse("sodium_mg", "Sodium", 1100.0, "mg", null),
+                    ComorbidityFactResponse("sugars_grams", "Sugars", Double.NaN, "g", null),
+                ),
+                sugarNote = "Sugar-free doesn't mean carb-free ...",
+                source = "USDA FoodData Central",
+            ),
+        ).toDomain()
+        val comorbidity = domain.comorbidityNutrition
+        assertTrue("block should survive on the sodium fact", comorbidity != null)
+        assertEquals(listOf("Sodium"), comorbidity?.facts?.map { it.label })
+        assertNull(comorbidity?.sugarNote)
     }
 
     @Test

--- a/apps/web/__tests__/components/dashboard/data-sources-freshness-card.test.tsx
+++ b/apps/web/__tests__/components/dashboard/data-sources-freshness-card.test.tsx
@@ -43,14 +43,13 @@ function dexcomIntegration(
   overrides: Partial<IntegrationResponse> = {}
 ): IntegrationResponse {
   return {
-    id: "int-dex",
     integration_type: "dexcom",
     status: "connected",
     last_sync_at: new Date(NOW_MS - 5 * 60_000).toISOString(), // 5m ago
     last_error: null,
-    has_credentials: true,
     created_at: "2026-05-01T00:00:00.000Z",
     updated_at: "2026-05-01T00:00:00.000Z",
+    region: null,
     ...overrides,
   };
 }

--- a/apps/web/__tests__/meals/common-food-actions.test.tsx
+++ b/apps/web/__tests__/meals/common-food-actions.test.tsx
@@ -50,6 +50,7 @@ function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
     grounding_source_url: null,
     grounding_trust_tier: null,
     nutrition_facts: null,
+    comorbidity_nutrition: null,
     created_at: "2026-06-19T12:00:01Z",
     ...overrides,
   };

--- a/apps/web/__tests__/meals/common-foods-api.test.ts
+++ b/apps/web/__tests__/meals/common-foods-api.test.ts
@@ -4,6 +4,12 @@
  * save-as + link, and the owner-scoped 404 / 409 / 422 error contract.
  */
 
+// Force module scope: this file uses in-test `require()` rather than top-level
+// imports, so without an export it is a global script and its `jsonResponse`
+// collides with the identically-named helper in meal-api.test.ts ("Duplicate
+// function implementation" under tsc).
+export {};
+
 function jsonResponse(status: number, body: unknown, ok?: boolean) {
   return {
     ok: ok ?? (status >= 200 && status < 300),

--- a/apps/web/__tests__/meals/meal-api.test.ts
+++ b/apps/web/__tests__/meals/meal-api.test.ts
@@ -4,6 +4,12 @@
  * the multipart upload, the meal-intelligence probe, and owner-scoped errors.
  */
 
+// Force module scope: this file uses in-test `require()` rather than top-level
+// imports, so without an export it is a global script and its `jsonResponse`
+// collides with the identically-named helper in common-foods-api.test.ts
+// ("Duplicate function implementation" under tsc).
+export {};
+
 function jsonResponse(status: number, body: unknown, ok?: boolean) {
   return {
     ok: ok ?? (status >= 200 && status < 300),

--- a/apps/web/__tests__/meals/meal-audit.test.tsx
+++ b/apps/web/__tests__/meals/meal-audit.test.tsx
@@ -51,6 +51,7 @@ function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
     grounding_source_url: null,
     grounding_trust_tier: null,
     nutrition_facts: null,
+    comorbidity_nutrition: null,
     created_at: "2026-06-19T12:00:01Z",
     ...overrides,
   };

--- a/apps/web/__tests__/meals/meal-detail.test.tsx
+++ b/apps/web/__tests__/meals/meal-detail.test.tsx
@@ -97,6 +97,7 @@ function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
       disclaimer:
         "These nutrition figures are rough AI estimates that describe the meal — never use it to dose or bolus.",
     },
+    comorbidity_nutrition: null,
     created_at: "2026-06-19T12:00:01Z",
     ...overrides,
   };
@@ -490,5 +491,90 @@ describe("Meal detail page", () => {
     await waitFor(() =>
       expect(mockConfirm).toHaveBeenCalledWith("rec-1", "Saved oatmeal")
     );
+  });
+
+  // --- grounding-backed comorbidity nutrition ---
+
+  const groundedComorbidityRecord = () =>
+    makeRecord({
+      identity_confirmed: true,
+      confirmed_food_name: "Cheeseburger",
+      source: "external_grounded",
+      grounding_source: "USDA FoodData Central",
+      grounding_source_url: "https://fdc.nal.usda.gov/",
+      grounding_trust_tier: "AUTHORITATIVE",
+      comorbidity_nutrition: {
+        facts: [
+          {
+            key: "saturated_fat_grams",
+            label: "Saturated fat",
+            value: 12,
+            unit: "g",
+            note: "Saturated fat is a heart-health signal, not a glucose one — it doesn't change your sugar rise, but it's worth knowing for cardiovascular health.",
+          },
+          {
+            key: "sugars_grams",
+            label: "Sugars",
+            value: 8,
+            unit: "g",
+            note: "Sugars are carbohydrates that tend to spike glucose sooner than starches do.",
+          },
+          {
+            key: "sodium_mg",
+            label: "Sodium",
+            value: 1100,
+            unit: "mg",
+            note: "Sodium matters for blood pressure — it doesn't affect glucose, but it's worth keeping an eye on for cardiovascular health.",
+          },
+        ],
+        sugar_note:
+          "Sugar-free doesn't mean carb-free — sugar alcohols and starches still raise glucose, so count total carbohydrates.",
+        source: "USDA FoodData Central",
+        source_url: "https://fdc.nal.usda.gov/",
+        trust_tier: "AUTHORITATIVE",
+        disclaimer:
+          "These figures come from published nutrition data, shown for blood-pressure and heart-health awareness — a descriptive reference only; never use it to dose or bolus.",
+      },
+    });
+
+  it("surfaces grounded comorbidity nutrition as BP/CVD awareness, attributed, with no dose element", async () => {
+    mockGet.mockResolvedValue(groundedComorbidityRecord());
+    render(<MealDetailPage />);
+
+    const card = await screen.findByTestId("meal-comorbidity");
+    // Sodium + saturated fat read as blood-pressure / cardiovascular awareness.
+    expect(card).toHaveTextContent("Saturated fat");
+    expect(card).toHaveTextContent("Sodium");
+    expect(card).toHaveTextContent(/blood pressure/i);
+    expect(card).toHaveTextContent(/cardiovascular/i);
+    // Sugars frame an earlier spike + carry the "sugar-free isn't carb-free" note.
+    expect(card).toHaveTextContent(/spike glucose sooner/i);
+    expect(
+      screen.getByTestId("meal-comorbidity-sugar-note")
+    ).toHaveTextContent(/sugar-free.*carb-free/i);
+    // Values render with units; three grounded facts shown.
+    expect(screen.getAllByTestId("meal-comorbidity-fact")).toHaveLength(3);
+    expect(screen.getByTestId("meal-comorbidity")).toHaveTextContent("1100 mg");
+    // Attribution is distinct from the vision estimate: a safe outbound link.
+    expect(screen.getByTestId("meal-comorbidity-source")).toHaveTextContent(
+      "USDA FoodData Central"
+    );
+    const link = screen.getByTestId("meal-comorbidity-link");
+    expect(link).toHaveAttribute("href", "https://fdc.nal.usda.gov/");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    // The block carries the never-dose prohibition; nothing here is a dose.
+    expect(
+      screen.getByTestId("meal-comorbidity-disclaimer")
+    ).toHaveTextContent(/never use it to dose or bolus/i);
+    expect(card).not.toHaveTextContent(/insulin|how much/i);
+  });
+
+  it("omits the comorbidity card when nothing was grounded", async () => {
+    mockGet.mockResolvedValue(makeRecord({ comorbidity_nutrition: null }));
+    render(<MealDetailPage />);
+
+    // Wait for the page to settle on a known element, then assert absence.
+    expect(await screen.findByTestId("meal-carb-range")).toBeInTheDocument();
+    expect(screen.queryByTestId("meal-comorbidity")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/__tests__/meals/meal-format.test.ts
+++ b/apps/web/__tests__/meals/meal-format.test.ts
@@ -45,6 +45,7 @@ function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
     grounding_source_url: null,
     grounding_trust_tier: null,
     nutrition_facts: null,
+    comorbidity_nutrition: null,
     created_at: "2026-06-19T12:00:01Z",
     ...overrides,
   };

--- a/apps/web/__tests__/meals/meals-page.test.tsx
+++ b/apps/web/__tests__/meals/meals-page.test.tsx
@@ -66,6 +66,7 @@ function makeRecord(overrides: Partial<FoodRecord> = {}): FoodRecord {
     grounding_source_url: null,
     grounding_trust_tier: null,
     nutrition_facts: null,
+    comorbidity_nutrition: null,
     created_at: "2026-06-19T12:00:01Z",
     ...overrides,
   };

--- a/apps/web/jest-dom.d.ts
+++ b/apps/web/jest-dom.d.ts
@@ -1,0 +1,8 @@
+// Makes @testing-library/jest-dom's custom matcher type augmentations
+// (toBeInTheDocument, toHaveAttribute, toHaveTextContent, ...) visible to `tsc`
+// for every test file. The runtime import lives in jest.setup.js, but that is a
+// .js file the tsconfig `include` (**/*.ts / **/*.tsx) does not pick up, so its
+// global augmentation was invisible to the type-checker and every matcher call
+// in __tests__/ reported "Property '...' does not exist on JestMatchers". This
+// side-effect import loads those augmentations into the TS program.
+import "@testing-library/jest-dom";

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -27,6 +27,7 @@
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/jest": "^29.5.14",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3879,6 +3880,52 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch"
   },
@@ -30,6 +31,7 @@
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/web/src/app/dashboard/meals/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/meals/[id]/page.tsx
@@ -36,6 +36,7 @@ import {
   MealAssumedPortion,
   MealNutritionFacts,
   MealNutritionDisclaimer,
+  MealComorbidityNutrition,
   MealErrorPanel,
 } from "@/components/meals/meal-ui";
 import {
@@ -311,6 +312,20 @@ export default function MealDetailPage() {
 
         {facts?.disclaimer && (
           <MealNutritionDisclaimer disclaimer={facts.disclaimer} />
+        )}
+
+        {/* Grounding-backed comorbidity nutrition: saturated fat,
+            sugars, and sodium when an authoritative source published them. Only
+            renders for a grounded record (the block is absent otherwise), framed as
+            blood-pressure / cardiovascular awareness and attributed to its source —
+            distinct from the photo-estimated macros above. */}
+        {record.comorbidity_nutrition && (
+          <AnimatedCard delay={0.175}>
+            <MealComorbidityNutrition
+              record={record}
+              comorbidity={record.comorbidity_nutrition}
+            />
+          </AnimatedCard>
         )}
 
         {(record.ai_model || record.ai_provider) && (

--- a/apps/web/src/components/meals/meal-ui.tsx
+++ b/apps/web/src/components/meals/meal-ui.tsx
@@ -11,6 +11,7 @@ import {
   BadgeCheck,
   CheckCircle2,
   ExternalLink,
+  HeartPulse,
   ImageOff,
   ScanLine,
   Settings as SettingsIcon,
@@ -23,7 +24,12 @@ import {
   isSafeHttpUrl,
   sourceMeta,
 } from "@/lib/meal-format";
-import type { FoodRecord, FoodRecordSource, NutritionFacts } from "@/lib/api";
+import type {
+  ComorbidityNutrition,
+  FoodRecord,
+  FoodRecordSource,
+  NutritionFacts,
+} from "@/lib/api";
 import type { MealErrorInfo } from "@/lib/meal-errors";
 
 /** Provenance badge (AI estimate / corrected / grounded). */
@@ -190,6 +196,97 @@ export function MealNutritionDisclaimer({ disclaimer }: { disclaimer: string }) 
     >
       {disclaimer}
     </p>
+  );
+}
+
+/**
+ * Grounding-backed comorbidity / label nutrition: saturated fat,
+ * sugars/added sugars, and sodium when an authoritative grounded source published
+ * them. GROUNDING-ONLY (never from the photo) and identity-gated, so this only
+ * renders for a grounded record. Framed as blood-pressure / cardiovascular
+ * awareness, never a directive: every figure carries its descriptive note, sugars
+ * carry the "sugar-free isn't carb-free" reminder, the block is attributed to its
+ * source (distinct from the vision estimate), and the never-dose disclaimer closes
+ * it. All copy is rendered verbatim from the server. Read-only -- nothing is a dose.
+ */
+export function MealComorbidityNutrition({
+  record,
+  comorbidity,
+}: {
+  record: FoodRecord;
+  comorbidity: ComorbidityNutrition;
+}) {
+  return (
+    <div
+      data-testid="meal-comorbidity"
+      className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 space-y-4"
+    >
+      <div className="flex items-center gap-2">
+        <HeartPulse className="h-4 w-4 text-rose-500 dark:text-rose-400" />
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+          Heart &amp; blood-pressure awareness
+        </h2>
+      </div>
+
+      <dl className="space-y-3">
+        {comorbidity.facts.map((fact) => (
+          <div
+            key={fact.key}
+            data-testid="meal-comorbidity-fact"
+            className="space-y-0.5"
+          >
+            <div className="flex items-baseline justify-between gap-3">
+              <dt className="text-sm text-slate-600 dark:text-slate-300">
+                {fact.label}
+              </dt>
+              <dd
+                data-testid="meal-comorbidity-value"
+                className="text-sm font-medium text-slate-900 dark:text-white"
+              >
+                {formatMacroValue(fact.value, fact.unit)}
+              </dd>
+            </div>
+            {fact.note && (
+              <p
+                data-testid="meal-comorbidity-note"
+                className="text-xs text-slate-500 dark:text-slate-400"
+              >
+                {fact.note}
+              </p>
+            )}
+          </div>
+        ))}
+      </dl>
+
+      {comorbidity.sugar_note && (
+        <div
+          role="note"
+          data-testid="meal-comorbidity-sugar-note"
+          className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-300"
+        >
+          <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+          <span>{comorbidity.sugar_note}</span>
+        </div>
+      )}
+
+      {/* These figures are published reference data, not the vision estimate, so
+          they carry their own source attribution (the same grounded source the
+          carb range was checked against). */}
+      <GroundedSourceNote
+        record={record}
+        label="From"
+        linkLabel="published data"
+        testId="meal-comorbidity-source"
+        linkTestId="meal-comorbidity-link"
+      />
+
+      <p
+        data-testid="meal-comorbidity-disclaimer"
+        className="text-xs text-slate-400 dark:text-slate-500"
+      >
+        {comorbidity.disclaimer}
+      </p>
+    </div>
   );
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4218,6 +4218,36 @@ export interface NutritionFacts {
 }
 
 /**
+ * One grounding-backed comorbidity nutrient with awareness framing.
+ * Read-only: `note` explains why the figure matters for blood-pressure /
+ * cardiovascular awareness -- never a dose.
+ */
+export interface ComorbidityFact {
+  key: string;
+  label: string;
+  value: number;
+  unit: string;
+  note: string;
+}
+
+/**
+ * Grounding-backed comorbidity / label nutrition. GROUNDING-ONLY
+ * and identity-gated: populated solely from an authoritative grounded source
+ * (USDA / Open Food Facts / restaurant) after identity confirmation, never from
+ * the photo. Carries its own attribution (distinct from the vision estimate) and a
+ * `disclaimer` carrying the never-dose framing. `sugar_note` (the "sugar-free is
+ * not carb-free" reminder) is present only when a sugars figure is surfaced.
+ */
+export interface ComorbidityNutrition {
+  facts: ComorbidityFact[];
+  sugar_note: string | null;
+  source: string | null;
+  source_url: string | null;
+  trust_tier: string | null;
+  disclaimer: string;
+}
+
+/**
  * A persisted food record. Mirrors `FoodRecordResponse`
  * (apps/api/src/schemas/food_record.py). `carbs_low`/`carbs_high` are the
  * original AI estimate; when corrected, `corrected_carbs_*` carry the user's
@@ -4259,6 +4289,13 @@ export interface FoodRecord {
   grounding_trust_tier: string | null;
   /** Server-computed, glucose-framed nutrition (portion + macros + net carbs). */
   nutrition_facts: NutritionFacts | null;
+  /**
+   * Grounding-backed comorbidity nutrition: the display-ready, awareness-framed,
+   * attributed block (saturated fat / sugars / sodium). Null on a record with no
+   * grounded comorbidity data. (The raw grounded values are an internal server
+   * column and are not part of the response.)
+   */
+  comorbidity_nutrition: ComorbidityNutrition | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

Surface a meal's **saturated fat, sugars/added sugars, and sodium** when an authoritative published source has them. These fields aren't reliably estimable from a plated-food photo and their value is comorbidity (blood-pressure / cardiovascular) awareness — so they are **grounding-only** and **identity-gated**: looked up solely via the existing USDA / Open Food Facts / restaurant grounding services after the user confirms identity, never asserted from the photo, framed as awareness rather than a directive, and attributed to their source (distinct from the vision estimate).

## What changed

**Backend**
- Grounding services capture the four fields: USDA by nutrient number with a name fallback, OFF per-100 g (sodium g→mg, with a salt fallback), restaurant per-item by nutrient name — all reject-not-clamp, cached in the existing shared / owner-scoped grounding caches. No new fetch path; the SSRF-guarded one is reused.
- Persisted in a new `food_records.grounding_nutrition_json` column (migration `074`), kept separate from the photo's `nutrition_json` so a photo can never assert a comorbidity value; reset whenever grounding is re-run.
- Awareness copy (sodium → blood pressure, saturated fat → cardiovascular, sugars → spike sooner) passes the dosing scrubber; the block disclaimer carries the never-dose prohibition. A "sugar-free isn't carb-free" note rides a surfaced sugars figure.
- The display block is computed read-side and never persisted; the raw column is excluded from the response. Comorbidity values are descriptive only and never read by IoB / treatment_safety / carb-ratio math (static guards extended).

**Web + mobile**
- New comorbidity card on the web meal detail view and the mobile meal screen, attributed to its grounded source.

**Out of scope:** net carbs (already shipped) and GI/GL/FPU (excluded per the epic decision).

## Incidental tooling fix

The web app had no `tsc` gate, so `@types/jest` was never installed and every `__tests__` file was untyped (`tsc` reported ~1000 errors, all invisible in CI). This PR adds `@types/jest` + a jest-dom type shim, a `typecheck` npm script, and a CI "Type check" step, and fixes the real errors that surfaced once type-checking worked (a duplicate global test helper in two script-scope files; a dashboard fixture that had drifted from `IntegrationResponse`). The web `tsc` is now clean and gated.

## Testing

- Backend: meal-related suite green (incl. new comorbidity capture/propagation/cache, persistence, re-confirmation reset, and no-coupling guards); ruff lint + format clean; migration upgrade/downgrade round-trip verified.
- Web: full jest suite green (added comorbidity detail tests); `tsc` clean; production build succeeds.
- Mobile: unit tests green (added mapper tests); lint + assemble clean.
- Adversarial + senior + security review and CodeRabbit CLI clean; Sentry-enabled validation run surfaced no new issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Heart & blood-pressure awareness” comorbidity/label nutrition card (saturated fat, sugars, added sugars, sodium) for grounded food items, including optional sugars reminder, source attribution, and a safety disclaimer.
  * The comorbidity card now appears on meal detail and logs in both web and mobile, based on whether grounded comorbidity data is available (and clears when no longer grounded).

* **Chores**
  * Enhanced the frontend CI workflow with an additional Type check step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->