### PR TITLE
feat: render glucose alerts and caregiver views in the user's unit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -109,7 +109,10 @@ reviews:
         - Proper pytest patterns: fixtures, parametrize, clear arrange/act/assert.
         - Mock isolation: external services (Dexcom, Tandem, AI providers) must
           be mocked, never called in tests.
-        - Edge cases: empty data, null values, boundary glucose values (40-400 mg/dL).
+        - Edge cases: empty data, null values, and the canonical glucose safety
+          bounds (20 and 500 mg/dL). For unit-conversion/display code, also their
+          mmol/L equivalents (about 1.1 and 27.8 mmol/L); a mmol/L literal in
+          display or test code is not a bounds violation.
 
     - path: "apps/web/**/*.{ts,tsx}"
       instructions: |
@@ -147,9 +150,12 @@ reviews:
           operation serialization, timeout handling.
         - Security: encrypted SharedPreferences for tokens, no sensitive data
           in logs.
-        - Medical safety: glucose values must be validated (range 20-500 mg/dL),
-          insulin doses must have hard caps, no auto-bolus without explicit user
-          confirmation.
+        - Medical safety: glucose is stored and compared in canonical mg/dL and
+          must be validated to the 20-500 mg/dL range; insulin doses must have
+          hard caps, no auto-bolus without explicit user confirmation. A
+          user-facing mmol/L display literal is not a bounds violation, but any
+          value persisted or compared as glucose must be canonical mg/dL in
+          20-500.
 
     - path: "plugins/pump-driver-api/**/*.kt"
       instructions: |
@@ -284,7 +290,24 @@ reviews:
         instructions: |
           If the PR modifies code that handles glucose values, insulin doses,
           bolus calculations, or pump commands:
-          - Verify glucose values are bounds-checked (20-500 mg/dL range).
+          - Glucose is STORED and COMPARED in canonical mg/dL. Verify every
+            persisted column, Pydantic bound, threshold/alert comparison, dedup
+            key, and safety check stays in mg/dL and is bounds-checked to the
+            20-500 mg/dL range.
+          - mmol/L is a DISPLAY and INPUT unit only. The single allowed
+            conversion factor is 18.0156 (mg/dL per mmol/L). Hard-FAIL if a
+            mapper, threshold, or input handler:
+              * stores or compares a mmol/L value as if it were mg/dL (e.g.
+                persisting 3.9 instead of ~70 -- this silently suppresses low
+                alerts), or
+              * converts the wrong direction (multiplies when it should divide,
+                or vice versa), or
+              * permits a stored mg/dL value outside 20-500 after conversion, or
+              * uses a conversion factor other than 18.0156 (e.g. 18.02, 18.0182).
+          - Do NOT flag a user-facing mmol/L display literal (e.g. 3.9, 10.0,
+            22.2) or a mmol/L input that is converted to mg/dL before storage as
+            a bounds violation -- only the stored/compared mg/dL value must
+            satisfy 20-500.
           - Verify insulin dose calculations have hard maximum caps.
           - Verify no auto-bolus logic exists without explicit user confirmation.
           - Verify AI-generated suggestions include safety disclaimers.

--- a/apps/api/src/routers/caregivers.py
+++ b/apps/api/src/routers/caregivers.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import CurrentUser, require_caregiver, require_diabetic
 from src.core.security import hash_password
+from src.core.units import GlucoseUnit
 from src.database import get_db
 from src.logging_config import get_logger
 from src.models.caregiver_link import CaregiverLink
