### PR TITLE
feat(web): mmol/L glucose unit toggle, display conversion, and input forms

### DIFF
--- a/apps/web/__tests__/components/dashboard/alert-card.test.tsx
+++ b/apps/web/__tests__/components/dashboard/alert-card.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Glucose-unit conversion on the alert card: current/predicted BG convert via
+ * formatGlucose and the trend RATE via formatTrendRate (2-decimal mmol so the
+ * arrow buckets don't collapse), never a naive toFixed(1).
+ */
+
+import { render } from "@testing-library/react";
+import { AlertCard } from "@/components/dashboard/alert-card";
+import type { PredictiveAlert } from "@/lib/api";
+
+function makeAlert(overrides: Partial<PredictiveAlert> = {}): PredictiveAlert {
+  return {
+    id: "a1",
+    alert_type: "predicted_low",
+    severity: "warning", // non-urgent: no EscalationTimeline / fetch
+    current_value: 180,
+    predicted_value: 70,
+    prediction_minutes: 30,
+    iob_value: null,
+    message: "Predicted low",
+    trend_rate: 3,
+    source: "predictive",
+    acknowledged: false,
+    acknowledged_at: null,
+    created_at: "2026-06-21T00:00:00Z",
+    expires_at: "2099-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("AlertCard glucose unit", () => {
+  it("renders mg/dL by default (value + 1-decimal trend rate)", () => {
+    const { container } = render(
+      <AlertCard alert={makeAlert()} onAcknowledge={jest.fn()} />
+    );
+    expect(container.textContent).toContain("180");
+    expect(container.textContent).toContain("mg/dL");
+    expect(container.textContent).toContain("+3.0 mg/dL/min");
+  });
+
+  it("converts current/predicted BG and the trend rate to mmol", () => {
+    const { container } = render(
+      <AlertCard alert={makeAlert()} onAcknowledge={jest.fn()} unit="mmol" />
+    );
+    expect(container.textContent).toContain("10.0"); // 180 mg/dL
+    expect(container.textContent).toContain("3.9"); // predicted 70 mg/dL
+    expect(container.textContent).toContain("mmol/L");
+    // 3 mg/dL/min -> 0.17 mmol/L/min (2 decimals; 1 decimal would collapse to 0.2)
+    expect(container.textContent).toContain("+0.17 mmol/L/min");
+  });
+});

--- a/apps/web/__tests__/components/dashboard/bolus-review-table.test.tsx
+++ b/apps/web/__tests__/components/dashboard/bolus-review-table.test.tsx
@@ -342,4 +342,21 @@ describe("BolusReviewTable", () => {
       expect(screen.getByTestId("bolus-review")).toHaveClass("custom-class");
     });
   });
