### PR TITLE
feat(api): render AI text and notifications in the user's glucose unit

### DIFF
--- a/apps/api/src/core/units.py
+++ b/apps/api/src/core/units.py
@@ -31,3 +31,122 @@ def mgdl_to_mmol(value_mgdl: int | float) -> float:
 def mmol_to_mgdl(value_mmol: int | float) -> int:
     """Convert mmol/L to integer mg/dL."""
     return int(round(value_mmol * MGDL_PER_MMOL))
+
+
+# ── Display formatting (AI-text layer) ──
+#
+# Storage is canonical mg/dL everywhere; these helpers are the single
+# choke-point that turns a stored mg/dL value into the text a user reads in
+# their preferred unit. They live here -- next to the one conversion constant
+# -- so no surface invents its own conversion or label and the mg/dL and mmol/L
+# representations can never drift. mg/dL output is byte-identical to the legacy
+# hand-written f-strings (integer, ``mg/dL`` label); mmol/L converts from the
+# most-precise mg/dL source and rounds to one decimal LAST so threshold anchors
+# land on their conventional values (70 -> 3.9, 180 -> 10.0, 120 -> 6.7).
+
+
+def glucose_unit_label(unit: GlucoseUnit) -> str:
+    """Return the user-facing label for a glucose unit (``mg/dL`` / ``mmol/L``)."""
+    return "mmol/L" if unit == GlucoseUnit.MMOL else "mg/dL"
+
+
+def format_glucose_value(value_mgdl: int | float, unit: GlucoseUnit) -> str:
+    """Format a stored mg/dL value as a bare number in the user's unit (no label).
+
+    mg/dL renders as a whole number (matching the legacy ``{value:.0f}``
+    output); mmol/L converts once and renders to one decimal place.
+    """
+    if unit == GlucoseUnit.MMOL:
+        return f"{mgdl_to_mmol(value_mgdl):.1f}"
+    return f"{value_mgdl:.0f}"
+
+
+def format_glucose(value_mgdl: int | float, unit: GlucoseUnit) -> str:
+    """Format a stored mg/dL value as a labeled string in the user's unit.
+
+    e.g. ``"120 mg/dL"`` or ``"6.7 mmol/L"``. The same helper renders glucose
+    *deltas* (a drop is a linear difference, so it converts by the same factor)
+    -- the caller phrases the surrounding text.
+    """
+    return f"{format_glucose_value(value_mgdl, unit)} {glucose_unit_label(unit)}"
+
+
+def format_glucose_range(
+    low_mgdl: int | float, high_mgdl: int | float, unit: GlucoseUnit
+) -> str:
+    """Format a stored mg/dL low-high range as a labeled string in the user's unit.
+
+    e.g. ``"70-180 mg/dL"`` or ``"3.9-10.0 mmol/L"``.
+    """
+    return (
+        f"{format_glucose_value(low_mgdl, unit)}-"
+        f"{format_glucose_value(high_mgdl, unit)} {glucose_unit_label(unit)}"
+    )
+
+
+def format_glucose_rate(value_mgdl_per_unit: int | float, unit: GlucoseUnit) -> str:
+    """Format an ISF-style rate (glucose drop per unit of insulin) in the user's unit.
+
+    The rate is a glucose delta per insulin unit, so it converts by the same
+    linear factor as a value: ``"50.0 mg/dL per unit"`` -> ``"2.8 mmol/L per unit"``.
+    """
+    if unit == GlucoseUnit.MMOL:
+        return f"{mgdl_to_mmol(value_mgdl_per_unit):.1f} mmol/L per unit"
+    return f"{value_mgdl_per_unit:.1f} mg/dL per unit"
+
+
+def format_correction_factor_value(
+    value_mgdl_per_unit: int | float, unit: GlucoseUnit
+) -> str:
+    """Format a correction-factor drop-per-unit value for ``1:X`` notation.
+
+    A correction factor is the same physical quantity as the observed ISF
+    (glucose drop per insulin unit), so it converts for mmol/L users -- a US
+    ``1:50`` (mg/dL per unit) is ``1:2.8`` mmol/L per unit, which keeps it on the
+    same scale as the converted observed ISF the prompt compares it against.
+    mg/dL keeps the stored value verbatim, preserving any fractional
+    (mmol-derived) precision and staying byte-identical to the legacy
+    ``1:{correction_factor}`` rendering. (Carb ratios are grams per unit, not a
+    glucose quantity, and never convert.)
+    """
+    if unit == GlucoseUnit.MMOL:
+        return f"{mgdl_to_mmol(value_mgdl_per_unit):.1f}"
+    return f"{value_mgdl_per_unit}"
+
+
+def glucose_unit_prompt_instruction(unit: GlucoseUnit) -> str:
+    """Return the explicit instruction telling the LLM which unit to report in.
+
+    The in-context glucose numbers are already converted to ``unit`` before the
+    prompt is built; this reinforces that and pins the output precision, because
+    the model's free-text cannot be post-converted (no ``mg/dL`` -> ``mmol/L``
+    rewriter exists for model prose).
+    """
+    if unit == GlucoseUnit.MMOL:
+        return (
+            "Report all glucose values in mmol/L to one decimal place; "
+            "the glucose data below is already in mmol/L."
+        )
+    return (
+        "Report all glucose values in mg/dL as whole numbers; "
+        "the glucose data below is already in mg/dL."
+    )
+
+
+def glucose_display_matches(
+    stored_mgdl: int | float, spoken_value: int | float, unit: GlucoseUnit
+) -> bool:
+    """Whether an AI-spoken glucose figure matches a stored mg/dL reading.
+
+    The spoken value is in ``unit``; the stored value is canonical mg/dL.
+    Comparison uses a display-rounding tolerance band (±1 mg/dL / ±0.1 mmol/L),
+    never equality -- converting and rounding to display precision can shift a
+    value by up to half a display step, so an exact check would spuriously fail.
+
+    This is the rounding-tolerant slice the AI-text layer needs now; the full
+    spoken-glucose citation verification is handled by the end-to-end
+    citation-verification work.
+    """
+    if unit == GlucoseUnit.MMOL:
+        return abs((stored_mgdl / MGDL_PER_MMOL) - spoken_value) <= 0.1 + 1e-9
+    return abs(stored_mgdl - spoken_value) <= 1.0 + 1e-9