@@ -462,11 +463,17 @@ async def get_caregiver_patient_status(
 
     glucose_data: CaregiverGlucoseData | None = None
     iob_data: CaregiverIoBData | None = None
+    # The PATIENT's display unit (never the caregiver's). Only meaningful when a
+    # glucose value is returned, so it is resolved inside the glucose block and
+    # defaults to mg/dL otherwise.
+    glucose_unit = GlucoseUnit.MGDL
 
     # Glucose data (if permitted)
     if permissions.can_view_glucose:
         from src.services.dexcom_sync import get_latest_glucose_reading
+        from src.services.glucose_unit import resolve_glucose_unit
 
+        glucose_unit = await resolve_glucose_unit(db, patient_id)
         reading = await get_latest_glucose_reading(db, patient_id)
         if reading is not None:
             now = datetime.now(UTC)
@@ -507,6 +514,7 @@ async def get_caregiver_patient_status(
         glucose=glucose_data,
         iob=iob_data,
         permissions=permissions,
+        glucose_unit=glucose_unit,
     )
 
 

--- a/apps/api/src/routers/caregivers.py
+++ b/apps/api/src/routers/caregivers.py
@@ -464,18 +464,19 @@ async def get_caregiver_patient_status(
     glucose_data: CaregiverGlucoseData | None = None
     iob_data: CaregiverIoBData | None = None
     # The PATIENT's display unit (never the caregiver's). Only meaningful when a
-    # glucose value is returned, so it is resolved inside the glucose block and
-    # defaults to mg/dL otherwise.
+    # glucose value is actually returned, so it is resolved alongside the reading
+    # and defaults to mg/dL otherwise.
     glucose_unit = GlucoseUnit.MGDL
 
     # Glucose data (if permitted)
     if permissions.can_view_glucose:
         from src.services.dexcom_sync import get_latest_glucose_reading
-        from src.services.glucose_unit import resolve_glucose_unit
 
-        glucose_unit = await resolve_glucose_unit(db, patient_id)
         reading = await get_latest_glucose_reading(db, patient_id)
         if reading is not None:
+            from src.services.glucose_unit import resolve_glucose_unit
+
+            glucose_unit = await resolve_glucose_unit(db, patient_id)
             now = datetime.now(UTC)
             delta = now - reading.reading_timestamp
             minutes_ago = int(delta.total_seconds() / 60)

--- a/apps/api/src/schemas/caregiver_dashboard.py
+++ b/apps/api/src/schemas/caregiver_dashboard.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
+from src.core.units import GlucoseUnit
 from src.schemas.caregiver_permissions import CaregiverPermissions
 
 
@@ -48,6 +49,11 @@ class CaregiverPatientStatus(BaseModel):
     glucose: CaregiverGlucoseData | None = None
     iob: CaregiverIoBData | None = None
     permissions: CaregiverPermissions
+    # The PATIENT's preferred display unit (never the viewing caregiver's). The
+    # glucose ``value`` stays canonical mg/dL; this only tells the client which
+    # unit to render it in, so a caregiver sees their patient's reading in the
+    # patient's own unit.
+    glucose_unit: GlucoseUnit = GlucoseUnit.MGDL
 
 
 class CaregiverGlucoseHistoryReading(BaseModel):

--- a/apps/api/tests/test_alert_sse.py
+++ b/apps/api/tests/test_alert_sse.py
@@ -210,3 +210,82 @@ class TestAlertEventPayload:
 
         for field in required_fields:
             assert field in parsed, f"Missing required field: {field}"
+
+    @patch("src.routers.glucose_stream.get_active_alerts")
+    @patch("src.routers.glucose_stream.get_latest_glucose_reading")
+    @patch(
+        "src.routers.glucose_stream.get_user_dia",
+        new_callable=AsyncMock,
+        return_value=4.0,
+    )
+    @patch("src.routers.glucose_stream.get_iob_projection")
+    @patch("src.routers.glucose_stream.get_db_session")
+    async def test_alert_payload_numerics_are_canonical_mgdl_without_unit_tag(
+        self, mock_db_session, mock_iob, mock_dia, mock_glucose, mock_alerts
+    ):
+        """The emitted SSE alert payload keeps current/predicted as canonical
+        mg/dL floats and carries NO unit tag. The web client converts off the
+        viewer's own glucose-unit preference, never off the payload, so nothing
+        double-interprets; mobile keeps mg/dL until a later unit story adds an
+        explicit tag plus numeric conversion verified with a mobile consumer.
+        """
+        from enum import Enum
+
+        class MockAlertType(Enum):
+            low_urgent = "low_urgent"
+
+        class MockSeverity(Enum):
+            emergency = "emergency"
+
+        mock_alert = MagicMock()
+        mock_alert.id = uuid.uuid4()
+        mock_alert.alert_type = MockAlertType.low_urgent
+        mock_alert.severity = MockSeverity.emergency
+        mock_alert.current_value = 70.0
+        mock_alert.predicted_value = 65.0
+        mock_alert.prediction_minutes = 15
+        mock_alert.iob_value = None
+        # The message is rendered in the patient's unit at persist (may be mmol);
+        # the numeric fields below stay canonical mg/dL.
+        mock_alert.message = "Urgent low glucose: 3.9 mmol/L"
+        mock_alert.trend_rate = -2.0
+        mock_alert.source = "predictive"
+        mock_alert.created_at = datetime.now(UTC)
+        mock_alert.expires_at = datetime.now(UTC) + timedelta(minutes=30)
+        mock_alerts.return_value = [mock_alert]
+        mock_glucose.return_value = None
+        mock_iob.return_value = None
+
+        mock_session = AsyncMock()
+        mock_db_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_db_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        mock_request = MagicMock()
+        call_count = 0
+
+        async def mock_is_disconnected():
+            nonlocal call_count
+            call_count += 1
+            return call_count > 2
+
+        mock_request.is_disconnected = mock_is_disconnected
+
+        events = []
+        with patch("asyncio.sleep", AsyncMock()):
+            async for event in generate_glucose_stream(
+                "00000000-0000-0000-0000-000000000001", mock_request
+            ):
+                events.append(event)
+
+        alert_events = [e for e in events if "event: alert" in e]
+        assert len(alert_events) == 1
+        data_line = [
+            line for line in alert_events[0].split("\n") if line.startswith("data:")
+        ][0]
+        parsed = json.loads(data_line[5:].strip())
+        # Numerics are canonical mg/dL, untouched by any unit preference.
+        assert parsed["current_value"] == 70.0
+        assert parsed["predicted_value"] == 65.0
+        # No unit tag on the payload (recorded decision for this cut).
+        assert "glucose_unit" not in parsed
+        assert "unit" not in parsed

--- a/apps/api/tests/test_caregiver_dashboard.py
+++ b/apps/api/tests/test_caregiver_dashboard.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.core.units import GlucoseUnit
 from src.models.caregiver_link import CaregiverLink
 from src.models.user import User, UserRole
 from src.schemas.caregiver_permissions import CaregiverPermissions
@@ -302,8 +303,15 @@ class TestStatusEndpointIntegration:
         # Mock for patient email lookup
         mock_email_result = MagicMock()
         mock_email_result.scalar_one_or_none.return_value = "patient@example.com"
+        # Mock for the patient's glucose-unit lookup (resolve_glucose_unit)
+        mock_unit_result = MagicMock()
+        mock_unit_result.scalar_one_or_none.return_value = GlucoseUnit.MGDL
 
-        db.execute.side_effect = [mock_link_result, mock_email_result]
+        db.execute.side_effect = [
+            mock_link_result,
+            mock_email_result,
+            mock_unit_result,
+        ]
 
         mock_user = MagicMock()
         mock_user.id = caregiver_id
@@ -333,12 +341,66 @@ class TestStatusEndpointIntegration:
 
         assert result.patient_id == patient_id
         assert result.patient_email == "patient@example.com"
+        assert result.glucose_unit == GlucoseUnit.MGDL
+        # The value stays canonical mg/dL; only the unit token selects display.
         assert result.glucose is not None
         assert result.glucose.value == 145
         assert result.iob is not None
         assert result.iob.current_iob == projection.projected_iob
         assert result.permissions.can_view_glucose is True
         assert result.permissions.can_view_iob is True
+
+    @pytest.mark.asyncio
+    async def test_status_renders_each_patient_in_their_own_unit(self):
+        """A caregiver watching a mmol patient and a mg/dL patient gets each
+        patient's OWN unit on the status payload (never the caregiver's). The
+        glucose value stays canonical mg/dL regardless of the display unit.
+        """
+        from src.routers.caregivers import get_caregiver_patient_status
+
+        caregiver_id = uuid.uuid4()
+
+        async def status_for(patient_unit: GlucoseUnit):
+            patient_id = uuid.uuid4()
+            link = make_link(
+                caregiver_id=caregiver_id,
+                patient_id=patient_id,
+                can_view_glucose=True,
+                can_view_iob=False,
+            )
+            db = AsyncMock()
+            mock_link_result = MagicMock()
+            mock_link_result.scalar_one_or_none.return_value = link
+            mock_email_result = MagicMock()
+            mock_email_result.scalar_one_or_none.return_value = "p@example.com"
+            mock_unit_result = MagicMock()
+            mock_unit_result.scalar_one_or_none.return_value = patient_unit
+            db.execute.side_effect = [
+                mock_link_result,
+                mock_email_result,
+                mock_unit_result,
+            ]
+            mock_user = MagicMock()
+            mock_user.id = caregiver_id
+            with patch(
+                "src.services.dexcom_sync.get_latest_glucose_reading",
+                new_callable=AsyncMock,
+                return_value=make_glucose_reading(value=90),
+            ):
+                return await get_caregiver_patient_status(
+                    patient_id=patient_id,
+                    current_user=mock_user,
+                    db=db,
+                )
+
+        mmol_status = await status_for(GlucoseUnit.MMOL)
+        mgdl_status = await status_for(GlucoseUnit.MGDL)
+
+        assert mmol_status.glucose_unit == GlucoseUnit.MMOL
+        assert mgdl_status.glucose_unit == GlucoseUnit.MGDL
+        # Same canonical mg/dL value regardless of the display unit.
+        assert mmol_status.glucose.value == 90
+        assert mgdl_status.glucose.value == 90
 
     @pytest.mark.asyncio
     async def test_full_status_glucose_denied_omits_data(self):
@@ -374,6 +436,8 @@ class TestStatusEndpointIntegration:
         assert result.iob is None
         assert result.permissions.can_view_glucose is False
         assert result.permissions.can_view_iob is False
+        # No glucose shown -> the unit token defaults to mg/dL (and is unused).
+        assert result.glucose_unit == GlucoseUnit.MGDL
 
     @pytest.mark.asyncio
     async def test_unlinked_patient_raises_404(self):
@@ -451,6 +515,9 @@ class TestCaregiverDashboardSchemas:
         )
         assert status.glucose is None
         assert status.iob is None
+        # glucose_unit is optional and defaults to mg/dL (back-compat: callers
+        # that don't set it keep the canonical default).
+        assert status.glucose_unit == GlucoseUnit.MGDL
 
     def test_glucose_data_schema(self):
         """CaregiverGlucoseData validates all required fields."""

--- a/apps/api/tests/test_threshold_unit_round_trip.py
+++ b/apps/api/tests/test_threshold_unit_round_trip.py
@@ -1,0 +1,128 @@
+"""Round-trip + safety-bound property tests for mmol/L threshold input.
+
+The web converts a user's mmol/L threshold entry to integer mg/dL and clamps it
+to the canonical bound before it leaves the browser; the API stays canonical
+mg/dL and rejects out-of-range values via the Pydantic schema bounds. These
+tests guard that safety contract on the BACKEND side too -- the conversion
+factor (18.0156) and rounding are shared with the web, and Telegram/escalation
+are fire-and-forget (no runtime signal), so the round-trip and factor/anchor
+assertions below are the guard against a mis-converted threshold silently
+suppressing a life-safety alert.
+"""
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from src.core.units import MGDL_PER_MMOL, mgdl_to_mmol, mmol_to_mgdl
+from src.schemas.alert_threshold import AlertThresholdUpdate
+from src.schemas.safety_limits import SafetyLimitsUpdate
+from src.schemas.target_glucose_range import TargetGlucoseRangeUpdate
+
+# Canonical platform-wide glucose safety invariant.
+SAFETY_MIN_MGDL = 20
+SAFETY_MAX_MGDL = 500
+
+
+def _store_from_mmol(
+    mmol: float, lo: int = SAFETY_MIN_MGDL, hi: int = SAFETY_MAX_MGDL
+) -> int:
+    """Mirror the web save path: mmol/L entry -> integer mg/dL -> clamp to bound.
+
+    ``mmol_to_mgdl`` already rounds to an int (matching the web ``toStoredMgdl``);
+    the clamp matches the web ``clampMgdl`` so a 1-decimal boundary overshoot
+    (e.g. 27.8 mmol -> 501) never crosses the canonical ceiling.
+    """
+    return min(hi, max(lo, mmol_to_mgdl(mmol)))
+
+
+def _mmol_domain() -> list[float]:
+    """A 0.1-step sweep across (and beyond) the displayable mmol/L range."""
+    return [round(0.1 * n, 1) for n in range(5, 351)]  # 0.5 .. 35.0 mmol/L
+
+
+class TestMmolStorePathStaysInBounds:
+    """No mmol entry can write a sub-20 or super-500 mg/dL value."""
+
+    def test_clamped_store_is_always_within_the_safety_invariant(self):
+        for mmol in _mmol_domain():
+            stored = _store_from_mmol(mmol)
+            assert SAFETY_MIN_MGDL <= stored <= SAFETY_MAX_MGDL, (
+                f"{mmol} mmol stored as {stored} mg/dL escapes 20-500"
+            )
+
+    def test_hypo_floor_is_not_evaded_by_the_mmol_path(self):
+        # The classic hazard: storing 3.9 *as if mg/dL* instead of converting it.
+        # 3.9 mmol/L must persist as ~70 mg/dL (the hypo threshold), never 3.9.
+        assert mmol_to_mgdl(3.9) == 70
+        assert _store_from_mmol(3.9) == 70
+        # A direction error (dividing instead of multiplying) would yield ~0.2;
+        # the real conversion never produces a sub-floor value for a real reading.
+        assert _store_from_mmol(3.9) >= SAFETY_MIN_MGDL
+
+
+class TestMmolRoundTrip:
+    """A mmol entry round-trips to the same displayed mmol value."""
+
+    def test_round_trip_pins_the_canonical_conversion_factor(self):
+        # The round-trip below is self-consistent under any factor; these
+        # assertions pin the single canonical 18.0156 so a wrong factor (18.02 /
+        # 18.0182) fails here directly, not only in the core-units anchor tests.
+        assert MGDL_PER_MMOL == 18.0156
+        # Hard-coded expected mg/dL for known mmol entries (round(mmol*18.0156)).
+        assert mmol_to_mgdl(3.9) == 70
+        assert mmol_to_mgdl(5.6) == 101
+        assert mmol_to_mgdl(10.0) == 180
+
+    def test_clinical_anchors_round_trip_exactly(self):
+        # 70/180/120 mg/dL display as 3.9/10.0/6.7 mmol; entering those mmol
+        # values stores an integer mg/dL that displays as the same mmol again.
+        for mmol in (3.9, 10.0, 6.7):
+            assert mgdl_to_mmol(mmol_to_mgdl(mmol)) == mmol
+
+    def test_displayable_domain_round_trips_within_one_display_step(self):
+        # INT mg/dL storage means the mmol value may "snap" by at most one
+        # 0.1-mmol display step; it never drifts further (the rounding policy).
+        for mmol in [round(0.1 * n, 1) for n in range(11, 278)]:  # 1.1 .. 27.7
+            back = mgdl_to_mmol(mmol_to_mgdl(mmol))
+            assert math.isclose(back, mmol, abs_tol=0.1 + 1e-9), (
+                f"{mmol} mmol -> {mmol_to_mgdl(mmol)} mg/dL -> {back} mmol drifts"
+            )
+
+    def test_int_column_rounding_is_what_the_user_sees(self):
+        # SafetyLimits min/max are INT columns. 5.5 mmol persists as 99
+        # mg/dL and re-displays as 5.5 -- the persisted value the UI surfaces.
+        stored = mmol_to_mgdl(5.5)
+        assert stored == 99
+        assert mgdl_to_mmol(stored) == 5.5
+
+
+class TestSchemaBoundsRejectOutOfRangeMmolEntries:
+    """The Pydantic mg/dL bounds reject a mmol entry that converts out of range,
+    so the mmol input path cannot evade the canonical limits."""
+
+    def test_alert_threshold_rejects_dangerously_low_urgent_low(self):
+        # 1.0 mmol -> 18 mg/dL, below urgent_low's 30 mg/dL floor.
+        with pytest.raises(ValidationError):
+            AlertThresholdUpdate(urgent_low=float(mmol_to_mgdl(1.0)))
+
+    def test_alert_threshold_accepts_in_range_converted_value(self):
+        # 3.1 mmol -> 56 mg/dL, within urgent_low's 30-80 mg/dL range.
+        model = AlertThresholdUpdate(urgent_low=float(mmol_to_mgdl(3.1)))
+        assert model.urgent_low == 56
+
+    def test_target_range_rejects_super_ceiling_urgent_high(self):
+        # 30 mmol -> 540 mg/dL, above urgent_high's 500 mg/dL ceiling.
+        with pytest.raises(ValidationError):
+            TargetGlucoseRangeUpdate(urgent_high=float(mmol_to_mgdl(30.0)))
+
+    def test_safety_limits_rejects_sub_floor_min_glucose(self):
+        # 0.5 mmol -> 9 mg/dL, below the 20 mg/dL floor.
+        with pytest.raises(ValidationError):
+            SafetyLimitsUpdate(min_glucose_mgdl=mmol_to_mgdl(0.5))
+
+    def test_safety_limits_accepts_in_range_converted_min_glucose(self):
+        # 3.9 mmol -> 70 mg/dL, within min_glucose's 20-499 range.
+        model = SafetyLimitsUpdate(min_glucose_mgdl=mmol_to_mgdl(3.9))
+        assert model.min_glucose_mgdl == 70

--- a/apps/web/__tests__/caregiver/page.test.tsx
+++ b/apps/web/__tests__/caregiver/page.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Caregiver dashboard renders each patient's glucose in the PATIENT's own unit
+ * (never the viewing caregiver's), while the glucose color / status bands stay
+ * computed from the raw mg/dL value. Guards the per-patient (overview cards) vs
+ * selected-patient (detail view) unit resolution and the mg/dL-banding contract.
+ */
+
+import { render, screen } from "@testing-library/react";
+import {
+  listLinkedPatients,
+  getCaregiverPatientStatus,
+  type CaregiverPatientStatus,
+} from "@/lib/api";
+
+jest.mock("@/lib/api");
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn() }),
+  usePathname: () => "/dashboard/caregiver",
+}));
+
+// The viewer is a caregiver; the page must render PATIENT units, not a viewer
+// unit, so it deliberately does NOT call useGlucoseUnit.
+jest.mock("@/providers", () => ({
+  useUserContext: () => ({
+    user: { id: "cg1", email: "cg@example.com", role: "caregiver" },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Chat card is gated off below; stub the markdown renderer so importing the
+// page never pulls heavy markdown deps into jsdom.
+jest.mock("@/components/ui/markdown-content", () => ({
+  MarkdownContent: () => null,
+}));
+
+import CaregiverDashboardPage from "@/app/dashboard/caregiver/page";
+
+const mockListPatients = listLinkedPatients as jest.Mock;
+const mockGetStatus = getCaregiverPatientStatus as jest.Mock;
+
+function makeStatus(
+  patientId: string,
+  email: string,
+  unit: "mmol" | "mgdl",
+  valueMgdl: number
+): CaregiverPatientStatus {
+  return {
+    patient_id: patientId,
+    patient_email: email,
+    glucose: {
+      value: valueMgdl,
+      trend: "Flat",
+      trend_rate: null,
+      reading_timestamp: "2026-06-21T12:00:00Z",
+      minutes_ago: 2,
+      is_stale: false,
+    },
+    iob: null,
+    permissions: {
+      can_view_glucose: true,
+      can_view_history: true,
+      can_view_iob: false,
+      can_view_ai_suggestions: false,
+      can_receive_alerts: true,
+    },
+    glucose_unit: unit,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("caregiver overview — per-patient unit, mg/dL color bands", () => {
+  it("renders two patients with the SAME stored value in each patient's own unit", async () => {
+    // Same canonical 90 mg/dL for both; only the display unit differs.
+    mockListPatients.mockResolvedValue({
+      count: 2,
+      patients: [
+        { patient_id: "A", patient_email: "amy@example.com", linked_at: "" },
+        { patient_id: "B", patient_email: "bob@example.com", linked_at: "" },
+      ],
+    });
+    mockGetStatus.mockImplementation((id: string) =>
+      Promise.resolve(
+        id === "A"
+          ? makeStatus("A", "amy@example.com", "mmol", 90)
+          : makeStatus("B", "bob@example.com", "mgdl", 90)
+      )
+    );
+
+    render(<CaregiverDashboardPage />);
+
+    // Patient A: 90 mg/dL renders as 5.0 mmol/L; patient B as 90 mg/dL — proving
+    // per-patient resolution, not one shared/viewer unit.
+    const aValue = await screen.findByText("5.0");
+    expect(screen.getByText("90")).toBeInTheDocument();
+    expect(screen.getByText("mmol/L")).toBeInTheDocument();
+    expect(screen.getByText("mg/dL")).toBeInTheDocument();
+
+    // The band reads the RAW mg/dL value: 90 mg/dL is in-range (green). A naive
+    // band of the displayed "5.0" would be < 70 -> red, so green proves the band
+    // is unaffected by the display unit.
+    expect(aValue).toHaveClass("text-green-400");
+    expect(screen.getByText("90")).toHaveClass("text-green-400");
+  });
+});
+
+describe("caregiver detail — selected patient unit, mg/dL color band", () => {
+  it("renders the selected patient in their unit and bands a low value by mg/dL", async () => {
+    // Single patient auto-selects into the detail view. 75 mg/dL is in the
+    // low-warning band (yellow); the displayed 4.2 mmol naively banded would be
+    // < 70 -> red, so yellow proves the detail view also bands on raw mg/dL.
+    mockListPatients.mockResolvedValue({
+      count: 1,
+      patients: [{ patient_id: "A", patient_email: "amy@example.com", linked_at: "" }],
+    });
+    mockGetStatus.mockResolvedValue(makeStatus("A", "amy@example.com", "mmol", 75));
+
+    render(<CaregiverDashboardPage />);
+
+    const value = await screen.findByText("4.2"); // 75 mg/dL -> 4.2 mmol/L
+    expect(screen.getByText("mmol/L")).toBeInTheDocument();
+    expect(value).toHaveClass("text-yellow-400");
+  });
+});

--- a/apps/web/__tests__/components/dashboard/alert-card.test.tsx
+++ b/apps/web/__tests__/components/dashboard/alert-card.test.tsx
@@ -4,7 +4,7 @@
  * arrow buckets don't collapse), never a naive toFixed(1).
  */
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { AlertCard } from "@/components/dashboard/alert-card";
 import type { PredictiveAlert } from "@/lib/api";
 
@@ -47,5 +47,41 @@ describe("AlertCard glucose unit", () => {
     expect(container.textContent).toContain("mmol/L");
     // 3 mg/dL/min -> 0.17 mmol/L/min (2 decimals; 1 decimal would collapse to 0.2)
     expect(container.textContent).toContain("+0.17 mmol/L/min");
+  });
+});
+
+describe("AlertCard message body", () => {
+  it("suppresses the frozen mg/dL message for a glucose alert (numbers come from fields)", () => {
+    render(
+      <AlertCard
+        alert={makeAlert({
+          alert_type: "low_warning",
+          message: "Low glucose warning: 70 mg/dL (threshold: 70)",
+        })}
+        onAcknowledge={jest.fn()}
+      />
+    );
+    // The structured glucose number is rendered from the fields...
+    expect(screen.getByText("180")).toBeInTheDocument();
+    // ...and the persisted message body is NOT echoed (its "(threshold: …)"
+    // text exists nowhere else on the card), so it can never read a stale unit.
+    expect(screen.queryByText(/threshold/i)).toBeNull();
+  });
+
+  it("renders an iob_warning message verbatim (insulin units, never unit-stale)", () => {
+    const message = "High insulin on board: 2.5 units (threshold: 2.0)";
+    render(
+      <AlertCard
+        alert={makeAlert({
+          alert_type: "iob_warning",
+          predicted_value: null,
+          prediction_minutes: null,
+          iob_value: 2.5,
+          message,
+        })}
+        onAcknowledge={jest.fn()}
+      />
+    );
+    expect(screen.getByText(message)).toBeInTheDocument();
   });
 });

--- a/apps/web/__tests__/components/dashboard/alert-toast.test.tsx
+++ b/apps/web/__tests__/components/dashboard/alert-toast.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * The alert toast renders glucose from the structured fields in the viewer's
+ * unit (via formatAlertSummary), not the persisted mg/dL message string.
+ */
+
+import { render } from "@testing-library/react";
+import { AlertToast } from "@/components/dashboard/alert-toast";
+import type { AlertEventData } from "@/hooks/use-glucose-stream";
+
+function makeAlert(overrides: Partial<AlertEventData> = {}): AlertEventData {
+  return {
+    id: "a1",
+    alert_type: "low_urgent",
+    severity: "warning", // 15s auto-dismiss; won't fire during the test
+    current_value: 70,
+    predicted_value: null,
+    prediction_minutes: null,
+    iob_value: null,
+    message: "Urgent low glucose: 70 mg/dL (threshold: 70)",
+    trend_rate: null,
+    source: "current",
+    created_at: "2026-06-21T00:00:00Z",
+    expires_at: "2099-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("AlertToast glucose unit", () => {
+  it("renders the summary in mg/dL by default", () => {
+    const { container } = render(
+      <AlertToast alert={makeAlert()} onDismiss={jest.fn()} />
+    );
+    expect(container.textContent).toContain("Urgent Low Glucose: 70 mg/dL");
+  });
+
+  it("renders the summary converted to the viewer's mmol unit", () => {
+    const { container } = render(
+      <AlertToast alert={makeAlert()} onDismiss={jest.fn()} unit="mmol" />
+    );
+    expect(container.textContent).toContain("Urgent Low Glucose: 3.9 mmol/L");
+  });
+});

--- a/apps/web/__tests__/lib/alert-utils.test.ts
+++ b/apps/web/__tests__/lib/alert-utils.test.ts
@@ -1,0 +1,71 @@
+/**
+ * formatAlertSummary renders the alert glucose line from the STRUCTURED numeric
+ * fields in the active unit (never the frozen mg/dL message string, which goes
+ * stale after a unit-preference change). IoB warnings describe insulin units and
+ * are returned verbatim — never glucose-converted.
+ */
+
+import { formatAlertSummary } from "@/lib/alert-utils";
+
+type SummaryArg = Parameters<typeof formatAlertSummary>[0];
+
+function makeAlert(overrides: Partial<SummaryArg> = {}): SummaryArg {
+  return {
+    alert_type: "low_urgent",
+    current_value: 70,
+    predicted_value: null,
+    prediction_minutes: null,
+    message: "Urgent low glucose: 70 mg/dL (threshold: 70)",
+    ...overrides,
+  };
+}
+
+describe("formatAlertSummary", () => {
+  it("renders a current-value glucose alert in mg/dL", () => {
+    expect(formatAlertSummary(makeAlert(), "mgdl")).toBe(
+      "Urgent Low Glucose: 70 mg/dL"
+    );
+  });
+
+  it("converts the current value to mmol/L", () => {
+    expect(formatAlertSummary(makeAlert(), "mmol")).toBe(
+      "Urgent Low Glucose: 3.9 mmol/L"
+    );
+  });
+
+  it("renders a predictive alert with current -> predicted in N min (mg/dL)", () => {
+    const alert = makeAlert({
+      alert_type: "high_warning",
+      current_value: 180,
+      predicted_value: 220,
+      prediction_minutes: 30,
+    });
+    expect(formatAlertSummary(alert, "mgdl")).toBe(
+      "High Glucose Warning: 180 mg/dL → 220 mg/dL in 30min"
+    );
+  });
+
+  it("converts both current and predicted to mmol/L", () => {
+    const alert = makeAlert({
+      alert_type: "high_warning",
+      current_value: 180,
+      predicted_value: 220,
+      prediction_minutes: 30,
+    });
+    // 180 -> 10.0, 220 -> 12.2 mmol/L
+    expect(formatAlertSummary(alert, "mmol")).toBe(
+      "High Glucose Warning: 10.0 mmol/L → 12.2 mmol/L in 30min"
+    );
+  });
+
+  it("returns the IoB-warning message verbatim (insulin units never convert)", () => {
+    const message = "High insulin on board: 2.5 units (threshold: 2.0)";
+    const alert = makeAlert({
+      alert_type: "iob_warning",
+      current_value: 120,
+      message,
+    });
+    expect(formatAlertSummary(alert, "mgdl")).toBe(message);
+    expect(formatAlertSummary(alert, "mmol")).toBe(message);
+  });
+});

--- a/apps/web/__tests__/settings/glucose-unit-convert-back.test.tsx
+++ b/apps/web/__tests__/settings/glucose-unit-convert-back.test.tsx
@@ -1,20 +1,25 @@
 /**
- * Wiring tests: the safety-limits and glucose-range forms must convert mmol
- * entries back to INTEGER mg/dL and clamp to the canonical bound before they
- * leave the browser. The conversion math is unit-tested in glucose-units.test;
- * these prove the input forms actually call it on save (so a refactor that
- * dropped the clamp/convert would fail here).
+ * Wiring tests: the safety-limits, glucose-range, and alert-threshold forms must
+ * convert mmol entries back to INTEGER mg/dL and clamp to the canonical bound
+ * before they leave the browser. The conversion math is unit-tested in
+ * glucose-units.test; these prove the input forms actually call it on save (so a
+ * refactor that dropped the clamp/convert would fail here).
  */
 
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SafetyLimitsPage from "@/app/dashboard/settings/safety-limits/page";
 import GlucoseRangePage from "@/app/dashboard/settings/glucose-range/page";
+import AlertSettingsPage from "@/app/dashboard/settings/alerts/page";
 import {
   getSafetyLimits,
   getSafetyLimitsDefaults,
   updateSafetyLimits,
   getTargetGlucoseRange,
   updateTargetGlucoseRange,
+  getAlertThresholds,
+  updateAlertThresholds,
+  getEscalationConfig,
+  updateEscalationConfig,
 } from "@/lib/api";
 
 jest.mock("@/lib/api");
@@ -39,6 +44,10 @@ const mockGetSafetyDefaults = getSafetyLimitsDefaults as jest.Mock;
 const mockUpdateSafety = updateSafetyLimits as jest.Mock;
 const mockGetRange = getTargetGlucoseRange as jest.Mock;
 const mockUpdateRange = updateTargetGlucoseRange as jest.Mock;
+const mockGetThresholds = getAlertThresholds as jest.Mock;
+const mockUpdateThresholds = updateAlertThresholds as jest.Mock;
+const mockGetEscalation = getEscalationConfig as jest.Mock;
+const mockUpdateEscalation = updateEscalationConfig as jest.Mock;
 
 const SAFETY_DEFAULTS = {
   min_glucose_mgdl: 20,
@@ -92,6 +101,64 @@ describe("safety-limits convert-back + clamp (medical safety)", () => {
     expect(Number.isInteger(payload.min_glucose_mgdl)).toBe(true);
     expect(payload.max_glucose_mgdl).toBeLessThanOrEqual(500);
     expect(payload.min_glucose_mgdl).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe("alert-thresholds convert-back (integer mg/dL on the wire)", () => {
+  it("converts an mmol urgent-high entry to integer mg/dL on save", async () => {
+    mockGetThresholds.mockResolvedValue({
+      id: "t1",
+      low_warning: 70, // 3.9 mmol
+      urgent_low: 55, // 3.1 mmol
+      high_warning: 180, // 10.0 mmol
+      urgent_high: 250, // 13.9 mmol
+      iob_warning: 3.0,
+      updated_at: "",
+    });
+    mockGetEscalation.mockResolvedValue({
+      reminder_delay_minutes: 5,
+      primary_contact_delay_minutes: 10,
+      all_contacts_delay_minutes: 20,
+    });
+    mockUpdateThresholds.mockResolvedValue({
+      id: "t1",
+      low_warning: 70,
+      urgent_low: 56,
+      high_warning: 180,
+      urgent_high: 252,
+      iob_warning: 3.0,
+      updated_at: "",
+    });
+    mockUpdateEscalation.mockResolvedValue({
+      reminder_delay_minutes: 5,
+      primary_contact_delay_minutes: 10,
+      all_contacts_delay_minutes: 20,
+    });
+
+    render(<AlertSettingsPage />);
+
+    const urgentHigh = await screen.findByLabelText(/Urgent High/i);
+    fireEvent.change(urgentHigh, { target: { value: "14.0" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(mockUpdateThresholds).toHaveBeenCalledTimes(1));
+    const payload = mockUpdateThresholds.mock.calls[0][0];
+    // 14.0 mmol -> 252 mg/dL (round(14 * 18.0156)).
+    expect(payload.urgent_high).toBe(252);
+    // The four glucose thresholds are integers within the 20-500 invariant.
+    for (const k of [
+      "low_warning",
+      "urgent_low",
+      "high_warning",
+      "urgent_high",
+    ]) {
+      expect(Number.isInteger(payload[k])).toBe(true);
+      expect(payload[k]).toBeGreaterThanOrEqual(20);
+      expect(payload[k]).toBeLessThanOrEqual(500);
+    }
+    // IoB stays in insulin units (never glucose-converted).
+    expect(payload.iob_warning).toBe(3.0);
   });
 });
 

--- a/apps/web/src/app/dashboard/caregiver/page.tsx
+++ b/apps/web/src/app/dashboard/caregiver/page.tsx
@@ -49,13 +49,14 @@ import {
 const REFRESH_INTERVAL_MS = 60_000;
 
 /**
- * Patient glucose renders in the PATIENT's unit, never the
- * caregiver's own preference. The patient's `glucose_unit` is not yet carried
- * on the caregiver status payload (added later); until then we fall
- * back to the canonical mg/dL — NOT `useGlucoseUnit()` (the viewer's unit).
- * When the caregiver payload carries the patient's unit, replace this with it.
+ * Patient glucose renders in the PATIENT's unit, never the caregiver's own
+ * preference. The unit comes from the patient's own `glucose_unit` on the
+ * caregiver status payload — NOT `useGlucoseUnit()` (the viewer's unit).
+ * Falls back to canonical mg/dL while a status is still loading.
  */
-const PATIENT_GLUCOSE_UNIT: GlucoseUnit = "mgdl";
+function patientUnit(status: CaregiverPatientStatus | null): GlucoseUnit {
+  return status?.glucose_unit ?? "mgdl";
+}
 
 function getTrendArrow(trend: string): string {
   const arrows: Record<string, string> = {
@@ -123,6 +124,10 @@ export default function CaregiverDashboardPage() {
   // Whether we're in multi-patient mode (show grid overview)
   const isMultiPatient = patients.length > 1;
   const showOverview = isMultiPatient && !selectedPatientId;
+
+  // Detail-view glucose renders in the selected patient's unit (overview cards
+  // resolve each patient's own unit individually).
+  const detailUnit = patientUnit(status);
 
   // Redirect non-caregivers away from this page
   useEffect(() => {
@@ -421,6 +426,7 @@ export default function CaregiverDashboardPage() {
               {patients.map((patient) => {
                 const ps = patientStatuses.get(patient.patient_id) || null;
                 const dotColor = getStatusDotColor(ps);
+                const unit = patientUnit(ps);
                 const g =
                   ps?.permissions.can_view_glucose && ps?.glucose
                     ? ps.glucose
@@ -458,9 +464,9 @@ export default function CaregiverDashboardPage() {
                               getGlucoseColor(g.value)
                             )}
                           >
-                            {formatGlucose(g.value, PATIENT_GLUCOSE_UNIT)}
+                            {formatGlucose(g.value, unit)}
                           </span>
-                          <span className="text-sm text-slate-500 dark:text-slate-400">{unitLabel(PATIENT_GLUCOSE_UNIT)}</span>
+                          <span className="text-sm text-slate-500 dark:text-slate-400">{unitLabel(unit)}</span>
                           <span className="text-lg">
                             {getTrendArrow(g.trend)}
                           </span>
@@ -562,9 +568,9 @@ export default function CaregiverDashboardPage() {
                         getGlucoseColor(status.glucose.value)
                       )}
                     >
-                      {formatGlucose(status.glucose.value, PATIENT_GLUCOSE_UNIT)}
+                      {formatGlucose(status.glucose.value, detailUnit)}
                     </span>
-                    <span className="text-2xl text-slate-500 dark:text-slate-400">{unitLabel(PATIENT_GLUCOSE_UNIT)}</span>
+                    <span className="text-2xl text-slate-500 dark:text-slate-400">{unitLabel(detailUnit)}</span>
                     <span className="text-2xl">
                       {getTrendArrow(status.glucose.trend)}
                     </span>
@@ -584,7 +590,7 @@ export default function CaregiverDashboardPage() {
                     {status.glucose.trend_rate !== null && (
                       <span>
                         {status.glucose.trend_rate > 0 ? "+" : ""}
-                        {formatTrendRate(status.glucose.trend_rate, PATIENT_GLUCOSE_UNIT)} {unitLabel(PATIENT_GLUCOSE_UNIT)}/min
+                        {formatTrendRate(status.glucose.trend_rate, detailUnit)} {unitLabel(detailUnit)}/min
                       </span>
                     )}
                   </div>

--- a/apps/web/src/components/dashboard/alert-card.tsx
+++ b/apps/web/src/components/dashboard/alert-card.tsx
@@ -122,8 +122,15 @@ export function AlertCard({
         )}
       </div>
 
-      {/* Message / Recommended action */}
-      <p className={clsx("text-sm mb-3", config.text)}>{alert.message}</p>
+      {/* The glucose value/prediction is already rendered live, in the active
+          unit, in the block above — so no message echo is shown for glucose
+          alerts (and the persisted mg/dL string is never the display source on a
+          mmol surface). IoB warnings are the exception: their threshold context
+          lives only in the message, and it is in insulin units, so it is never
+          unit-stale and is shown verbatim. */}
+      {alert.alert_type === "iob_warning" && (
+        <p className={clsx("text-sm mb-3", config.text)}>{alert.message}</p>
+      )}
 
       {/* Metadata */}
       <div className="flex items-center gap-4 mb-4 text-xs text-slate-500">

--- a/apps/web/src/components/dashboard/alert-toast.tsx
+++ b/apps/web/src/components/dashboard/alert-toast.tsx
@@ -14,7 +14,8 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { X } from "lucide-react";
 import clsx from "clsx";
 import type { AlertEventData } from "@/hooks/use-glucose-stream";
-import { getAlertIcon } from "@/lib/alert-utils";
+import { getAlertIcon, formatAlertSummary } from "@/lib/alert-utils";
+import type { GlucoseUnit } from "@/lib/glucose-units";
 
 const TOAST_CONFIG: Record<
   string,
@@ -59,9 +60,11 @@ const TOAST_CONFIG: Record<
 export interface AlertToastProps {
   alert: AlertEventData;
   onDismiss: (id: string) => void;
+  /** Viewer's glucose display unit (default mgdl). Values stay mg/dL internally. */
+  unit?: GlucoseUnit;
 }
 
-export function AlertToast({ alert, onDismiss }: AlertToastProps) {
+export function AlertToast({ alert, onDismiss, unit = "mgdl" }: AlertToastProps) {
   const config = TOAST_CONFIG[alert.severity] ?? TOAST_CONFIG.info;
   const [isVisible, setIsVisible] = useState(true);
   const Icon = getAlertIcon(alert.alert_type);
@@ -114,7 +117,9 @@ export function AlertToast({ alert, onDismiss }: AlertToastProps) {
           >
             {alert.severity}
           </div>
-          <p className={clsx("text-sm", config.text)}>{alert.message}</p>
+          <p className={clsx("text-sm", config.text)}>
+            {formatAlertSummary(alert, unit)}
+          </p>
         </div>
         <button
           onClick={handleDismiss}

--- a/apps/web/src/lib/alert-utils.ts
+++ b/apps/web/src/lib/alert-utils.ts
@@ -94,7 +94,12 @@ export function formatAlertTitle(alertType: string): string {
   );
 }
 
-/** Minimal alert shape needed to render a glucose summary line. */
+/**
+ * Minimal alert shape needed to render a glucose summary line. Kept as a local
+ * structural type (not a `Pick<>` of one payload) so the formatter stays
+ * decoupled from its two callers — the SSE `AlertEventData` (toast) and the REST
+ * `PredictiveAlert` (card) both satisfy it without privileging either.
+ */
 interface AlertGlucoseFields {
   alert_type: string;
   current_value: number;

--- a/apps/web/src/lib/alert-utils.ts
+++ b/apps/web/src/lib/alert-utils.ts
@@ -12,6 +12,7 @@ import {
   AlertTriangle,
   type LucideIcon,
 } from "lucide-react";
+import { formatGlucose, unitLabel, type GlucoseUnit } from "./glucose-units";
 
 /** Visual config per alert severity level */
 export const SEVERITY_CONFIG: Record<
@@ -91,4 +92,45 @@ export function formatAlertTitle(alertType: string): string {
     ALERT_TYPE_LABELS[alertType] ??
     alertType.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
   );
+}
+
+/** Minimal alert shape needed to render a glucose summary line. */
+interface AlertGlucoseFields {
+  alert_type: string;
+  current_value: number;
+  predicted_value: number | null;
+  prediction_minutes: number | null;
+  message: string;
+}
+
+/**
+ * Build a one-line alert summary in the active unit from the alert's STRUCTURED
+ * numeric fields (mg/dL), so the displayed glucose number is never the frozen
+ * mg/dL `message` string — which is rendered once at persist and would read in a
+ * stale unit after the user changes their display preference.
+ *
+ * The persisted message also carried a "(threshold: X)" parenthetical; it is
+ * intentionally dropped here because the threshold is not a structured field on
+ * the alert payload and so cannot be re-rendered in the active unit. This helper
+ * feeds the toast and browser notification — transient surfaces with no separate
+ * glucose block — where a non-stale value + unit beats a stale-prone threshold
+ * annotation (the alert title already conveys which threshold was crossed).
+ *
+ * IoB warnings describe insulin units (never converted), so their persisted
+ * message is already unit-stable and is shown verbatim.
+ */
+export function formatAlertSummary(
+  alert: AlertGlucoseFields,
+  unit: GlucoseUnit
+): string {
+  if (alert.alert_type === "iob_warning") {
+    return alert.message;
+  }
+  const title = formatAlertTitle(alert.alert_type);
+  const current = `${formatGlucose(alert.current_value, unit)} ${unitLabel(unit)}`;
+  if (alert.predicted_value != null && alert.prediction_minutes != null) {
+    const predicted = `${formatGlucose(alert.predicted_value, unit)} ${unitLabel(unit)}`;
+    return `${title}: ${current} → ${predicted} in ${alert.prediction_minutes}min`;
+  }
+  return `${title}: ${current}`;
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1346,6 +1346,11 @@ export interface CaregiverPatientStatus {
   glucose: CaregiverGlucoseData | null;
   iob: CaregiverIoBData | null;
   permissions: CaregiverPermissions;
+  /**
+   * The PATIENT's preferred display unit (never the viewing caregiver's). The
+   * glucose `value` stays canonical mg/dL; this only selects the render unit.
+   */
+  glucose_unit: GlucoseUnit;
 }
 
 export interface CaregiverGlucoseHistoryReading {

--- a/apps/web/src/providers/alert-notification-provider.tsx
+++ b/apps/web/src/providers/alert-notification-provider.tsx
@@ -20,6 +20,8 @@ import {
 
 import { AlertToast } from "@/components/dashboard/alert-toast";
 import type { AlertEventData } from "@/hooks/use-glucose-stream";
+import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
+import { formatAlertSummary } from "@/lib/alert-utils";
 import { playAlertSound } from "@/lib/audio";
 import { showBrowserNotification } from "@/lib/browser-notifications";
 import { GlucoseStreamProvider } from "./glucose-stream-provider";
@@ -126,6 +128,16 @@ export function AlertNotificationProvider({
   // Eagerly initialize dismissed set to avoid race with SSE alerts (Fix #4)
   const dismissedRef = useRef<Set<string>>(getDismissedAlerts());
 
+  // Viewer's glucose unit. The dashboard SSE only streams the viewer's OWN
+  // alerts, so viewer == owner and rendering toast/notification glucose in this
+  // unit is correct. Kept in a ref so the alert callback reads the latest value
+  // without re-subscribing to the stream.
+  const unit = useGlucoseUnit();
+  const unitRef = useRef(unit);
+  useEffect(() => {
+    unitRef.current = unit;
+  }, [unit]);
+
   // Load preferences from localStorage on mount
   useEffect(() => {
     setPreferencesState(loadPreferences());
@@ -180,7 +192,10 @@ export function AlertNotificationProvider({
       prefsRef.current.browserNotificationsEnabled &&
       (alert.severity === "urgent" || alert.severity === "emergency")
     ) {
-      showBrowserNotification(alert.severity, alert.message);
+      showBrowserNotification(
+        alert.severity,
+        formatAlertSummary(alert, unitRef.current)
+      );
     }
   }, []);
 
@@ -204,6 +219,7 @@ export function AlertNotificationProvider({
               key={alert.id}
               alert={alert}
               onDismiss={handleDismiss}
+              unit={unit}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
Renders the caregiver dashboard, alert card, alert toast, and browser notification in the user's preferred glucose unit (mmol/L or mg/dL), converting from the canonical mg/dL structured fields rather than a frozen mg/dL message string. Storage, thresholds, comparisons, dedup/ordering, and the 20-500 mg/dL safety invariant all stay canonical mg/dL.

## Changes
- **Caregiver status API + web type**: carry the patient's `glucose_unit` (the reading value stays mg/dL; the token only selects the display unit), resolved for the patient behind the existing caregiver-link authorization gate.
- **Caregiver dashboard**: renders each patient in their own unit; the glucose color and status-dot bands stay in mg/dL.
- **Alert card / toast / browser notification**: format glucose from the structured current/predicted fields via a shared `formatAlertSummary`; IoB warnings keep their insulin-unit message verbatim.
- **Alert payload (REST/SSE)**: stays canonical mg/dL with no unit tag; the web converts off the viewer's own preference. Mobile keeps mg/dL until a later unit story adds an explicit tag plus numeric conversion.
- **`.coderabbit.yaml` medical-safety gate**: understands the canonical-mg/dL storage vs mmol display split — still hard-fails mis-converted / wrong-direction / out-of-range / wrong-factor mappers, without false-flagging mmol display literals.

## Tests
- Backend round-trip / bounds property tests and schema rejection of out-of-range mmol entries; caregiver per-patient unit; SSE canonical-mg/dL payload pin.
- Web threshold convert-back and alert-summary tests.
- Full backend and web suites pass; lint and typecheck clean.

## Verification
- Browser (mmol user): alert card and toast render converted values from the structured fields with no stale mg/dL.
- Caregiver status endpoint returns the patient's unit with the value in canonical mg/dL.

Closes #761


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Caregiver dashboard now shows each patient’s glucose in their preferred unit (mg/dL or mmol/L), including per-patient unit metadata.
  * Alert summaries/toasts and browser notifications now use unit-aware glucose formatting.

* **Bug Fixes**
  * Alert cards now show the correct alert message content by alert type, avoiding stale/generic text for glucose alerts.

* **Tests**
  * Added coverage for glucose unit conversion, threshold bounds, and per-patient glucose unit rendering.
  * Added alert payload and UI tests to ensure correct unit display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->