+
+  // BG converts to the active unit; the value stays mg/dL on the
+  // wire. 185 mg/dL -> 10.3 mmol/L.
+  describe("glucose unit", () => {
+    it("defaults to mg/dL BG", () => {
+      mockHookReturn.data = makeData();
+      renderComponent();
+      expect(screen.getByText("185 mg/dL")).toBeInTheDocument();
+    });
+
+    it("renders BG in mmol/L when unit=mmol", () => {
+      mockHookReturn.data = makeData();
+      renderComponent({ unit: "mmol" });
+      expect(screen.getByText("10.3 mmol/L")).toBeInTheDocument();
+      expect(screen.queryByText("185 mg/dL")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/__tests__/components/dashboard/cgm-summary-stats.test.tsx
+++ b/apps/web/__tests__/components/dashboard/cgm-summary-stats.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Glucose-unit conversion on the CGM summary: mean and SD convert (SD scaled by
+ * /18.0156 like a value, keeping mmol precision); CV%/GMI stay percentages.
+ */
+
+import { render } from "@testing-library/react";
+import { CgmSummaryStats } from "@/components/dashboard/cgm-summary-stats";
+import type { GlucoseStats } from "@/lib/api";
+
+const stats: GlucoseStats = {
+  mean_glucose: 180,
+  std_dev: 36,
+  cv_pct: 20,
+  gmi: 7.0,
+  cgm_active_pct: 90,
+  readings_count: 288,
+  period_minutes: 1440,
+};
+
+describe("CgmSummaryStats glucose unit", () => {
+  it("shows mean + SD in mg/dL by default", () => {
+    const { container } = render(
+      <CgmSummaryStats
+        stats={stats}
+        isLoading={false}
+        period="24h"
+        onPeriodChange={jest.fn()}
+      />
+    );
+    expect(container.textContent).toContain("180"); // mean
+    expect(container.textContent).toContain("36"); // SD
+    expect(container.textContent).toContain("mg/dL");
+  });
+
+  it("converts mean + SD to mmol (CV%/GMI stay percentages)", () => {
+    const { container } = render(
+      <CgmSummaryStats
+        stats={stats}
+        isLoading={false}
+        period="24h"
+        onPeriodChange={jest.fn()}
+        unit="mmol"
+      />
+    );
+    expect(container.textContent).toContain("10.0"); // mean 180 mg/dL
+    expect(container.textContent).toContain("2.0"); // SD 36 mg/dL -> 2.0 mmol
+    expect(container.textContent).toContain("mmol/L");
+    // CV% and GMI are percentages, never converted.
+    expect(container.textContent).toContain("20.0%");
+    expect(container.textContent).toContain("7.0%");
+  });
+});

--- a/apps/web/__tests__/components/dashboard/glucose-hero.accessibility.test.tsx
+++ b/apps/web/__tests__/components/dashboard/glucose-hero.accessibility.test.tsx
@@ -32,8 +32,8 @@ describe("GlucoseHero Accessibility", () => {
       );
     });
 
-    it("has exact announcement format matching AC1 pattern", () => {
-      // AC1 pattern: "Glucose {value} milligrams per deciliter, {trend}, {range status}"
+    it("has exact announcement format", () => {
+      // Pattern: "Glucose {value} milligrams per deciliter, {trend}, {range status}"
       // Example: "Glucose 142 milligrams per deciliter, falling, in target range"
       render(<GlucoseHero value={142} trend="Falling" iob={null} basalRate={null} batteryPct={null} reservoirUnits={null} />);
 
@@ -233,6 +233,19 @@ describe("Accessibility Helper Functions", () => {
     it("rounds glucose value", () => {
       const result = buildGlucoseAnnouncement(142.7, "stable", "in-range");
       expect(result).toContain("Glucose 143");
+    });
+
+    it("speaks the converted value and British 'litre' for mmol users", () => {
+      // value stays mg/dL (180); spoken as the converted 10.0 mmol.
+      const result = buildGlucoseAnnouncement(
+        180,
+        "falling slowly",
+        "in-range",
+        "mmol"
+      );
+      expect(result).toBe(
+        "Glucose 10.0 millimoles per litre, falling slowly, in target range"
+      );
     });
   });
 

--- a/apps/web/__tests__/components/dashboard/glucose-hero.test.tsx
+++ b/apps/web/__tests__/components/dashboard/glucose-hero.test.tsx
@@ -151,10 +151,18 @@ describe("GlucoseHero", () => {
       expect(screen.getByTestId("glucose-unit")).toHaveTextContent("mg/dL");
     });
 
-    it("displays custom unit when provided", () => {
-      render(<GlucoseHero {...defaultProps} unit="mmol/L" />);
+    it("displays the mmol/L label and converts the value when unit=mmol", () => {
+      // value stays mg/dL; display converts (180 -> 10.0).
+      render(<GlucoseHero {...defaultProps} value={180} unit="mmol" />);
 
       expect(screen.getByTestId("glucose-unit")).toHaveTextContent("mmol/L");
+      expect(screen.getByTestId("glucose-value")).toHaveTextContent("10.0");
+    });
+
+    it("shows 1-decimal mmol for the clinical anchor 70 -> 3.9", () => {
+      render(<GlucoseHero {...defaultProps} value={70} unit="mmol" />);
+
+      expect(screen.getByTestId("glucose-value")).toHaveTextContent("3.9");
     });
   });
 

--- a/apps/web/__tests__/components/dashboard/glucose-trend-chart.test.tsx
+++ b/apps/web/__tests__/components/dashboard/glucose-trend-chart.test.tsx
@@ -286,11 +286,11 @@ describe("GlucoseTrendChart", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders the range legend derived from thresholds", () => {
+    it("renders the range legend derived from thresholds (with the unit label)", () => {
       mockHookReturn.readings = [makeReading(120, 5)];
       renderChart();
       expect(
-        screen.getByText(`${GLUCOSE_THRESHOLDS.LOW}-${GLUCOSE_THRESHOLDS.HIGH} Target`)
+        screen.getByText(`${GLUCOSE_THRESHOLDS.LOW}-${GLUCOSE_THRESHOLDS.HIGH} mg/dL Target`)
       ).toBeInTheDocument();
       expect(screen.getByText("High/Low")).toBeInTheDocument();
       expect(screen.getByText("Urgent")).toBeInTheDocument();

--- a/apps/web/__tests__/components/dashboard/time-in-range-bar.test.tsx
+++ b/apps/web/__tests__/components/dashboard/time-in-range-bar.test.tsx
@@ -246,6 +246,13 @@ describe("TimeInRangeBar component", () => {
       render(<TimeInRangeBar {...baseProps} targetRange="80-140 mg/dL" />);
       expect(screen.getByText(/Target: 80-140 mg\/dL/)).toBeInTheDocument();
     });
+
+    it("renders an mmol/L target range string from the parent", () => {
+      // The parent dashboard converts the target before passing it down; the
+      // bar renders whatever unit string it receives.
+      render(<TimeInRangeBar {...baseProps} targetRange="3.9-10.0 mmol/L" />);
+      expect(screen.getByText(/Target: 3\.9-10\.0 mmol\/L/)).toBeInTheDocument();
+    });
   });
 
   describe("5-segment rendering", () => {

--- a/apps/web/__tests__/lib/glucose-units.test.ts
+++ b/apps/web/__tests__/lib/glucose-units.test.ts
@@ -1,0 +1,149 @@
+import {
+  MGDL_PER_MMOL,
+  mgdlToMmol,
+  mmolToMgdl,
+  formatGlucose,
+  formatTrendRate,
+  unitLabel,
+  spokenUnit,
+  toDisplayNumber,
+  clampMgdl,
+  toStoredMgdl,
+} from "@/lib/glucose-units";
+
+describe("glucose-units", () => {
+  describe("MGDL_PER_MMOL", () => {
+    it("is the single canonical constant 18.0156", () => {
+      // Mirrors the backend src/core/units.py MGDL_PER_MMOL. A second value
+      // (18.02 / 18.0182) anywhere is a bug; this pins the exact factor.
+      expect(MGDL_PER_MMOL).toBe(18.0156);
+    });
+  });
+
+  describe("clinical anchors", () => {
+    // 70 / 18.0156 = 3.886 -> 3.9 ; 180 -> 9.99 -> 10.0 ; 120 -> 6.66 -> 6.7
+    it("formats 70 mg/dL as 3.9 mmol", () => {
+      expect(formatGlucose(70, "mmol")).toBe("3.9");
+    });
+    it("formats 180 mg/dL as 10.0 mmol", () => {
+      expect(formatGlucose(180, "mmol")).toBe("10.0");
+    });
+    it("formats 120 mg/dL as 6.7 mmol", () => {
+      expect(formatGlucose(120, "mmol")).toBe("6.7");
+    });
+  });
+
+  describe("formatGlucose precision", () => {
+    it("rounds mg/dL to an integer string", () => {
+      expect(formatGlucose(142.6, "mgdl")).toBe("143");
+      expect(formatGlucose(99.2, "mgdl")).toBe("99");
+    });
+    it("always shows exactly 1 decimal for mmol", () => {
+      expect(formatGlucose(100, "mmol")).toBe("5.6"); // 100/18.0156 = 5.55
+      expect(formatGlucose(90, "mmol")).toBe("5.0"); // 90/18.0156 = 4.996 -> 5.0
+    });
+    it("does not mutate the input", () => {
+      const v = 123;
+      formatGlucose(v, "mmol");
+      expect(v).toBe(123);
+    });
+  });
+
+  describe("round-trip within tolerance", () => {
+    it("mmolToMgdl(mgdlToMmol(x)) stays within +/-1 mg/dL", () => {
+      for (const x of [20, 55, 70, 100, 120, 180, 250, 400, 500]) {
+        expect(Math.abs(mmolToMgdl(mgdlToMmol(x)) - x)).toBeLessThanOrEqual(1);
+      }
+    });
+    it("a saved mmol input round-trips through integer mg/dL within tolerance", () => {
+      // 5.5 mmol -> 99 mg/dL -> 5.5 mmol (the expected, acceptable 'snap').
+      const storedMgdl = toStoredMgdl(5.5, "mmol");
+      expect(storedMgdl).toBe(99); // round(5.5 * 18.0156) = round(99.08) = 99
+      expect(formatGlucose(storedMgdl, "mmol")).toBe("5.5");
+    });
+  });
+
+  describe("formatTrendRate precision", () => {
+    it("keeps 1 decimal for mg/dL/min", () => {
+      expect(formatTrendRate(3, "mgdl")).toBe("3.0");
+      expect(formatTrendRate(-1.5, "mgdl")).toBe("-1.5");
+    });
+    it("uses 2 decimals for mmol/L/min so arrows stay distinguishable", () => {
+      // 3 mg/dL/min / 18.0156 = 0.166 -> 0.17 (1 decimal would collapse to 0.2)
+      expect(formatTrendRate(3, "mmol")).toBe("0.17");
+      expect(formatTrendRate(1, "mmol")).toBe("0.06");
+    });
+  });
+
+  describe("safety bounds display + clamp (medical safety)", () => {
+    it("displays the 20-500 mg/dL invariant as 1.1-27.8 mmol", () => {
+      expect(toDisplayNumber(20, "mmol")).toBe(1.1);
+      expect(toDisplayNumber(500, "mmol")).toBe(27.8);
+    });
+    it("keeps mg/dL bounds as integers", () => {
+      expect(toDisplayNumber(20, "mgdl")).toBe(20);
+      expect(toDisplayNumber(500, "mgdl")).toBe(500);
+    });
+    it("clamp pins a boundary unit-rounding overshoot to the canonical bound", () => {
+      // Entering the displayed max (27.8 mmol) round-trips to 501; clamp keeps
+      // the wire value at the 500 ceiling (no drift, never crosses).
+      expect(toStoredMgdl(27.8, "mmol")).toBe(501);
+      expect(clampMgdl(toStoredMgdl(27.8, "mmol"), 20, 500)).toBe(500);
+      // A stored value exactly at the bound stays put (no silent drift).
+      expect(clampMgdl(500, 20, 500)).toBe(500);
+      expect(clampMgdl(20, 20, 500)).toBe(20);
+      // In-range values are untouched.
+      expect(clampMgdl(toStoredMgdl(5.5, "mmol"), 20, 500)).toBe(99);
+    });
+    it("the displayed bound is enterable: clamp(round-trip) stays in range, and a stored bound value displays as that bound", () => {
+      // Every input min/max across the four settings forms.
+      const FORM_BOUNDS: Array<{ min: number; max: number }> = [
+        { min: 20, max: 499 }, // safety-limits min-glucose field
+        { min: 21, max: 500 }, // safety-limits max-glucose field
+        { min: 30, max: 70 }, // glucose-range urgent low
+        { min: 40, max: 200 }, // glucose-range low target
+        { min: 80, max: 400 }, // glucose-range high target
+        { min: 200, max: 500 }, // glucose-range urgent high
+        { min: 30, max: 80 }, // alerts urgent low
+        { min: 40, max: 100 }, // alerts low warning
+        { min: 120, max: 300 }, // alerts high warning
+        { min: 150, max: 400 }, // alerts urgent high
+      ];
+      for (const b of FORM_BOUNDS) {
+        const dispMin = toDisplayNumber(b.min, "mmol");
+        const dispMax = toDisplayNumber(b.max, "mmol");
+        // Entering the advertised bound, after clamp, is always WITHIN the
+        // canonical range (never rejected, never crosses the bound). mmol's
+        // 1-decimal granularity means it may not hit the bound exactly, but it
+        // is always a valid in-range value.
+        const storedFromMin = clampMgdl(toStoredMgdl(dispMin, "mmol"), b.min, b.max);
+        const storedFromMax = clampMgdl(toStoredMgdl(dispMax, "mmol"), b.min, b.max);
+        expect(storedFromMin).toBeGreaterThanOrEqual(b.min);
+        expect(storedFromMin).toBeLessThanOrEqual(b.max);
+        expect(storedFromMax).toBeGreaterThanOrEqual(b.min);
+        expect(storedFromMax).toBeLessThanOrEqual(b.max);
+        // mg/dL identity.
+        expect(toDisplayNumber(b.min, "mgdl")).toBe(b.min);
+        expect(toDisplayNumber(b.max, "mgdl")).toBe(b.max);
+      }
+    });
+    it("the safety floor/ceiling are enterable at their displayed value (no false invalid on load)", () => {
+      // The regression the visual pass caught: default max_glucose 500 loaded as
+      // 27.8 must be accepted, not flagged invalid. Display == bound, clamp pins
+      // the overshoot back to exactly the floor/ceiling.
+      expect(clampMgdl(toStoredMgdl(toDisplayNumber(500, "mmol"), "mmol"), 20, 500)).toBe(500);
+      expect(clampMgdl(toStoredMgdl(toDisplayNumber(20, "mmol"), "mmol"), 20, 500)).toBe(20);
+    });
+  });
+
+  describe("labels", () => {
+    it("unitLabel", () => {
+      expect(unitLabel("mgdl")).toBe("mg/dL");
+      expect(unitLabel("mmol")).toBe("mmol/L");
+    });
+    it("spokenUnit uses British 'litre' for mmol", () => {
+      expect(spokenUnit("mgdl")).toBe("milligrams per deciliter");
+      expect(spokenUnit("mmol")).toBe("millimoles per litre");
+    });
+  });
+});

--- a/apps/web/__tests__/settings/glucose-unit-convert-back.test.tsx
+++ b/apps/web/__tests__/settings/glucose-unit-convert-back.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Wiring tests: the safety-limits and glucose-range forms must convert mmol
+ * entries back to INTEGER mg/dL and clamp to the canonical bound before they
+ * leave the browser. The conversion math is unit-tested in glucose-units.test;
+ * these prove the input forms actually call it on save (so a refactor that
+ * dropped the clamp/convert would fail here).
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import SafetyLimitsPage from "@/app/dashboard/settings/safety-limits/page";
+import GlucoseRangePage from "@/app/dashboard/settings/glucose-range/page";
+import {
+  getSafetyLimits,
+  getSafetyLimitsDefaults,
+  updateSafetyLimits,
+  getTargetGlucoseRange,
+  updateTargetGlucoseRange,
+} from "@/lib/api";
+
+jest.mock("@/lib/api");
+
+// Force mmol display so entries are in mmol and must convert back to mg/dL.
+jest.mock("@/hooks/use-glucose-unit", () => ({
+  useGlucoseUnit: () => "mmol",
+}));
+
+// safety-limits gates on the user role via the shared context.
+jest.mock("@/providers", () => ({
+  useUserContext: () => ({
+    user: { id: "u1", role: "diabetic" },
+    isLoading: false,
+    error: null,
+    refreshUser: jest.fn(),
+  }),
+}));
+
+const mockGetSafety = getSafetyLimits as jest.Mock;
+const mockGetSafetyDefaults = getSafetyLimitsDefaults as jest.Mock;
+const mockUpdateSafety = updateSafetyLimits as jest.Mock;
+const mockGetRange = getTargetGlucoseRange as jest.Mock;
+const mockUpdateRange = updateTargetGlucoseRange as jest.Mock;
+
+const SAFETY_DEFAULTS = {
+  min_glucose_mgdl: 20,
+  max_glucose_mgdl: 500,
+  max_basal_rate_milliunits: 15000,
+  max_bolus_dose_milliunits: 25000,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("safety-limits convert-back + clamp (medical safety)", () => {
+  it("sends integer mg/dL clamped to the bound when entering the displayed mmol max", async () => {
+    // Loaded max 450 mg/dL renders as 25.0 mmol; the user raises it to the
+    // displayed ceiling 27.8 mmol, which round-trips to 501 and must clamp to 500.
+    mockGetSafety.mockResolvedValue({
+      id: "s1",
+      min_glucose_mgdl: 70, // 3.9 mmol
+      max_glucose_mgdl: 450, // 25.0 mmol
+      max_basal_rate_milliunits: 15000,
+      max_bolus_dose_milliunits: 25000,
+      updated_at: "",
+    });
+    mockGetSafetyDefaults.mockResolvedValue(SAFETY_DEFAULTS);
+    mockUpdateSafety.mockResolvedValue({
+      id: "s1",
+      min_glucose_mgdl: 70,
+      max_glucose_mgdl: 500,
+      max_basal_rate_milliunits: 15000,
+      max_bolus_dose_milliunits: 25000,
+      updated_at: "",
+    });
+
+    render(<SafetyLimitsPage />);
+
+    const maxInput = await screen.findByLabelText(/Maximum Glucose/i);
+    fireEvent.change(maxInput, { target: { value: "27.8" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    // Confirmation dialog -> confirm
+    fireEvent.click(await screen.findByRole("button", { name: /^confirm$/i }));
+
+    await waitFor(() => expect(mockUpdateSafety).toHaveBeenCalledTimes(1));
+    const payload = mockUpdateSafety.mock.calls[0][0];
+    // Max clamped from 501 -> 500 (never crosses the ceiling); min stays 70.
+    expect(payload.max_glucose_mgdl).toBe(500);
+    expect(payload.min_glucose_mgdl).toBe(70);
+    // Everything on the wire is an integer mg/dL within the 20-500 invariant.
+    expect(Number.isInteger(payload.max_glucose_mgdl)).toBe(true);
+    expect(Number.isInteger(payload.min_glucose_mgdl)).toBe(true);
+    expect(payload.max_glucose_mgdl).toBeLessThanOrEqual(500);
+    expect(payload.min_glucose_mgdl).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe("glucose-range convert-back (integer mg/dL on the wire)", () => {
+  it("converts an mmol urgent-high entry to integer mg/dL on save", async () => {
+    mockGetRange.mockResolvedValue({
+      urgent_low: 55, // 3.1 mmol
+      low_target: 70, // 3.9 mmol
+      high_target: 180, // 10.0 mmol
+      urgent_high: 250, // 13.9 mmol
+    });
+    mockUpdateRange.mockResolvedValue({
+      urgent_low: 55,
+      low_target: 70,
+      high_target: 180,
+      urgent_high: 252,
+    });
+
+    render(<GlucoseRangePage />);
+
+    const urgentHigh = await screen.findByLabelText(/Urgent High/i);
+    fireEvent.change(urgentHigh, { target: { value: "14.0" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(mockUpdateRange).toHaveBeenCalledTimes(1));
+    const payload = mockUpdateRange.mock.calls[0][0];
+    // 14.0 mmol -> 252 mg/dL (round(14 * 18.0156)).
+    expect(payload.urgent_high).toBe(252);
+    // All four thresholds are integers within the 20-500 invariant.
+    for (const k of ["urgent_low", "low_target", "high_target", "urgent_high"]) {
+      expect(Number.isInteger(payload[k])).toBe(true);
+      expect(payload[k]).toBeGreaterThanOrEqual(20);
+      expect(payload[k]).toBeLessThanOrEqual(500);
+    }
+  });
+});

--- a/apps/web/src/app/dashboard/alerts/page.tsx
+++ b/apps/web/src/app/dashboard/alerts/page.tsx
@@ -43,14 +43,29 @@ import {
 import { useAlertNotifications } from "@/providers";
 import { requestNotificationPermission } from "@/lib/browser-notifications";
 import { AlertCard } from "@/components/dashboard/alert-card";
+import {
+  toDisplayNumber,
+  clampMgdl,
+  toStoredMgdl,
+  formatGlucose,
+  unitLabel,
+  stepFor,
+} from "@/lib/glucose-units";
+import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
+import {
+  ALERT_THRESHOLD_DEFAULTS,
+  GLUCOSE_THRESHOLD_BOUNDS,
+  IOB_THRESHOLD_BOUNDS,
+} from "@/lib/alert-thresholds";
 
-const DEFAULTS = {
-  low_warning: 70,
-  urgent_low: 55,
-  high_warning: 180,
-  urgent_high: 250,
-  iob_warning: 3.0,
-};
+// Glucose threshold fields carry config unit "mg/dL"; only those convert for
+// display. The IoB field ("units") is never converted. Field min/max bounds
+// stay canonical mg/dL and are stored/validated/sent in mg/dL. Defaults +
+// bounds come from one shared source so this page and the settings alerts page
+// cannot drift.
+const GLUCOSE_FIELD_UNIT = "mg/dL";
+
+const DEFAULTS = ALERT_THRESHOLD_DEFAULTS;
 
 interface ThresholdFieldConfig {
   key: keyof AlertThresholdUpdate;
@@ -68,8 +83,7 @@ const THRESHOLD_FIELDS: ThresholdFieldConfig[] = [
     key: "urgent_low",
     label: "Urgent Low",
     unit: "mg/dL",
-    min: 30,
-    max: 80,
+    ...GLUCOSE_THRESHOLD_BOUNDS.urgentLow,
     step: 1,
     description: "Critical low glucose alert",
     color: "text-red-400",
@@ -78,8 +92,7 @@ const THRESHOLD_FIELDS: ThresholdFieldConfig[] = [
     key: "low_warning",
     label: "Low Warning",
     unit: "mg/dL",
-    min: 40,
-    max: 100,
+    ...GLUCOSE_THRESHOLD_BOUNDS.lowWarning,
     step: 1,
     description: "Low glucose warning",
     color: "text-amber-400",
@@ -88,8 +101,7 @@ const THRESHOLD_FIELDS: ThresholdFieldConfig[] = [
     key: "high_warning",
     label: "High Warning",
     unit: "mg/dL",
-    min: 120,
-    max: 300,
+    ...GLUCOSE_THRESHOLD_BOUNDS.highWarning,
     step: 1,
     description: "High glucose warning",
     color: "text-amber-400",
@@ -98,8 +110,7 @@ const THRESHOLD_FIELDS: ThresholdFieldConfig[] = [
     key: "urgent_high",
     label: "Urgent High",
     unit: "mg/dL",
-    min: 150,
-    max: 400,
+    ...GLUCOSE_THRESHOLD_BOUNDS.urgentHigh,
     step: 1,
     description: "Critical high glucose alert",
     color: "text-red-400",
@@ -108,8 +119,7 @@ const THRESHOLD_FIELDS: ThresholdFieldConfig[] = [
     key: "iob_warning",
     label: "IoB Warning",
     unit: "units",
-    min: 0.5,
-    max: 20,
+    ...IOB_THRESHOLD_BOUNDS,
     step: 0.1,
     description: "Insulin on Board warning threshold",
     color: "text-purple-400",
@@ -123,7 +133,27 @@ const ESCALATION_DEFAULTS = {
 };
 
 export default function AlertsPage() {
-  const [formValues, setFormValues] = useState<AlertThresholdUpdate>({});
+  const unit = useGlucoseUnit();
+  // Build input strings from canonical values: glucose fields convert to the
+  // active unit, the IoB field is shown verbatim.
+  const buildInputs = useCallback(
+    (values: AlertThresholdUpdate): Record<string, string> => {
+      const next: Record<string, string> = {};
+      for (const f of THRESHOLD_FIELDS) {
+        const v = values[f.key];
+        next[f.key] =
+          v == null
+            ? ""
+            : f.unit === GLUCOSE_FIELD_UNIT
+              ? formatGlucose(v, unit)
+              : String(v);
+      }
+      return next;
+    },
+    [unit]
+  );
+  // Input strings keyed by field (display unit for glucose, units for IoB).
+  const [inputValues, setInputValues] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -174,13 +204,7 @@ export default function AlertsPage() {
     try {
       setError(null);
       const data = await getAlertThresholds();
-      setFormValues({
-        low_warning: data.low_warning,
-        urgent_low: data.urgent_low,
-        high_warning: data.high_warning,
-        urgent_high: data.urgent_high,
-        iob_warning: data.iob_warning,
-      });
+      setInputValues(buildInputs(data));
       setHasChanges(false);
     } catch (err) {
       if (!(err instanceof Error && err.message.includes("401"))) {
@@ -189,11 +213,11 @@ export default function AlertsPage() {
         );
       }
       // Show defaults on any error so inputs aren't empty
-      setFormValues({ ...DEFAULTS });
+      setInputValues(buildInputs(DEFAULTS));
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [buildInputs]);
 
   const fetchEscalationConfig = useCallback(async () => {
     try {
@@ -323,31 +347,49 @@ export default function AlertsPage() {
   }, [fetchThresholds, fetchEscalationConfig, fetchAlerts]);
 
   const handleChange = (key: keyof AlertThresholdUpdate, value: string) => {
-    const numValue = parseFloat(value);
-    if (isNaN(numValue)) return;
-
-    setFormValues((prev) => ({ ...prev, [key]: numValue }));
+    setInputValues((prev) => ({ ...prev, [key]: value }));
     setHasChanges(true);
     setSaveSuccess(false);
   };
 
   const handleSave = async () => {
-    // Client-side ordering validation
-    const ul = formValues.urgent_low ?? DEFAULTS.urgent_low;
-    const lw = formValues.low_warning ?? DEFAULTS.low_warning;
-    const hw = formValues.high_warning ?? DEFAULTS.high_warning;
-    const uh = formValues.urgent_high ?? DEFAULTS.urgent_high;
+    // Build the canonical payload: glucose fields convert the entered display
+    // value back to integer mg/dL; IoB stays units.
+    const payload: AlertThresholdUpdate = {};
+    for (const f of THRESHOLD_FIELDS) {
+      const raw = parseFloat(inputValues[f.key] ?? "");
+      payload[f.key] = isNaN(raw)
+        ? NaN
+        : f.unit === GLUCOSE_FIELD_UNIT
+          ? clampMgdl(toStoredMgdl(raw, unit), f.min, f.max)
+          : // Non-glucose (IoB, units): clamp to the field's own range so a
+            // free-typed value past the HTML min/max never reaches the API.
+            Math.max(f.min, Math.min(f.max, raw));
+    }
+
+    if (Object.values(payload).some((v) => v == null || isNaN(v as number))) {
+      setError("Please enter valid numbers for all fields");
+      return;
+    }
+
+    // Client-side ordering validation in canonical mg/dL; messages render in
+    // the active unit.
+    const ul = payload.urgent_low as number;
+    const lw = payload.low_warning as number;
+    const hw = payload.high_warning as number;
+    const uh = payload.urgent_high as number;
+    const u = unitLabel(unit);
 
     if (ul >= lw) {
-      setError(`Urgent Low (${ul}) must be less than Low Warning (${lw})`);
+      setError(`Urgent Low (${formatGlucose(ul, unit)} ${u}) must be less than Low Warning (${formatGlucose(lw, unit)} ${u})`);
       return;
     }
     if (lw >= hw) {
-      setError(`Low Warning (${lw}) must be less than High Warning (${hw})`);
+      setError(`Low Warning (${formatGlucose(lw, unit)} ${u}) must be less than High Warning (${formatGlucose(hw, unit)} ${u})`);
       return;
     }
     if (hw >= uh) {
-      setError(`High Warning (${hw}) must be less than Urgent High (${uh})`);
+      setError(`High Warning (${formatGlucose(hw, unit)} ${u}) must be less than Urgent High (${formatGlucose(uh, unit)} ${u})`);
       return;
     }
 
@@ -356,14 +398,8 @@ export default function AlertsPage() {
     setSaveSuccess(false);
 
     try {
-      const data = await updateAlertThresholds(formValues);
-      setFormValues({
-        low_warning: data.low_warning,
-        urgent_low: data.urgent_low,
-        high_warning: data.high_warning,
-        urgent_high: data.urgent_high,
-        iob_warning: data.iob_warning,
-      });
+      const data = await updateAlertThresholds(payload);
+      setInputValues(buildInputs(data));
       setHasChanges(false);
       setSaveSuccess(true);
     } catch (err) {
@@ -376,7 +412,7 @@ export default function AlertsPage() {
   };
 
   const handleReset = () => {
-    setFormValues({ ...DEFAULTS });
+    setInputValues(buildInputs(DEFAULTS));
     setHasChanges(true);
     setSaveSuccess(false);
   };
@@ -469,10 +505,10 @@ export default function AlertsPage() {
                         <input
                           id={field.key}
                           type="number"
-                          min={field.min}
-                          max={field.max}
-                          step={field.step}
-                          value={formValues[field.key] ?? ""}
+                          min={field.unit === GLUCOSE_FIELD_UNIT ? toDisplayNumber(field.min, unit) : field.min}
+                          max={field.unit === GLUCOSE_FIELD_UNIT ? toDisplayNumber(field.max, unit) : field.max}
+                          step={field.unit === GLUCOSE_FIELD_UNIT ? stepFor(unit) : field.step}
+                          value={inputValues[field.key] ?? ""}
                           onChange={(e) =>
                             handleChange(field.key, e.target.value)
                           }
@@ -485,14 +521,14 @@ export default function AlertsPage() {
                           aria-describedby={`${field.key}-range`}
                         />
                         <span className="text-xs text-slate-500 shrink-0">
-                          {field.unit}
+                          {field.unit === GLUCOSE_FIELD_UNIT ? unitLabel(unit) : field.unit}
                         </span>
                       </div>
                       <p
                         id={`${field.key}-range`}
                         className="text-xs text-slate-600 mt-1"
                       >
-                        Range: {field.min}–{field.max} {field.unit}
+                        Range: {field.unit === GLUCOSE_FIELD_UNIT ? toDisplayNumber(field.min, unit) : field.min}–{field.unit === GLUCOSE_FIELD_UNIT ? toDisplayNumber(field.max, unit) : field.max} {field.unit === GLUCOSE_FIELD_UNIT ? unitLabel(unit) : field.unit}
                       </p>
                     </div>
                   )
@@ -524,7 +560,7 @@ export default function AlertsPage() {
                         min={field.min}
                         max={field.max}
                         step={field.step}
-                        value={formValues[field.key] ?? ""}
+                        value={inputValues[field.key] ?? ""}
                         onChange={(e) =>
                           handleChange(field.key, e.target.value)
                         }
@@ -640,6 +676,7 @@ export default function AlertsPage() {
                 alert={alert}
                 onAcknowledge={handleAcknowledge}
                 isAcknowledging={acknowledgingId === alert.id}
+                unit={unit}
               />
             ))}
           </div>

--- a/apps/web/src/app/dashboard/caregiver/page.tsx
+++ b/apps/web/src/app/dashboard/caregiver/page.tsx
@@ -39,8 +39,23 @@ import {
 } from "@/lib/api";
 import { MarkdownContent } from "@/components/ui/markdown-content";
 import { useUserContext } from "@/providers";
+import {
+  formatGlucose,
+  formatTrendRate,
+  unitLabel,
+  type GlucoseUnit,
+} from "@/lib/glucose-units";
 
 const REFRESH_INTERVAL_MS = 60_000;
+
+/**
+ * Patient glucose renders in the PATIENT's unit, never the
+ * caregiver's own preference. The patient's `glucose_unit` is not yet carried
+ * on the caregiver status payload (added later); until then we fall
+ * back to the canonical mg/dL — NOT `useGlucoseUnit()` (the viewer's unit).
+ * When the caregiver payload carries the patient's unit, replace this with it.
+ */
+const PATIENT_GLUCOSE_UNIT: GlucoseUnit = "mgdl";
 
 function getTrendArrow(trend: string): string {
   const arrows: Record<string, string> = {
@@ -443,9 +458,9 @@ export default function CaregiverDashboardPage() {
                               getGlucoseColor(g.value)
                             )}
                           >
-                            {g.value}
+                            {formatGlucose(g.value, PATIENT_GLUCOSE_UNIT)}
                           </span>
-                          <span className="text-sm text-slate-500 dark:text-slate-400">mg/dL</span>
+                          <span className="text-sm text-slate-500 dark:text-slate-400">{unitLabel(PATIENT_GLUCOSE_UNIT)}</span>
                           <span className="text-lg">
                             {getTrendArrow(g.trend)}
                           </span>
@@ -547,9 +562,9 @@ export default function CaregiverDashboardPage() {
                         getGlucoseColor(status.glucose.value)
                       )}
                     >
-                      {status.glucose.value}
+                      {formatGlucose(status.glucose.value, PATIENT_GLUCOSE_UNIT)}
                     </span>
-                    <span className="text-2xl text-slate-500 dark:text-slate-400">mg/dL</span>
+                    <span className="text-2xl text-slate-500 dark:text-slate-400">{unitLabel(PATIENT_GLUCOSE_UNIT)}</span>
                     <span className="text-2xl">
                       {getTrendArrow(status.glucose.trend)}
                     </span>
@@ -569,7 +584,7 @@ export default function CaregiverDashboardPage() {
                     {status.glucose.trend_rate !== null && (
                       <span>
                         {status.glucose.trend_rate > 0 ? "+" : ""}
-                        {status.glucose.trend_rate.toFixed(1)} mg/dL/min
+                        {formatTrendRate(status.glucose.trend_rate, PATIENT_GLUCOSE_UNIT)} {unitLabel(PATIENT_GLUCOSE_UNIT)}/min
                       </span>
                     )}
                   </div>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -44,6 +44,8 @@ import {
   PERIOD_LABELS,
 } from "@/components/dashboard";
 import { useGlucoseStreamContext, useUserContext } from "@/providers";
+import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
+import { formatGlucose, unitLabel } from "@/lib/glucose-units";
 import { useTimeInRangeDetailStats } from "@/hooks/use-time-in-range-stats";
 import { useGlucoseStats } from "@/hooks/use-glucose-stats";
 import { useGlucoseRange } from "@/hooks/use-glucose-range";
@@ -74,6 +76,7 @@ function mapLoopStatus(
 export default function DashboardPage() {
   const router = useRouter();
   const { user, isLoading: isUserLoading } = useUserContext();
+  const unit = useGlucoseUnit();
 
   // All hooks must be called before any early return
   const {
@@ -98,9 +101,13 @@ export default function DashboardPage() {
     }
   }, [glucose?.reading_timestamp]);
 
-  // Fetch user's configured glucose range thresholds
+  // Fetch user's configured glucose range thresholds (always mg/dL; display
+  // converts to the active unit).
   const glucoseThresholds = useGlucoseRange();
-  const targetRange = `${glucoseThresholds.low}-${glucoseThresholds.high} mg/dL`;
+  const targetRange = `${formatGlucose(glucoseThresholds.low, unit)}-${formatGlucose(
+    glucoseThresholds.high,
+    unit
+  )} ${unitLabel(unit)}`;
 
   // Fetch latest pump status (basal, battery, reservoir) for hero card
   const pumpStatus = usePumpStatus(chartRefreshKey);
@@ -249,6 +256,7 @@ export default function DashboardPage() {
           }
           isLoading={!isLive && !glucose}
           thresholds={glucoseThresholds}
+          unit={unit}
         />
       </AnimatedCard>
 
@@ -258,6 +266,7 @@ export default function DashboardPage() {
           refreshKey={chartRefreshKey}
           thresholds={glucoseThresholds}
           forecast={forecast}
+          unit={unit}
         />
       </AnimatedCard>
 
@@ -269,12 +278,13 @@ export default function DashboardPage() {
           error={cgmError}
           period={cgmPeriod}
           onPeriodChange={setCgmPeriod}
+          unit={unit}
         />
       </AnimatedCard>
 
       {/* AGP Percentile Band Chart - Story 30.5 */}
       <AnimatedCard delay={0.2}>
-        <AgpChart thresholds={glucoseThresholds} />
+        <AgpChart thresholds={glucoseThresholds} unit={unit} />
       </AnimatedCard>
 
       {/* Insulin Summary & Bolus Review - Story 30.7 */}
@@ -282,7 +292,7 @@ export default function DashboardPage() {
         <InsulinSummaryStats />
       </AnimatedCard>
       <AnimatedCard delay={0.3}>
-        <BolusReviewTable />
+        <BolusReviewTable unit={unit} />
       </AnimatedCard>
 
       {/* Metrics grid with proper heading hierarchy */}

--- a/apps/web/src/app/dashboard/reports/clinical/page.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/page.tsx
@@ -76,6 +76,8 @@ import {
   type AnalyticsConfigResponse,
   type DisplayLabel,
 } from "@/lib/api";
+import { formatGlucose, unitLabel, type GlucoseUnit } from "@/lib/glucose-units";
+import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -429,9 +431,11 @@ function getPointColor(value: number, low: number, high: number, urgentLow = 54,
 function GlucoseChartTooltip({
   active,
   payload,
+  unit = "mgdl",
 }: {
   active?: boolean;
   payload?: Array<{ payload: ChartPoint }>;
+  unit?: GlucoseUnit;
 }) {
   if (!active || !payload?.[0]) return null;
   const point = payload[0].payload;
@@ -445,7 +449,7 @@ function GlucoseChartTooltip({
     <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg px-3 py-2 shadow-lg print:hidden">
       <p className="text-xs text-slate-500 dark:text-slate-400">{time}</p>
       <p className="text-sm font-semibold text-slate-900 dark:text-white">
-        {point.value} mg/dL
+        {formatGlucose(point.value, unit)} {unitLabel(unit)}
       </p>
     </div>
   );
@@ -477,6 +481,7 @@ function ReportGlucoseChart({
   high,
   urgentLow = 54,
   urgentHigh = 250,
+  unit = "mgdl",
 }: {
   readings: GlucoseHistoryReading[];
   startDate: string;
@@ -485,6 +490,7 @@ function ReportGlucoseChart({
   high: number;
   urgentLow?: number;
   urgentHigh?: number;
+  unit?: GlucoseUnit;
 }) {
   const points = useMemo(() => transformReadings(readings), [readings]);
   const renderPoint = useMemo(
@@ -521,8 +527,8 @@ function ReportGlucoseChart({
       month: "short",
       day: "numeric",
     });
-    return `Glucose trend chart showing ${points.length} readings from ${startLabel} to ${endLabel}, average ${avg} mg/dL`;
-  }, [points, domainStart, domainEnd]);
+    return `Glucose trend chart showing ${points.length} readings from ${startLabel} to ${endLabel}, average ${formatGlucose(avg, unit)} ${unitLabel(unit)}`;
+  }, [points, domainStart, domainEnd, unit]);
 
   if (points.length === 0) {
     return (
@@ -560,8 +566,10 @@ function ReportGlucoseChart({
             dataKey="value"
             domain={[40, 350]}
             ticks={[urgentLow, low, high, urgentHigh]}
+            // Tick positions + domain stay mg/dL; only labels convert.
+            tickFormatter={(v: number) => formatGlucose(v, unit)}
             tick={{ fontSize: 10, fill: "#94a3b8" }}
-            width={35}
+            width={unit === "mmol" ? 40 : 35}
           />
           <ReferenceArea y1={low} y2={high} fill="#22c55e" fillOpacity={0.08} />
           <ReferenceLine
@@ -576,7 +584,7 @@ function ReportGlucoseChart({
             strokeDasharray="4 4"
             strokeOpacity={0.6}
           />
-          <RechartsTooltip content={<GlucoseChartTooltip />} cursor={false} />
+          <RechartsTooltip content={<GlucoseChartTooltip unit={unit} />} cursor={false} />
           <Scatter data={points} shape={renderPoint} />
         </ScatterChart>
       </ResponsiveContainer>
@@ -590,12 +598,14 @@ function AgpChartSection({
   high,
   urgentLow = 54,
   urgentHigh = 250,
+  unit = "mgdl",
 }: {
   buckets: AgpBucket[];
   low: number;
   high: number;
   urgentLow?: number;
   urgentHigh?: number;
+  unit?: GlucoseUnit;
 }) {
   const data = useMemo(() => {
     const filtered = buckets.filter((b) => b.count > 0);
@@ -636,8 +646,9 @@ function AgpChartSection({
           <YAxis
             domain={[40, 350]}
             ticks={[urgentLow, low, high, urgentHigh]}
+            tickFormatter={(v: number) => formatGlucose(v, unit)}
             tick={{ fontSize: 10, fill: "#94a3b8" }}
-            width={35}
+            width={unit === "mmol" ? 40 : 35}
           />
           <ReferenceArea y1={low} y2={high} fill="#22c55e" fillOpacity={0.06} />
           <ReferenceLine
@@ -686,12 +697,14 @@ function DailyOverlayChart({
   high,
   urgentLow = 54,
   urgentHigh = 250,
+  unit = "mgdl",
 }: {
   readings: GlucoseHistoryReading[];
   low: number;
   high: number;
   urgentLow?: number;
   urgentHigh?: number;
+  unit?: GlucoseUnit;
 }) {
   const MAX_OVERLAY_DAYS = 14;
   const overlayData = useMemo(() => buildDailyOverlay(readings), [readings]);
@@ -769,8 +782,9 @@ function DailyOverlayChart({
           <YAxis
             domain={[40, 350]}
             ticks={[urgentLow, low, high, urgentHigh]}
+            tickFormatter={(v: number) => formatGlucose(v, unit)}
             tick={{ fontSize: 10, fill: "#94a3b8" }}
-            width={35}
+            width={unit === "mmol" ? 40 : 35}
           />
           <ReferenceArea y1={low} y2={high} fill="#22c55e" fillOpacity={0.06} />
           {days.map((day, i) => (
@@ -882,7 +896,7 @@ function PatientDeviceHeader({
   );
 }
 
-function CgmStatsSection({ stats }: { stats: GlucoseStats }) {
+function CgmStatsSection({ stats, unit = "mgdl" }: { stats: GlucoseStats; unit?: GlucoseUnit }) {
   const eA1C = stats.gmi;
 
   return (
@@ -902,8 +916,8 @@ function CgmStatsSection({ stats }: { stats: GlucoseStats }) {
             Average Glucose
           </p>
           <p className="text-4xl font-bold text-slate-900 dark:text-white print:text-black mt-1">
-            {Math.round(stats.mean_glucose)}
-            <span className="text-lg font-normal ml-1">mg/dL</span>
+            {formatGlucose(stats.mean_glucose, unit)}
+            <span className="text-lg font-normal ml-1">{unitLabel(unit)}</span>
           </p>
         </div>
         <div className="text-center">
@@ -925,7 +939,7 @@ function CgmStatsSection({ stats }: { stats: GlucoseStats }) {
           {[
             {
               label: "Standard Deviation",
-              value: `${Math.round(stats.std_dev)} mg/dL`,
+              value: `${formatGlucose(stats.std_dev, unit)} ${unitLabel(unit)}`,
             },
             {
               label: "CGM Active Time",
@@ -954,7 +968,7 @@ function CgmStatsSection({ stats }: { stats: GlucoseStats }) {
   );
 }
 
-function TirSection({ tir }: { tir: TimeInRangeDetailStats }) {
+function TirSection({ tir, unit = "mgdl" }: { tir: TimeInRangeDetailStats; unit?: GlucoseUnit }) {
   const t = tir.thresholds;
   const orderedLabels = [
     "urgent_low",
@@ -967,18 +981,20 @@ function TirSection({ tir }: { tir: TimeInRangeDetailStats }) {
     .map((label) => tir.buckets.find((b) => b.label === label))
     .filter((b): b is TirBucket => !!b);
 
+  // Thresholds are mg/dL; the displayed range bounds convert to the active unit.
+  const fmt = (v: number) => formatGlucose(v, unit);
   function rangeLabel(bucket: string): string {
     switch (bucket) {
       case "urgent_low":
-        return `<${t.urgent_low}`;
+        return `<${fmt(t.urgent_low)}`;
       case "low":
-        return `${t.urgent_low}-${t.low}`;
+        return `${fmt(t.urgent_low)}-${fmt(t.low)}`;
       case "in_range":
-        return `${t.low}-${t.high}`;
+        return `${fmt(t.low)}-${fmt(t.high)}`;
       case "high":
-        return `${t.high}-${t.urgent_high}`;
+        return `${fmt(t.high)}-${fmt(t.urgent_high)}`;
       case "urgent_high":
-        return `>${t.urgent_high}`;
+        return `>${fmt(t.urgent_high)}`;
       default:
         return "";
     }
@@ -1012,7 +1028,7 @@ function TirSection({ tir }: { tir: TimeInRangeDetailStats }) {
               Range
             </th>
             <th className="py-1.5 text-left text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
-              mg/dL
+              {unitLabel(unit)}
             </th>
             <th className="py-1.5 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
               % Time
@@ -1083,11 +1099,13 @@ function HypoSection({
   periodDays,
   low = 70,
   urgentLow = 54,
+  unit = "mgdl",
 }: {
   events: HypoEvent[];
   periodDays: number;
   low?: number;
   urgentLow?: number;
+  unit?: GlucoseUnit;
 }) {
   const urgentEvents = events.filter((e) => e.isUrgent);
   const totalDuration = events.reduce((s, e) => s + e.durationMinutes, 0);
@@ -1112,7 +1130,7 @@ function HypoSection({
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         <div>
           <p className="text-xs text-slate-500 print:text-slate-600 mb-1">
-            Low Events (&lt;{low})
+            Low Events (&lt;{formatGlucose(low, unit)})
           </p>
           <p className="text-2xl font-bold text-slate-900 dark:text-white print:text-black">
             {events.length}
@@ -1121,7 +1139,7 @@ function HypoSection({
         </div>
         <div>
           <p className="text-xs text-slate-500 print:text-slate-600 mb-1">
-            Urgent Lows (&lt;{urgentLow})
+            Urgent Lows (&lt;{formatGlucose(urgentLow, unit)})
           </p>
           <p className={`text-2xl font-bold ${urgentEvents.length > 0 ? "text-red-600" : "text-slate-900 dark:text-white print:text-black"}`}>
             {urgentEvents.length}
@@ -1140,9 +1158,9 @@ function HypoSection({
             Lowest Reading
           </p>
           <p className="text-2xl font-bold text-slate-900 dark:text-white print:text-black">
-            {lowestNadir ?? "---"}
+            {lowestNadir != null ? formatGlucose(lowestNadir, unit) : "---"}
             {lowestNadir != null && (
-              <span className="text-sm font-normal ml-1">mg/dL</span>
+              <span className="text-sm font-normal ml-1">{unitLabel(unit)}</span>
             )}
           </p>
         </div>
@@ -1164,8 +1182,10 @@ function HypoSection({
 
 function OvernightSection({
   stats,
+  unit = "mgdl",
 }: {
   stats: { avg: number; count: number; lowPct: number; highPct: number; inRangePct: number };
+  unit?: GlucoseUnit;
 }) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
@@ -1174,8 +1194,8 @@ function OvernightSection({
           Overnight Avg (10PM-6AM)
         </p>
         <p className="text-2xl font-bold text-slate-900 dark:text-white print:text-black">
-          {stats.avg}
-          <span className="text-sm font-normal ml-1">mg/dL</span>
+          {formatGlucose(stats.avg, unit)}
+          <span className="text-sm font-normal ml-1">{unitLabel(unit)}</span>
         </p>
       </div>
       <div>
@@ -1293,8 +1313,10 @@ function InsulinSection({ insulin }: { insulin: InsulinSummaryResponse }) {
 
 function PumpSettingsSection({
   profile,
+  unit = "mgdl",
 }: {
   profile: PumpProfileSummaryResponse;
+  unit?: GlucoseUnit;
 }) {
   const segments = profile.segments;
 
@@ -1343,7 +1365,7 @@ function PumpSettingsSection({
                 Carb Ratio (g/U)
               </th>
               <th className="py-1.5 px-2 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
-                Correction (mg/dL/U)
+                Correction ({unitLabel(unit)}/U)
               </th>
               <th className="py-1.5 px-2 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
                 Target BG
@@ -1367,11 +1389,11 @@ function PumpSettingsSection({
                 </td>
                 <td className="py-1.5 px-2 text-right text-slate-900 dark:text-white print:text-black">
                   {seg.correction_factor != null
-                    ? Math.round(seg.correction_factor)
+                    ? formatGlucose(seg.correction_factor, unit)
                     : "---"}
                 </td>
                 <td className="py-1.5 px-2 text-right text-slate-900 dark:text-white print:text-black">
-                  {seg.target_bg ?? "---"}
+                  {seg.target_bg != null ? formatGlucose(seg.target_bg, unit) : "---"}
                 </td>
               </tr>
             ))}
@@ -1395,9 +1417,11 @@ function PumpSettingsSection({
 function BolusTable({
   boluses,
   totalCount,
+  unit = "mgdl",
 }: {
   boluses: BolusReviewItem[];
   totalCount: number;
+  unit?: GlucoseUnit;
 }) {
   if (boluses.length === 0) {
     return (
@@ -1476,7 +1500,7 @@ function BolusTable({
                   </td>
                   <td className="py-1.5 px-2 text-right text-slate-600 dark:text-slate-300 print:text-slate-700">
                     {b.bg_at_event != null
-                      ? `${Math.round(b.bg_at_event)}`
+                      ? formatGlucose(b.bg_at_event, unit)
                       : "---"}
                   </td>
                   <td className="py-1.5 px-2 text-right text-slate-600 dark:text-slate-300 print:text-slate-700">
@@ -1603,12 +1627,15 @@ function PlatformSettingsSection({
   glucoseRange,
   plugin,
   analyticsConfig,
+  unit = "mgdl",
 }: {
   glucoseRange: { urgentLow: number; low: number; high: number; urgentHigh: number };
   plugin: PluginDeclarationResponse | null;
   analyticsConfig: AnalyticsConfigResponse | null;
+  unit?: GlucoseUnit;
 }) {
   const displayLabels = analyticsConfig?.display_labels ?? null;
+  const label = unitLabel(unit);
 
   return (
     <div className="space-y-4">
@@ -1620,19 +1647,19 @@ function PlatformSettingsSection({
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
           <div>
             <p className="text-xs text-slate-400">Urgent Low</p>
-            <p className="font-medium text-red-600 print:text-red-700">&lt;{glucoseRange.urgentLow} mg/dL</p>
+            <p className="font-medium text-red-600 print:text-red-700">&lt;{formatGlucose(glucoseRange.urgentLow, unit)} {label}</p>
           </div>
           <div>
             <p className="text-xs text-slate-400">Low</p>
-            <p className="font-medium text-amber-500">{glucoseRange.urgentLow}-{glucoseRange.low} mg/dL</p>
+            <p className="font-medium text-amber-500">{formatGlucose(glucoseRange.urgentLow, unit)}-{formatGlucose(glucoseRange.low, unit)} {label}</p>
           </div>
           <div>
             <p className="text-xs text-slate-400">Target Range</p>
-            <p className="font-medium text-green-600 print:text-green-700">{glucoseRange.low}-{glucoseRange.high} mg/dL</p>
+            <p className="font-medium text-green-600 print:text-green-700">{formatGlucose(glucoseRange.low, unit)}-{formatGlucose(glucoseRange.high, unit)} {label}</p>
           </div>
           <div>
             <p className="text-xs text-slate-400">High</p>
-            <p className="font-medium text-orange-500">&gt;{glucoseRange.high} mg/dL</p>
+            <p className="font-medium text-orange-500">&gt;{formatGlucose(glucoseRange.high, unit)} {label}</p>
           </div>
         </div>
       </div>
@@ -1692,6 +1719,8 @@ const PRESETS = [
 ];
 
 export default function ClinicalReportPage() {
+  // Self-view report: render in the logged-in user's preferred unit.
+  const unit = useGlucoseUnit();
   const [startDate, setStartDate] = useState(daysAgoDateString(13));
   const [endDate, setEndDate] = useState(todayDateString());
   const [selectedPreset, setSelectedPreset] = useState<number | null>(14);
@@ -2025,6 +2054,7 @@ export default function ClinicalReportPage() {
               glucoseRange={thresholds}
               plugin={reportData.plugin}
               analyticsConfig={reportData.analyticsConfig}
+              unit={unit}
             />
           </ReportSection>
 
@@ -2032,7 +2062,7 @@ export default function ClinicalReportPage() {
           {reportData.cgmStats &&
             reportData.cgmStats.readings_count > 0 && (
               <ReportSection title="CGM Summary">
-                <CgmStatsSection stats={reportData.cgmStats} />
+                <CgmStatsSection stats={reportData.cgmStats} unit={unit} />
               </ReportSection>
             )}
 
@@ -2040,7 +2070,7 @@ export default function ClinicalReportPage() {
           {reportData.tirStats &&
             reportData.tirStats.readings_count > 0 && (
               <ReportSection title="Time in Range">
-                <TirSection tir={reportData.tirStats} />
+                <TirSection tir={reportData.tirStats} unit={unit} />
               </ReportSection>
             )}
 
@@ -2053,6 +2083,7 @@ export default function ClinicalReportPage() {
                 high={thresholds.high}
                 urgentLow={thresholds.urgentLow}
                 urgentHigh={thresholds.urgentHigh}
+                unit={unit}
               />
             </ReportSection>
           )}
@@ -2068,6 +2099,7 @@ export default function ClinicalReportPage() {
                 high={thresholds.high}
                 urgentLow={thresholds.urgentLow}
                 urgentHigh={thresholds.urgentHigh}
+                unit={unit}
               />
             </ReportSection>
           )}
@@ -2081,6 +2113,7 @@ export default function ClinicalReportPage() {
                 high={thresholds.high}
                 urgentLow={thresholds.urgentLow}
                 urgentHigh={thresholds.urgentHigh}
+                unit={unit}
               />
             </ReportSection>
           )}
@@ -2088,14 +2121,14 @@ export default function ClinicalReportPage() {
           {/* 7. Hypoglycemia Analysis */}
           {reportData.readings.length > 0 && (
             <ReportSection title="Hypoglycemia Analysis">
-              <HypoSection events={hypoEvents} periodDays={reportDays} low={thresholds.low} urgentLow={thresholds.urgentLow} />
+              <HypoSection events={hypoEvents} periodDays={reportDays} low={thresholds.low} urgentLow={thresholds.urgentLow} unit={unit} />
             </ReportSection>
           )}
 
           {/* 8. Overnight Pattern */}
           {overnightStats && (
             <ReportSection title="Overnight Pattern (10 PM - 6 AM)">
-              <OvernightSection stats={overnightStats} />
+              <OvernightSection stats={overnightStats} unit={unit} />
             </ReportSection>
           )}
 
@@ -2111,7 +2144,7 @@ export default function ClinicalReportPage() {
           {/* 10. Active Pump Settings */}
           {reportData.pumpProfile && (
             <ReportSection title="Active Pump Settings">
-              <PumpSettingsSection profile={reportData.pumpProfile} />
+              <PumpSettingsSection profile={reportData.pumpProfile} unit={unit} />
             </ReportSection>
           )}
 
@@ -2121,6 +2154,7 @@ export default function ClinicalReportPage() {
               <BolusTable
                 boluses={reportData.boluses}
                 totalCount={reportData.totalBolusCount}
+                unit={unit}
               />
             </ReportSection>
           )}

--- a/apps/web/src/app/dashboard/settings/alerts/page.tsx
+++ b/apps/web/src/app/dashboard/settings/alerts/page.tsx
@@ -28,15 +28,25 @@ import {
   type AlertThresholdResponse,
   type EscalationConfigResponse,
 } from "@/lib/api";
+import {
+  toDisplayNumber,
+  clampMgdl,
+  toStoredMgdl,
+  formatGlucose,
+  unitLabel,
+  stepFor,
+} from "@/lib/glucose-units";
+import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
+import {
+  ALERT_THRESHOLD_DEFAULTS,
+  GLUCOSE_THRESHOLD_BOUNDS,
+} from "@/lib/alert-thresholds";
 import { OfflineBanner } from "@/components/ui/offline-banner";
 
-const THRESHOLD_DEFAULTS = {
-  low_warning: 70,
-  urgent_low: 55,
-  high_warning: 180,
-  urgent_high: 250,
-  iob_warning: 3.0,
-};
+// Defaults + canonical mg/dL glucose bounds come from one shared source so this
+// page and the dashboard alerts page cannot drift.
+const THRESHOLD_DEFAULTS = ALERT_THRESHOLD_DEFAULTS;
+const GLUCOSE_BOUNDS = GLUCOSE_THRESHOLD_BOUNDS;
 
 const ESCALATION_DEFAULTS = {
   reminder_delay_minutes: 5,
@@ -45,6 +55,12 @@ const ESCALATION_DEFAULTS = {
 };
 
 export default function AlertSettingsPage() {
+  const unit = useGlucoseUnit();
+  // Display a stored mg/dL glucose threshold as the active-unit input string.
+  const toDisplay = useCallback(
+    (mgdl: number) => formatGlucose(mgdl, unit),
+    [unit]
+  );
   const [thresholds, setThresholds] =
     useState<AlertThresholdResponse | null>(null);
   const [escalation, setEscalation] =
@@ -76,10 +92,10 @@ export default function AlertSettingsPage() {
       ]);
 
       setThresholds(thresholdData);
-      setLowWarning(String(thresholdData.low_warning));
-      setUrgentLow(String(thresholdData.urgent_low));
-      setHighWarning(String(thresholdData.high_warning));
-      setUrgentHigh(String(thresholdData.urgent_high));
+      setLowWarning(toDisplay(thresholdData.low_warning));
+      setUrgentLow(toDisplay(thresholdData.urgent_low));
+      setHighWarning(toDisplay(thresholdData.high_warning));
+      setUrgentHigh(toDisplay(thresholdData.urgent_high));
       setIobWarning(String(thresholdData.iob_warning));
 
       setEscalation(escalationData);
@@ -95,10 +111,10 @@ export default function AlertSettingsPage() {
       setThresholds({
         ...THRESHOLD_DEFAULTS,
       } as AlertThresholdResponse);
-      setLowWarning(String(THRESHOLD_DEFAULTS.low_warning));
-      setUrgentLow(String(THRESHOLD_DEFAULTS.urgent_low));
-      setHighWarning(String(THRESHOLD_DEFAULTS.high_warning));
-      setUrgentHigh(String(THRESHOLD_DEFAULTS.urgent_high));
+      setLowWarning(toDisplay(THRESHOLD_DEFAULTS.low_warning));
+      setUrgentLow(toDisplay(THRESHOLD_DEFAULTS.urgent_low));
+      setHighWarning(toDisplay(THRESHOLD_DEFAULTS.high_warning));
+      setUrgentHigh(toDisplay(THRESHOLD_DEFAULTS.urgent_high));
       setIobWarning(String(THRESHOLD_DEFAULTS.iob_warning));
 
       setEscalation({
@@ -114,7 +130,7 @@ export default function AlertSettingsPage() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [toDisplay]);
 
   useEffect(() => {
     fetchData();
@@ -128,11 +144,16 @@ export default function AlertSettingsPage() {
   }, [success]);
 
   // --- Validation ---
+  // Display-unit values (what the user typed / sees in inputs + preview).
   const lowWarn = parseFloat(lowWarning);
   const urgLow = parseFloat(urgentLow);
   const highWarn = parseFloat(highWarning);
   const urgHigh = parseFloat(urgentHigh);
   const iobWarn = parseFloat(iobWarning);
+  // Range validity in DISPLAY space so the displayed bound is accepted; saved
+  // glucose values are clamped to canonical mg/dL.
+  const inRange = (v: number, b: { min: number; max: number }) =>
+    v >= toDisplayNumber(b.min, unit) && v <= toDisplayNumber(b.max, unit);
   const remDelay = parseInt(reminderDelay, 10);
   const priDelay = parseInt(primaryDelay, 10);
   const allDelay = parseInt(allContactsDelay, 10);
@@ -143,14 +164,10 @@ export default function AlertSettingsPage() {
     !isNaN(highWarn) &&
     !isNaN(urgHigh) &&
     !isNaN(iobWarn) &&
-    urgLow >= 30 &&
-    urgLow <= 80 &&
-    lowWarn >= 40 &&
-    lowWarn <= 100 &&
-    highWarn >= 120 &&
-    highWarn <= 300 &&
-    urgHigh >= 150 &&
-    urgHigh <= 400 &&
+    inRange(urgLow, GLUCOSE_BOUNDS.urgentLow) &&
+    inRange(lowWarn, GLUCOSE_BOUNDS.lowWarning) &&
+    inRange(highWarn, GLUCOSE_BOUNDS.highWarning) &&
+    inRange(urgHigh, GLUCOSE_BOUNDS.urgentHigh) &&
     iobWarn >= 0.5 &&
     iobWarn <= 20 &&
     urgLow < lowWarn &&
@@ -171,12 +188,14 @@ export default function AlertSettingsPage() {
 
   const isValid = thresholdsValid && escalationValid;
 
+  // Compare glucose in display space so the load-time round-trip "snap" doesn't
+  // read as an unsaved change; IoB compares numerically.
   const thresholdsChanged =
     thresholds !== null &&
-    (parseFloat(lowWarning) !== thresholds.low_warning ||
-      parseFloat(urgentLow) !== thresholds.urgent_low ||
-      parseFloat(highWarning) !== thresholds.high_warning ||
-      parseFloat(urgentHigh) !== thresholds.urgent_high ||
+    (lowWarning !== toDisplay(thresholds.low_warning) ||
+      urgentLow !== toDisplay(thresholds.urgent_low) ||
+      highWarning !== toDisplay(thresholds.high_warning) ||
+      urgentHigh !== toDisplay(thresholds.urgent_high) ||
       parseFloat(iobWarning) !== thresholds.iob_warning);
 
   const escalationChanged =
@@ -200,10 +219,12 @@ export default function AlertSettingsPage() {
     const results = await Promise.allSettled([
       thresholdsChanged
         ? updateAlertThresholds({
-            low_warning: lowWarn,
-            urgent_low: urgLow,
-            high_warning: highWarn,
-            urgent_high: urgHigh,
+            // Glucose thresholds convert back to integer mg/dL, clamped to each
+            // bound; IoB stays units.
+            low_warning: clampMgdl(toStoredMgdl(lowWarn, unit), GLUCOSE_BOUNDS.lowWarning.min, GLUCOSE_BOUNDS.lowWarning.max),
+            urgent_low: clampMgdl(toStoredMgdl(urgLow, unit), GLUCOSE_BOUNDS.urgentLow.min, GLUCOSE_BOUNDS.urgentLow.max),
+            high_warning: clampMgdl(toStoredMgdl(highWarn, unit), GLUCOSE_BOUNDS.highWarning.min, GLUCOSE_BOUNDS.highWarning.max),
+            urgent_high: clampMgdl(toStoredMgdl(urgHigh, unit), GLUCOSE_BOUNDS.urgentHigh.min, GLUCOSE_BOUNDS.urgentHigh.max),
             iob_warning: iobWarn,
           })
         : Promise.resolve(thresholds!),
@@ -218,7 +239,14 @@ export default function AlertSettingsPage() {
 
     // Update state for whichever calls succeeded
     if (results[0].status === "fulfilled") {
-      setThresholds(results[0].value);
+      const t = results[0].value;
+      setThresholds(t);
+      // Re-sync glucose inputs to the canonical-converted display (snap).
+      setLowWarning(toDisplay(t.low_warning));
+      setUrgentLow(toDisplay(t.urgent_low));
+      setHighWarning(toDisplay(t.high_warning));
+      setUrgentHigh(toDisplay(t.urgent_high));
+      setIobWarning(String(t.iob_warning));
     }
     if (results[1].status === "fulfilled") {
       setEscalation(results[1].value);
@@ -262,10 +290,10 @@ export default function AlertSettingsPage() {
       ]);
 
       setThresholds(updatedThresholds);
-      setLowWarning(String(THRESHOLD_DEFAULTS.low_warning));
-      setUrgentLow(String(THRESHOLD_DEFAULTS.urgent_low));
-      setHighWarning(String(THRESHOLD_DEFAULTS.high_warning));
-      setUrgentHigh(String(THRESHOLD_DEFAULTS.urgent_high));
+      setLowWarning(toDisplay(THRESHOLD_DEFAULTS.low_warning));
+      setUrgentLow(toDisplay(THRESHOLD_DEFAULTS.urgent_low));
+      setHighWarning(toDisplay(THRESHOLD_DEFAULTS.high_warning));
+      setUrgentHigh(toDisplay(THRESHOLD_DEFAULTS.urgent_high));
       setIobWarning(String(THRESHOLD_DEFAULTS.iob_warning));
 
       setEscalation(updatedEscalation);
@@ -387,14 +415,14 @@ export default function AlertSettingsPage() {
                     htmlFor="urgent-low"
                     className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
                   >
-                    Urgent Low (mg/dL)
+                    Urgent Low ({unitLabel(unit)})
                   </label>
                   <input
                     id="urgent-low"
                     type="number"
-                    min={30}
-                    max={80}
-                    step={1}
+                    min={toDisplayNumber(GLUCOSE_BOUNDS.urgentLow.min, unit)}
+                    max={toDisplayNumber(GLUCOSE_BOUNDS.urgentLow.max, unit)}
+                    step={stepFor(unit)}
                     value={urgentLow}
                     onChange={(e) => setUrgentLow(e.target.value)}
                     disabled={isSaving}
@@ -410,7 +438,7 @@ export default function AlertSettingsPage() {
                     id="urgent-low-hint"
                     className="text-xs text-slate-500 mt-1"
                   >
-                    Range: 30-80. Default: 55 mg/dL
+                    Range: {toDisplayNumber(GLUCOSE_BOUNDS.urgentLow.min, unit)}-{toDisplayNumber(GLUCOSE_BOUNDS.urgentLow.max, unit)} {unitLabel(unit)}. Default: {toDisplay(THRESHOLD_DEFAULTS.urgent_low)} {unitLabel(unit)}
                   </p>
                 </div>
 
@@ -419,14 +447,14 @@ export default function AlertSettingsPage() {
                     htmlFor="low-warning"
                     className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
                   >
-                    Low Warning (mg/dL)
+                    Low Warning ({unitLabel(unit)})
                   </label>
                   <input
                     id="low-warning"
                     type="number"
-                    min={40}
-                    max={100}
-                    step={1}
+                    min={toDisplayNumber(GLUCOSE_BOUNDS.lowWarning.min, unit)}
+                    max={toDisplayNumber(GLUCOSE_BOUNDS.lowWarning.max, unit)}
+                    step={stepFor(unit)}
                     value={lowWarning}
                     onChange={(e) => setLowWarning(e.target.value)}
                     disabled={isSaving}
@@ -442,7 +470,7 @@ export default function AlertSettingsPage() {
                     id="low-warning-hint"
                     className="text-xs text-slate-500 mt-1"
                   >
-                    Range: 40-100. Default: 70 mg/dL
+                    Range: {toDisplayNumber(GLUCOSE_BOUNDS.lowWarning.min, unit)}-{toDisplayNumber(GLUCOSE_BOUNDS.lowWarning.max, unit)} {unitLabel(unit)}. Default: {toDisplay(THRESHOLD_DEFAULTS.low_warning)} {unitLabel(unit)}
                   </p>
                 </div>
               </div>
@@ -468,14 +496,14 @@ export default function AlertSettingsPage() {
                     htmlFor="high-warning"
                     className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
                   >
-                    High Warning (mg/dL)
+                    High Warning ({unitLabel(unit)})
                   </label>
                   <input
                     id="high-warning"
                     type="number"
-                    min={120}
-                    max={300}
-                    step={1}
+                    min={toDisplayNumber(GLUCOSE_BOUNDS.highWarning.min, unit)}
+                    max={toDisplayNumber(GLUCOSE_BOUNDS.highWarning.max, unit)}
+                    step={stepFor(unit)}
                     value={highWarning}
                     onChange={(e) => setHighWarning(e.target.value)}
                     disabled={isSaving}
@@ -491,7 +519,7 @@ export default function AlertSettingsPage() {
                     id="high-warning-hint"
                     className="text-xs text-slate-500 mt-1"
                   >
-                    Range: 120-300. Default: 180 mg/dL
+                    Range: {toDisplayNumber(GLUCOSE_BOUNDS.highWarning.min, unit)}-{toDisplayNumber(GLUCOSE_BOUNDS.highWarning.max, unit)} {unitLabel(unit)}. Default: {toDisplay(THRESHOLD_DEFAULTS.high_warning)} {unitLabel(unit)}
                   </p>
                 </div>
 
@@ -500,14 +528,14 @@ export default function AlertSettingsPage() {
                     htmlFor="urgent-high"
                     className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
                   >
-                    Urgent High (mg/dL)
+                    Urgent High ({unitLabel(unit)})
                   </label>
                   <input
                     id="urgent-high"
                     type="number"
-                    min={150}
-                    max={400}
-                    step={1}
+                    min={toDisplayNumber(GLUCOSE_BOUNDS.urgentHigh.min, unit)}
+                    max={toDisplayNumber(GLUCOSE_BOUNDS.urgentHigh.max, unit)}
+                    step={stepFor(unit)}
                     value={urgentHigh}
                     onChange={(e) => setUrgentHigh(e.target.value)}
                     disabled={isSaving}
@@ -523,7 +551,7 @@ export default function AlertSettingsPage() {
                     id="urgent-high-hint"
                     className="text-xs text-slate-500 mt-1"
                   >
-                    Range: 150-400. Default: 250 mg/dL
+                    Range: {toDisplayNumber(GLUCOSE_BOUNDS.urgentHigh.min, unit)}-{toDisplayNumber(GLUCOSE_BOUNDS.urgentHigh.max, unit)} {unitLabel(unit)}. Default: {toDisplay(THRESHOLD_DEFAULTS.urgent_high)} {unitLabel(unit)}
                   </p>
                 </div>
               </div>
@@ -586,25 +614,25 @@ export default function AlertSettingsPage() {
                   <div>
                     <span className="text-red-600 dark:text-red-400">Urgent Low:</span>{" "}
                     <span className="text-slate-700 dark:text-slate-200">
-                      &lt; {urgLow} mg/dL
+                      &lt; {urgLow} {unitLabel(unit)}
                     </span>
                   </div>
                   <div>
                     <span className="text-amber-600 dark:text-amber-400">Low Warning:</span>{" "}
                     <span className="text-slate-700 dark:text-slate-200">
-                      &lt; {lowWarn} mg/dL
+                      &lt; {lowWarn} {unitLabel(unit)}
                     </span>
                   </div>
                   <div>
                     <span className="text-amber-600 dark:text-amber-400">High Warning:</span>{" "}
                     <span className="text-slate-700 dark:text-slate-200">
-                      &gt; {highWarn} mg/dL
+                      &gt; {highWarn} {unitLabel(unit)}
                     </span>
                   </div>
                   <div>
                     <span className="text-red-600 dark:text-red-400">Urgent High:</span>{" "}
                     <span className="text-slate-700 dark:text-slate-200">
-                      &gt; {urgHigh} mg/dL
+                      &gt; {urgHigh} {unitLabel(unit)}
                     </span>
                   </div>
                   <div className="col-span-2">

--- a/apps/web/src/app/dashboard/settings/glucose-range/page.tsx
+++ b/apps/web/src/app/dashboard/settings/glucose-range/page.tsx
@@ -23,13 +23,32 @@ import {
   updateTargetGlucoseRange,
   type TargetGlucoseRangeResponse,
 } from "@/lib/api";
+import {
+  toDisplayNumber,
+  clampMgdl,
+  toStoredMgdl,
+  formatGlucose,
+  unitLabel,
+  stepFor,
+} from "@/lib/glucose-units";
+import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
 import { OfflineBanner } from "@/components/ui/offline-banner";
 
+// All thresholds are stored and validated in canonical mg/dL (locked decision
+// 6). The form displays/accepts the active unit and converts on the edges.
 const DEFAULTS = {
   urgent_low: 55,
   low_target: 70,
   high_target: 180,
   urgent_high: 250,
+};
+
+// mg/dL validation bounds per field (never converted).
+const BOUNDS = {
+  urgentLow: { min: 30, max: 70 },
+  lowTarget: { min: 40, max: 200 },
+  highTarget: { min: 80, max: 400 },
+  urgentHigh: { min: 200, max: 500 },
 };
 
 export default function GlucoseRangePage() {
@@ -40,7 +59,14 @@ export default function GlucoseRangePage() {
   const [isSaving, setIsSaving] = useState(false);
   const [isOffline, setIsOffline] = useState(false);
 
-  // Form state
+  const unit = useGlucoseUnit();
+  // Display a stored mg/dL threshold as the active-unit string for an input.
+  const toDisplay = useCallback(
+    (mgdl: number) => formatGlucose(mgdl, unit),
+    [unit]
+  );
+
+  // Form state (holds DISPLAY-unit strings; converted to mg/dL on save).
   const [urgentLow, setUrgentLow] = useState<string>("55");
   const [lowTarget, setLowTarget] = useState<string>("70");
   const [highTarget, setHighTarget] = useState<string>("180");
@@ -51,10 +77,10 @@ export default function GlucoseRangePage() {
       setError(null);
       const data = await getTargetGlucoseRange();
       setRange(data);
-      setUrgentLow(String(data.urgent_low));
-      setLowTarget(String(data.low_target));
-      setHighTarget(String(data.high_target));
-      setUrgentHigh(String(data.urgent_high));
+      setUrgentLow(toDisplay(data.urgent_low));
+      setLowTarget(toDisplay(data.low_target));
+      setHighTarget(toDisplay(data.high_target));
+      setUrgentHigh(toDisplay(data.urgent_high));
       setIsOffline(false);
     } catch (err) {
       if (!(err instanceof Error && err.message.includes("401"))) {
@@ -69,7 +95,7 @@ export default function GlucoseRangePage() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [toDisplay]);
 
   useEffect(() => {
     fetchRange();
@@ -87,16 +113,24 @@ export default function GlucoseRangePage() {
     setError(null);
     setSuccess(null);
 
-    const ul = parseFloat(urgentLow);
-    const low = parseFloat(lowTarget);
-    const high = parseFloat(highTarget);
-    const uh = parseFloat(urgentHigh);
+    const ulInput = parseFloat(urgentLow);
+    const lowInput = parseFloat(lowTarget);
+    const highInput = parseFloat(highTarget);
+    const uhInput = parseFloat(urgentHigh);
 
-    if ([ul, low, high, uh].some(isNaN)) {
+    if ([ulInput, lowInput, highInput, uhInput].some(isNaN)) {
       setError("Please enter valid numbers for all fields");
       setIsSaving(false);
       return;
     }
+
+    // Convert the entered display values back to canonical integer mg/dL,
+    // CLAMPED to each field's bound so a boundary
+    // unit-rounding overshoot (e.g. 27.8 mmol -> 501) never crosses the bound.
+    const ul = clampMgdl(toStoredMgdl(ulInput, unit), BOUNDS.urgentLow.min, BOUNDS.urgentLow.max);
+    const low = clampMgdl(toStoredMgdl(lowInput, unit), BOUNDS.lowTarget.min, BOUNDS.lowTarget.max);
+    const high = clampMgdl(toStoredMgdl(highInput, unit), BOUNDS.highTarget.min, BOUNDS.highTarget.max);
+    const uh = clampMgdl(toStoredMgdl(uhInput, unit), BOUNDS.urgentHigh.min, BOUNDS.urgentHigh.max);
 
     if (!(ul < low && low < high && high < uh)) {
       setError(
@@ -114,6 +148,12 @@ export default function GlucoseRangePage() {
         urgent_high: uh,
       });
       setRange(updated);
+      // Re-sync inputs to the canonical-converted display values; a saved mmol
+      // value may visibly "snap" (e.g. 5.5 -> 99 mg/dL -> 5.5). Expected.
+      setUrgentLow(toDisplay(updated.urgent_low));
+      setLowTarget(toDisplay(updated.low_target));
+      setHighTarget(toDisplay(updated.high_target));
+      setUrgentHigh(toDisplay(updated.urgent_high));
       setSuccess("Glucose thresholds updated successfully");
     } catch (err) {
       setError(
@@ -137,10 +177,10 @@ export default function GlucoseRangePage() {
         urgent_high: DEFAULTS.urgent_high,
       });
       setRange(updated);
-      setUrgentLow(String(DEFAULTS.urgent_low));
-      setLowTarget(String(DEFAULTS.low_target));
-      setHighTarget(String(DEFAULTS.high_target));
-      setUrgentHigh(String(DEFAULTS.urgent_high));
+      setUrgentLow(toDisplay(DEFAULTS.urgent_low));
+      setLowTarget(toDisplay(DEFAULTS.low_target));
+      setHighTarget(toDisplay(DEFAULTS.high_target));
+      setUrgentHigh(toDisplay(DEFAULTS.urgent_high));
       setSuccess("Glucose thresholds reset to defaults");
     } catch (err) {
       setError(
@@ -151,27 +191,30 @@ export default function GlucoseRangePage() {
     }
   };
 
+  // Display-unit values (what the user typed / sees in the inputs + preview).
   const ulNum = parseFloat(urgentLow);
   const lowNum = parseFloat(lowTarget);
   const highNum = parseFloat(highTarget);
   const uhNum = parseFloat(urgentHigh);
   const allParsed = [ulNum, lowNum, highNum, uhNum].every((n) => !isNaN(n));
+  // Range validity in DISPLAY space so the displayed bound is accepted; the
+  // saved value is clamped to canonical mg/dL.
+  const inRange = (v: number, b: { min: number; max: number }) =>
+    v >= toDisplayNumber(b.min, unit) && v <= toDisplayNumber(b.max, unit);
+  // Compare in display space so the load-time round-trip "snap" doesn't read
+  // as an unsaved change.
   const hasChanges =
     range &&
-    (ulNum !== range.urgent_low ||
-      lowNum !== range.low_target ||
-      highNum !== range.high_target ||
-      uhNum !== range.urgent_high);
+    (urgentLow !== toDisplay(range.urgent_low) ||
+      lowTarget !== toDisplay(range.low_target) ||
+      highTarget !== toDisplay(range.high_target) ||
+      urgentHigh !== toDisplay(range.urgent_high));
   const isValid =
     allParsed &&
-    ulNum >= 30 &&
-    ulNum <= 70 &&
-    lowNum >= 40 &&
-    lowNum <= 200 &&
-    highNum >= 80 &&
-    highNum <= 400 &&
-    uhNum >= 200 &&
-    uhNum <= 500 &&
+    inRange(ulNum, BOUNDS.urgentLow) &&
+    inRange(lowNum, BOUNDS.lowTarget) &&
+    inRange(highNum, BOUNDS.highTarget) &&
+    inRange(uhNum, BOUNDS.urgentHigh) &&
     ulNum < lowNum &&
     lowNum < highNum &&
     highNum < uhNum;
@@ -255,14 +298,14 @@ export default function GlucoseRangePage() {
                   htmlFor="urgent-low"
                   className="block text-sm font-medium text-red-400 mb-1"
                 >
-                  Urgent Low (mg/dL)
+                  Urgent Low ({unitLabel(unit)})
                 </label>
                 <input
                   id="urgent-low"
                   type="number"
-                  min={30}
-                  max={70}
-                  step={1}
+                  min={toDisplayNumber(BOUNDS.urgentLow.min, unit)}
+                  max={toDisplayNumber(BOUNDS.urgentLow.max, unit)}
+                  step={stepFor(unit)}
                   value={urgentLow}
                   onChange={(e) => setUrgentLow(e.target.value)}
                   disabled={isSaving}
@@ -278,7 +321,7 @@ export default function GlucoseRangePage() {
                   id="urgent-low-hint"
                   className="text-xs text-slate-500 mt-1"
                 >
-                  Range: 30-70 mg/dL. Default: 55 mg/dL
+                  Range: {toDisplayNumber(BOUNDS.urgentLow.min, unit)}-{toDisplayNumber(BOUNDS.urgentLow.max, unit)} {unitLabel(unit)}. Default: {toDisplay(DEFAULTS.urgent_low)} {unitLabel(unit)}
                 </p>
               </div>
 
@@ -288,14 +331,14 @@ export default function GlucoseRangePage() {
                   htmlFor="low-target"
                   className="block text-sm font-medium text-amber-400 mb-1"
                 >
-                  Low Target (mg/dL)
+                  Low Target ({unitLabel(unit)})
                 </label>
                 <input
                   id="low-target"
                   type="number"
-                  min={40}
-                  max={200}
-                  step={1}
+                  min={toDisplayNumber(BOUNDS.lowTarget.min, unit)}
+                  max={toDisplayNumber(BOUNDS.lowTarget.max, unit)}
+                  step={stepFor(unit)}
                   value={lowTarget}
                   onChange={(e) => setLowTarget(e.target.value)}
                   disabled={isSaving}
@@ -308,7 +351,7 @@ export default function GlucoseRangePage() {
                   aria-describedby="low-target-hint"
                 />
                 <p id="low-target-hint" className="text-xs text-slate-500 mt-1">
-                  Range: 40-200 mg/dL. Default: 70 mg/dL
+                  Range: {toDisplayNumber(BOUNDS.lowTarget.min, unit)}-{toDisplayNumber(BOUNDS.lowTarget.max, unit)} {unitLabel(unit)}. Default: {toDisplay(DEFAULTS.low_target)} {unitLabel(unit)}
                 </p>
               </div>
 
@@ -318,14 +361,14 @@ export default function GlucoseRangePage() {
                   htmlFor="high-target"
                   className="block text-sm font-medium text-amber-400 mb-1"
                 >
-                  High Target (mg/dL)
+                  High Target ({unitLabel(unit)})
                 </label>
                 <input
                   id="high-target"
                   type="number"
-                  min={80}
-                  max={400}
-                  step={1}
+                  min={toDisplayNumber(BOUNDS.highTarget.min, unit)}
+                  max={toDisplayNumber(BOUNDS.highTarget.max, unit)}
+                  step={stepFor(unit)}
                   value={highTarget}
                   onChange={(e) => setHighTarget(e.target.value)}
                   disabled={isSaving}
@@ -341,7 +384,7 @@ export default function GlucoseRangePage() {
                   id="high-target-hint"
                   className="text-xs text-slate-500 mt-1"
                 >
-                  Range: 80-400 mg/dL. Default: 180 mg/dL
+                  Range: {toDisplayNumber(BOUNDS.highTarget.min, unit)}-{toDisplayNumber(BOUNDS.highTarget.max, unit)} {unitLabel(unit)}. Default: {toDisplay(DEFAULTS.high_target)} {unitLabel(unit)}
                 </p>
               </div>
 
@@ -351,14 +394,14 @@ export default function GlucoseRangePage() {
                   htmlFor="urgent-high"
                   className="block text-sm font-medium text-red-400 mb-1"
                 >
-                  Urgent High (mg/dL)
+                  Urgent High ({unitLabel(unit)})
                 </label>
                 <input
                   id="urgent-high"
                   type="number"
-                  min={200}
-                  max={500}
-                  step={1}
+                  min={toDisplayNumber(BOUNDS.urgentHigh.min, unit)}
+                  max={toDisplayNumber(BOUNDS.urgentHigh.max, unit)}
+                  step={stepFor(unit)}
                   value={urgentHigh}
                   onChange={(e) => setUrgentHigh(e.target.value)}
                   disabled={isSaving}
@@ -374,7 +417,7 @@ export default function GlucoseRangePage() {
                   id="urgent-high-hint"
                   className="text-xs text-slate-500 mt-1"
                 >
-                  Range: 200-500 mg/dL. Default: 250 mg/dL
+                  Range: {toDisplayNumber(BOUNDS.urgentHigh.min, unit)}-{toDisplayNumber(BOUNDS.urgentHigh.max, unit)} {unitLabel(unit)}. Default: {toDisplay(DEFAULTS.urgent_high)} {unitLabel(unit)}
                 </p>
               </div>
             </div>
@@ -389,7 +432,7 @@ export default function GlucoseRangePage() {
                   <span className="text-amber-400 font-medium">{lowNum}</span>
                   <span className="text-slate-600">---</span>
                   <span className="text-lg font-semibold text-green-400">
-                    Target: {lowNum}-{highNum} mg/dL
+                    Target: {lowNum}-{highNum} {unitLabel(unit)}
                   </span>
                   <span className="text-slate-600">---</span>
                   <span className="text-amber-400 font-medium">{highNum}</span>
@@ -458,8 +501,9 @@ export default function GlucoseRangePage() {
           dashboard, where the target range band appears on charts, and what
           counts as &quot;in range&quot; for the Time in Range bar. They also
           influence AI-generated suggestions and alert triggers. The standard
-          target range for most people with diabetes is 70-180 mg/dL with urgent
-          thresholds at 55 and 250 mg/dL. Consult your healthcare provider
+          target range for most people with diabetes is {toDisplay(70)}-{toDisplay(180)}{" "}
+          {unitLabel(unit)} with urgent thresholds at {toDisplay(55)} and{" "}
+          {toDisplay(250)} {unitLabel(unit)}. Consult your healthcare provider
           before changing these values.
         </p>
       </div>

--- a/apps/web/src/app/dashboard/settings/profile/page.tsx
+++ b/apps/web/src/app/dashboard/settings/profile/page.tsx
@@ -16,16 +16,26 @@ import {
   ArrowLeft,
   Key,
   Shield,
+  Droplet,
 } from "lucide-react";
 import Link from "next/link";
 import clsx from "clsx";
 import {
   getCurrentUser,
   updateProfile,
+  updateGlucoseUnit,
   changePassword,
   type CurrentUserResponse,
 } from "@/lib/api";
+import { unitLabel, type GlucoseUnit } from "@/lib/glucose-units";
+import { useUserContext } from "@/providers";
 import { OfflineBanner } from "@/components/ui/offline-banner";
+
+const GLUCOSE_UNIT_OPTIONS: { value: GlucoseUnit; label: string; hint: string }[] =
+  [
+    { value: "mgdl", label: "mg/dL", hint: "US standard" },
+    { value: "mmol", label: "mmol/L", hint: "International (UK, EU, AU)" },
+  ];
 
 const ROLE_LABELS: Record<string, string> = {
   diabetic: "Diabetic",
@@ -43,6 +53,11 @@ export default function ProfilePage() {
   // Display name form
   const [displayName, setDisplayName] = useState("");
   const [isSavingName, setIsSavingName] = useState(false);
+
+  // Glucose display unit. Persists via the dedicated glucose-unit
+  // endpoint and refreshes the shared user context so the dashboard re-renders.
+  const { refreshUser } = useUserContext();
+  const [isSavingUnit, setIsSavingUnit] = useState(false);
 
   // Password form
   const [showPasswordForm, setShowPasswordForm] = useState(false);
@@ -127,6 +142,36 @@ export default function ProfilePage() {
       );
     } finally {
       setIsSavingPassword(false);
+    }
+  };
+
+  const handleSelectUnit = async (unit: GlucoseUnit) => {
+    if (!profile || (profile.glucose_unit ?? "mgdl") === unit || isSavingUnit)
+      return;
+    setIsSavingUnit(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await updateGlucoseUnit(unit);
+      // Persisted. Update local state + report success BEFORE the best-effort
+      // context refresh so a refresh failure never reads as a save failure.
+      // Functional update so a concurrent profile change isn't clobbered.
+      setProfile((prev) => (prev ? { ...prev, glucose_unit: unit } : prev));
+      setSuccess(`Glucose unit set to ${unitLabel(unit)}`);
+      // Propagate to the shared user context so display sites across the
+      // dashboard switch units immediately. Best-effort: the unit is
+      // already saved and will apply on the next load if this refresh fails.
+      try {
+        await refreshUser();
+      } catch {
+        // Non-fatal — the preference is persisted.
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to update glucose unit"
+      );
+    } finally {
+      setIsSavingUnit(false);
     }
   };
 
@@ -325,6 +370,71 @@ export default function ProfilePage() {
               {isSavingName ? "Saving..." : "Save Changes"}
             </button>
           </form>
+        </div>
+      )}
+
+      {/* Glucose Display Unit */}
+      {!isLoading && profile && (
+        <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 p-6">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="p-2 bg-sky-500/10 rounded-lg">
+              <Droplet className="h-5 w-5 text-sky-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Glucose Display Unit</h2>
+              <p className="text-xs text-slate-500">
+                Choose how glucose values are shown across your dashboard
+              </p>
+            </div>
+          </div>
+
+          <div
+            role="radiogroup"
+            aria-label="Glucose display unit"
+            className="grid grid-cols-2 gap-3 max-w-md"
+          >
+            {GLUCOSE_UNIT_OPTIONS.map((option) => {
+              const isActive = (profile.glucose_unit ?? "mgdl") === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  onClick={() => handleSelectUnit(option.value)}
+                  disabled={isSavingUnit || isOffline}
+                  title={
+                    isOffline ? "Cannot change unit while disconnected" : undefined
+                  }
+                  className={clsx(
+                    "flex flex-col items-start gap-0.5 rounded-lg border px-4 py-3 text-left",
+                    "transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-sky-500",
+                    "disabled:cursor-not-allowed disabled:opacity-60",
+                    isActive
+                      ? "border-sky-500 bg-sky-500/10"
+                      : "border-slate-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700"
+                  )}
+                >
+                  <span className="flex items-center gap-1.5 text-sm font-medium text-slate-800 dark:text-slate-100">
+                    {isActive && (
+                      <Check className="h-4 w-4 text-sky-500" aria-hidden="true" />
+                    )}
+                    {option.label}
+                  </span>
+                  <span className="text-xs text-slate-500">{option.hint}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          <p className="text-xs text-slate-500 mt-3 flex items-center gap-1.5">
+            {isSavingUnit && (
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+            )}
+            {isSavingUnit
+              ? "Saving..."
+              : "Your glucose data is always stored in mg/dL; this only changes how it is displayed."}
+          </p>
         </div>
       )}
 

--- a/apps/web/src/app/dashboard/settings/safety-limits/page.tsx
+++ b/apps/web/src/app/dashboard/settings/safety-limits/page.tsx
@@ -27,8 +27,24 @@ import {
   type SafetyLimitsResponse,
   type SafetyLimitsDefaults,
 } from "@/lib/api";
+import {
+  toDisplayNumber,
+  clampMgdl,
+  toStoredMgdl,
+  formatGlucose,
+  unitLabel,
+  stepFor,
+} from "@/lib/glucose-units";
+import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
 import { OfflineBanner } from "@/components/ui/offline-banner";
 import { useUserContext } from "@/providers";
+
+// The glucose validation bounds are a medical-safety invariant: they are ALWAYS
+// stored, validated, and sent to the API as integer mg/dL.
+// mmol users see/enter the bounds in mmol/L; conversion happens only at the
+// edges. min_glucose accepts 20-499 mg/dL, max_glucose 21-500 mg/dL.
+const MIN_GLUCOSE_BOUNDS = { min: 20, max: 499 };
+const MAX_GLUCOSE_BOUNDS = { min: 21, max: 500 };
 
 // Hardcoded fallback if the defaults endpoint is unreachable
 const FALLBACK_DEFAULTS: SafetyLimitsDefaults = {
@@ -57,6 +73,13 @@ function unitsToMilliunits(u: number): number {
 
 export default function SafetyLimitsPage() {
   const { user } = useUserContext();
+  const unit = useGlucoseUnit();
+  const isMmol = unit === "mmol";
+  // Display a stored mg/dL glucose bound as the active-unit string for an input.
+  const toDisplay = useCallback(
+    (mgdl: number) => formatGlucose(mgdl, unit),
+    [unit]
+  );
   const [defaults, setDefaults] = useState<SafetyLimitsDefaults>(FALLBACK_DEFAULTS);
   const [limits, setLimits] = useState<SafetyLimitsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -83,8 +106,8 @@ export default function SafetyLimitsPage() {
       ]);
       setLimits(data);
       setDefaults(serverDefaults);
-      setMinGlucose(String(data.min_glucose_mgdl));
-      setMaxGlucose(String(data.max_glucose_mgdl));
+      setMinGlucose(toDisplay(data.min_glucose_mgdl));
+      setMaxGlucose(toDisplay(data.max_glucose_mgdl));
       setMaxBasal(milliunitsToUnits(data.max_basal_rate_milliunits));
       setMaxBolus(milliunitsToUnits(data.max_bolus_dose_milliunits));
       setIsOffline(false);
@@ -100,14 +123,14 @@ export default function SafetyLimitsPage() {
         max_bolus_dose_milliunits: FALLBACK_DEFAULTS.max_bolus_dose_milliunits,
         updated_at: "",
       });
-      setMinGlucose(String(FALLBACK_DEFAULTS.min_glucose_mgdl));
-      setMaxGlucose(String(FALLBACK_DEFAULTS.max_glucose_mgdl));
+      setMinGlucose(toDisplay(FALLBACK_DEFAULTS.min_glucose_mgdl));
+      setMaxGlucose(toDisplay(FALLBACK_DEFAULTS.max_glucose_mgdl));
       setMaxBasal(milliunitsToUnits(FALLBACK_DEFAULTS.max_basal_rate_milliunits));
       setMaxBolus(milliunitsToUnits(FALLBACK_DEFAULTS.max_bolus_dose_milliunits));
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [toDisplay]);
 
   useEffect(() => {
     fetchLimits();
@@ -147,20 +170,51 @@ export default function SafetyLimitsPage() {
     e.preventDefault();
     if (isSaving) return;
 
-    const minG = parseInt(minGlucose, 10);
-    const maxG = parseInt(maxGlucose, 10);
+    const minGInput = parseFloat(minGlucose);
+    const maxGInput = parseFloat(maxGlucose);
     const basalU = parseFloat(maxBasal);
     const bolusU = parseFloat(maxBolus);
 
-    if ([minG, maxG].some(isNaN) || [basalU, bolusU].some(isNaN)) {
+    if ([minGInput, maxGInput].some(isNaN) || [basalU, bolusU].some(isNaN)) {
       setError("Please enter valid numbers for all fields");
       return;
     }
 
-    if (String(minG) !== minGlucose.trim() || String(maxG) !== maxGlucose.trim()) {
+    // mg/dL must be entered as whole numbers; mmol entries carry one decimal
+    // and round-trip to integer mg/dL on save.
+    if (
+      !isMmol &&
+      (String(parseInt(minGlucose, 10)) !== minGlucose.trim() ||
+        String(parseInt(maxGlucose, 10)) !== maxGlucose.trim())
+    ) {
       setError("Glucose values must be whole numbers (no decimals)");
       return;
     }
+
+    // Range check in DISPLAY space so the displayed bound is accepted (e.g. the
+    // 500 ceiling shows as 27.8 mmol — entering it must be valid).
+    if (
+      minGInput < toDisplayNumber(MIN_GLUCOSE_BOUNDS.min, unit) ||
+      minGInput > toDisplayNumber(MIN_GLUCOSE_BOUNDS.max, unit) ||
+      maxGInput < toDisplayNumber(MAX_GLUCOSE_BOUNDS.min, unit) ||
+      maxGInput > toDisplayNumber(MAX_GLUCOSE_BOUNDS.max, unit)
+    ) {
+      setError("One or more values are outside the allowed range");
+      return;
+    }
+
+    // Canonical integer mg/dL, CLAMPED to the bound — the value on the wire is
+    // ALWAYS within range (medical-safety guarantee).
+    const minG = clampMgdl(
+      toStoredMgdl(minGInput, unit),
+      MIN_GLUCOSE_BOUNDS.min,
+      MIN_GLUCOSE_BOUNDS.max
+    );
+    const maxG = clampMgdl(
+      toStoredMgdl(maxGInput, unit),
+      MAX_GLUCOSE_BOUNDS.min,
+      MAX_GLUCOSE_BOUNDS.max
+    );
 
     if (minG >= maxG) {
       setError("Minimum glucose must be less than maximum glucose");
@@ -169,8 +223,7 @@ export default function SafetyLimitsPage() {
 
     const basalMu = unitsToMilliunits(basalU);
     const bolusMu = unitsToMilliunits(bolusU);
-    if (minG < 20 || minG > 499 || maxG < 21 || maxG > 500 ||
-        basalMu < 1 || basalMu > 15000 || bolusMu < 1 || bolusMu > 25000) {
+    if (basalMu < 1 || basalMu > 15000 || bolusMu < 1 || bolusMu > 25000) {
       setError("One or more values are outside the allowed range");
       return;
     }
@@ -185,8 +238,18 @@ export default function SafetyLimitsPage() {
     setError(null);
     setSuccess(null);
 
-    const minG = parseInt(minGlucose, 10);
-    const maxG = parseInt(maxGlucose, 10);
+    // Recompute the canonical integer mg/dL (clamped to the bound) from the
+    // entered display values.
+    const minG = clampMgdl(
+      toStoredMgdl(parseFloat(minGlucose), unit),
+      MIN_GLUCOSE_BOUNDS.min,
+      MIN_GLUCOSE_BOUNDS.max
+    );
+    const maxG = clampMgdl(
+      toStoredMgdl(parseFloat(maxGlucose), unit),
+      MAX_GLUCOSE_BOUNDS.min,
+      MAX_GLUCOSE_BOUNDS.max
+    );
     const basalU = parseFloat(maxBasal);
     const bolusU = parseFloat(maxBolus);
     const basalMu = unitsToMilliunits(basalU);
@@ -200,8 +263,8 @@ export default function SafetyLimitsPage() {
         max_bolus_dose_milliunits: bolusMu,
       });
       setLimits(updated);
-      setMinGlucose(String(updated.min_glucose_mgdl));
-      setMaxGlucose(String(updated.max_glucose_mgdl));
+      setMinGlucose(toDisplay(updated.min_glucose_mgdl));
+      setMaxGlucose(toDisplay(updated.max_glucose_mgdl));
       setMaxBasal(milliunitsToUnits(updated.max_basal_rate_milliunits));
       setMaxBolus(milliunitsToUnits(updated.max_bolus_dose_milliunits));
       setSuccess("Safety limits updated successfully");
@@ -233,8 +296,8 @@ export default function SafetyLimitsPage() {
         max_bolus_dose_milliunits: defaults.max_bolus_dose_milliunits,
       });
       setLimits(updated);
-      setMinGlucose(String(updated.min_glucose_mgdl));
-      setMaxGlucose(String(updated.max_glucose_mgdl));
+      setMinGlucose(toDisplay(updated.min_glucose_mgdl));
+      setMaxGlucose(toDisplay(updated.max_glucose_mgdl));
       setMaxBasal(milliunitsToUnits(updated.max_basal_rate_milliunits));
       setMaxBolus(milliunitsToUnits(updated.max_bolus_dose_milliunits));
       setSuccess("Safety limits reset to defaults");
@@ -257,29 +320,41 @@ export default function SafetyLimitsPage() {
     setPendingAction(null);
   };
 
-  const minGNum = parseInt(minGlucose, 10);
-  const maxGNum = parseInt(maxGlucose, 10);
+  // Display-unit values (what the user typed / sees in inputs + preview).
+  const minGInput = parseFloat(minGlucose);
+  const maxGInput = parseFloat(maxGlucose);
   const basalNum = parseFloat(maxBasal);
   const bolusNum = parseFloat(maxBolus);
+  // Canonical integer mg/dL — all glucose-bound validation runs here.
+  // Range validity in DISPLAY space so the displayed bound (e.g. 27.8 mmol for
+  // the 500 ceiling) is accepted; the saved value is clamped to canonical mg/dL.
+  const minGInRange =
+    !isNaN(minGInput) &&
+    minGInput >= toDisplayNumber(MIN_GLUCOSE_BOUNDS.min, unit) &&
+    minGInput <= toDisplayNumber(MIN_GLUCOSE_BOUNDS.max, unit);
+  const maxGInRange =
+    !isNaN(maxGInput) &&
+    maxGInput >= toDisplayNumber(MAX_GLUCOSE_BOUNDS.min, unit) &&
+    maxGInput <= toDisplayNumber(MAX_GLUCOSE_BOUNDS.max, unit);
   const basalMuNum = isNaN(basalNum) ? NaN : unitsToMilliunits(basalNum);
   const bolusMuNum = isNaN(bolusNum) ? NaN : unitsToMilliunits(bolusNum);
 
-  const allParsed = [minGNum, maxGNum, basalNum, bolusNum].every(
+  const allParsed = [minGInput, maxGInput, basalNum, bolusNum].every(
     (n) => !isNaN(n)
   );
+  // Compare glucose in display space so the load-time round-trip "snap"
+  // doesn't read as an unsaved change; insulin compares in milliunits.
   const hasChanges =
     limits &&
-    (minGNum !== limits.min_glucose_mgdl ||
-      maxGNum !== limits.max_glucose_mgdl ||
+    (minGlucose !== toDisplay(limits.min_glucose_mgdl) ||
+      maxGlucose !== toDisplay(limits.max_glucose_mgdl) ||
       basalMuNum !== limits.max_basal_rate_milliunits ||
       bolusMuNum !== limits.max_bolus_dose_milliunits);
   const isValid =
     allParsed &&
-    minGNum >= 20 &&
-    minGNum <= 499 &&
-    maxGNum >= 21 &&
-    maxGNum <= 500 &&
-    minGNum < maxGNum &&
+    minGInRange &&
+    maxGInRange &&
+    minGInput < maxGInput &&
     basalMuNum >= 1 &&
     basalMuNum <= 15000 &&
     bolusMuNum >= 1 &&
@@ -474,22 +549,22 @@ export default function SafetyLimitsPage() {
                     htmlFor="min-glucose"
                     className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
                   >
-                    Minimum Glucose (mg/dL)
+                    Minimum Glucose ({unitLabel(unit)})
                   </label>
                   <input
                     id="min-glucose"
                     type="number"
-                    min={20}
-                    max={499}
-                    step={1}
+                    min={toDisplayNumber(MIN_GLUCOSE_BOUNDS.min, unit)}
+                    max={toDisplayNumber(MIN_GLUCOSE_BOUNDS.max, unit)}
+                    step={stepFor(unit)}
                     value={minGlucose}
                     onChange={(e) => setMinGlucose(e.target.value)}
                     disabled={isSaving || showConfirm}
-                    aria-invalid={!isNaN(minGNum) && (minGNum < 20 || minGNum > 499) ? true : undefined}
+                    aria-invalid={!isNaN(minGInput) && !minGInRange ? true : undefined}
                     className={clsx(
                       "w-full rounded-lg border px-3 py-2 text-sm",
                       "bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-200",
-                      !isNaN(minGNum) && (minGNum < 20 || minGNum > 499)
+                      !isNaN(minGInput) && !minGInRange
                         ? "border-red-500 focus:ring-red-500"
                         : "border-slate-300 dark:border-slate-700 focus:ring-orange-500",
                       "focus:outline-hidden focus:ring-2 focus:border-transparent",
@@ -501,7 +576,7 @@ export default function SafetyLimitsPage() {
                     id="min-glucose-hint"
                     className="text-xs text-slate-500 mt-1"
                   >
-                    Range: 20-499 mg/dL. Default: {defaults.min_glucose_mgdl} mg/dL
+                    Range: {toDisplayNumber(MIN_GLUCOSE_BOUNDS.min, unit)}-{toDisplayNumber(MIN_GLUCOSE_BOUNDS.max, unit)} {unitLabel(unit)}. Default: {toDisplay(defaults.min_glucose_mgdl)} {unitLabel(unit)}
                   </p>
                 </div>
 
@@ -511,22 +586,22 @@ export default function SafetyLimitsPage() {
                     htmlFor="max-glucose"
                     className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
                   >
-                    Maximum Glucose (mg/dL)
+                    Maximum Glucose ({unitLabel(unit)})
                   </label>
                   <input
                     id="max-glucose"
                     type="number"
-                    min={21}
-                    max={500}
-                    step={1}
+                    min={toDisplayNumber(MAX_GLUCOSE_BOUNDS.min, unit)}
+                    max={toDisplayNumber(MAX_GLUCOSE_BOUNDS.max, unit)}
+                    step={stepFor(unit)}
                     value={maxGlucose}
                     onChange={(e) => setMaxGlucose(e.target.value)}
                     disabled={isSaving || showConfirm}
-                    aria-invalid={!isNaN(maxGNum) && (maxGNum < 21 || maxGNum > 500) ? true : undefined}
+                    aria-invalid={!isNaN(maxGInput) && !maxGInRange ? true : undefined}
                     className={clsx(
                       "w-full rounded-lg border px-3 py-2 text-sm",
                       "bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-200",
-                      !isNaN(maxGNum) && (maxGNum < 21 || maxGNum > 500)
+                      !isNaN(maxGInput) && !maxGInRange
                         ? "border-red-500 focus:ring-red-500"
                         : "border-slate-300 dark:border-slate-700 focus:ring-orange-500",
                       "focus:outline-hidden focus:ring-2 focus:border-transparent",
@@ -538,20 +613,20 @@ export default function SafetyLimitsPage() {
                     id="max-glucose-hint"
                     className="text-xs text-slate-500 mt-1"
                   >
-                    Range: 21-500 mg/dL. Default: {defaults.max_glucose_mgdl} mg/dL
+                    Range: {toDisplayNumber(MAX_GLUCOSE_BOUNDS.min, unit)}-{toDisplayNumber(MAX_GLUCOSE_BOUNDS.max, unit)} {unitLabel(unit)}. Default: {toDisplay(defaults.max_glucose_mgdl)} {unitLabel(unit)}
                   </p>
                 </div>
               </div>
 
               {/* Visual preview for glucose bounds */}
-              {isValid && minGNum < maxGNum && (
+              {isValid && minGInput < maxGInput && (
                 <div className="bg-slate-100/50 dark:bg-slate-800/50 rounded-lg p-4 border border-slate-300/50 dark:border-slate-700/50">
                   <p className="text-xs text-slate-500 mb-2">Valid Glucose Range</p>
                   <p className="text-lg font-semibold text-orange-700 dark:text-orange-400">
-                    {minGNum} - {maxGNum} mg/dL
+                    {minGInput} - {maxGInput} {unitLabel(unit)}
                   </p>
                   <p className="text-xs text-slate-500 mt-1">
-                    Readings below {minGNum} or above {maxGNum} mg/dL will be
+                    Readings below {minGInput} or above {maxGInput} {unitLabel(unit)} will be
                     rejected as sensor errors
                   </p>
                 </div>

--- a/apps/web/src/components/dashboard/agp-chart.tsx
+++ b/apps/web/src/components/dashboard/agp-chart.tsx
@@ -26,6 +26,7 @@ import {
   AGP_PERIOD_LABELS,
 } from "@/hooks/use-glucose-percentiles";
 import type { AGPBucket } from "@/lib/api";
+import { formatGlucose, unitLabel, type GlucoseUnit } from "@/lib/glucose-units";
 
 // --- Constants ---
 
@@ -48,6 +49,9 @@ const AGP_PERIODS: { value: AgpPeriod; label: string }[] = [
 export interface AgpChartProps {
   className?: string;
   thresholds?: { urgentLow: number; low: number; high: number; urgentHigh: number };
+  /** Active glucose display unit (default mgdl). Band math + domain stay
+   * mg/dL; only axis tick labels, the axis title, and tooltip convert. */
+  unit?: GlucoseUnit;
 }
 
 // --- Data transformation ---
@@ -107,10 +111,12 @@ export function transformBuckets(buckets: AGPBucket[]): AgpChartPoint[] {
 function AgpTooltipContent({
   active,
   payload,
+  unit = "mgdl",
 }: {
   active?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload?: Array<{ payload: any }>;
+  unit?: GlucoseUnit;
 }) {
   if (!active || !payload?.length) return null;
   const d = payload[0]?.payload as AgpChartPoint | undefined;
@@ -123,12 +129,13 @@ function AgpTooltipContent({
       </div>
     );
   }
+  const label = unitLabel(unit);
   return (
     <div className="bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-700 rounded-lg px-3 py-2 text-xs shadow-lg">
       <p className="font-semibold text-slate-800 dark:text-slate-200 mb-1">{d.label}</p>
-      <p className="text-teal-700 dark:text-teal-400">Median: {Math.round(d.p50)} mg/dL</p>
-      <p className="text-slate-600 dark:text-slate-300">25th-75th: {Math.round(d.p25)}-{Math.round(d.p75)} mg/dL</p>
-      <p className="text-slate-500 dark:text-slate-400">10th-90th: {Math.round(d.p10)}-{Math.round(d.p90)} mg/dL</p>
+      <p className="text-teal-700 dark:text-teal-400">Median: {formatGlucose(d.p50, unit)} {label}</p>
+      <p className="text-slate-600 dark:text-slate-300">25th-75th: {formatGlucose(d.p25, unit)}-{formatGlucose(d.p75, unit)} {label}</p>
+      <p className="text-slate-500 dark:text-slate-400">10th-90th: {formatGlucose(d.p10, unit)}-{formatGlucose(d.p90, unit)} {label}</p>
       <p className="text-slate-500 dark:text-slate-400 mt-1">{d.count} readings</p>
     </div>
   );
@@ -200,7 +207,7 @@ function PeriodSelector({
 
 // --- Main component ---
 
-export function AgpChart({ className, thresholds }: AgpChartProps) {
+export function AgpChart({ className, thresholds, unit = "mgdl" }: AgpChartProps) {
   const {
     data,
     isLoading,
@@ -358,17 +365,19 @@ export function AgpChart({ className, thresholds }: AgpChartProps) {
             />
             <YAxis
               domain={yDomain}
+              // Domain stays mg/dL; only the tick LABEL converts.
+              tickFormatter={(v: number) => formatGlucose(v, unit)}
               tick={{ fill: "#94a3b8", fontSize: 11 }}
               axisLine={{ stroke: "#475569" }}
               tickLine={{ stroke: "#475569" }}
               label={{
-                value: "mg/dL",
+                value: unitLabel(unit),
                 angle: -90,
                 position: "insideLeft",
                 style: { fill: "#64748b", fontSize: 11 },
               }}
             />
-            <Tooltip content={<AgpTooltipContent />} />
+            <Tooltip content={<AgpTooltipContent unit={unit} />} />
 
             {/* Target range reference lines */}
             <ReferenceLine

--- a/apps/web/src/components/dashboard/alert-card.tsx
+++ b/apps/web/src/components/dashboard/alert-card.tsx
@@ -21,18 +21,27 @@ import {
   formatTimeAgo,
   formatCountdown,
 } from "@/lib/alert-utils";
+import {
+  formatGlucose,
+  formatTrendRate,
+  unitLabel,
+  type GlucoseUnit,
+} from "@/lib/glucose-units";
 import { EscalationTimeline } from "./escalation-timeline";
 
 export interface AlertCardProps {
   alert: PredictiveAlert;
   onAcknowledge: (alertId: string) => Promise<void>;
   isAcknowledging?: boolean;
+  /** Active glucose display unit (default mgdl). Values stay mg/dL internally. */
+  unit?: GlucoseUnit;
 }
 
 export function AlertCard({
   alert,
   onAcknowledge,
   isAcknowledging = false,
+  unit = "mgdl",
 }: AlertCardProps) {
   const config = SEVERITY_CONFIG[alert.severity] ?? SEVERITY_CONFIG.info;
   const Icon = getAlertIcon(alert.alert_type);
@@ -96,18 +105,18 @@ export function AlertCard({
       <div className="flex items-baseline gap-4 mb-3">
         <div>
           <span className={clsx("text-2xl font-bold", config.text)}>
-            {alert.current_value}
+            {formatGlucose(alert.current_value, unit)}
           </span>
-          <span className="text-sm text-slate-400 ml-1">mg/dL</span>
+          <span className="text-sm text-slate-400 ml-1">{unitLabel(unit)}</span>
         </div>
         {alert.predicted_value != null && alert.prediction_minutes != null && (
           <div className="text-sm text-slate-400">
             <span className="mr-1">&rarr;</span>
             <span className={clsx("font-medium", config.text)}>
-              {alert.predicted_value}
+              {formatGlucose(alert.predicted_value, unit)}
             </span>
             <span className="ml-1">
-              mg/dL in {alert.prediction_minutes}min
+              {unitLabel(unit)} in {alert.prediction_minutes}min
             </span>
           </div>
         )}
@@ -128,7 +137,7 @@ export function AlertCard({
         {alert.trend_rate != null && (
           <span>
             {alert.trend_rate > 0 ? "+" : ""}
-            {alert.trend_rate.toFixed(1)} mg/dL/min
+            {formatTrendRate(alert.trend_rate, unit)} {unitLabel(unit)}/min
           </span>
         )}
       </div>

--- a/apps/web/src/components/dashboard/bolus-review-table.tsx
+++ b/apps/web/src/components/dashboard/bolus-review-table.tsx
@@ -15,9 +15,12 @@ import {
   BOLUS_PERIOD_LABELS,
 } from "@/hooks/use-bolus-review";
 import type { BolusReviewItem } from "@/lib/api";
+import { formatGlucose, unitLabel, type GlucoseUnit } from "@/lib/glucose-units";
 
 export interface BolusReviewTableProps {
   className?: string;
+  /** Active glucose display unit (default mgdl). BG stays mg/dL internally. */
+  unit?: GlucoseUnit;
 }
 
 const PERIOD_OPTIONS: { value: BolusReviewPeriod; label: string }[] = [
@@ -77,13 +80,15 @@ function isBasalInjection(item: BolusReviewItem): boolean {
   return item.event_type === "basal_injection";
 }
 
-function formatBg(value: number | null | undefined): string {
+function formatBg(value: number | null | undefined, unit: GlucoseUnit): string {
   if (value == null || !Number.isFinite(value)) return "---";
-  const clamped = Math.min(BG_MAX, Math.max(BG_MIN, Math.round(value)));
-  return `${clamped} mg/dL`;
+  // Clamp the 20-500 mg/dL invariant FIRST (canonical units), then convert
+  // for display so mmol precision is correct.
+  const clamped = Math.min(BG_MAX, Math.max(BG_MIN, value));
+  return `${formatGlucose(clamped, unit)} ${unitLabel(unit)}`;
 }
 
-function BolusRow({ bolus }: { bolus: BolusReviewItem }) {
+function BolusRow({ bolus, unit }: { bolus: BolusReviewItem; unit: GlucoseUnit }) {
   const basalInjection = isBasalInjection(bolus);
   const unitsMax = basalInjection ? MAX_BASAL_INJECTION_DISPLAY : MAX_BOLUS_DISPLAY;
   const typeLabel = basalInjection
@@ -118,7 +123,7 @@ function BolusRow({ bolus }: { bolus: BolusReviewItem }) {
         )}
       </td>
       <td className="px-4 py-3 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
-        {basalInjection ? "---" : formatBg(bolus.bg_at_event)}
+        {basalInjection ? "---" : formatBg(bolus.bg_at_event, unit)}
       </td>
       <td className="px-4 py-3 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
         {basalInjection ? "---" : formatUnits(bolus.iob_at_event, 1)}
@@ -134,7 +139,7 @@ function BolusRow({ bolus }: { bolus: BolusReviewItem }) {
   );
 }
 
-export function BolusReviewTable({ className }: BolusReviewTableProps) {
+export function BolusReviewTable({ className, unit = "mgdl" }: BolusReviewTableProps) {
   const { data, isLoading, error, period, setPeriod, refetch } = useBolusReview();
   const periodLabel = BOLUS_PERIOD_LABELS[period] ?? period;
   const buttonsRef = useRef<(HTMLButtonElement | null)[]>([]);
@@ -264,7 +269,7 @@ export function BolusReviewTable({ className }: BolusReviewTableProps) {
             </thead>
             <tbody>
               {data.boluses.map((bolus, i) => (
-                <BolusRow key={`${bolus.event_timestamp}-${i}`} bolus={bolus} />
+                <BolusRow key={`${bolus.event_timestamp}-${i}`} bolus={bolus} unit={unit} />
               ))}
             </tbody>
           </table>

--- a/apps/web/src/components/dashboard/cgm-summary-stats.tsx
+++ b/apps/web/src/components/dashboard/cgm-summary-stats.tsx
@@ -13,6 +13,7 @@ import { AlertCircle, BarChart3, TrendingUp, Percent, Heart, Radio, Hash } from 
 import type { GlucoseStats } from "@/lib/api";
 import type { StatsPeriod } from "@/hooks/use-glucose-stats";
 import { PERIOD_LABELS } from "@/components/dashboard/time-in-range-bar";
+import { formatGlucose, unitLabel, type GlucoseUnit } from "@/lib/glucose-units";
 
 export interface CgmSummaryStatsProps {
   stats: GlucoseStats | null;
@@ -20,6 +21,8 @@ export interface CgmSummaryStatsProps {
   error?: string | null;
   period: StatsPeriod;
   onPeriodChange: (p: StatsPeriod) => void;
+  /** Active glucose display unit (default mgdl). Stats stay mg/dL internally. */
+  unit?: GlucoseUnit;
 }
 
 const PERIOD_OPTIONS: { value: StatsPeriod; label: string }[] = [
@@ -120,6 +123,7 @@ export function CgmSummaryStats({
   error,
   period,
   onPeriodChange,
+  unit = "mgdl",
 }: CgmSummaryStatsProps) {
   const noData = !stats || !Number.isFinite(stats.readings_count) || stats.readings_count <= 0;
   const cvAssessment = stats && Number.isFinite(stats.cv_pct) ? getCvAssessment(stats.cv_pct) : null;
@@ -211,17 +215,18 @@ export function CgmSummaryStats({
           <StatCard
             icon={<TrendingUp className="h-4 w-4 text-blue-400" aria-hidden="true" />}
             label="Avg Glucose"
-            value={isReasonableGlucose(stats.mean_glucose) ? safeRound(stats.mean_glucose) : "--"}
-            subtitle="mg/dL"
-            ariaLabel={`Average glucose: ${isReasonableGlucose(stats.mean_glucose) ? `${safeRound(stats.mean_glucose)} mg/dL` : "unavailable"}`}
+            value={isReasonableGlucose(stats.mean_glucose) ? formatGlucose(stats.mean_glucose, unit) : "--"}
+            subtitle={unitLabel(unit)}
+            ariaLabel={`Average glucose: ${isReasonableGlucose(stats.mean_glucose) ? `${formatGlucose(stats.mean_glucose, unit)} ${unitLabel(unit)}` : "unavailable"}`}
           />
 
           <StatCard
             icon={<BarChart3 className="h-4 w-4 text-purple-400" aria-hidden="true" />}
             label="Std Dev"
-            value={isValidStdDev(stats.std_dev) ? safeRound(stats.std_dev) : "--"}
-            subtitle="mg/dL"
-            ariaLabel={`Standard deviation: ${isValidStdDev(stats.std_dev) ? `${safeRound(stats.std_dev)} mg/dL` : "unavailable"}`}
+            // SD is a spread: scaled by /18.0156 like a value (mmol keeps 1 decimal).
+            value={isValidStdDev(stats.std_dev) ? formatGlucose(stats.std_dev, unit) : "--"}
+            subtitle={unitLabel(unit)}
+            ariaLabel={`Standard deviation: ${isValidStdDev(stats.std_dev) ? `${formatGlucose(stats.std_dev, unit)} ${unitLabel(unit)}` : "unavailable"}`}
           />
 
           <StatCard

--- a/apps/web/src/components/dashboard/glucose-hero.tsx
+++ b/apps/web/src/components/dashboard/glucose-hero.tsx
@@ -18,6 +18,12 @@
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import clsx from "clsx";
 import {
+  formatGlucose,
+  unitLabel,
+  spokenUnit,
+  type GlucoseUnit,
+} from "@/lib/glucose-units";
+import {
   type TrendDirection,
   TREND_ARROWS,
   TREND_DESCRIPTIONS,
@@ -112,8 +118,8 @@ export interface GlucoseHeroProps {
    * are deferred to a follow-up. Null = no active override.
    */
   override?: OverrideInfo | null;
-  /** Unit label (default: mg/dL) */
-  unit?: string;
+  /** Active glucose display unit (default: mgdl). Values stay mg/dL internally. */
+  unit?: GlucoseUnit;
   /** Minutes since last reading */
   minutesAgo?: number;
   /** Whether data is considered stale (>10 minutes) */
@@ -180,18 +186,20 @@ export function getRangeStatus(range: GlucoseRange): RangeStatus {
 /**
  * Build accessible announcement for screen readers.
  * Format: "Glucose 142 milligrams per deciliter, falling slowly, in target range"
+ * (mmol users hear e.g. "Glucose 7.9 millimoles per litre, ...").
  */
 export function buildGlucoseAnnouncement(
   value: number | null,
   trendDescription: string,
-  rangeStatus: RangeStatus
+  rangeStatus: RangeStatus,
+  unit: GlucoseUnit = "mgdl"
 ): string {
   if (value === null) {
     return "Glucose reading unavailable";
   }
 
   const rangeText = RANGE_STATUS_TEXT[rangeStatus];
-  return `Glucose ${Math.round(value)} milligrams per deciliter, ${trendDescription}, ${rangeText}`;
+  return `Glucose ${formatGlucose(value, unit)} ${spokenUnit(unit)}, ${trendDescription}, ${rangeText}`;
 }
 
 /**
@@ -392,7 +400,7 @@ export function GlucoseHero({
   cobGrams,
   loopStatus,
   override,
-  unit = "mg/dL",
+  unit = "mgdl",
   minutesAgo,
   isStale = false,
   isLoading = false,
@@ -438,12 +446,17 @@ export function GlucoseHero({
   const arrow = TREND_ARROWS[trend];
   const trendDescription = TREND_DESCRIPTIONS[trend];
 
-  // Format display value
-  const displayValue = safeValue !== null ? Math.round(safeValue).toString() : "--";
+  // Format display value (mg/dL integer, mmol 1-decimal); value stays mg/dL.
+  const displayValue = safeValue !== null ? formatGlucose(safeValue, unit) : "--";
 
   // Accessibility: Build announcement and determine aria-live priority
   const rangeStatus = getRangeStatus(range);
-  const announcement = buildGlucoseAnnouncement(safeValue, trendDescription, rangeStatus);
+  const announcement = buildGlucoseAnnouncement(
+    safeValue,
+    trendDescription,
+    rangeStatus,
+    unit
+  );
   const isUrgent = isUrgentState(range);
   const ariaLivePriority = isUrgent ? "assertive" : "polite";
 
@@ -504,7 +517,7 @@ export function GlucoseHero({
           className="text-slate-400 text-base sm:text-lg"
           data-testid="glucose-unit"
         >
-          {unit}
+          {unitLabel(unit)}
         </p>
 
         {/* Stale data warning */}

--- a/apps/web/src/components/dashboard/glucose-trend-chart.tsx
+++ b/apps/web/src/components/dashboard/glucose-trend-chart.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/api";
 import { lttbDownsample } from "@/lib/downsample";
 import { type ChartTimePeriod, PERIOD_TO_MS, isMultiDay } from "@/lib/chart-periods";
+import { formatGlucose, unitLabel, type GlucoseUnit } from "@/lib/glucose-units";
 import { GLUCOSE_THRESHOLDS, prettySourceName } from "./glucose-hero";
 import { useGlucoseHistory } from "@/hooks/use-glucose-history";
 import { usePumpEvents } from "@/hooks/use-pump-events";
@@ -224,10 +225,12 @@ function ChartTooltip({
   active,
   payload,
   multiDay,
+  unit = "mgdl",
 }: {
   active?: boolean;
   payload?: Array<{ payload: Record<string, unknown> }>;
   multiDay?: boolean;
+  unit?: GlucoseUnit;
 }) {
   if (!active || !payload?.length) return null;
   const point = payload[0].payload;
@@ -264,7 +267,7 @@ function ChartTooltip({
           <p className="text-slate-500 dark:text-slate-400 text-xs">IoB: {iob.toFixed(1)}u</p>
         )}
         {bg != null && (
-          <p className="text-slate-500 dark:text-slate-400 text-xs">BG: {bg} mg/dL</p>
+          <p className="text-slate-500 dark:text-slate-400 text-xs">BG: {formatGlucose(bg, unit)} {unitLabel(unit)}</p>
         )}
         {ts != null && <p className="text-slate-500 dark:text-slate-400 text-xs">{formatTime(ts)}</p>}
       </div>
@@ -303,7 +306,7 @@ function ChartTooltip({
   return (
     <div className="bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-700 rounded-lg px-3 py-2 text-sm shadow-lg">
       <p className="font-semibold" style={{ color: point.color as string }}>
-        {point.value} mg/dL
+        {formatGlucose(point.value, unit)} {unitLabel(unit)}
         {trendArrow && trendArrow !== "?" && (
           <span className="ml-1">{trendArrow}</span>
         )}
@@ -601,6 +604,9 @@ export interface GlucoseTrendChartProps {
    * when no forecast-publishing integration is connected. Only rendered
    * on 3H / 6H periods so longer historical views stay clean. */
   forecast?: ForecastReadResponse | null;
+  /** Active glucose display unit (default mgdl). Chart data + domains stay
+   * mg/dL; only axis tick labels and tooltip text convert. */
+  unit?: GlucoseUnit;
 }
 
 const FORECAST_OVERLAY_PERIODS: ReadonlySet<ChartTimePeriod> = new Set<ChartTimePeriod>([
@@ -626,6 +632,7 @@ export function GlucoseTrendChart({
   className,
   thresholds,
   forecast,
+  unit = "mgdl",
 }: GlucoseTrendChartProps) {
   const { readings, isLoading, error, period, setPeriod, refetch } =
     useGlucoseHistory("3h");
@@ -1013,7 +1020,9 @@ export function GlucoseTrendChart({
 
   const lowThreshold = thresholds?.low ?? GLUCOSE_THRESHOLDS.LOW;
   const highThreshold = thresholds?.high ?? GLUCOSE_THRESHOLDS.HIGH;
-  const targetLabel = `${lowThreshold}-${highThreshold} Target`;
+  // Thresholds stay mg/dL for the band geometry; the legend label converts and
+  // carries the unit so the range isn't ambiguous (e.g. "3.9-10.0 mmol/L Target").
+  const targetLabel = `${formatGlucose(lowThreshold, unit)}-${formatGlucose(highThreshold, unit)} ${unitLabel(unit)} Target`;
 
   return (
     <div
@@ -1092,6 +1101,8 @@ export function GlucoseTrendChart({
               dataKey="value"
               type="number"
               domain={yDomain}
+              // Domain + data stay mg/dL; only the tick LABEL converts.
+              tickFormatter={(v: number) => formatGlucose(v, unit)}
               tick={{ fill: "#94a3b8", fontSize: 12 }}
               axisLine={{ stroke: "#475569" }}
               tickLine={{ stroke: "#475569" }}
@@ -1195,7 +1206,7 @@ export function GlucoseTrendChart({
             )}
 
             <Tooltip
-              content={isDragging ? () => null : <ChartTooltip multiDay={multiDay} />}
+              content={isDragging ? () => null : <ChartTooltip multiDay={multiDay} unit={unit} />}
               cursor={false}
             />
           </ComposedChart>

--- a/apps/web/src/components/dashboard/trend-arrow.tsx
+++ b/apps/web/src/components/dashboard/trend-arrow.tsx
@@ -13,6 +13,9 @@ import { useReducedMotion } from "@/hooks/use-reduced-motion";
 
 /**
  * Trend direction enum matching CGM API values.
+ *
+ * These bucket thresholds are ALWAYS evaluated in mg/dL/min internally and are independent of the user's display unit — only
+ * the displayed trend RATE relabels to mmol/L/min (see `formatTrendRate`).
  * - RisingFast: Glucose increasing > 3 mg/dL/min
  * - Rising: Glucose increasing 1-3 mg/dL/min
  * - Stable: Glucose change -1 to +1 mg/dL/min

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -22,3 +22,5 @@ export {
 } from "./use-glucose-range";
 
 export { useReducedMotion } from "./use-reduced-motion";
+
+export { useGlucoseUnit } from "./use-glucose-unit";

--- a/apps/web/src/hooks/use-glucose-unit.ts
+++ b/apps/web/src/hooks/use-glucose-unit.ts
@@ -1,0 +1,23 @@
+"use client";
+
+/**
+ * useGlucoseUnit hook.
+ *
+ * Reads the logged-in user's preferred glucose display unit from the shared
+ * UserProvider context (one /api/auth/me fetch for the whole dashboard) so
+ * pages and components can render in the active unit WITHOUT prop-drilling
+ *. Defaults to "mgdl" while the user is loading or the field is absent,
+ * preserving existing mg/dL behavior.
+ *
+ * NOTE: this is the SELF-VIEW unit. The caregiver page must render patient
+ * data in the PATIENT's unit, not the viewer's — it does not use this
+ * hook for patient values.
+ */
+
+import { useUserContext } from "@/providers";
+import type { GlucoseUnit } from "@/lib/glucose-units";
+
+export function useGlucoseUnit(): GlucoseUnit {
+  const { user } = useUserContext();
+  return user?.glucose_unit ?? "mgdl";
+}

--- a/apps/web/src/lib/alert-thresholds.ts
+++ b/apps/web/src/lib/alert-thresholds.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared alert-threshold defaults and canonical validation bounds.
+ *
+ * Both the dashboard alerts page and the settings alerts page consume these so
+ * the two surfaces cannot drift apart. The four glucose bounds are canonical
+ * mg/dL (never converted on the wire); the IoB bound is in units.
+ */
+
+// Keys are the API payload field names (snake_case, matching
+// AlertThresholdUpdate) so these spread straight into update calls — distinct
+// on purpose from GLUCOSE_THRESHOLD_BOUNDS' per-field camelCase lookup keys.
+export const ALERT_THRESHOLD_DEFAULTS = {
+  low_warning: 70,
+  urgent_low: 55,
+  high_warning: 180,
+  urgent_high: 250,
+  iob_warning: 3.0,
+};
+
+/**
+ * Canonical mg/dL min/max for the four glucose alert thresholds.
+ *
+ * The per-field ranges intentionally OVERLAP (e.g. urgent-low and low-warning
+ * both span 40-80) so users keep reasonable individual latitude. The required
+ * ordering — urgent_low < low_warning < high_warning < urgent_high — is NOT
+ * encoded here; it is enforced by cross-field validation on save in both the
+ * dashboard and settings alert pages.
+ */
+export const GLUCOSE_THRESHOLD_BOUNDS = {
+  urgentLow: { min: 30, max: 80 },
+  lowWarning: { min: 40, max: 100 },
+  highWarning: { min: 120, max: 300 },
+  urgentHigh: { min: 150, max: 400 },
+};
+
+/** IoB alert threshold bound (units, never converted). */
+export const IOB_THRESHOLD_BOUNDS = { min: 0.5, max: 20 };

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,7 +4,10 @@
  * Story 1.3: First-Run Safety Disclaimer
  * Story 15.1: Authentication API functions
  * Story 15.4: Global 401 handling via apiFetch wrapper
+ * Glucose unit preference on the current user + update endpoint
  */
+
+import type { GlucoseUnit } from "./glucose-units";
 
 /**
  * Resolve the API base URL.
@@ -1210,6 +1213,13 @@ export interface CurrentUserResponse {
   // an older disclaimer version, so the gate re-prompts on a version bump.
   disclaimer_acknowledged: boolean;
   disclaimer_version: string | null;
+  /**
+   * Preferred glucose display unit. Read from /api/auth/me.
+   * Optional so a transient deploy skew (web bundle hitting an older API that
+   * predates the glucose-unit backend) is type-safe; callers default to "mgdl" (see
+   * `useGlucoseUnit`) so existing mg/dL behavior is preserved.
+   */
+  glucose_unit?: GlucoseUnit;
   created_at: string;
 }
 
@@ -1259,6 +1269,32 @@ export async function updateProfile(data: {
   if (!response.ok) {
     const error = await response.json().catch(() => ({}));
     throw new Error(error.detail || `Failed to update profile: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Update the current user's glucose display unit preference.
+ *
+ * Persists via the dedicated PATCH /api/settings/glucose-unit endpoint
+ * (the backend field owner). Web-only: no profile-payload change. Callers
+ * refresh the user context afterward so dashboard display switches units.
+ */
+export async function updateGlucoseUnit(
+  glucose_unit: GlucoseUnit
+): Promise<{ glucose_unit: GlucoseUnit }> {
+  const response = await apiFetch(`${API_BASE_URL}/api/settings/glucose-unit`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ glucose_unit }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to update glucose unit: ${response.status}`
+    );
   }
 
   return response.json();

--- a/apps/web/src/lib/glucose-units.ts
+++ b/apps/web/src/lib/glucose-units.ts
@@ -1,0 +1,136 @@
+/**
+ * Glucose unit conversion + formatting — the single source of truth for the web
+ * client.
+ *
+ * Canonical storage and transport are ALWAYS mg/dL: the API,
+ * the SSE proxy, chart data/domains, and every threshold on the wire stay in
+ * mg/dL. All comparison, range classification, alert banding, and safety-limit
+ * enforcement also stay in mg/dL. This module converts ONLY
+ * the numbers and labels shown to the user, and converts user-entered values
+ * back to integer mg/dL before they leave the browser.
+ *
+ * Round once, round LAST: convert from the most-precise
+ * mg/dL source a single time and round only at the display edge. Never write a
+ * re-converted value back to storage.
+ */
+
+/** User's preferred glucose display unit. Mirrors the backend `GlucoseUnit` enum. */
+export type GlucoseUnit = "mgdl" | "mmol";
+
+/**
+ * The ONE canonical conversion factor: 1 mmol/L = 18.0156 mg/dL — the exact
+ * glucose mass-to-molarity factor. Mirrors the backend's
+ * `src/core/units.py` `MGDL_PER_MMOL`. Do NOT introduce a second value
+ * (18.02 / 18.0182); a drift here desyncs the client from the server.
+ */
+export const MGDL_PER_MMOL = 18.0156;
+
+/** Convert mg/dL → mmol/L. No rounding — round LAST at the display edge. */
+export function mgdlToMmol(mgdl: number): number {
+  return mgdl / MGDL_PER_MMOL;
+}
+
+/** Convert mmol/L → mg/dL. No rounding. */
+export function mmolToMgdl(mmol: number): number {
+  return mmol * MGDL_PER_MMOL;
+}
+
+/**
+ * Format a stored glucose value (mg/dL) for display in the active unit.
+ *
+ * Converts from the precise mg/dL source ONCE and rounds LAST: an integer for
+ * mg/dL, exactly one decimal for mmol/L. Returns
+ * the numeric string only — pair it with {@link unitLabel} for the unit text.
+ * Does not mutate or re-store the input.
+ */
+export function formatGlucose(valueMgdl: number, unit: GlucoseUnit): string {
+  if (unit === "mmol") {
+    return mgdlToMmol(valueMgdl).toFixed(1);
+  }
+  return Math.round(valueMgdl).toString();
+}
+
+/**
+ * Format a glucose trend RATE (stored mg/dL per minute) for display.
+ *
+ * mg/dL/min keeps one decimal; mmol/L/min uses two because ÷18.0156 yields
+ * roughly 0.06–0.17, where one decimal collapses otherwise-distinct trend
+ * arrows. The trend-arrow buckets themselves stay mg/dL/min internally; this only relabels the displayed rate. Returns the
+ * numeric string only; the caller supplies the `${unitLabel}/min` suffix.
+ */
+export function formatTrendRate(mgdlPerMin: number, unit: GlucoseUnit): string {
+  if (unit === "mmol") {
+    return mgdlToMmol(mgdlPerMin).toFixed(2);
+  }
+  return mgdlPerMin.toFixed(1);
+}
+
+/** Display label for the active unit: `"mg/dL"` | `"mmol/L"`. */
+export function unitLabel(unit: GlucoseUnit): string {
+  return unit === "mmol" ? "mmol/L" : "mg/dL";
+}
+
+/**
+ * Numeric-input `step` for a glucose field in the active unit: 0.1 for mmol/L
+ * (one decimal), 1 for mg/dL (integer).
+ */
+export function stepFor(unit: GlucoseUnit): number {
+  return unit === "mmol" ? 0.1 : 1;
+}
+
+/**
+ * Spoken unit for screen-reader announcements. Uses the British "litre"
+ * spelling for mmol/L to match clinical convention in mmol markets.
+ */
+export function spokenUnit(unit: GlucoseUnit): string {
+  return unit === "mmol"
+    ? "millimoles per litre"
+    : "milligrams per deciliter";
+}
+
+/**
+ * Convert a stored mg/dL bound into the active unit as a NUMBER, for an input's
+ * `min`/`max` attribute and the matching range hint (e.g. 20 → 1.1, 500 → 27.8).
+ *
+ * Uses naive 1-decimal rounding so the displayed bound matches how a stored
+ * value at that bound renders (a stored 500 shows 27.8, and so does the max
+ * bound — no "value above its own max" mismatch). mmol's 1-decimal granularity
+ * means the displayed bound can round-trip ±1 mg/dL past the canonical limit
+ * (27.8 → 501); that is contained by {@link clampMgdl} on save so the value on
+ * the wire never crosses the canonical bound. mg/dL stays an integer.
+ */
+export function toDisplayNumber(valueMgdl: number, unit: GlucoseUnit): number {
+  if (unit === "mmol") {
+    return Math.round(mgdlToMmol(valueMgdl) * 10) / 10;
+  }
+  return Math.round(valueMgdl);
+}
+
+/**
+ * Clamp a canonical mg/dL value into `[min, max]`. Applied on save AFTER
+ * {@link toStoredMgdl} so a unit-rounding overshoot at the boundary (e.g. an
+ * entered 27.8 mmol → 501 mg/dL against a 500 ceiling) is pinned to the
+ * canonical bound rather than crossing it. This is the medical-safety
+ * guarantee for threshold inputs: the stored value is ALWAYS within range.
+ */
+export function clampMgdl(valueMgdl: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, valueMgdl));
+}
+
+/**
+ * Convert a user-entered value (in the active unit) back to the canonical
+ * integer mg/dL that is stored and sent to the API.
+ *
+ * The value on the wire is ALWAYS integer mg/dL: mmol
+ * entries round-trip through {@link mmolToMgdl} + `Math.round`, mg/dL entries
+ * just round. A saved mmol value may visibly "snap" on reload (e.g.
+ * 5.5 mmol → 99 mg/dL → 5.5) — this is expected and acceptable. This is the
+ * medical-safety chokepoint for threshold inputs: a mis-conversion here would
+ * silently move a hypo/safety limit, so it is round-trip property-tested.
+ */
+export function toStoredMgdl(value: number, unit: GlucoseUnit): number {
+  if (unit === "mmol") {
+    return Math.round(mmolToMgdl(value));
+  }
+  return Math.round(value);
+}


### PR DESCRIPTION
## Summary

Adds a per-user **mmol/L vs mg/dL** display-unit preference and applies it across the web dashboard, charts, settings forms, and the clinical report. Builds on the backend glucose-unit foundation (the backend stores `users.glucose_unit`, exposes it on `/api/auth/me`, and provides a dedicated `PATCH /api/settings/glucose-unit`).

All glucose math, comparisons, range/alert classification, and the 20–500 mg/dL safety invariant stay in **canonical mg/dL**. Only displayed numbers/labels and form entry convert, and entries convert back to integer mg/dL (clamped to the canonical bound) before they leave the browser. This is a web-only change; no backend code is touched.

## Implementation

- **`apps/web/src/lib/glucose-units.ts`** — single conversion/format chokepoint: one `18.0156` constant (mirrors the backend), converters, formatters, and the input convert-back helpers (`toStoredMgdl` + `clampMgdl`, so a boundary unit-rounding overshoot never crosses a canonical bound).
- **`useGlucoseUnit()`** reads the shared user context (no prop-drilling); the profile-page toggle persists via the dedicated settings endpoint.
- **Display sweep:** hero (+ screen-reader announcement), trend and AGP charts (axis tick labels and tooltips only — chart data, domains, and reference bands stay mg/dL), CGM summary, time-in-range, bolus review, alert card, and the printable clinical report.
- **Input forms** (glucose-range, both alerts pages, safety-limits): display/accept the active unit, validate in display space, and clamp + convert back to integer mg/dL on save. The four glucose alert-threshold bounds + defaults are hoisted into one shared module so the two alert pages cannot drift.
- **Caregiver page** renders the **patient's** unit (defaults to mg/dL), never the viewer's. Nightscout ingestion copy and the SSE proxy stay mg/dL.

## Testing

- New `glucose-units.test` covers the clinical anchors (70→3.9, 180→10.0, 120→6.7), round-trip tolerance, trend-rate precision, and the safety bounds + clamp. Page-level wiring tests prove the safety-limits and glucose-range forms send integer mg/dL clamped to the canonical bound. Component tests cover the alert card (incl. trend-rate) and CGM summary in mmol. Full suite green (`tsc`, `next lint`, `next build` clean).
- Visual verification (Playwright, full stack): mg/dL default → toggle to mmol (hero, charts, CGM/AGP/TIR, settings forms) → end-to-end save (e.g. 14.0 mmol persisted as 252 mg/dL) → toggle back to mg/dL.

Refs #757, GLY-31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persisted glucose display unit setting (mg/dL or mmol/L).
  * Updated dashboard and clinical report glucose displays (hero, trends, charts/tooltips, stats, tables, and alerts) to render in the selected unit.
  * Made alert thresholds, safety limits, and glucose range editing/viewing unit-aware, including correct bounds and save-time conversion.
* **Tests**
  * Expanded unit, conversion/rounding, clamping, and accessibility test coverage for mg/dL vs mmol/L announcements and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->