--- a/apps/api/src/services/alert_notifier.py
+++ b/apps/api/src/services/alert_notifier.py
@@ -11,6 +11,7 @@ import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import GlucoseUnit, format_glucose
 from src.logging_config import get_logger
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.services.telegram_bot import (
@@ -67,11 +68,16 @@ def trend_description(trend_rate: float | None) -> str:
     return "\u2193\u2193 falling fast"
 
 
-def format_alert_message(alert: Alert) -> str:
+def format_alert_message(
+    alert: Alert,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
+) -> str:
     """Format an Alert into a rich HTML Telegram message.
 
     Args:
         alert: The Alert model instance.
+        unit: The patient's glucose display unit; the current and predicted
+            glucose render in it (stored values stay canonical mg/dL).
 
     Returns:
         HTML-formatted message string for Telegram.
@@ -84,13 +90,14 @@ def format_alert_message(alert: Alert) -> str:
     lines = [
         f"{emoji} <b>{headline}</b>",
         "",
-        f"\U0001f4c9 <b>Glucose:</b> {alert.current_value:.0f} mg/dL",
+        f"\U0001f4c9 <b>Glucose:</b> {format_glucose(alert.current_value, unit)}",
         f"\U0001f4c8 <b>Trend:</b> {trend}",
     ]
 
     if alert.predicted_value is not None and alert.prediction_minutes is not None:
         lines.append(
-            f"\U0001f52e <b>Predicted:</b> {alert.predicted_value:.0f} mg/dL "
+            f"\U0001f52e <b>Predicted:</b> "
+            f"{format_glucose(alert.predicted_value, unit)} "
             f"in {alert.prediction_minutes} min"
         )
 
@@ -113,6 +120,7 @@ def format_escalation_contact_message(
     alert: Alert,
     user_email: str,
     tier_label: str,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str:
     """Format a Telegram message for an emergency contact escalation.
 
@@ -120,6 +128,8 @@ def format_escalation_contact_message(
         alert: The Alert model instance.
         user_email: The user's email for identification.
         tier_label: Human-readable tier label.
+        unit: The PATIENT's glucose display unit -- the contact sees the
+            patient's glucose in the patient's unit, never the contact's own.
 
     Returns:
         HTML-formatted message string for Telegram.
@@ -137,7 +147,7 @@ def format_escalation_contact_message(
         f"<b>{safe_email}</b> has an unacknowledged glucose alert.",
         "",
         f"\U0001f4cb <b>Alert:</b> {headline}",
-        f"\U0001f4c9 <b>Glucose:</b> {alert.current_value:.0f} mg/dL",
+        f"\U0001f4c9 <b>Glucose:</b> {format_glucose(alert.current_value, unit)}",
         f"\U0001f4c8 <b>Trend:</b> {trend}",
         "",
         "Please check on them immediately.",
@@ -150,6 +160,7 @@ async def notify_user_of_alerts(
     db: AsyncSession,
     user_id: uuid.UUID,
     alerts: list[Alert],
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> int:
     """Send Telegram notifications to the user for newly created alerts.
 
@@ -160,6 +171,7 @@ async def notify_user_of_alerts(
         db: Database session (for looking up TelegramLink).
         user_id: The user's UUID.
         alerts: List of newly created Alert instances.
+        unit: The patient's glucose display unit for the rendered messages.
 
     Returns:
         Number of messages successfully sent.
@@ -178,7 +190,7 @@ async def notify_user_of_alerts(
     sent_count = 0
     for alert in alerts:
         try:
-            message = format_alert_message(alert)
+            message = format_alert_message(alert, unit)
             await send_message(link.chat_id, message)
             sent_count += 1
             logger.info(

--- a/apps/api/src/services/brief_notifier.py
+++ b/apps/api/src/services/brief_notifier.py
@@ -10,6 +10,7 @@ import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import GlucoseUnit, format_glucose
 from src.logging_config import get_logger
 from src.models.brief_delivery_config import DeliveryChannel
 from src.models.daily_brief import DailyBrief
@@ -46,13 +47,17 @@ def _truncate(text: str, max_len: int = 150) -> str:
     return text[: max_len - 1] + "\u2026"
 
 
-def format_brief_message(brief: DailyBrief) -> str:
+def format_brief_message(
+    brief: DailyBrief,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
+) -> str:
     """Format a DailyBrief into a concise HTML Telegram message.
 
     The message is kept under 500 characters for readability.
 
     Args:
         brief: The DailyBrief model instance.
+        unit: The patient's glucose display unit; the average renders in it.
 
     Returns:
         HTML-formatted message string for Telegram.
@@ -63,7 +68,7 @@ def format_brief_message(brief: DailyBrief) -> str:
         f"{emoji} <b>Daily Brief</b>",
         "",
         f"\U0001f3af <b>TIR:</b> {brief.time_in_range_pct:.0f}%"
-        f"  |  <b>Avg:</b> {brief.average_glucose:.0f} mg/dL",
+        f"  |  <b>Avg:</b> {format_glucose(brief.average_glucose, unit)}",
     ]
 
     # Low/high counts on one compact line
@@ -90,6 +95,7 @@ async def notify_user_of_brief(
     db: AsyncSession,
     user_id: uuid.UUID,
     brief: DailyBrief,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> bool:
     """Send a Telegram notification with the daily brief summary.
 
@@ -100,6 +106,7 @@ async def notify_user_of_brief(
         db: Database session (for looking up TelegramLink).
         user_id: The user's UUID.
         brief: The generated DailyBrief instance.
+        unit: The patient's glucose display unit for the rendered message.
 
     Returns:
         True if the message was sent successfully, False otherwise.
@@ -123,7 +130,7 @@ async def notify_user_of_brief(
         return False
 
     try:
-        message = format_brief_message(brief)
+        message = format_brief_message(brief, unit)
         await send_message(link.chat_id, message)
         logger.info(
             "Telegram daily brief sent",

--- a/apps/api/src/services/correction_analysis.py
+++ b/apps/api/src/services/correction_analysis.py
@@ -10,6 +10,14 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import (
+    GlucoseUnit,
+    format_correction_factor_value,
+    format_glucose,
+    format_glucose_rate,
+    glucose_unit_label,
+    glucose_unit_prompt_instruction,
+)
 from src.logging_config import get_logger
 from src.models.correction_analysis import CorrectionAnalysis
 from src.models.glucose import GlucoseReading
@@ -48,7 +56,20 @@ TIME_PERIODS = {
     "evening": (17, 22),
 }
 
-SYSTEM_PROMPT = """\
+
+def _build_system_prompt(unit: GlucoseUnit = GlucoseUnit.MGDL) -> str:
+    """Build the correction-analysis system prompt in the user's glucose unit.
+
+    Glucose anchors (the over-correction floor) and the ISF rate units render
+    in ``unit``; a closing instruction pins the model's output unit.
+    The ``1:X`` ISF example renders on the user's scale (a US 1:50 -> 1:2.8 for
+    mmol/L), matching how the observed ISF and the pump's configured correction
+    factor are converted, so the comparison the prompt asks for stays same-unit.
+    """
+    over_floor = format_glucose(LOW_THRESHOLD, unit)
+    unit_label = glucose_unit_label(unit)
+    cf_example = format_correction_factor_value(50, unit)
+    return f"""\
 You are a diabetes management assistant analyzing correction bolus outcomes \
 for a person with Type 1 diabetes using a Tandem insulin pump with Control-IQ \
 and a Dexcom G7 CGM.
@@ -56,20 +77,20 @@ and a Dexcom G7 CGM.
 You are reviewing correction factor (insulin sensitivity factor / ISF) data \
 organized by time of day. For each time period, you have the number of \
 corrections analyzed, how many under-corrected (glucose stayed above target) \
-vs over-corrected (glucose dropped below 70 mg/dL), the average observed ISF \
-(mg/dL drop per unit of insulin), and the average glucose drop.
+vs over-corrected (glucose dropped below {over_floor}), the average observed ISF \
+({unit_label} drop per unit of insulin), and the average glucose drop.
 
 When the user's pump profile is provided, compare the observed ISF against \
 the user's currently configured correction factors for each time period. \
 Reference the current configured values when explaining the pattern, but keep \
-recommendations directional only (e.g., "your morning ISF is currently 1:50 \
+recommendations directional only (e.g., "your morning ISF is currently 1:{cf_example} \
 but observed corrections suggest it may be weaker than needed for this period").
 
 Guidelines:
 - Identify which time periods show consistent under- or over-correction
 - For problematic periods, suggest whether the factor may need to be stronger \
 or weaker, using the current ISF only as context
-- Explain reasoning: "Your morning corrections average only X mg/dL drop per \
+- Explain reasoning: "Your morning corrections average only X {unit_label} drop per \
 unit, suggesting your ISF may be too weak for this period"
 - Use encouraging, non-judgmental language
 - Clearly state that these are observations to discuss with their endocrinologist
@@ -77,7 +98,8 @@ unit, suggesting your ISF may be too weak for this period"
 - If data shows effective corrections for a period, acknowledge it
 - If insufficient data for a period, note that more data is needed
 - Account for the fact that Control-IQ may have also delivered automated \
-corrections that affect the observed glucose response\
+corrections that affect the observed glucose response
+- {glucose_unit_prompt_instruction(unit)}\
 """
 
 
@@ -108,6 +130,7 @@ def _build_correction_prompt(
     total_corrections: int,
     days: int,
     profile_summary: PumpProfileSummary | None = None,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str:
     """Build the analysis prompt with time period data.
 
@@ -116,10 +139,15 @@ def _build_correction_prompt(
         total_corrections: Total corrections analyzed.
         days: Number of days in the analysis window.
         profile_summary: Optional pump profile for ISF context.
+        unit: The user's glucose display unit. The over/under anchors, the
+            observed ISF rate, and the average glucose drop render in it; the
+            ±20% safety math downstream is unit-relative and unchanged.
 
     Returns:
         Formatted prompt string.
     """
+    target = format_glucose(TARGET_GLUCOSE, unit)
+    low = format_glucose(LOW_THRESHOLD, unit)
     lines = [
         f"Analyze the following {days}-day correction bolus outcome data:",
         f"Total correction boluses analyzed: {total_corrections}",
@@ -131,15 +159,15 @@ def _build_correction_prompt(
             f"**{tp.period.capitalize()}** ({tp.correction_count} corrections):"
         )
         lines.append(
-            f"  - Under-corrections (glucose stayed >120 mg/dL): {tp.under_count}"
+            f"  - Under-corrections (glucose stayed >{target}): {tp.under_count}"
+        )
+        lines.append(f"  - Over-corrections (glucose dropped <{low}): {tp.over_count}")
+        lines.append(
+            f"  - Average observed ISF: {format_glucose_rate(tp.avg_observed_isf, unit)}"
         )
         lines.append(
-            f"  - Over-corrections (glucose dropped <70 mg/dL): {tp.over_count}"
+            f"  - Average glucose drop: {format_glucose(tp.avg_glucose_drop, unit)}"
         )
-        lines.append(
-            f"  - Average observed ISF: {tp.avg_observed_isf:.1f} mg/dL per unit"
-        )
-        lines.append(f"  - Average glucose drop: {tp.avg_glucose_drop:.0f} mg/dL")
         if tp.correction_count > 0:
             effective = tp.correction_count - tp.under_count - tp.over_count
             eff_pct = (effective / tp.correction_count) * 100
@@ -147,7 +175,7 @@ def _build_correction_prompt(
         lines.append("")
 
     if profile_summary:
-        lines.append(format_pump_profile_for_prompt(profile_summary))
+        lines.append(format_pump_profile_for_prompt(profile_summary, unit))
         lines.append("")
 
     lines.append(
@@ -310,6 +338,10 @@ async def generate_correction_analysis(
     period_end = datetime.now(UTC)
     period_start = period_end - timedelta(days=days)
 
+    # The prompt, persisted analysis text, and ISF rate units render in the
+    # user's unit; the observed-ISF math stays canonical mg/dL.
+    unit = user.glucose_unit
+
     # Analyze correction outcomes
     time_periods = await analyze_correction_outcomes(
         user.id, db, period_start, period_end
@@ -355,7 +387,7 @@ async def generate_correction_analysis(
 
     # Build prompt and generate
     user_prompt = _build_correction_prompt(
-        time_periods, total_corrections, days, profile_summary
+        time_periods, total_corrections, days, profile_summary, unit
     )
 
     logger.info(
@@ -369,10 +401,11 @@ async def generate_correction_analysis(
 
     ai_response = await ai_client.generate(
         messages=[AIMessage(role="user", content=user_prompt)],
-        system_prompt=SYSTEM_PROMPT,
+        system_prompt=_build_system_prompt(unit),
     )
 
-    # Safety validation (Story 5.6)
+    # Safety validation (Story 5.6). Unit-agnostic: the regexes accept either
+    # suffix and the ±20% check is unit-relative once a suffix matches.
     safety_result = validate_ai_suggestion(ai_response.content, "correction_analysis")
 
     # Store the analysis with sanitized text

--- a/apps/api/src/services/daily_brief.py
+++ b/apps/api/src/services/daily_brief.py
@@ -13,6 +13,12 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
+from src.core.units import (
+    GlucoseUnit,
+    format_glucose,
+    format_glucose_value,
+    glucose_unit_prompt_instruction,
+)
 from src.database import get_session_maker
 from src.logging_config import get_logger
 from src.models.brief_delivery_config import BriefDeliveryConfig
@@ -72,12 +78,24 @@ dosing inputs, and never suggest a dose for a meal
 """
 
 
+def _build_system_prompt(unit: GlucoseUnit = GlucoseUnit.MGDL) -> str:
+    """Append the report-in-unit instruction to the static brief prompt.
+
+    The brief's ``SYSTEM_PROMPT`` carries no embedded glucose anchors, so -- unlike
+    the correction/meal analyzers, whose prompt bodies interpolate converted
+    thresholds -- the only unit-dependent piece is this trailing instruction.
+    Kept as a helper for parity with those siblings and to make it testable.
+    """
+    return f"{SYSTEM_PROMPT}\n- {glucose_unit_prompt_instruction(unit)}"
+
+
 def _build_analysis_prompt(
     metrics: DailyBriefMetrics,
     hours: int,
     profile_context: str | None = None,
     iob_context: str | None = None,
     meals_context: str | None = None,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str:
     """Build the user prompt with glucose and pump metrics.
 
@@ -89,6 +107,9 @@ def _build_analysis_prompt(
         meals_context: Optional logged-meals text block. Carries
             the reflect-and-ask, never-dose-or-bolus framing; never a dosing
             input.
+        unit: The user's glucose display unit. The average and the
+            range/low/high anchors render in it; the precomputed mg/dL
+            ``average_glucose`` converts once and rounds last.
 
     Returns:
         Formatted prompt string for the AI provider.
@@ -97,10 +118,14 @@ def _build_analysis_prompt(
         f"Analyze the following {hours}-hour glucose and insulin summary:",
         "",
         f"- Readings: {metrics.readings_count}",
-        f"- Average glucose: {metrics.average_glucose:.0f} mg/dL",
-        f"- Time in range (70-180): {metrics.time_in_range_pct:.1f}%",
-        f"- Low readings (<{LOW_THRESHOLD}): {metrics.low_count}",
-        f"- High readings (>{HIGH_THRESHOLD}): {metrics.high_count}",
+        f"- Average glucose: {format_glucose(metrics.average_glucose, unit)}",
+        f"- Time in range ({format_glucose_value(LOW_THRESHOLD, unit)}-"
+        f"{format_glucose_value(HIGH_THRESHOLD, unit)}): "
+        f"{metrics.time_in_range_pct:.1f}%",
+        f"- Low readings (<{format_glucose_value(LOW_THRESHOLD, unit)}): "
+        f"{metrics.low_count}",
+        f"- High readings (>{format_glucose_value(HIGH_THRESHOLD, unit)}): "
+        f"{metrics.high_count}",
         f"- Control-IQ auto-corrections: {metrics.correction_count}",
     ]
 
@@ -383,6 +408,10 @@ async def generate_daily_brief(
     period_end = datetime.now(UTC)
     period_start = period_end - timedelta(hours=hours)
 
+    # The brief's prompt, persisted AI summary, and Telegram delivery all render
+    # glucose in the user's unit; metrics math stays canonical mg/dL.
+    unit = user.glucose_unit
+
     # Resolve the primary-CGM exclusion once (Story 43.10) and thread it into
     # the metrics so the brief reflects the primary source only.
     excluded = await get_excluded_cgm_sources(db, user.id)
@@ -408,7 +437,7 @@ async def generate_daily_brief(
     try:
         profile_summary = await get_pump_profile_summary(db, user.id)
         if profile_summary:
-            profile_context = format_pump_profile_for_prompt(profile_summary)
+            profile_context = format_pump_profile_for_prompt(profile_summary, unit)
     except Exception:
         logger.warning(
             "Failed to fetch pump profile for daily brief",
@@ -442,7 +471,7 @@ async def generate_daily_brief(
 
     # Build prompt and generate
     user_prompt = _build_analysis_prompt(
-        metrics, hours, profile_context, iob_context, meals_context
+        metrics, hours, profile_context, iob_context, meals_context, unit
     )
 
     logger.info(
@@ -454,7 +483,7 @@ async def generate_daily_brief(
 
     ai_response = await ai_client.generate(
         messages=[AIMessage(role="user", content=user_prompt)],
-        system_prompt=SYSTEM_PROMPT,
+        system_prompt=_build_system_prompt(unit),
     )
 
     # Verify any cited meal carb figure against the period's logged meals before
@@ -510,7 +539,7 @@ async def generate_daily_brief(
 
     # Story 7.3: Telegram delivery
     try:
-        await notify_user_of_brief(db, user.id, brief)
+        await notify_user_of_brief(db, user.id, brief, unit)
     except Exception as e:
         logger.warning(
             "Telegram brief delivery failed",

--- a/apps/api/src/services/diabetes_context.py
+++ b/apps/api/src/services/diabetes_context.py
@@ -11,12 +11,20 @@ correction analysis, and chat all share the same context pipeline.
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
+from src.core.units import (
+    GlucoseUnit,
+    format_correction_factor_value,
+    format_glucose,
+    format_glucose_range,
+    format_glucose_value,
+)
 from src.logging_config import get_logger
 from src.services.alert_notifier import trend_description
 from src.services.iob_projection import get_iob_projection, get_user_dia
@@ -97,8 +105,13 @@ class PumpProfileSummary:
 async def build_glucose_section(
     db: AsyncSession,
     user_id: uuid.UUID,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str | None:
-    """Build glucose summary section from recent CGM readings."""
+    """Build glucose summary section from recent CGM readings.
+
+    Glucose numbers render in ``unit``; the time-in-range membership test stays
+    in canonical mg/dL and only the displayed range bounds convert.
+    """
     from src.models.glucose import GlucoseReading
     from src.models.target_glucose_range import TargetGlucoseRange
     from src.services.cgm_source import (
@@ -150,9 +163,12 @@ async def build_glucose_section(
 
     lines = [
         f"[Glucose - last {GLUCOSE_CONTEXT_HOURS}h]",
-        f"- Current: {latest.value} mg/dL ({trend})",
-        f"- Range: {min_val}-{max_val} mg/dL, Avg: {avg_val:.0f} mg/dL",
-        f"- Time in range ({low:.0f}-{high:.0f}): {tir_pct:.0f}%",
+        f"- Current: {format_glucose(latest.value, unit)} ({trend})",
+        f"- Range: {format_glucose_range(min_val, max_val, unit)}, "
+        f"Avg: {format_glucose(avg_val, unit)}",
+        f"- Time in range "
+        f"({format_glucose_value(low, unit)}-{format_glucose_value(high, unit)}): "
+        f"{tir_pct:.0f}%",
         f"- Readings: {len(readings)}",
     ]
     return "\n".join(lines)
@@ -614,8 +630,13 @@ async def build_control_iq_section(
 async def build_settings_section(
     db: AsyncSession,
     user_id: uuid.UUID,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str | None:
-    """Build user settings section (target range, insulin config)."""
+    """Build user settings section (target range, insulin config).
+
+    The glucose target range renders in ``unit``; insulin config (DIA, onset)
+    is unit-agnostic and unchanged.
+    """
     from src.models.insulin_config import InsulinConfig
     from src.models.target_glucose_range import TargetGlucoseRange
 
@@ -627,7 +648,10 @@ async def build_settings_section(
     target_range = range_result.scalar_one_or_none()
     if target_range:
         parts.append(
-            f"- Target range: {target_range.low_target:.0f}-{target_range.high_target:.0f} mg/dL"
+            "- Target range: "
+            + format_glucose_range(
+                target_range.low_target, target_range.high_target, unit
+            )
         )
 
     config_result = await db.execute(
@@ -649,6 +673,7 @@ async def build_settings_section(
 async def build_pump_profile_section(
     db: AsyncSession,
     user_id: uuid.UUID,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str | None:
     """Build pump profile section from the active Tandem pump profile.
 
@@ -658,7 +683,7 @@ async def build_pump_profile_section(
     summary = await get_pump_profile_summary(db, user_id)
     if not summary:
         return None
-    return format_pump_profile_for_prompt(summary)
+    return format_pump_profile_for_prompt(summary, unit)
 
 
 # ── Composite context builder ──
@@ -695,6 +720,7 @@ async def build_diabetes_context(
     db: AsyncSession,
     user_id: uuid.UUID,
     query: str | None = None,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str:
     """Build comprehensive diabetes context from all available data.
 
@@ -707,30 +733,35 @@ async def build_diabetes_context(
         db: Database session.
         user_id: User's UUID.
         query: Optional user question for knowledge retrieval.
+        unit: The data owner's glucose display unit. Glucose-rendering sections
+            convert to it; all stored values and metric math stay mg/dL.
 
     Returns:
         A formatted string describing all available diabetes data,
         or a fallback message if no data is available.
     """
+    # Each builder is bound to its arguments here so the dispatch loop stays
+    # uniform while only the glucose-rendering sections receive the user's unit
+    # (IoB, pump activity, Control-IQ and meals carry no glucose values).
     builders: list[tuple[str, object]] = [
-        ("glucose", build_glucose_section),
-        ("iob", build_iob_section),
-        ("pump", build_pump_section),
-        ("control_iq", build_control_iq_section),
-        ("settings", build_settings_section),
-        ("pump_profile", build_pump_profile_section),
+        ("glucose", partial(build_glucose_section, db, user_id, unit)),
+        ("iob", partial(build_iob_section, db, user_id)),
+        ("pump", partial(build_pump_section, db, user_id)),
+        ("control_iq", partial(build_control_iq_section, db, user_id)),
+        ("settings", partial(build_settings_section, db, user_id, unit)),
+        ("pump_profile", partial(build_pump_profile_section, db, user_id, unit)),
     ]
 
     # Logged meals are only surfaced when the meal-intelligence feature is on
     # Gated here -- not inside the builder -- so the feature stays
     # fully invisible (no query, no section) while the flag is off.
     if settings.meal_intelligence_enabled:
-        builders.append(("meals", build_meals_section))
+        builders.append(("meals", partial(build_meals_section, db, user_id)))
 
     sections: list[str] = []
     for name, builder in builders:
         try:
-            section = await builder(db, user_id)
+            section = await builder()
             if section:
                 sections.append(section)
         except Exception:
@@ -824,21 +855,31 @@ def _sanitize_for_prompt(value: str) -> str:
     return value.replace("\n", " ").replace("\r", " ").strip()
 
 
-def format_pump_profile_for_prompt(summary: PumpProfileSummary) -> str:
+def format_pump_profile_for_prompt(
+    summary: PumpProfileSummary,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
+) -> str:
     """Format a pump profile summary as a text block for AI prompts.
 
     Includes all segments with basal rates, correction factors, carb ratios,
     and target BG values. Also includes insulin duration, max bolus, and
     CGM alert thresholds.
+
+    Glucose-valued fields render in ``unit``: the segment target BG, the CGM
+    high/low alert thresholds, and the correction factor (``CF 1:X`` -- a glucose
+    drop per insulin unit, the same quantity as the observed ISF, so it stays on
+    the same scale the analysis prompt compares it against). The carb ratio
+    (``CR 1:X``) is grams per unit, not a glucose quantity, and never converts.
     """
     safe_name = _sanitize_for_prompt(summary.profile_name)
     lines = [f'[Pump Profile - "{safe_name}" (active)]']
     for seg in summary.segments:
         safe_time = _sanitize_for_prompt(seg.time)
+        cf = format_correction_factor_value(seg.correction_factor, unit)
         lines.append(
             f"- {safe_time}: Basal {seg.basal_rate:.3f} u/hr, "
-            f"CF 1:{seg.correction_factor}, CR 1:{seg.carb_ratio:g}, "
-            f"Target {seg.target_bg}"
+            f"CF 1:{cf}, CR 1:{seg.carb_ratio:g}, "
+            f"Target {format_glucose(seg.target_bg, unit)}"
         )
 
     extras = []
@@ -854,9 +895,9 @@ def format_pump_profile_for_prompt(summary: PumpProfileSummary) -> str:
 
     alert_parts = []
     if summary.cgm_high_alert_mgdl is not None:
-        alert_parts.append(f"High {summary.cgm_high_alert_mgdl} mg/dL")
+        alert_parts.append(f"High {format_glucose(summary.cgm_high_alert_mgdl, unit)}")
     if summary.cgm_low_alert_mgdl is not None:
-        alert_parts.append(f"Low {summary.cgm_low_alert_mgdl} mg/dL")
+        alert_parts.append(f"Low {format_glucose(summary.cgm_low_alert_mgdl, unit)}")
     if alert_parts:
         lines.append(f"- CGM alerts: {', '.join(alert_parts)}")
 

--- a/apps/api/src/services/escalation_engine.py
+++ b/apps/api/src/services/escalation_engine.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import GlucoseUnit, format_glucose
 from src.logging_config import get_logger
 from src.models.alert import Alert, AlertSeverity
 from src.models.emergency_contact import ContactPriority, EmergencyContact
@@ -24,6 +25,7 @@ from src.models.escalation_event import (
 )
 from src.models.telegram_link import TelegramLink
 from src.services.escalation_config import get_or_create_config
+from src.services.glucose_unit import resolve_glucose_unit
 from src.services.telegram_bot import TelegramBotError, send_message
 
 logger = get_logger(__name__)
@@ -224,6 +226,7 @@ def build_escalation_message(
     alert: Alert,
     tier: EscalationTier,
     user_email: str,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str:
     """Build the notification message for an escalation tier.
 
@@ -231,19 +234,23 @@ def build_escalation_message(
         alert: The alert being escalated.
         tier: Escalation tier.
         user_email: User's email (for identification).
+        unit: The PATIENT's glucose display unit; the current glucose renders
+            in it. ``alert.message`` was already rendered in the patient's unit
+            at persist time, so it is embedded verbatim.
 
     Returns:
         Formatted message string.
     """
     safe_email = html.escape(user_email)
     safe_message = html.escape(alert.message)
+    current_glucose = format_glucose(alert.current_value, unit)
 
     if tier == EscalationTier.REMINDER:
         return (
             f"[REMINDER] You have an unacknowledged "
             f"{alert.severity.value.upper()} alert:\n"
             f"{safe_message}\n"
-            f"Current glucose: {alert.current_value:.0f} mg/dL\n"
+            f"Current glucose: {current_glucose}\n"
             f"Please acknowledge this alert if you are okay."
         )
 
@@ -251,7 +258,7 @@ def build_escalation_message(
         return (
             f"{safe_email} has a glucose emergency and has not responded.\n"
             f"Alert: {safe_message}\n"
-            f"Current glucose: {alert.current_value:.0f} mg/dL\n"
+            f"Current glucose: {current_glucose}\n"
             f"Severity: {alert.severity.value.upper()}\n"
             f"Please check on them immediately."
         )
@@ -260,7 +267,7 @@ def build_escalation_message(
     return (
         f"{safe_email} has a glucose emergency and has not responded.\n"
         f"Alert: {safe_message}\n"
-        f"Current glucose: {alert.current_value:.0f} mg/dL\n"
+        f"Current glucose: {current_glucose}\n"
         f"Severity: {alert.severity.value.upper()}\n"
         f"Primary contact has not responded. Please check on them immediately."
     )
@@ -426,6 +433,7 @@ async def escalate_alert(
     db: AsyncSession,
     alert: Alert,
     user_email: str,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> EscalationEvent | None:
     """Escalate an alert to the next tier if appropriate.
 
@@ -433,6 +441,8 @@ async def escalate_alert(
         db: Database session.
         alert: The alert to potentially escalate.
         user_email: User's email (for message formatting).
+        unit: The PATIENT's glucose display unit; escalation messages (to the
+            patient and to emergency contacts) render glucose in it.
 
     Returns:
         EscalationEvent if escalation occurred, None otherwise.
@@ -468,9 +478,9 @@ async def escalate_alert(
             if tier == EscalationTier.PRIMARY_CONTACT
             else "All Contacts Alert"
         )
-        message = format_escalation_contact_message(alert, user_email, tier_label)
+        message = format_escalation_contact_message(alert, user_email, tier_label, unit)
     else:
-        message = build_escalation_message(alert, tier, user_email)
+        message = build_escalation_message(alert, tier, user_email, unit)
 
     # Persist event as PENDING first to ensure audit trail exists
     # before dispatching notification
@@ -519,9 +529,13 @@ async def process_escalations_for_user(
     if not alerts:
         return 0
 
+    # Resolve the patient's display unit once; escalation messages -- to the
+    # patient and to emergency contacts -- render glucose in the patient's unit.
+    unit = await resolve_glucose_unit(db, user_id)
+
     escalation_count = 0
     for alert in alerts:
-        event = await escalate_alert(db, alert, user_email)
+        event = await escalate_alert(db, alert, user_email, unit)
         if event:
             escalation_count += 1
 

--- a/apps/api/src/services/glucose_unit.py
+++ b/apps/api/src/services/glucose_unit.py
@@ -1,0 +1,27 @@
+"""Resolve a user's preferred glucose display unit.
+
+Backend text-rendering paths -- predictive alerts, escalations, Telegram
+notifications and command replies -- often hold only a ``user_id`` but must
+render glucose in the *data owner's* unit (the patient's, never a caregiver's
+or an emergency contact's). This is the single helper they share so the lookup
+and the mg/dL fallback live in one place.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.units import GlucoseUnit
+from src.models.user import User
+
+
+async def resolve_glucose_unit(db: AsyncSession, user_id: uuid.UUID) -> GlucoseUnit:
+    """Return the user's configured glucose display unit, defaulting to mg/dL.
+
+    Reads only the ``glucose_unit`` column (no full ``User`` load). Falls back
+    to mg/dL if the user can't be found, matching the column's non-null
+    ``server_default`` so a missing row can never surface mmol unexpectedly.
+    """
+    result = await db.execute(select(User.glucose_unit).where(User.id == user_id))
+    return result.scalar_one_or_none() or GlucoseUnit.MGDL

--- a/apps/api/src/services/meal_analysis.py
+++ b/apps/api/src/services/meal_analysis.py
@@ -10,6 +10,12 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import (
+    GlucoseUnit,
+    format_glucose,
+    glucose_unit_label,
+    glucose_unit_prompt_instruction,
+)
 from src.logging_config import get_logger
 from src.models.glucose import GlucoseReading
 from src.models.meal_analysis import MealAnalysis
@@ -44,14 +50,25 @@ MEAL_PERIODS = {
     "snack": None,  # Everything else
 }
 
-SYSTEM_PROMPT = """\
+
+def _build_system_prompt(unit: GlucoseUnit = GlucoseUnit.MGDL) -> str:
+    """Build the meal-analysis system prompt in the user's glucose unit.
+
+    The spike threshold and the example peak render in ``unit``; a closing
+    instruction pins the model's output unit. The carb-ratio ``1:X`` example
+    stays in its native notation -- a carb ratio is grams per unit, not a
+    glucose reading.
+    """
+    spike = format_glucose(SPIKE_THRESHOLD, unit)
+    unit_label = glucose_unit_label(unit)
+    return f"""\
 You are a diabetes management assistant analyzing post-meal glucose patterns \
 for a person with Type 1 diabetes using a Tandem insulin pump with Control-IQ \
 and a Dexcom G7 CGM.
 
 You are reviewing meal pattern data organized by meal period. For each meal \
 period, you have the number of boluses analyzed, the number of post-meal spikes \
-(>180 mg/dL within 2 hours), the average peak glucose, and the average glucose \
+(>{spike} within 2 hours), the average peak glucose, and the average glucose \
 at 2 hours post-bolus.
 
 When the user's pump profile is provided, compare observed spike patterns \
@@ -64,12 +81,13 @@ Guidelines:
 - Identify which meal periods have consistent post-meal spikes
 - For problematic periods, suggest whether the ratio may need to be stronger \
 or weaker, using the current ratio only as context
-- Explain reasoning: "Your breakfast peaks average X mg/dL despite Control-IQ corrections"
+- Explain reasoning: "Your breakfast peaks average X {unit_label} despite Control-IQ corrections"
 - Use encouraging, non-judgmental language
 - Clearly state that these are observations to discuss with their endocrinologist
 - Do NOT provide specific dosing instructions; suggest directional changes only
 - If data shows good control for a period, acknowledge it
-- If insufficient data for a period, note that more data is needed\
+- If insufficient data for a period, note that more data is needed
+- {glucose_unit_prompt_instruction(unit)}\
 """
 
 
@@ -95,6 +113,7 @@ def _build_meal_prompt(
     total_boluses: int,
     days: int,
     profile_summary: PumpProfileSummary | None = None,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str:
     """Build the analysis prompt with meal period data.
 
@@ -103,10 +122,14 @@ def _build_meal_prompt(
         total_boluses: Total boluses analyzed.
         days: Number of days in the analysis window.
         profile_summary: Optional pump profile for carb ratio context.
+        unit: The user's glucose display unit. The spike threshold, average
+            peak, and 2hr post-meal glucose render in it; spike-membership math
+            stays canonical mg/dL.
 
     Returns:
         Formatted prompt string.
     """
+    spike = format_glucose(SPIKE_THRESHOLD, unit)
     lines = [
         f"Analyze the following {days}-day post-meal glucose pattern data:",
         f"Total meal boluses analyzed: {total_boluses}",
@@ -115,10 +138,13 @@ def _build_meal_prompt(
 
     for mp in meal_periods:
         lines.append(f"**{mp.period.capitalize()}** ({mp.bolus_count} meals):")
-        lines.append(f"  - Post-meal spikes (>180 mg/dL): {mp.spike_count}")
-        lines.append(f"  - Average peak glucose: {mp.avg_peak_glucose:.0f} mg/dL")
+        lines.append(f"  - Post-meal spikes (>{spike}): {mp.spike_count}")
         lines.append(
-            f"  - Average 2hr post-meal glucose: {mp.avg_2hr_glucose:.0f} mg/dL"
+            f"  - Average peak glucose: {format_glucose(mp.avg_peak_glucose, unit)}"
+        )
+        lines.append(
+            f"  - Average 2hr post-meal glucose: "
+            f"{format_glucose(mp.avg_2hr_glucose, unit)}"
         )
         if mp.bolus_count > 0:
             spike_pct = (mp.spike_count / mp.bolus_count) * 100
@@ -126,7 +152,7 @@ def _build_meal_prompt(
         lines.append("")
 
     if profile_summary:
-        lines.append(format_pump_profile_for_prompt(profile_summary))
+        lines.append(format_pump_profile_for_prompt(profile_summary, unit))
         lines.append("")
 
     lines.append(
@@ -272,6 +298,10 @@ async def generate_meal_analysis(
     period_end = datetime.now(UTC)
     period_start = period_end - timedelta(days=days)
 
+    # The prompt and persisted analysis text render glucose in the user's unit;
+    # spike-detection math stays canonical mg/dL.
+    unit = user.glucose_unit
+
     # Analyze post-meal patterns
     meal_periods = await analyze_post_meal_patterns(
         user.id, db, period_start, period_end
@@ -314,7 +344,9 @@ async def generate_meal_analysis(
         )
 
     # Build prompt and generate
-    user_prompt = _build_meal_prompt(meal_periods, total_boluses, days, profile_summary)
+    user_prompt = _build_meal_prompt(
+        meal_periods, total_boluses, days, profile_summary, unit
+    )
 
     logger.info(
         "Generating meal pattern analysis",
@@ -326,10 +358,11 @@ async def generate_meal_analysis(
 
     ai_response = await ai_client.generate(
         messages=[AIMessage(role="user", content=user_prompt)],
-        system_prompt=SYSTEM_PROMPT,
+        system_prompt=_build_system_prompt(unit),
     )
 
-    # Safety validation (Story 5.6)
+    # Safety validation (Story 5.6). Unit-agnostic: the regexes accept either
+    # suffix and the ±20% check is unit-relative once a suffix matches.
     safety_result = validate_ai_suggestion(ai_response.content, "meal_analysis")
 
     # Store the analysis with sanitized text

--- a/apps/api/src/services/predictive_alerts.py
+++ b/apps/api/src/services/predictive_alerts.py
@@ -12,12 +12,14 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import and_, desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import GlucoseUnit, format_glucose, format_glucose_value
 from src.logging_config import get_logger
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.alert_threshold import AlertThreshold
 from src.models.glucose import GlucoseReading
 from src.services.alert_notifier import notify_user_of_alerts
 from src.services.alert_threshold import get_or_create_thresholds
+from src.services.glucose_unit import resolve_glucose_unit
 from src.services.iob_projection import get_iob_projection, get_user_dia
 
 logger = get_logger(__name__)
@@ -147,6 +149,7 @@ def check_threshold_crossings(
     trajectory: GlucoseTrajectory,
     thresholds: AlertThreshold,
     iob_value: float | None,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> list[AlertCandidate]:
     """Check if glucose trajectory crosses any configured thresholds.
 
@@ -157,12 +160,26 @@ def check_threshold_crossings(
         trajectory: Calculated glucose trajectory.
         thresholds: User's configured alert thresholds.
         iob_value: Current IoB value (for severity escalation).
+        unit: The patient's glucose display unit. The persisted
+            ``Alert.message`` text renders in it (rendered once at persist; the
+            numeric ``current_value``/``predicted_value`` stay canonical mg/dL).
+            All threshold comparisons remain in mg/dL.
 
     Returns:
         List of AlertCandidate objects for threshold crossings found.
     """
     candidates: list[AlertCandidate] = []
     current = trajectory.current_value
+    # Pre-render the message figures in the patient's unit once. ``current_labeled``
+    # carries the unit label for the headline figure; ``current_value`` and the
+    # ``*_disp`` threshold strings are the bare numbers shown inside the
+    # parentheticals. Threshold comparisons below still use the raw mg/dL columns.
+    current_labeled = format_glucose(current, unit)
+    current_value = format_glucose_value(current, unit)
+    urgent_low_disp = format_glucose_value(thresholds.urgent_low, unit)
+    low_warning_disp = format_glucose_value(thresholds.low_warning, unit)
+    urgent_high_disp = format_glucose_value(thresholds.urgent_high, unit)
+    high_warning_disp = format_glucose_value(thresholds.high_warning, unit)
 
     # Check current value against thresholds
     if current <= thresholds.urgent_low:
@@ -177,8 +194,8 @@ def check_threshold_crossings(
                 prediction_minutes=None,
                 iob_value=iob_value,
                 message=(
-                    f"Urgent low glucose: {current:.0f} mg/dL "
-                    f"(threshold: {thresholds.urgent_low:.0f})"
+                    f"Urgent low glucose: {current_labeled} "
+                    f"(threshold: {urgent_low_disp})"
                 ),
                 trend_rate=trajectory.trend_rate,
                 source="current",
@@ -196,8 +213,8 @@ def check_threshold_crossings(
                 prediction_minutes=None,
                 iob_value=iob_value,
                 message=(
-                    f"Low glucose warning: {current:.0f} mg/dL "
-                    f"(threshold: {thresholds.low_warning:.0f})"
+                    f"Low glucose warning: {current_labeled} "
+                    f"(threshold: {low_warning_disp})"
                 ),
                 trend_rate=trajectory.trend_rate,
                 source="current",
@@ -216,8 +233,8 @@ def check_threshold_crossings(
                 prediction_minutes=None,
                 iob_value=iob_value,
                 message=(
-                    f"Urgent high glucose: {current:.0f} mg/dL "
-                    f"(threshold: {thresholds.urgent_high:.0f})"
+                    f"Urgent high glucose: {current_labeled} "
+                    f"(threshold: {urgent_high_disp})"
                 ),
                 trend_rate=trajectory.trend_rate,
                 source="current",
@@ -235,8 +252,8 @@ def check_threshold_crossings(
                 prediction_minutes=None,
                 iob_value=iob_value,
                 message=(
-                    f"High glucose warning: {current:.0f} mg/dL "
-                    f"(threshold: {thresholds.high_warning:.0f})"
+                    f"High glucose warning: {current_labeled} "
+                    f"(threshold: {high_warning_disp})"
                 ),
                 trend_rate=trajectory.trend_rate,
                 source="current",
@@ -263,9 +280,9 @@ def check_threshold_crossings(
                     prediction_minutes=minutes,
                     iob_value=iob_value,
                     message=(
-                        f"Predicted urgent low: {predicted:.0f} mg/dL "
-                        f"in {minutes} min (current: {current:.0f}, "
-                        f"threshold: {thresholds.urgent_low:.0f})"
+                        f"Predicted urgent low: {format_glucose(predicted, unit)} "
+                        f"in {minutes} min "
+                        f"(current: {current_value}, threshold: {urgent_low_disp})"
                     ),
                     trend_rate=trajectory.trend_rate,
                     source="predictive",
@@ -289,9 +306,9 @@ def check_threshold_crossings(
                     prediction_minutes=minutes,
                     iob_value=iob_value,
                     message=(
-                        f"Predicted low glucose: {predicted:.0f} mg/dL "
-                        f"in {minutes} min (current: {current:.0f}, "
-                        f"threshold: {thresholds.low_warning:.0f})"
+                        f"Predicted low glucose: {format_glucose(predicted, unit)} "
+                        f"in {minutes} min "
+                        f"(current: {current_value}, threshold: {low_warning_disp})"
                     ),
                     trend_rate=trajectory.trend_rate,
                     source="predictive",
@@ -315,9 +332,9 @@ def check_threshold_crossings(
                     prediction_minutes=minutes,
                     iob_value=iob_value,
                     message=(
-                        f"Predicted urgent high: {predicted:.0f} mg/dL "
-                        f"in {minutes} min (current: {current:.0f}, "
-                        f"threshold: {thresholds.urgent_high:.0f})"
+                        f"Predicted urgent high: {format_glucose(predicted, unit)} "
+                        f"in {minutes} min "
+                        f"(current: {current_value}, threshold: {urgent_high_disp})"
                     ),
                     trend_rate=trajectory.trend_rate,
                     source="predictive",
@@ -341,9 +358,9 @@ def check_threshold_crossings(
                     prediction_minutes=minutes,
                     iob_value=iob_value,
                     message=(
-                        f"Predicted high glucose: {predicted:.0f} mg/dL "
-                        f"in {minutes} min (current: {current:.0f}, "
-                        f"threshold: {thresholds.high_warning:.0f})"
+                        f"Predicted high glucose: {format_glucose(predicted, unit)} "
+                        f"in {minutes} min "
+                        f"(current: {current_value}, threshold: {high_warning_disp})"
                     ),
                     trend_rate=trajectory.trend_rate,
                     source="predictive",
@@ -589,6 +606,11 @@ async def evaluate_alerts_for_user(
     # Get user's thresholds
     thresholds = await get_or_create_thresholds(user_id, db)
 
+    # Resolve the patient's display unit once. Alert.message is rendered in it
+    # at persist time (historical alerts are not backfilled on a unit change);
+    # the numeric current/predicted columns stay canonical mg/dL.
+    unit = await resolve_glucose_unit(db, user_id)
+
     # Get IoB projection
     iob_value = None
     try:
@@ -604,7 +626,7 @@ async def evaluate_alerts_for_user(
         )
 
     # Check threshold crossings
-    candidates = check_threshold_crossings(trajectory, thresholds, iob_value)
+    candidates = check_threshold_crossings(trajectory, thresholds, iob_value, unit)
 
     # Check IoB threshold
     if iob_value is not None:
@@ -638,7 +660,7 @@ async def evaluate_alerts_for_user(
 
         # Story 7.2: Immediate Telegram delivery
         try:
-            await notify_user_of_alerts(db, user_id, new_alerts)
+            await notify_user_of_alerts(db, user_id, new_alerts, unit)
         except Exception as e:
             logger.warning(
                 "Telegram alert delivery failed",

--- a/apps/api/src/services/safety_validation.py
+++ b/apps/api/src/services/safety_validation.py
@@ -44,35 +44,55 @@ DANGEROUS_PATTERNS = [
     r"(?i)\b(?:take|bolus|inject|give)\s+\d+\s*(?:units?|u)\b",
 ]
 
+# Glucose-unit suffix shared by the ISF patterns and the carb-ratio lookahead.
+# Both units must be accepted: when a mmol/L user's assistant is told to report
+# in mmol/L, an ISF suggestion arrives suffixed "mmol/L" instead of "mg/dL", and
+# the ±20% over-change flag must still fire (and ISF must still be distinguished
+# from a unitless carb ratio). Longer alternatives lead so "mg/dL" wins over a
+# bare "mg" and "mmol/L" over a bare "mmol".
+_GLUCOSE_UNIT_SUFFIX = r"mg/dL|mg|mmol/L|mmol"
+
+
+def _canonical_glucose_suffix(matched: str) -> str:
+    """Normalize a matched glucose-unit suffix to its canonical display label."""
+    return "mmol/L" if matched.lower().startswith("mmol") else "mg/dL"
+
+
 # Pattern to extract carb ratio suggestions like "1:8 to 1:7" or "from 1:10 to 1:8"
-# Negative lookahead excludes matches followed by mg/dL (those are ISF values)
-# (?!\d) prevents backtracking from consuming fewer digits to bypass the lookahead
+# Negative lookahead excludes matches followed by a glucose unit (mg/dL or
+# mmol/L) -- those are ISF values, not carb ratios.
+# (?!\d) prevents backtracking from consuming fewer digits to bypass the lookahead;
+# (?!\.\d) additionally stops it from truncating a *decimal* ISF (e.g. "1:2.8 to
+# 1:2.5 mmol/L") down to its integer part ("1:2") and mis-flagging it as a carb
+# ratio -- mmol/L correction factors are routinely decimals.
 CARB_RATIO_PATTERN = re.compile(
     r"(?:from\s+)?1\s*:\s*(\d+(?:\.\d+)?)\s+"
     r"(?:to|→|->)\s+"
     r"1\s*:\s*(\d+(?:\.\d+)?)"
-    r"(?!\d|\s*(?:mg/dL|mg\b))",
+    rf"(?!\d|\.\d|\s*(?:{_GLUCOSE_UNIT_SUFFIX})\b)",
     re.IGNORECASE,
 )
 
-# Pattern to extract ISF suggestions with 1:X notation requiring mg/dL suffix
-# e.g., "from 1:50 to 1:45 mg/dL" — the mg/dL suffix distinguishes ISF from carb ratios
+# Pattern to extract ISF suggestions with 1:X notation requiring a glucose-unit
+# suffix, e.g. "from 1:50 to 1:45 mg/dL" or "from 1:2.8 to 1:2.5 mmol/L" -- the
+# suffix distinguishes ISF from carb ratios. Group 3 captures the matched unit.
 ISF_PATTERN = re.compile(
     r"(?:from\s+)?1\s*:\s*(\d+(?:\.\d+)?)\s+"
     r"(?:to|→|->)\s+"
     r"(?:1\s*:\s*)?(\d+(?:\.\d+)?)"
-    r"\s*(?:mg/dL|mg)",
+    rf"\s*({_GLUCOSE_UNIT_SUFFIX})\b",
     re.IGNORECASE,
 )
 
 # ISF pattern with context keywords (does not require 1: prefix)
-# e.g., "correction factor from 50 to 45 mg/dL" or "ISF should be 50 to 45 mg/dL"
+# e.g., "correction factor from 50 to 45 mg/dL" or "ISF should be 2.8 to 2.5 mmol/L"
+# Group 3 captures the matched unit.
 ISF_CONTEXT_PATTERN = re.compile(
     r"(?:ISF|correction\s+factor|sensitivity\s+factor|CF)"
     r".*?(?:from\s+)?(\d+(?:\.\d+)?)\s+"
     r"(?:to|→|->)\s+"
     r"(\d+(?:\.\d+)?)"
-    r"\s*(?:mg/dL|mg)",
+    rf"\s*({_GLUCOSE_UNIT_SUFFIX})\b",
     re.IGNORECASE,
 )
 
@@ -153,6 +173,10 @@ def _extract_isf_changes(text: str) -> list[FlaggedSuggestion]:
         for match in pattern.finditer(text):
             original = float(match.group(1))
             suggested = float(match.group(2))
+            # The reason echoes the unit the model actually used, derived from
+            # the matched suffix -- not the configured display unit -- so the
+            # text the user reads stays consistent with what was flagged.
+            unit_label = _canonical_glucose_suffix(match.group(3))
 
             if original == 0:
                 continue
@@ -175,7 +199,7 @@ def _extract_isf_changes(text: str) -> list[FlaggedSuggestion]:
                         max_allowed_pct=MAX_CHANGE_PCT,
                         reason=(
                             f"Correction factor change of {change_pct:.0f}% "
-                            f"({original} to {suggested} mg/dL) exceeds "
+                            f"({original} to {suggested} {unit_label}) exceeds "
                             f"maximum allowed change of {MAX_CHANGE_PCT:.0f}%"
                         ),
                     )

--- a/apps/api/src/services/telegram_caregiver.py
+++ b/apps/api/src/services/telegram_caregiver.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from src.core.units import GlucoseUnit, format_glucose
 from src.logging_config import get_logger
 from src.models.caregiver_link import CaregiverLink
 
@@ -114,9 +115,12 @@ async def _handle_caregiver_status(
             lines.append(f"\u2022 <b>{patient_label}:</b> No data available")
         else:
             trend = trend_description(reading.trend_rate)
-            lines.append(
-                f"\u2022 <b>{patient_label}:</b> {reading.value:.0f} mg/dL ({trend})"
-            )
+            # Each patient's glucose renders in that patient's own unit. The
+            # column is non-nullable, but default to mg/dL defensively here
+            # since this loop renders several patients in one message.
+            unit = patient.glucose_unit or GlucoseUnit.MGDL
+            glucose = format_glucose(reading.value, unit)
+            lines.append(f"\u2022 <b>{patient_label}:</b> {glucose} ({trend})")
 
     return "\n".join(lines)
 

--- a/apps/api/src/services/telegram_chat.py
+++ b/apps/api/src/services/telegram_chat.py
@@ -23,6 +23,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import GlucoseUnit, glucose_unit_prompt_instruction
 from src.logging_config import get_logger
 from src.models.chat_message import ChatRole
 from src.models.user import User
@@ -119,21 +120,31 @@ class ChatResult:
     output_tokens: int
 
 
-def _build_system_prompt(diabetes_context: str) -> str:
-    """Build the system prompt with diabetes context embedded.
+def _compose_system_prompt(
+    prefix: str,
+    diabetes_context: str,
+    unit: GlucoseUnit,
+) -> str:
+    """Append the report-in-unit instruction to a prefix, then the context.
 
-    Uses string concatenation instead of str.format() to avoid
-    injection if the context contains brace characters.
-
-    Args:
-        diabetes_context: Formatted diabetes data string.
-
-    Returns:
-        Complete system prompt for the AI provider.
+    The instruction is added as a final guideline bullet so the model reports
+    glucose in the data owner's unit -- the in-context numbers are already
+    converted, and model prose cannot be post-converted. Uses string
+    concatenation (not ``str.format``) so brace characters in the context can't
+    trigger format injection.
     """
+    guidelines = prefix.rstrip() + f"\n- {glucose_unit_prompt_instruction(unit)}\n\n"
     if diabetes_context:
-        return _SYSTEM_PROMPT_PREFIX + diabetes_context
-    return _SYSTEM_PROMPT_PREFIX.rstrip()
+        return guidelines + diabetes_context
+    return guidelines.rstrip()
+
+
+def _build_system_prompt(
+    diabetes_context: str,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
+) -> str:
+    """Build the Telegram chat system prompt with diabetes context embedded."""
+    return _compose_system_prompt(_SYSTEM_PROMPT_PREFIX, diabetes_context, unit)
 
 
 def _truncate_response(text: str) -> str:
@@ -213,10 +224,11 @@ async def handle_chat(
     # Load conversation history
     history = await get_recent_messages(db, user_id, conversation_id)
 
-    # Build context and prompt
+    # Build context and prompt in the user's glucose unit
+    unit = user.glucose_unit
     try:
         diabetes_context = await build_diabetes_context(
-            db, user_id, query=truncated_text
+            db, user_id, query=truncated_text, unit=unit
         )
     except Exception:
         logger.error(
@@ -225,7 +237,7 @@ async def handle_chat(
             exc_info=True,
         )
         diabetes_context = "Recent diabetes data: unavailable due to a temporary error."
-    system_prompt = _build_system_prompt(diabetes_context)
+    system_prompt = _build_system_prompt(diabetes_context, unit)
 
     # Build messages array: history + current user message
     messages = history + [AIMessage(role="user", content=truncated_text)]
@@ -365,9 +377,10 @@ async def handle_chat_web(
     # Load conversation history
     history = await get_recent_messages(db, user_id, conversation_id)
 
+    unit = user.glucose_unit
     try:
         diabetes_context = await build_diabetes_context(
-            db, user_id, query=truncated_text
+            db, user_id, query=truncated_text, unit=unit
         )
     except Exception:
         logger.error(
@@ -377,10 +390,9 @@ async def handle_chat_web(
         )
         diabetes_context = "Recent diabetes data: unavailable due to a temporary error."
 
-    if diabetes_context:
-        system_prompt = _WEB_SYSTEM_PROMPT_PREFIX + diabetes_context
-    else:
-        system_prompt = _WEB_SYSTEM_PROMPT_PREFIX.rstrip()
+    system_prompt = _compose_system_prompt(
+        _WEB_SYSTEM_PROMPT_PREFIX, diabetes_context, unit
+    )
 
     # Build messages array: history + current user message
     messages = history + [AIMessage(role="user", content=truncated_text)]
@@ -485,6 +497,7 @@ Guidelines:
 def _build_caregiver_system_prompt(
     patient_email: str,
     diabetes_context: str,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> str:
     """Build a system prompt for caregiver AI chat.
 
@@ -493,14 +506,21 @@ def _build_caregiver_system_prompt(
     Args:
         patient_email: Patient's email for identification.
         diabetes_context: Formatted diabetes data string.
+        unit: The PATIENT's glucose display unit. The context is built from the
+            patient's data, so the caregiver reads it -- and the model reports
+            it -- in the patient's unit, never the caregiver's.
 
     Returns:
         Complete system prompt for the AI provider.
     """
+    prefix = (
+        _CAREGIVER_SYSTEM_PROMPT_PREFIX.rstrip()
+        + f"\n- {glucose_unit_prompt_instruction(unit)}\n\n"
+    )
     patient_line = f"Patient: {patient_email}\n"
     if diabetes_context:
-        return _CAREGIVER_SYSTEM_PROMPT_PREFIX + patient_line + diabetes_context
-    return (_CAREGIVER_SYSTEM_PROMPT_PREFIX + patient_line).rstrip()
+        return prefix + patient_line + diabetes_context
+    return (prefix + patient_line).rstrip()
 
 
 async def handle_caregiver_chat(
@@ -565,10 +585,11 @@ async def handle_caregiver_chat(
     # Truncate overly long user messages
     truncated_text = text[:MAX_USER_MESSAGE_LENGTH]
 
-    # Build context from patient's data
+    # Build context from patient's data, in the PATIENT's glucose unit
+    unit = patient.glucose_unit
     try:
         diabetes_context = await build_diabetes_context(
-            db, patient_id, query=truncated_text
+            db, patient_id, query=truncated_text, unit=unit
         )
     except Exception:
         logger.error(
@@ -578,7 +599,9 @@ async def handle_caregiver_chat(
             exc_info=True,
         )
         diabetes_context = "Recent diabetes data: unavailable due to a temporary error."
-    system_prompt = _build_caregiver_system_prompt(patient.email, diabetes_context)
+    system_prompt = _build_caregiver_system_prompt(
+        patient.email, diabetes_context, unit
+    )
 
     # Generate AI response
     try:
@@ -672,9 +695,10 @@ async def handle_caregiver_chat_web(
 
     truncated_text = text[:MAX_USER_MESSAGE_LENGTH]
 
+    unit = patient.glucose_unit
     try:
         diabetes_context = await build_diabetes_context(
-            db, patient_id, query=truncated_text
+            db, patient_id, query=truncated_text, unit=unit
         )
     except Exception:
         logger.error(
@@ -685,7 +709,9 @@ async def handle_caregiver_chat_web(
         )
         diabetes_context = "Recent diabetes data: unavailable due to a temporary error."
 
-    system_prompt = _build_caregiver_system_prompt(patient.email, diabetes_context)
+    system_prompt = _build_caregiver_system_prompt(
+        patient.email, diabetes_context, unit
+    )
 
     try:
         ai_response = await ai_client.generate(

--- a/apps/api/src/services/telegram_commands.py
+++ b/apps/api/src/services/telegram_commands.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import format_glucose
 from src.logging_config import get_logger
 from src.models.glucose import GlucoseReading
 from src.models.telegram_link import TelegramLink
@@ -29,6 +30,7 @@ from src.models.user import User, UserRole
 from src.services.alert_notifier import trend_description
 from src.services.brief_notifier import format_brief_message
 from src.services.daily_brief import list_briefs
+from src.services.glucose_unit import resolve_glucose_unit
 from src.services.iob_projection import get_iob_projection, get_user_dia
 from src.services.predictive_alerts import acknowledge_alert, get_active_alerts
 
@@ -111,10 +113,11 @@ async def _handle_status(db: AsyncSession, user_id: uuid.UUID) -> str:
     if reading is None:
         return "\u2139\ufe0f No glucose data available yet."
 
+    unit = await resolve_glucose_unit(db, user_id)
     lines = [
         "\U0001f4ca <b>Current Status</b>",
         "",
-        f"\U0001f3af <b>Glucose:</b> {reading.value:.0f} mg/dL",
+        f"\U0001f3af <b>Glucose:</b> {format_glucose(reading.value, unit)}",
         f"\U0001f4c8 <b>Trend:</b> {trend_description(reading.trend_rate)}",
         f"\U0001f551 <b>Reading:</b> {_reading_age(reading.reading_timestamp)}",
     ]
@@ -170,7 +173,8 @@ async def _handle_brief(db: AsyncSession, user_id: uuid.UUID) -> str:
     if not briefs:
         return "\u2139\ufe0f No daily briefs available yet."
 
-    return format_brief_message(briefs[0])
+    unit = await resolve_glucose_unit(db, user_id)
+    return format_brief_message(briefs[0], unit)
 
 
 def _handle_help() -> str:

--- a/apps/api/tests/test_alert_notifier.py
+++ b/apps/api/tests/test_alert_notifier.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.core.units import GlucoseUnit
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.services.alert_notifier import (
     SEVERITY_EMOJI,
@@ -183,6 +184,15 @@ class TestFormatAlertMessage:
             emoji = SEVERITY_EMOJI[severity]
             assert emoji in msg
 
+    def test_renders_mmol_unit(self):
+        """Current (55->3.1) and predicted (45->2.5) render in the patient's
+        unit; mg/dL never appears."""
+        alert = make_alert(current_value=55.0, predicted_value=45.0)
+        msg = format_alert_message(alert, GlucoseUnit.MMOL)
+        assert "3.1 mmol/L" in msg
+        assert "2.5 mmol/L" in msg
+        assert "mg/dL" not in msg
+
 
 # ---------------------------------------------------------------------------
 # Format escalation contact message tests (pure function)
@@ -205,6 +215,16 @@ class TestFormatEscalationContactMessage:
         msg = format_escalation_contact_message(alert, "u@t.com", "Tier")
         assert "180 mg/dL" in msg
         assert "rising" in msg
+
+    def test_contact_sees_patient_unit(self):
+        """The contact reads the patient's glucose in the PATIENT's unit
+        (180 -> 10.0 mmol/L), never the contact's own."""
+        alert = make_alert(current_value=180.0, trend_rate=2.0)
+        msg = format_escalation_contact_message(
+            alert, "u@t.com", "Tier", GlucoseUnit.MMOL
+        )
+        assert "10.0 mmol/L" in msg
+        assert "mg/dL" not in msg
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_brief_notifier.py
+++ b/apps/api/tests/test_brief_notifier.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.core.units import GlucoseUnit
 from src.models.brief_delivery_config import DeliveryChannel
 from src.models.daily_brief import DailyBrief
 from src.services.brief_notifier import (
@@ -122,6 +123,13 @@ class TestFormatBriefMessage:
         brief = make_brief(avg=145.6)
         msg = format_brief_message(brief)
         assert "146 mg/dL" in msg
+
+    def test_avg_glucose_renders_mmol(self):
+        """The average converts to the patient's unit (145.6 -> 8.1)."""
+        brief = make_brief(avg=145.6)
+        msg = format_brief_message(brief, GlucoseUnit.MMOL)
+        assert "8.1 mmol/L" in msg
+        assert "mg/dL" not in msg
 
     def test_contains_low_count(self):
         brief = make_brief(lows=3, highs=0)

--- a/apps/api/tests/test_correction_analysis.py
+++ b/apps/api/tests/test_correction_analysis.py
@@ -9,12 +9,14 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.config import settings
+from src.core.units import GlucoseUnit
 from src.main import app
 from src.models.ai_provider import AIProviderType
 from src.schemas.ai_response import AIResponse, AIUsage
 from src.schemas.correction_analysis import TimePeriodData
 from src.services.correction_analysis import (
     _build_correction_prompt,
+    _build_system_prompt,
     _classify_time_period,
     analyze_correction_outcomes,
 )
@@ -147,6 +149,82 @@ class TestBuildCorrectionPrompt:
 
         assert "Overnight" in prompt
         assert "Effective correction rate" not in prompt
+
+    def _periods(self) -> list[TimePeriodData]:
+        return [
+            TimePeriodData(
+                period="morning",
+                correction_count=5,
+                under_count=3,
+                over_count=0,
+                avg_observed_isf=40.0,
+                avg_glucose_drop=80.0,
+            ),
+        ]
+
+    def test_prompt_mgdl_unchanged_from_legacy(self):
+        """mg/dL output is byte-identical to the pre-unit format (default unit)."""
+        prompt = _build_correction_prompt(self._periods(), 5, 7, unit=GlucoseUnit.MGDL)
+
+        assert "glucose stayed >120 mg/dL" in prompt
+        assert "glucose dropped <70 mg/dL" in prompt
+        assert "Average observed ISF: 40.0 mg/dL per unit" in prompt
+        assert "Average glucose drop: 80 mg/dL" in prompt
+
+    def test_prompt_renders_mmol_unit(self):
+        """Anchors (120->6.7, 70->3.9), the ISF rate, and the drop convert;
+        the ISF rate converts as a rate (40 mg/dL/U -> 2.2 mmol/L/U)."""
+        prompt = _build_correction_prompt(self._periods(), 5, 7, unit=GlucoseUnit.MMOL)
+
+        assert "glucose stayed >6.7 mmol/L" in prompt
+        assert "glucose dropped <3.9 mmol/L" in prompt
+        assert "Average observed ISF: 2.2 mmol/L per unit" in prompt
+        assert "Average glucose drop: 4.4 mmol/L" in prompt
+        assert "mg/dL" not in prompt
+
+    def test_mmol_prompt_keeps_cf_and_observed_isf_same_scale(self):
+        """The configured correction factor and the observed ISF the prompt asks
+        the model to compare must be on the same scale for an mmol/L user (both
+        mmol/L per unit), not a mg/dL CF against a mmol observed ISF."""
+        from src.services.diabetes_context import ProfileSegment, PumpProfileSummary
+
+        summary = PumpProfileSummary(
+            profile_name="Default",
+            segments=[
+                ProfileSegment(
+                    time="00:00",
+                    start_minutes=0,
+                    basal_rate=0.5,
+                    correction_factor=50,
+                    carb_ratio=8,
+                    target_bg=120,
+                ),
+            ],
+        )
+        prompt = _build_correction_prompt(
+            self._periods(), 5, 7, summary, GlucoseUnit.MMOL
+        )
+        assert "CF 1:2.8" in prompt  # configured CF on the mmol scale
+        assert "2.2 mmol/L per unit" in prompt  # observed ISF on the same scale
+        assert "CF 1:50" not in prompt
+
+    def test_system_prompt_states_user_unit(self):
+        """Each system prompt names the report unit and the ISF rate unit."""
+        mgdl = _build_system_prompt(GlucoseUnit.MGDL)
+        assert "mg/dL drop per unit of insulin" in mgdl
+        assert "Report all glucose values in mg/dL" in mgdl
+        assert "dropped below 70 mg/dL" in mgdl
+
+        # The ISF example renders on the user's scale so observed ISF and the
+        # configured correction factor stay same-unit (1:50 mg/dL -> 1:2.8 mmol).
+        assert "currently 1:50" in mgdl
+
+        mmol = _build_system_prompt(GlucoseUnit.MMOL)
+        assert "mmol/L drop per unit of insulin" in mmol
+        assert "Report all glucose values in mmol/L" in mmol
+        assert "dropped below 3.9 mmol/L" in mmol
+        assert "currently 1:2.8" in mmol
+        assert "currently 1:50" not in mmol
 
 
 class TestAnalyzeCorrectionOutcomes:
@@ -512,7 +590,7 @@ class TestGenerateCorrectionAnalysis:
         mock_client.generate.return_value = _mock_ai_response()
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         analysis = await generate_correction_analysis(mock_user, mock_db, days=7)
@@ -573,7 +651,7 @@ class TestGenerateCorrectionAnalysis:
             ),
         ]
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         with pytest.raises(HTTPException) as exc_info:
@@ -631,7 +709,7 @@ class TestGenerateCorrectionAnalysis:
         mock_client.generate.side_effect = RuntimeError("AI failed")
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         with pytest.raises(RuntimeError, match="AI failed"):

--- a/apps/api/tests/test_daily_brief.py
+++ b/apps/api/tests/test_daily_brief.py
@@ -9,6 +9,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.config import settings
+from src.core.units import GlucoseUnit
 from src.main import app
 from src.models.ai_provider import AIProviderType
 from src.schemas.ai_response import AIResponse, AIUsage
@@ -18,6 +19,7 @@ from src.services.daily_brief import (
     LOW_THRESHOLD,
     MIN_READINGS,
     _build_analysis_prompt,
+    _build_system_prompt,
     calculate_metrics,
 )
 
@@ -263,6 +265,46 @@ class TestBuildAnalysisPrompt:
         assert "4" in prompt  # corrections
         assert "35.2 units" in prompt
 
+    def test_prompt_mgdl_unchanged_from_legacy(self):
+        """mg/dL output is byte-identical to the pre-unit format (default unit)."""
+        metrics = DailyBriefMetrics(
+            time_in_range_pct=75.5,
+            average_glucose=142.3,
+            low_count=2,
+            high_count=5,
+            readings_count=288,
+            correction_count=4,
+            total_insulin=35.2,
+        )
+
+        prompt = _build_analysis_prompt(metrics, 24, unit=GlucoseUnit.MGDL)
+
+        assert "- Average glucose: 142 mg/dL" in prompt
+        assert "- Time in range (70-180): 75.5%" in prompt
+        assert "- Low readings (<70): 2" in prompt
+        assert "- High readings (>180): 5" in prompt
+
+    def test_prompt_renders_mmol_unit(self):
+        """mmol/L users see the average and anchors converted; mg/dL never
+        leaks. 145 -> 8.0, 70 -> 3.9, 180 -> 10.0."""
+        metrics = DailyBriefMetrics(
+            time_in_range_pct=75.5,
+            average_glucose=145.0,
+            low_count=2,
+            high_count=5,
+            readings_count=288,
+            correction_count=4,
+            total_insulin=35.2,
+        )
+
+        prompt = _build_analysis_prompt(metrics, 24, unit=GlucoseUnit.MMOL)
+
+        assert "- Average glucose: 8.0 mmol/L" in prompt
+        assert "- Time in range (3.9-10.0): 75.5%" in prompt
+        assert "- Low readings (<3.9): 2" in prompt
+        assert "- High readings (>10.0): 5" in prompt
+        assert "mg/dL" not in prompt
+
     def test_prompt_without_insulin_data(self):
         """Test that insulin line is omitted when data is None."""
         metrics = DailyBriefMetrics(
@@ -326,6 +368,15 @@ class TestBuildAnalysisPrompt:
         assert "never as dosing inputs" in lowered
         assert "never suggest a dose" in lowered
 
+    def test_system_prompt_states_user_unit(self):
+        """The brief's system prompt names the user's report unit."""
+        assert "Report all glucose values in mg/dL" in _build_system_prompt(
+            GlucoseUnit.MGDL
+        )
+        assert "Report all glucose values in mmol/L" in _build_system_prompt(
+            GlucoseUnit.MMOL
+        )
+
 
 class TestGenerateDailyBrief:
     """Tests for the generate_daily_brief service function."""
@@ -357,7 +408,7 @@ class TestGenerateDailyBrief:
         mock_client.generate.return_value = _mock_ai_response()
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         brief = await generate_daily_brief(mock_user, mock_db, hours=24)
@@ -397,7 +448,7 @@ class TestGenerateDailyBrief:
             correction_count=0,
         )
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         with pytest.raises(HTTPException) as exc_info:
@@ -429,7 +480,7 @@ class TestGenerateDailyBrief:
         mock_client.generate.side_effect = RuntimeError("AI provider failed")
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         with pytest.raises(RuntimeError, match="AI provider failed"):
@@ -461,7 +512,7 @@ class TestGenerateDailyBrief:
         mock_client.generate.return_value = _mock_ai_response()
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         brief = await generate_daily_brief(mock_user, mock_db, hours=48)

--- a/apps/api/tests/test_diabetes_context.py
+++ b/apps/api/tests/test_diabetes_context.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.config import settings
+from src.core.units import GlucoseUnit
 from src.services.diabetes_context import (
     MEAL_CONTEXT_HOURS,
     MEAL_DESCRIPTION_MAX_LEN,
@@ -202,6 +203,22 @@ class TestFormatPumpProfileForPrompt:
         assert "Max bolus: 15.0u" in result
         assert "High 200 mg/dL" in result
         assert "Low 55 mg/dL" in result
+
+    def test_renders_mmol_unit(self):
+        """Target BG (120->6.7, 100->5.6), CGM alert thresholds
+        (200->11.1, 55->3.1), and the correction factor (a glucose drop per
+        unit: 1:50->1:2.8) convert; the carb ratio (grams per unit) stays 1:8."""
+        summary = _make_summary()
+        result = format_pump_profile_for_prompt(summary, GlucoseUnit.MMOL)
+
+        assert "Target 6.7 mmol/L" in result
+        assert "Target 5.6 mmol/L" in result
+        assert "High 11.1 mmol/L" in result
+        assert "Low 3.1 mmol/L" in result
+        assert "CF 1:2.8" in result  # 50 mg/dL per unit -> 2.8 mmol/L per unit
+        assert "CF 1:50" not in result  # must not leave the mg/dL-scaled value
+        assert "CR 1:8" in result  # carb ratio is grams per unit, unchanged
+        assert "mg/dL" not in result
 
     def test_no_extras_when_none(self):
         summary = _make_summary(

--- a/apps/api/tests/test_escalation_engine.py
+++ b/apps/api/tests/test_escalation_engine.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from src.config import settings
+from src.core.units import GlucoseUnit
 from src.database import get_session_maker
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.emergency_contact import ContactPriority, EmergencyContact
@@ -289,6 +290,21 @@ class TestBuildEscalationMessage:
         )
 
         assert "42 mg/dL" in msg
+
+    def test_message_renders_current_glucose_in_mmol(self):
+        """The 'Current glucose' line converts to the patient's unit
+        (42 -> 2.3); Alert.message is already rendered in mmol at persist time."""
+        user_id = uuid.uuid4()
+        alert = make_alert(user_id)
+        alert.current_value = 42.0
+        alert.message = "Predicted low glucose: 2.3 mmol/L"
+
+        msg = build_escalation_message(
+            alert, EscalationTier.REMINDER, "user@test.com", GlucoseUnit.MMOL
+        )
+
+        assert "Current glucose: 2.3 mmol/L" in msg
+        assert "mg/dL" not in msg
 
 
 # ── Dispatch notification tests ──

--- a/apps/api/tests/test_glucose_units.py
+++ b/apps/api/tests/test_glucose_units.py
@@ -1,0 +1,169 @@
+"""Tests for the shared glucose display-formatting helpers.
+
+These helpers are the single choke-point that renders a stored mg/dL value as
+the text a user reads in their preferred unit. The contract they must hold:
+
+* mg/dL output is byte-identical to the legacy hand-written f-strings
+  (whole number + ``mg/dL`` label).
+* mmol/L converts from the most-precise mg/dL value and rounds to one decimal
+  LAST, so the conventional clinical anchors fall out of the ``18.0156`` factor
+  (70 -> 3.9, 180 -> 10.0, 120 -> 6.7) and the textbook 100 -> 5.6 (not 5.5).
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.core.units import (
+    MGDL_PER_MMOL,
+    GlucoseUnit,
+    format_correction_factor_value,
+    format_glucose,
+    format_glucose_range,
+    format_glucose_rate,
+    format_glucose_value,
+    glucose_display_matches,
+    glucose_unit_label,
+    glucose_unit_prompt_instruction,
+    mmol_to_mgdl,
+)
+from src.services.glucose_unit import resolve_glucose_unit
+
+# The clinically conventional mg/dL -> mmol/L anchors. These are what a mmol/L
+# user expects to see; if any drifts the user distrusts the number.
+CONVENTIONAL_ANCHORS = {
+    54: "3.0",
+    70: "3.9",
+    100: "5.6",  # the 18.0182-vs-18.0156 tell: must be 5.6, not 5.5
+    120: "6.7",
+    180: "10.0",
+    250: "13.9",
+}
+
+
+class TestFormatGlucoseMgdl:
+    """mg/dL rendering must be byte-identical to the pre-unit f-strings."""
+
+    @pytest.mark.parametrize("value", [20, 55, 70, 99, 100, 120, 180, 250, 400, 500])
+    def test_value_is_whole_number_with_label(self, value):
+        assert format_glucose(value, GlucoseUnit.MGDL) == f"{value} mg/dL"
+
+    def test_value_only_has_no_label(self):
+        assert format_glucose_value(120, GlucoseUnit.MGDL) == "120"
+
+    def test_range(self):
+        assert format_glucose_range(70, 180, GlucoseUnit.MGDL) == "70-180 mg/dL"
+
+    def test_float_value_rounds_to_whole(self):
+        # Averages arrive as floats; legacy used ``:.0f``.
+        assert format_glucose(145.7, GlucoseUnit.MGDL) == "146 mg/dL"
+
+    def test_rate(self):
+        assert format_glucose_rate(50.0, GlucoseUnit.MGDL) == "50.0 mg/dL per unit"
+
+    def test_correction_factor_value_verbatim(self):
+        # The CF feeds ``1:X`` notation; mg/dL keeps the stored value exactly,
+        # including any fractional (mmol-derived) precision -- no rounding.
+        assert format_correction_factor_value(50, GlucoseUnit.MGDL) == "50"
+        assert format_correction_factor_value(27.8, GlucoseUnit.MGDL) == "27.8"
+
+    def test_label(self):
+        assert glucose_unit_label(GlucoseUnit.MGDL) == "mg/dL"
+
+
+class TestFormatGlucoseMmol:
+    """mmol/L rendering converts once and rounds to one decimal last."""
+
+    @pytest.mark.parametrize("mgdl,expected", CONVENTIONAL_ANCHORS.items())
+    def test_conventional_anchors(self, mgdl, expected):
+        assert format_glucose_value(mgdl, GlucoseUnit.MMOL) == expected
+        assert format_glucose(mgdl, GlucoseUnit.MMOL) == f"{expected} mmol/L"
+
+    def test_99_vs_100_boundary(self):
+        # 99 -> 5.49 -> "5.5"; 100 -> 5.55 -> "5.6" (Gotcha G3).
+        assert format_glucose_value(99, GlucoseUnit.MMOL) == "5.5"
+        assert format_glucose_value(100, GlucoseUnit.MMOL) == "5.6"
+
+    def test_range(self):
+        assert format_glucose_range(70, 180, GlucoseUnit.MMOL) == "3.9-10.0 mmol/L"
+
+    def test_rate_converts_as_a_rate(self):
+        # 50 mg/dL per unit -> 2.8 mmol/L per unit (same linear factor).
+        assert format_glucose_rate(50.0, GlucoseUnit.MMOL) == "2.8 mmol/L per unit"
+
+    def test_correction_factor_value_converts(self):
+        # CF is a glucose drop per unit, so it converts like the observed ISF:
+        # 1:50 (mg/dL/U) -> 1:2.8 (mmol/L/U); 1:27.8 -> 1:1.5.
+        assert format_correction_factor_value(50, GlucoseUnit.MMOL) == "2.8"
+        assert format_correction_factor_value(27.8, GlucoseUnit.MMOL) == "1.5"
+
+    def test_label(self):
+        assert glucose_unit_label(GlucoseUnit.MMOL) == "mmol/L"
+
+
+class TestRoundTripNoDrift:
+    """Anchors hold and no displayed value drifts past the tolerance band."""
+
+    def test_anchors_are_pure_division_of_the_one_factor(self):
+        # The anchors must be exactly ``round(mgdl / 18.0156, 1)`` -- no special
+        # anchor table, so they can never disagree with the conversion factor.
+        for mgdl, expected in CONVENTIONAL_ANCHORS.items():
+            assert f"{round(mgdl / MGDL_PER_MMOL, 1):.1f}" == expected
+
+    @pytest.mark.parametrize("mgdl", range(20, 501))
+    def test_displayed_mmol_round_trips_within_tolerance(self, mgdl):
+        # Render to mmol, parse it back, and confirm it matches the stored mg/dL
+        # within the display tolerance band (no silent drift across the range).
+        shown = float(format_glucose_value(mgdl, GlucoseUnit.MMOL))
+        assert glucose_display_matches(mgdl, shown, GlucoseUnit.MMOL)
+        # And it converts back to within 1 mg/dL of the original.
+        assert abs(mmol_to_mgdl(shown) - mgdl) <= 1
+
+
+class TestGlucoseDisplayMatches:
+    """The rounding-tolerant comparison helper (citation-tolerance slice)."""
+
+    def test_mgdl_within_one(self):
+        assert glucose_display_matches(120, 120, GlucoseUnit.MGDL)
+        assert glucose_display_matches(120, 121, GlucoseUnit.MGDL)
+        assert not glucose_display_matches(120, 122, GlucoseUnit.MGDL)
+
+    def test_mmol_within_one_tenth(self):
+        assert glucose_display_matches(120, 6.7, GlucoseUnit.MMOL)
+        assert glucose_display_matches(120, 6.6, GlucoseUnit.MMOL)
+        assert not glucose_display_matches(120, 6.4, GlucoseUnit.MMOL)
+
+
+class TestPromptInstruction:
+    """The instruction pins both the unit and the precision."""
+
+    def test_mgdl(self):
+        text = glucose_unit_prompt_instruction(GlucoseUnit.MGDL)
+        assert "mg/dL" in text
+        assert "mmol/L" not in text
+
+    def test_mmol(self):
+        text = glucose_unit_prompt_instruction(GlucoseUnit.MMOL)
+        assert "mmol/L" in text
+        assert "one decimal" in text
+
+
+class TestResolveGlucoseUnit:
+    """The by-user_id resolver used by the alert/escalation/command paths."""
+
+    async def _resolve(self, scalar_value):
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = scalar_value
+        db = AsyncMock()
+        db.execute.return_value = result
+        return await resolve_glucose_unit(db, uuid.uuid4())
+
+    @pytest.mark.asyncio
+    async def test_returns_configured_unit(self):
+        assert await self._resolve(GlucoseUnit.MMOL) == GlucoseUnit.MMOL
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_mgdl_when_missing(self):
+        # A missing user (None) falls back to mg/dL, matching the non-null column.
+        assert await self._resolve(None) == GlucoseUnit.MGDL

--- a/apps/api/tests/test_meal_analysis.py
+++ b/apps/api/tests/test_meal_analysis.py
@@ -9,12 +9,14 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.config import settings
+from src.core.units import GlucoseUnit
 from src.main import app
 from src.models.ai_provider import AIProviderType
 from src.schemas.ai_response import AIResponse, AIUsage
 from src.schemas.meal_analysis import MealPeriodData
 from src.services.meal_analysis import (
     _build_meal_prompt,
+    _build_system_prompt,
     _classify_meal_period,
     analyze_post_meal_patterns,
 )
@@ -126,6 +128,45 @@ class TestBuildMealPrompt:
         assert "195" in prompt
         assert "160" in prompt
         assert "Spike rate: 60%" in prompt  # 3/5
+
+    def _periods(self) -> list[MealPeriodData]:
+        return [
+            MealPeriodData(
+                period="breakfast",
+                bolus_count=5,
+                spike_count=3,
+                avg_peak_glucose=195.0,
+                avg_2hr_glucose=140.0,
+            ),
+        ]
+
+    def test_prompt_mgdl_unchanged_from_legacy(self):
+        """mg/dL output is byte-identical to the pre-unit format (default unit)."""
+        prompt = _build_meal_prompt(self._periods(), 5, 7, unit=GlucoseUnit.MGDL)
+
+        assert "Post-meal spikes (>180 mg/dL): 3" in prompt
+        assert "Average peak glucose: 195 mg/dL" in prompt
+        assert "Average 2hr post-meal glucose: 140 mg/dL" in prompt
+
+    def test_prompt_renders_mmol_unit(self):
+        """Spike threshold (180->10.0), peak (195->10.8) and 2hr (140->7.8)
+        convert; mg/dL never leaks."""
+        prompt = _build_meal_prompt(self._periods(), 5, 7, unit=GlucoseUnit.MMOL)
+
+        assert "Post-meal spikes (>10.0 mmol/L): 3" in prompt
+        assert "Average peak glucose: 10.8 mmol/L" in prompt
+        assert "Average 2hr post-meal glucose: 7.8 mmol/L" in prompt
+        assert "mg/dL" not in prompt
+
+    def test_system_prompt_states_user_unit(self):
+        """Each system prompt names its report unit and spike threshold."""
+        mgdl = _build_system_prompt(GlucoseUnit.MGDL)
+        assert "(>180 mg/dL within 2 hours)" in mgdl
+        assert "Report all glucose values in mg/dL" in mgdl
+
+        mmol = _build_system_prompt(GlucoseUnit.MMOL)
+        assert "(>10.0 mmol/L within 2 hours)" in mmol
+        assert "Report all glucose values in mmol/L" in mmol
 
     def test_prompt_with_zero_bolus_period(self):
         """Test that zero-bolus periods don't produce spike rate."""
@@ -375,7 +416,7 @@ class TestGenerateMealAnalysis:
         mock_client.generate.return_value = _mock_ai_response()
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         analysis = await generate_meal_analysis(mock_user, mock_db, days=7)
@@ -429,7 +470,7 @@ class TestGenerateMealAnalysis:
             ),
         ]
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         with pytest.raises(HTTPException) as exc_info:
@@ -481,7 +522,7 @@ class TestGenerateMealAnalysis:
         mock_client.generate.side_effect = RuntimeError("AI failed")
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         with pytest.raises(RuntimeError, match="AI failed"):

--- a/apps/api/tests/test_predictive_alerts.py
+++ b/apps/api/tests/test_predictive_alerts.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import AsyncClient
 
 from src.config import settings
+from src.core.units import GlucoseUnit
 from src.models.alert import AlertSeverity, AlertType
 from src.services.predictive_alerts import (
     calculate_trajectory,
@@ -174,6 +175,39 @@ class TestCheckThresholdCrossings:
         candidates = check_threshold_crossings(trajectory, thresholds, None)
         assert len(candidates) == 1
         assert candidates[0].alert_type == AlertType.LOW_URGENT
+
+    def test_message_mgdl_unchanged_from_legacy(self):
+        """The persisted message is byte-identical for mg/dL (default)."""
+        trajectory = calculate_trajectory(50.0, 0.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(trajectory, thresholds, None)
+        assert candidates[0].message == "Urgent low glucose: 50 mg/dL (threshold: 55)"
+
+    def test_message_renders_mmol(self):
+        """The persisted message renders in the patient's unit
+        (50->2.8, threshold 55->3.1) when the unit is mmol/L."""
+        trajectory = calculate_trajectory(50.0, 0.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(
+            trajectory, thresholds, None, GlucoseUnit.MMOL
+        )
+        assert candidates[0].message == (
+            "Urgent low glucose: 2.8 mmol/L (threshold: 3.1)"
+        )
+
+    def test_predicted_message_renders_mmol(self):
+        """Predicted messages convert the predicted, current, and
+        threshold figures to the patient's unit."""
+        # Falling fast: current 90 -> predicted low within the horizon.
+        trajectory = calculate_trajectory(90.0, -2.0)
+        thresholds = self._make_thresholds()
+        candidates = check_threshold_crossings(
+            trajectory, thresholds, None, GlucoseUnit.MMOL
+        )
+        predicted = [c for c in candidates if c.source == "predictive"]
+        assert predicted
+        assert "mmol/L" in predicted[0].message
+        assert "mg/dL" not in predicted[0].message
 
     def test_current_high_warning(self):
         """Current glucose at high_warning should trigger HIGH_WARNING."""
@@ -348,6 +382,11 @@ class TestEvaluateAlertsForUser:
                 "src.services.predictive_alerts.get_user_dia",
                 new_callable=AsyncMock,
                 return_value=4.0,
+            ),
+            patch(
+                "src.services.predictive_alerts.resolve_glucose_unit",
+                new_callable=AsyncMock,
+                return_value=GlucoseUnit.MGDL,
             ),
         ):
             result = await evaluate_alerts_for_user(mock_db, user_id)

--- a/apps/api/tests/test_safety_validation.py
+++ b/apps/api/tests/test_safety_validation.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from httpx import ASGITransport, AsyncClient
 
 from src.config import settings
+from src.core.units import GlucoseUnit
 from src.main import app
 from src.schemas.safety_validation import SafetyStatus, SuggestionType
 from src.services.safety_validation import (
@@ -210,6 +211,57 @@ class TestExtractISFChanges:
         flagged = _extract_isf_changes(text)
         assert len(flagged) == 0
 
+    # ── The ±20% ISF flag must still fire when the model reports in mmol/L ──
+
+    def test_mmol_isf_exceeds_bounds_flagged(self):
+        """A >20% ISF change suffixed mmol/L still fires the over-change flag."""
+        # 1:2.8 to 1:2.0 = 28.6% change
+        text = "Consider adjusting correction factor from 1:2.8 to 1:2.0 mmol/L."
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 1
+        assert flagged[0].suggestion_type == SuggestionType.CORRECTION_FACTOR
+        assert flagged[0].original_value == 2.8
+        assert flagged[0].suggested_value == 2.0
+        # Reason echoes the unit the model actually used, not mg/dL.
+        assert "mmol/L" in flagged[0].reason
+        assert "mg/dL" not in flagged[0].reason
+
+    def test_mmol_isf_within_bounds_not_flagged(self):
+        """A ≤20% ISF change suffixed mmol/L is not flagged (parity with mg/dL)."""
+        # 1:2.8 to 1:2.6 = 7.1% change
+        text = "Consider moving from 1:2.8 to 1:2.6 mmol/L for mornings."
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 0
+
+    def test_mmol_isf_context_keyword_without_prefix(self):
+        """mmol/L ISF stated without a 1: prefix is still caught by context."""
+        text = "Your ISF should change from 2.8 to 2.0 mmol/L for mornings."
+        flagged = _extract_isf_changes(text)
+        assert len(flagged) == 1
+        assert "mmol/L" in flagged[0].reason
+
+    def test_mmol_suffix_distinguishes_isf_from_carb_ratio(self):
+        """A 1:X change suffixed mmol/L is an ISF, never a carb ratio -- the
+        negative lookahead must exclude it from the carb-ratio matcher."""
+        text = "Adjust from 1:8 to 1:5 mmol/L."
+        assert len(_extract_carb_ratio_changes(text)) == 0
+        isf = _extract_isf_changes(text)
+        assert len(isf) == 1
+        assert isf[0].suggestion_type == SuggestionType.CORRECTION_FACTOR
+
+    def test_decimal_mmol_isf_not_partially_matched_as_carb_ratio(self):
+        """A *decimal* mmol/L ISF (routine for mmol correction factors) must not
+        be truncated to its integer part and mis-flagged as a carb ratio -- the
+        lookahead's `(?!\\.\\d)` guard prevents consuming `1:3.5 to 1:2` out of
+        `1:3.5 to 1:2.5 mmol/L`. It must flag ONLY as a correction factor."""
+        text = "Consider correction factor from 1:3.5 to 1:2.5 mmol/L."  # 28.6%
+        assert len(_extract_carb_ratio_changes(text)) == 0
+        isf = _extract_isf_changes(text)
+        assert len(isf) == 1
+        assert isf[0].suggestion_type == SuggestionType.CORRECTION_FACTOR
+        assert isf[0].original_value == 3.5
+        assert isf[0].suggested_value == 2.5
+
 
 class TestValidateAISuggestion:
     """Tests for validate_ai_suggestion."""
@@ -402,7 +454,7 @@ class TestMealAnalysisSafetyIntegration:
         )
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         analysis = await generate_meal_analysis(mock_user, mock_db, days=7)
@@ -461,7 +513,7 @@ class TestMealAnalysisSafetyIntegration:
         )
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         analysis = await generate_meal_analysis(mock_user, mock_db, days=7)
@@ -531,7 +583,7 @@ class TestCorrectionAnalysisSafetyIntegration:
         )
         mock_get_client.return_value = mock_client
 
-        mock_user = SimpleNamespace(id=uuid.uuid4())
+        mock_user = SimpleNamespace(id=uuid.uuid4(), glucose_unit=GlucoseUnit.MGDL)
         mock_db = AsyncMock()
 
         analysis = await generate_correction_analysis(mock_user, mock_db, days=7)

--- a/apps/api/tests/test_telegram_caregiver.py
+++ b/apps/api/tests/test_telegram_caregiver.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.core.units import GlucoseUnit
 from src.models.caregiver_link import CaregiverLink
 from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.user import User, UserRole
@@ -26,12 +27,14 @@ from src.services.telegram_caregiver import (
 def make_user(
     role: UserRole = UserRole.DIABETIC,
     email: str = "patient@example.com",
+    glucose_unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> MagicMock:
     """Create a mock User."""
     user = MagicMock(spec=User)
     user.id = uuid.uuid4()
     user.email = email
     user.role = role
+    user.glucose_unit = glucose_unit
     return user
 
 
@@ -155,6 +158,34 @@ class TestHandleCaregiverStatus:
         assert "110 mg/dL" in result
         assert "200 mg/dL" in result
         assert "Linked Patients" in result
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.dexcom_sync.get_latest_glucose_reading", new_callable=AsyncMock
+    )
+    @patch("src.services.caregiver.check_caregiver_permission", new_callable=AsyncMock)
+    async def test_multiple_patients_each_in_own_unit(self, mock_perm, mock_glucose):
+        """Each patient's glucose renders in THAT patient's own unit within the
+        same status message -- a regression to one shared unit must fail here."""
+        mock_perm.return_value = True
+        patient_mgdl = make_user(
+            email="alice@example.com", glucose_unit=GlucoseUnit.MGDL
+        )
+        patient_mmol = make_user(email="bob@example.com", glucose_unit=GlucoseUnit.MMOL)
+        caregiver_id = uuid.uuid4()
+        link1 = make_link(caregiver_id=caregiver_id, patient=patient_mgdl)
+        link2 = make_link(caregiver_id=caregiver_id, patient=patient_mmol)
+
+        # Same stored mg/dL value (200) so only the per-patient unit differs.
+        mock_glucose.side_effect = [make_reading(value=200), make_reading(value=200)]
+
+        db = AsyncMock()
+        result = await _handle_caregiver_status(db, caregiver_id, [link1, link2])
+
+        assert "alice@example.com" in result
+        assert "200 mg/dL" in result  # mg/dL patient
+        assert "bob@example.com" in result
+        assert "11.1 mmol/L" in result  # mmol patient: 200 -> 11.1
 
     @pytest.mark.asyncio
     @patch(

--- a/apps/api/tests/test_telegram_chat.py
+++ b/apps/api/tests/test_telegram_chat.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.core.units import GlucoseUnit
 from src.models.ai_provider import AIProviderType
 from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.user import User
@@ -25,9 +26,11 @@ from src.services.telegram_chat import (
     SAFETY_DISCLAIMER,
     TELEGRAM_MAX_LENGTH,
     WEB_MAX_RESPONSE_TOKENS,
+    _build_caregiver_system_prompt,
     _build_system_prompt,
     _resolve_max_tokens_for_user,
     _truncate_response,
+    handle_caregiver_chat,
     handle_chat,
 )
 
@@ -178,6 +181,25 @@ class TestBuildGlucoseSection:
         assert "[Glucose - last 6h]" in result
         assert "150 mg/dL" in result
         assert "Readings: 10" in result
+
+    @pytest.mark.asyncio
+    async def test_renders_mmol_unit(self):
+        """Glucose figures convert (150->8.3) and the TIR membership math
+        stays mg/dL while the displayed default anchors convert (70-180 ->
+        3.9-10.0)."""
+        readings = [make_reading(value=150, trend_rate=1.5, minutes_ago=3)]
+        readings += [make_reading(value=120, minutes_ago=i * 5) for i in range(1, 10)]
+
+        db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = readings
+        db.execute = AsyncMock(side_effect=[mock_result, _mock_none_scalar()])
+
+        result = await build_glucose_section(db, uuid.uuid4(), GlucoseUnit.MMOL)
+
+        assert "Current: 8.3 mmol/L" in result
+        assert "Time in range (3.9-10.0)" in result
+        assert "mg/dL" not in result
 
     @pytest.mark.asyncio
     async def test_uses_custom_target_range_for_tir(self):
@@ -750,6 +772,23 @@ class TestBuildSystemPrompt:
         assert "pump activity" in prompt.lower() or "Control-IQ" in prompt
         assert "basal rates" in prompt or "correction frequency" in prompt
 
+    def test_states_report_unit(self):
+        """The report-in-unit instruction is appended per request."""
+        assert "Report all glucose values in mg/dL" in _build_system_prompt(
+            "", GlucoseUnit.MGDL
+        )
+        assert "Report all glucose values in mmol/L" in _build_system_prompt(
+            "", GlucoseUnit.MMOL
+        )
+
+    def test_caregiver_prompt_uses_passed_unit(self):
+        """The caregiver prompt reports in the supplied unit (the patient's)."""
+        prompt = _build_caregiver_system_prompt(
+            "patient@example.com", "", GlucoseUnit.MMOL
+        )
+        assert "Report all glucose values in mmol/L" in prompt
+        assert "Patient: patient@example.com" in prompt
+
 
 # ---------------------------------------------------------------------------
 # _truncate_response tests
@@ -1191,3 +1230,32 @@ class TestResolveMaxTokensForUser:
                 db, user, WEB_MAX_RESPONSE_TOKENS
             )
         assert result == WEB_MAX_RESPONSE_TOKENS
+
+
+class TestCaregiverChatPatientUnit:
+    """Caregiver chat renders the PATIENT's unit."""
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat.build_diabetes_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_context_built_in_patient_unit(self, mock_get_client, mock_context):
+        """The context is built for the PATIENT in the PATIENT's unit, never
+        the caregiver's."""
+        mock_context.return_value = "[Glucose]\n- Current: 6.7 mmol/L (stable)"
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("Looks stable.")
+        mock_get_client.return_value = mock_client
+
+        patient = make_user()
+        patient.glucose_unit = GlucoseUnit.MMOL
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = patient
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        await handle_caregiver_chat(db, uuid.uuid4(), patient.id, "How is my patient?")
+
+        mock_context.assert_awaited_once()
+        args, kwargs = mock_context.call_args
+        assert args[1] == patient.id  # context built for the patient
+        assert kwargs["unit"] == GlucoseUnit.MMOL  # in the patient's unit

--- a/apps/api/tests/test_telegram_commands.py
+++ b/apps/api/tests/test_telegram_commands.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.core.units import GlucoseUnit
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.daily_brief import DailyBrief
 from src.models.glucose import GlucoseReading, TrendDirection
@@ -176,6 +177,17 @@ class TestGetUserIdByChatId:
 class TestHandleStatus:
     """Tests for _handle_status."""
 
+    @pytest.fixture(autouse=True)
+    def _mgdl_unit(self):
+        # _handle_status resolves the patient's unit before rendering; default it
+        # to mg/dL so the existing assertions check a real resolved unit rather
+        # than passing on MagicMock truthiness. The mmol test overrides this.
+        with patch(
+            "src.services.telegram_commands.resolve_glucose_unit",
+            new=AsyncMock(return_value=GlucoseUnit.MGDL),
+        ):
+            yield
+
     @pytest.mark.asyncio
     @patch(
         "src.services.telegram_commands.get_user_dia",
@@ -278,6 +290,33 @@ class TestHandleStatus:
 
         assert "falling" in msg.lower()
 
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_commands.resolve_glucose_unit",
+        new=AsyncMock(return_value=GlucoseUnit.MMOL),
+    )
+    @patch(
+        "src.services.telegram_commands.get_user_dia",
+        new_callable=AsyncMock,
+        return_value=4.0,
+    )
+    @patch("src.services.telegram_commands.get_iob_projection", new_callable=AsyncMock)
+    async def test_renders_mmol_unit(self, mock_iob, mock_dia):
+        """An mmol/L patient's /status renders glucose in mmol (120 -> 6.7);
+        mg/dL must not appear."""
+        mock_iob.return_value = None
+
+        reading = make_reading(value=120, trend_rate=0.5)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = reading
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        msg = await _handle_status(db, uuid.uuid4())
+
+        assert "6.7 mmol/L" in msg
+        assert "mg/dL" not in msg
+
 
 # ---------------------------------------------------------------------------
 # /acknowledge command tests
@@ -367,6 +406,10 @@ class TestHandleBrief:
     """Tests for _handle_brief."""
 
     @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_commands.resolve_glucose_unit",
+        new=AsyncMock(return_value=GlucoseUnit.MGDL),
+    )
     @patch("src.services.telegram_commands.list_briefs", new_callable=AsyncMock)
     @patch("src.services.telegram_commands.format_brief_message")
     async def test_latest_brief_returned(self, mock_format, mock_list):
@@ -377,7 +420,7 @@ class TestHandleBrief:
         msg = await _handle_brief(AsyncMock(), uuid.uuid4())
 
         assert "Daily Brief" in msg
-        mock_format.assert_called_once_with(brief)
+        mock_format.assert_called_once_with(brief, GlucoseUnit.MGDL)
 
     @pytest.mark.asyncio
     @patch("src.services.telegram_commands.list_briefs", new_callable=AsyncMock)
@@ -389,6 +432,10 @@ class TestHandleBrief:
         assert "No daily briefs" in msg
 
     @pytest.mark.asyncio
+    @patch(
+        "src.services.telegram_commands.resolve_glucose_unit",
+        new=AsyncMock(return_value=GlucoseUnit.MGDL),
+    )
     @patch("src.services.telegram_commands.list_briefs", new_callable=AsyncMock)
     @patch("src.services.telegram_commands.format_brief_message")
     async def test_reuses_format_brief_message(self, mock_format, mock_list):
@@ -398,7 +445,7 @@ class TestHandleBrief:
 
         await _handle_brief(AsyncMock(), uuid.uuid4())
 
-        mock_format.assert_called_once_with(brief)
+        mock_format.assert_called_once_with(brief, GlucoseUnit.MGDL)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The AI assistant's context, chat replies, daily briefs, correction/meal analyses, and alert/Telegram messages now state glucose values in the user's preferred unit (mg/dL or mmol/L) instead of always mg/dL.

This is a backend presentation layer at the prompt and notifier boundary: stored glucose stays canonical mg/dL and all glucose math (time-in-range, alert thresholds, spike detection, GMI/eAG) is unchanged — only the displayed/spoken number and its label convert. mg/dL output is byte-identical to the previous hand-written strings, so existing mg/dL users see no change.

## What changed
- **Shared formatters** in `core/units.py` routed through the single 18.0156 factor (`format_glucose`, `format_glucose_range`/`_value`/`_rate`, the correction-factor formatter, the report-in-unit prompt instruction, and a rounding-tolerant comparison helper). The conventional clinical anchors fall out of the factor: 70→3.9, 180→10.0, 120→6.7, 100→5.6.
- **Context + prompts**: the diabetes-context builders, the daily-brief / correction / meal prompts and system prompts, and all four chat handlers render glucose in the data owner's unit and instruct the model to report in it.
- **Caregiver & escalation** render the patient's unit, never the caregiver's or emergency contact's.
- **Notifications**: alert, escalation, brief, and `/status` Telegram text — and the persisted predictive `Alert.message` (rendered at persist) — use the patient's unit.
- **Safety validators**: the ISF and carb-ratio regexes accept mmol/L as well as mg/dL, so the ±20% correction-factor over-change flag still fires under mmol and an ISF is never misread as a carb ratio.

The configured correction factor is a glucose drop per insulin unit (the same quantity as the observed ISF), so it converts with the rest (`CF 1:50` → `1:2.8`); the carb ratio is grams per unit and stays in its native notation.

## Testing
- New `tests/test_glucose_units.py`: formatters, anchors, resolver, tolerance helper, and a 481-case round-trip no-drift property test.
- Every changed builder / prompt / alert / chat / safety path is parameterized by unit (mg/dL byte-identical assertions + mmol fixtures), including a mixed-unit caregiver-status test (each patient in their own unit) and a mmol `/status` test.
- Full API suite green (3469 passed, 14 skipped); `ruff check` + `ruff format --check` clean on `src/` and `tests/`.
- A Sentry-enabled validation run on seeded mmol data exercised the context / alert / brief paths through a live DB session with zero error-level issues.

## Notes for reviewers
- `glucose_display_matches` in `core/units.py` has no caller in this PR by design — it's the rounding-tolerant comparison slice the end-to-end spoken-glucose citation-verification work will consume. It is fully unit-tested and underpins the round-trip no-drift property test here.

Closes #760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Glucose values now render in each patient’s configured display unit (mg/dL or mmol/L) across alerts, escalation contacts, daily briefs, Telegram chat/commands, and caregiver/status outputs.
  * AI-generated prompts and analyses now explicitly request glucose reporting in the patient’s chosen unit, including ranges and guidance examples.
  * Insulin sensitivity and correction-factor values are displayed using the selected unit/precision.

* **Tests**
  * Added extensive unit tests to verify correct conversion, formatting, unit consistency in AI prompts, and safety validation behavior for both mg/dL and mmol/L.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->