### PR TITLE
feat(api): verify AI-spoken glucose figures against the user's readings

### DIFF
--- a/apps/api/src/schemas/safety_validation.py
+++ b/apps/api/src/schemas/safety_validation.py
@@ -23,6 +23,11 @@ class SuggestionType(str, enum.Enum):
 
     CARB_RATIO = "carb_ratio"
     CORRECTION_FACTOR = "correction_factor"
+    # A glucose figure the model spoke that does not trace to a logged reading
+    # (rounding-tolerant). Not a ratio/factor change: its FlaggedSuggestion's
+    # ``original_value``/``suggested_value`` carry the spoken value and nearest
+    # reading, both in canonical mg/dL, and ``change_pct`` is unused (0).
+    GLUCOSE_CITATION = "glucose_citation"
 
 
 class FlaggedSuggestion(BaseModel):

--- a/apps/api/src/schemas/safety_validation.py
+++ b/apps/api/src/schemas/safety_validation.py
@@ -34,9 +34,24 @@ class FlaggedSuggestion(BaseModel):
     """A single flagged suggestion extracted from AI output."""
 
     suggestion_type: SuggestionType
-    original_value: float = Field(..., description="Original ratio/factor value")
-    suggested_value: float = Field(..., description="Suggested ratio/factor value")
-    change_pct: float = Field(..., description="Percentage change from original")
+    original_value: float = Field(
+        ...,
+        description=(
+            "For ratio/factor types, the original value; for GLUCOSE_CITATION, "
+            "the spoken glucose value in canonical mg/dL"
+        ),
+    )
+    suggested_value: float = Field(
+        ...,
+        description=(
+            "For ratio/factor types, the suggested value; for GLUCOSE_CITATION, "
+            "the nearest logged reading in canonical mg/dL"
+        ),
+    )
+    change_pct: float = Field(
+        ...,
+        description="Percentage change from original (0 for GLUCOSE_CITATION)",
+    )
     max_allowed_pct: float = Field(
         default=20.0, description="Maximum allowed percentage change"
     )

--- a/apps/api/src/services/correction_analysis.py
+++ b/apps/api/src/services/correction_analysis.py
@@ -28,6 +28,7 @@ from src.schemas.correction_analysis import TimePeriodData
 from src.services.ai_client import get_ai_client
 from src.services.diabetes_context import (
     PumpProfileSummary,
+    build_allowed_glucose,
     format_pump_profile_for_prompt,
     get_pump_profile_summary,
 )
@@ -405,8 +406,39 @@ async def generate_correction_analysis(
     )
 
     # Safety validation (Story 5.6). Unit-agnostic: the regexes accept either
-    # suffix and the ±20% check is unit-relative once a suffix matches.
-    safety_result = validate_ai_suggestion(ai_response.content, "correction_analysis")
+    # suffix and the ±20% check is unit-relative once a suffix matches. Any
+    # glucose figure the model spoke is also flagged if it doesn't trace to the
+    # period's readings; a failed allow-set fails open (no glucose flag) rather
+    # than break the analysis, matching the pump-profile fetch above. ``extra``
+    # admits the derived figures this prompt renders -- the post-correction
+    # target, the over-correction threshold, and each period's average glucose
+    # drop -- so restating them is not mis-flagged as an unverifiable reading.
+    allowed_glucose: list[int] = []
+    try:
+        allow = await build_allowed_glucose(
+            db,
+            user.id,
+            window_start=period_start,
+            window_end=period_end,
+            extra=[
+                TARGET_GLUCOSE,
+                LOW_THRESHOLD,
+                *(tp.avg_glucose_drop for tp in time_periods),
+            ],
+        )
+        allowed_glucose = allow.match
+    except Exception:
+        logger.warning(
+            "Failed to build glucose allow-set for correction analysis",
+            user_id=str(user.id),
+            exc_info=True,
+        )
+    safety_result = validate_ai_suggestion(
+        ai_response.content,
+        "correction_analysis",
+        records=allowed_glucose,
+        unit=unit,
+    )
 
     # Store the analysis with sanitized text
     analysis = CorrectionAnalysis(

--- a/apps/api/src/services/daily_brief.py
+++ b/apps/api/src/services/daily_brief.py
@@ -43,6 +43,7 @@ from src.services.diabetes_context import (
     format_meals_for_brief,
     format_pump_profile_for_prompt,
     get_pump_profile_summary,
+    verify_glucose_reading_citations,
     verify_meal_citations,
 )
 from src.services.safety_validation import log_safety_validation, validate_ai_suggestion
@@ -497,6 +498,21 @@ async def generate_daily_brief(
         window_start=period_start,
         window_end=period_end,
         now=period_end,
+    )
+    # Correct-or-scrub any glucose figure the same way, over the brief's period,
+    # so the brief handles its glucose and carb numbers consistently. The brief
+    # renders the period average (computed over the unfiltered period readings),
+    # so pass it as an extra allowed figure rather than let the allow-set
+    # recompute a slightly different one.
+    verified_text = await verify_glucose_reading_citations(
+        db,
+        user.id,
+        verified_text,
+        surface="daily_brief",
+        unit=unit,
+        window_start=period_start,
+        window_end=period_end,
+        extra=[metrics.average_glucose],
     )
 
     # Safety validation (Story 5.6)

--- a/apps/api/src/services/diabetes_context.py
+++ b/apps/api/src/services/diabetes_context.py
@@ -671,6 +671,31 @@ async def build_allowed_glucose(
     match.add(int(target.low_target if target else DEFAULT_LOW_TARGET))
     match.add(int(target.high_target if target else DEFAULT_HIGH_TARGET))
 
+    # The model is also shown the user's configured thresholds -- pump-profile
+    # segment targets and the CGM high/low alert levels (rendered into every chat
+    # prompt by build_diabetes_context and into the analysis prompts) -- so a
+    # reply faithfully restating one is not an invention and must not be scrubbed.
+    # Fetched fail-soft: a profile read error must not empty the allow-set (which
+    # would fail-closed scrub every figure in chat). Non-configured clinical
+    # anchors (54, 250...) are deliberately NOT seeded -- the directive/threshold
+    # exemption already passes those through, and seeding them as always-citable
+    # would mask a genuine misquote that happens to equal an anchor.
+    try:
+        profile = await get_pump_profile_summary(db, user_id)
+    except Exception:
+        logger.warning(
+            "Pump-profile fetch for glucose allow-set failed",
+            user_id=str(user_id),
+            exc_info=True,
+        )
+        profile = None
+    if profile is not None:
+        thresholds = [segment.target_bg for segment in profile.segments]
+        thresholds += [profile.cgm_high_alert_mgdl, profile.cgm_low_alert_mgdl]
+        for value in thresholds:
+            if value is not None and 20 <= value <= 500:
+                match.add(int(round(value)))
+
     # Surface-specific rendered figures (a brief's exact average, an analysis'
     # post-correction target / average glucose drop). Zero/empty placeholders are
     # skipped -- they are "no data", not a citable figure.

--- a/apps/api/src/services/diabetes_context.py
+++ b/apps/api/src/services/diabetes_context.py
@@ -9,6 +9,7 @@ correction analysis, and chat all share the same context pipeline.
 """
 
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from functools import partial
@@ -27,6 +28,7 @@ from src.core.units import (
 )
 from src.logging_config import get_logger
 from src.services.alert_notifier import trend_description
+from src.services.glucose_citation import verify_glucose_citations
 from src.services.iob_projection import get_iob_projection, get_user_dia
 from src.services.meal_citation import AllowedCarb, verify_carb_citations
 from src.vision.carb_contract import (
@@ -586,6 +588,178 @@ async def verify_meal_citations(
             corrected=outcome.citations_corrected,
             scrubbed=outcome.citations_scrubbed,
             timestamp_mismatches=outcome.timestamp_mismatches,
+        )
+    return outcome.text
+
+
+@dataclass(frozen=True)
+class GlucoseAllowSet:
+    """The glucose figures a model response may cite for a window.
+
+    ``match`` is every value a cited figure may verify against: the user's
+    distinct readings plus the rendered aggregates (window average, target
+    bounds) and any surface-specific ``extra`` figures the prompt also showed.
+    ``readings`` is the distinct real readings alone -- the referent basis for
+    single-reading correction, kept separate so the padded aggregates can't mask
+    a flat-line user as multi-referent.
+    """
+
+    match: list[int]
+    readings: list[int]
+
+
+async def build_allowed_glucose(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    window_start: datetime,
+    window_end: datetime | None = None,
+    limit: int | None = None,
+    extra: Sequence[float] = (),
+) -> GlucoseAllowSet:
+    """Build the set of glucose figures the model was allowed to cite for a window.
+
+    The allow-set is the user's real ``GlucoseReading`` values (canonical mg/dL,
+    primary-CGM-only and ``20-500``-filtered, exactly as ``build_glucose_section``
+    selects them) plus the rendered aggregates the model also saw: the window
+    average and the configured target-range bounds. A figure the model utters that
+    matches one of these within the display band traces to real data; anything
+    else is an invention.
+
+    ``limit`` selects the newest N readings (matching ``build_glucose_section``'s
+    cap for chat) so the allow-set average equals the one the model was shown;
+    surfaces whose prompt computes the average differently (the daily brief) or
+    renders derived figures/constants (the correction and meal analyses) pass
+    those exact values via ``extra`` instead. Returns distinct values so a busy
+    window can't bloat the comparison set.
+    """
+    from src.models.glucose import GlucoseReading
+    from src.models.target_glucose_range import TargetGlucoseRange
+    from src.services.cgm_source import (
+        get_excluded_cgm_sources,
+        glucose_source_exclusion_clause,
+    )
+
+    excluded = await get_excluded_cgm_sources(db, user_id)
+    conditions = [
+        GlucoseReading.user_id == user_id,
+        GlucoseReading.reading_timestamp >= window_start,
+        *glucose_source_exclusion_clause(excluded),
+    ]
+    if window_end is not None:
+        conditions.append(GlucoseReading.reading_timestamp < window_end)
+
+    stmt = select(GlucoseReading.value).where(*conditions)
+    if limit is not None:
+        stmt = stmt.order_by(GlucoseReading.reading_timestamp.desc()).limit(limit)
+    result = await db.execute(stmt)
+    values = [value for (value,) in result if 20 <= value <= 500]
+
+    readings = sorted(set(values))
+    match: set[int] = set(readings)
+    if values:
+        # Mirrors ``build_glucose_section``'s ``sum(values) / len(values)`` so the
+        # rendered average lands in the allow-set; the +/-1 band absorbs the
+        # display rounding.
+        match.add(round(sum(values) / len(values)))
+
+    target = (
+        await db.execute(
+            select(TargetGlucoseRange).where(TargetGlucoseRange.user_id == user_id)
+        )
+    ).scalar_one_or_none()
+    match.add(int(target.low_target if target else DEFAULT_LOW_TARGET))
+    match.add(int(target.high_target if target else DEFAULT_HIGH_TARGET))
+
+    # Surface-specific rendered figures (a brief's exact average, an analysis'
+    # post-correction target / average glucose drop). Zero/empty placeholders are
+    # skipped -- they are "no data", not a citable figure.
+    for value in extra:
+        if value and value > 0:
+            match.add(int(round(value)))
+
+    return GlucoseAllowSet(match=sorted(match), readings=readings)
+
+
+async def verify_glucose_reading_citations(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    content: str,
+    *,
+    surface: str,
+    unit: GlucoseUnit | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
+    extra: Sequence[float] = (),
+) -> str:
+    """Verify glucose figures in a model response against the user's readings.
+
+    The output-side choke-point for chat and the daily brief: it corrects or
+    scrubs any spoken glucose number that doesn't trace to the user's data,
+    mirroring the carb verifier at the same call sites so a single reply never
+    handles its glucose and carb figures with two different models. ``window_start``
+    defaults to the chat glucose window (``now - GLUCOSE_CONTEXT_HOURS``), and in
+    that default case the allow-set is capped to ``GLUCOSE_MAX_READINGS`` to match
+    what ``build_glucose_section`` rendered; callers with their own period pass it
+    (and their exact aggregates via ``extra``). ``unit`` is resolved from the data
+    owner when not supplied.
+
+    Fail-closed on the allow-set (a read failure scrubs every figure -- we never
+    emit a glucose number we couldn't verify), matching ``verify_meal_citations``.
+    A verifier exception (should be impossible on ``str`` input) returns the
+    content unchanged. Logs PHI-free counts only.
+    """
+    if not content:
+        return content
+
+    now = datetime.now(UTC)
+    limit: int | None = None
+    if window_start is None:
+        window_start = now - timedelta(hours=GLUCOSE_CONTEXT_HOURS)
+        limit = GLUCOSE_MAX_READINGS  # match build_glucose_section's chat cap
+    if unit is None:
+        from src.services.glucose_unit import resolve_glucose_unit
+
+        unit = await resolve_glucose_unit(db, user_id)
+
+    try:
+        allow = await build_allowed_glucose(
+            db,
+            user_id,
+            window_start=window_start,
+            window_end=window_end,
+            limit=limit,
+            extra=extra,
+        )
+        records, referents = allow.match, allow.readings
+    except Exception:
+        logger.warning(
+            "Glucose citation allow-set build failed; scrubbing unverifiable figures",
+            surface=surface,
+            user_id=str(user_id),
+            exc_info=True,
+        )
+        records, referents = [], []  # fail closed -> every glucose figure is scrubbed
+
+    try:
+        outcome = verify_glucose_citations(content, records, unit, referents=referents)
+    except Exception:
+        logger.warning(
+            "Glucose citation verification raised; returning content unchanged",
+            surface=surface,
+            user_id=str(user_id),
+            exc_info=True,
+        )
+        return content
+
+    if outcome.changed:
+        logger.info(
+            "Glucose citation rewrite",
+            surface=surface,
+            seen=outcome.citations_seen,
+            matched=outcome.citations_matched,
+            corrected=outcome.citations_corrected,
+            scrubbed=outcome.citations_scrubbed,
         )
     return outcome.text
 

--- a/apps/api/src/services/glucose_citation.py
+++ b/apps/api/src/services/glucose_citation.py
@@ -1,0 +1,390 @@
+"""Output-side glucose-citation verification (pure core).
+
+The AI-text layer renders the user's glucose data into the prompt in their
+preferred unit (``diabetes_context.build_glucose_section`` and the analysis
+prompt builders) and instructs the model to answer in that unit. This module
+closes the complementary gap on the model *output*: any glucose figure the model
+utters in a chat reply, daily brief, or analysis is verified against the user's
+real readings, and a figure that does not trace to one is corrected to the right
+value or removed -- never passed through as the model wrote it.
+
+The failure mode this defends is the same one the carb verifier
+(``meal_citation``) guards (diabettech.com "Five AI Models, Three Users"): models
+cite a user's own data with confident, false specifics. For glucose the stakes
+are higher -- a wrong glucose number is something a user might act on -- so the
+comparison is unit-aware and rounding-tolerant: turning on mmol/L display must
+never let a converted-and-rounded figure read as a mismatch (99 mg/dL -> "5.5",
+100 mg/dL -> "5.6"), nor let a genuinely wrong number slip through.
+
+Design (mirrors ``meal_citation``):
+  * Deterministic and pure -- ``re`` extraction + the shared rounding-tolerant
+    band (``core.units.glucose_display_matches``: +/-1 mg/dL or +/-0.1 mmol/L,
+    never equality). No second LLM call.
+  * The extractor matches a number anchored to glucose by a per-volume unit
+    suffix (``mg/dL`` / ``mmol/L``) and excludes the ``1:X`` ISF / carb-ratio
+    forms and ISF *rates* ("50 mg/dL per unit"), so a correction-factor figure is
+    never mis-flagged as a glucose reading (those are the safety layer's job).
+  * Two consumption models share one extraction + match core:
+      - rewrite (``verify_glucose_citations``): correct-or-scrub the reply text,
+        for the chat handlers and the daily brief -- consistent with the carb
+        verifier at the same call sites.
+      - flag (``find_glucose_citation_flags``): emit ``FlaggedSuggestion`` records
+        for the ``validate_ai_suggestion`` / ``ValidationResult`` path used by the
+        correction and meal analyses.
+  * Read-only: input is the model text + the canonical mg/dL records, output is a
+    rewritten string or a list of flags. A converted value is never persisted;
+    the stored record stays integer mg/dL.
+
+The allowed records are the user's real ``GlucoseReading`` values (canonical
+mg/dL) for the surface's window plus the rendered aggregates (average, target
+bounds) -- the set the model was shown. A cited figure that matches any of them
+within the display band traces to real data; anything else is an invention.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from src.core.units import (
+    MGDL_PER_MMOL,
+    GlucoseUnit,
+    format_glucose,
+    glucose_display_matches,
+    glucose_unit_label,
+)
+from src.schemas.safety_validation import FlaggedSuggestion, SuggestionType
+from src.services.safety_validation import (
+    CARB_RATIO_PATTERN,
+    ISF_CONTEXT_PATTERN,
+    ISF_PATTERN,
+)
+
+# ── Extraction regexes ──
+# A glucose citation is a number (single value or low-to-high range) immediately
+# carrying a per-volume glucose unit. Requiring the ``/dL`` // ``/L`` denominator
+# excludes a bare "mg"/"mmol" (the abbreviated ISF suffix) and a carb "g/dL"
+# concentration. 1-4 integer digits so a hallucinated out-of-range value
+# (e.g. "1200 mg/dL") is still caught and flagged rather than silently skipped;
+# optional comma-grouped thousands and an optional decimal written with a dot OR
+# a comma -- mmol/L users (and European-locale model output) routinely write
+# "6,7 mmol/L", and the whole token must be captured, never half-read as "7".
+# ``_to_float`` normalizes the separators.
+_NUM = r"\d{1,4}(?:,\d{3})*(?:[.,]\d+)?"
+# Range separator: hyphen, en/em dash, or "to". Spaces/tabs only (not ``\s``) so
+# it cannot span newlines; a flat alternation with no nested quantifier.
+_SEP = r"[ \t]*(?:-|–|—|to)[ \t]*"
+# The two display labels, tolerant of incidental spaces around the slash.
+_READING_SUFFIX = r"mg\s*/\s*dl|mmol\s*/\s*l"
+# ``(?<![\d.])`` keeps the match from starting mid-number; the optional range
+# group captures a second endpoint sharing the trailing suffix.
+GLUCOSE_VALUE_PATTERN = re.compile(
+    rf"(?<![\d.])(?P<low>{_NUM})(?:{_SEP}(?P<high>{_NUM}))?"
+    rf"\s*(?P<unit>{_READING_SUFFIX})\b",
+    re.IGNORECASE,
+)
+
+# An ISF / correction-factor *rate* ("50 mg/dL per unit", "50 mg/dL drop per
+# unit", "2.8 mmol/L / u") right after the suffix means the figure is a rate, not
+# a reading -- leave it to the correction-factor checks in ``safety_validation``.
+# The optional "drop" matches the phrasing the correction-analysis prompt teaches.
+_RATE_AFTER = re.compile(
+    r"[ \t]*(?:drop[ \t]+)?(?:per[ \t]+unit|/[ \t]*u(?:nit)?\b)", re.IGNORECASE
+)
+
+# Any ``1:X`` form (ISF or carb ratio), regardless of a trailing unit, so the
+# value after the colon is never treated as a glucose reading.
+_ONE_TO_X = re.compile(r"1\s*:\s*\d+(?:\.\d+)?")
+
+
+@dataclass(frozen=True)
+class _Citation:
+    """One extracted glucose-figure span (``values`` holds 1 value, or 2 for a
+    range), tagged with the unit its suffix named."""
+
+    start: int
+    end: int
+    values: tuple[float, ...]
+    unit: GlucoseUnit
+    is_range: bool
+
+
+@dataclass(frozen=True)
+class GlucoseCitationOutcome:
+    """PHI-free aggregate result of verifying one model response.
+
+    Only counts and the rewritten text -- never the user's glucose figures -- so
+    the choke-point can log it for observability without leaking protected health
+    information. Every cited figure lands in exactly one bucket, so
+    ``citations_seen == citations_matched + citations_corrected +
+    citations_scrubbed``.
+    """
+
+    text: str
+    citations_seen: int
+    citations_matched: int
+    citations_corrected: int
+    citations_scrubbed: int
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.citations_corrected or self.citations_scrubbed)
+
+
+# ── Replacement strings (rewrite model) ──
+# A figure with one unambiguous referent (the user's readings collapse to a
+# single value) is corrected to that value in the user's unit; otherwise it is
+# templated to a non-numeric phrase. The ``*_DET`` variant drops the leading
+# article for a span already preceded by a determiner so the rewrite reads
+# grammatically.
+_SCRUB_TEMPLATE = "a glucose value I can't verify against your readings"
+_SCRUB_TEMPLATE_DET = "glucose value I can't verify against your readings"
+_DET_BEFORE_RE = re.compile(r"\b(?:a|an|the|your|that|this)\s+$", re.IGNORECASE)
+_DET_LOOKBACK = 8
+
+
+def _unit_from_suffix(matched: str) -> GlucoseUnit:
+    """Map a matched suffix or unit token (``"mmol/L"``/``"mmol"``/``"mgdl"``...)
+    to its ``GlucoseUnit``."""
+    return (
+        GlucoseUnit.MMOL
+        if matched.strip().lower().startswith("mmol")
+        else GlucoseUnit.MGDL
+    )
+
+
+def _to_float(token: str) -> float:
+    """Parse a matched number token, treating a comma as either a thousands
+    separator (``"1,025"`` -> 1025) or a European decimal point (``"6,7"`` ->
+    6.7).
+
+    A comma followed by exactly three digits is a thousands group; a comma
+    followed by one or two digits (and no dot present) is a decimal separator.
+    Without this, ``"6,7 mmol/L"`` would half-extract as ``7`` and a correct
+    citation would read as a mismatch.
+    """
+    if "." in token:
+        return float(token.replace(",", ""))  # commas can only be thousands here
+    if re.fullmatch(r"\d{1,4}(?:,\d{3})+", token):
+        return float(token.replace(",", ""))  # 1,025 -> 1025
+    return float(token.replace(",", "."))  # 6,7 -> 6.7
+
+
+def verify_glucose_citation(
+    spoken_value: float, spoken_unit: str, record_mgdl: int
+) -> bool:
+    """Whether a single AI-spoken glucose figure matches a stored mg/dL reading.
+
+    The spoken value is in ``spoken_unit`` (``"mgdl"``/``"mmol"`` or a display
+    label); the record is canonical mg/dL. Thin wrapper over
+    ``core.units.glucose_display_matches`` with the argument order normalized.
+    """
+    return glucose_display_matches(
+        record_mgdl, spoken_value, _unit_from_suffix(spoken_unit)
+    )
+
+
+def _value_matches_any(value: float, unit: GlucoseUnit, records: Sequence[int]) -> bool:
+    return any(glucose_display_matches(record, value, unit) for record in records)
+
+
+def _citation_matches(citation: _Citation, records: Sequence[int]) -> bool:
+    """A citation verifies iff every endpoint traces to some allowed reading."""
+    return all(
+        _value_matches_any(value, citation.unit, records) for value in citation.values
+    )
+
+
+def _excluded_spans(text: str) -> list[tuple[int, int]]:
+    """Character spans covering ISF / carb-ratio *figures* (the numeric tokens,
+    not the surrounding prose), so a glucose candidate overlapping one (e.g.
+    "45 mg/dL" in "correction factor from 50 to 45 mg/dL") is not mis-extracted
+    as a reading -- while a genuine reading sharing the sentence ("BG 250 mg/dL,
+    move from 50 to 45 mg/dL") is still extracted and verified.
+
+    Bounding each ISF span to its captured number groups (not the whole match) is
+    what prevents ``ISF_CONTEXT_PATTERN``'s lazy ``.*?`` from stretching the
+    exclusion back over an unrelated reading between the keyword and the clause.
+    """
+    spans: list[tuple[int, int]] = []
+    # ISF patterns capture original (1), suggested (2) and unit (3); exclude only
+    # that "N to N unit" figure span.
+    for pattern in (ISF_PATTERN, ISF_CONTEXT_PATTERN):
+        spans.extend((m.start(1), m.end(3)) for m in pattern.finditer(text))
+    # Carb ratio captures the two ratio numbers (no unit group).
+    spans.extend((m.start(1), m.end(2)) for m in CARB_RATIO_PATTERN.finditer(text))
+    # Any bare ``1:X`` token.
+    spans.extend((m.start(), m.end()) for m in _ONE_TO_X.finditer(text))
+    return spans
+
+
+def _is_excluded(start: int, end: int, excluded: list[tuple[int, int]]) -> bool:
+    return any(s_start <= start < s_end for s_start, s_end in excluded)
+
+
+def _extract(text: str) -> list[_Citation]:
+    """Return non-overlapping glucose-figure spans, sorted by position.
+
+    Drops candidates that are ISF/carb-ratio figures or ISF rates, then resolves
+    overlaps left-to-right so each figure is verified exactly once.
+    """
+    excluded = _excluded_spans(text)
+    candidates: list[_Citation] = []
+    for match in GLUCOSE_VALUE_PATTERN.finditer(text):
+        if _is_excluded(match.start(), match.end(), excluded):
+            continue
+        if _RATE_AFTER.match(text, match.end()):
+            continue
+        unit = _unit_from_suffix(match.group("unit"))
+        low = _to_float(match.group("low"))
+        high = match.group("high")
+        values = (low,) if high is None else (low, _to_float(high))
+        candidates.append(
+            _Citation(
+                start=match.start(),
+                end=match.end(),
+                values=values,
+                unit=unit,
+                is_range=high is not None,
+            )
+        )
+
+    # Resolve overlaps left-to-right: earliest start wins, longer span on a tie.
+    candidates.sort(key=lambda c: (c.start, -(c.end - c.start)))
+    kept: list[_Citation] = []
+    max_end = 0
+    for cand in candidates:
+        if cand.start < max_end:
+            continue
+        kept.append(cand)
+        max_end = cand.end
+    return kept
+
+
+def _det_before(text: str, start: int) -> bool:
+    return bool(_DET_BEFORE_RE.search(text[max(0, start - _DET_LOOKBACK) : start]))
+
+
+def _scrub_replacement(text: str, start: int) -> str:
+    return _SCRUB_TEMPLATE_DET if _det_before(text, start) else _SCRUB_TEMPLATE
+
+
+def verify_glucose_citations(
+    text: str,
+    records: Sequence[int],
+    unit: GlucoseUnit,
+    *,
+    referents: Sequence[int] | None = None,
+) -> GlucoseCitationOutcome:
+    """Verify and rewrite every glucose figure in ``text``.
+
+    A figure is *matched* against ``records`` -- the full set the model was shown
+    (the user's readings plus the rendered aggregates: average, target bounds).
+    An unverifiable single figure is *corrected* only when there is one
+    unambiguous reading to point at: ``referents`` (the user's distinct real
+    readings, excluding the padded aggregates so a flat-line user is still a
+    single referent; defaults to ``records``) collapses to one value. Otherwise
+    it is templated to a non-numeric phrase. The corrected value renders in
+    ``unit`` (the user's configured display unit). An empty ``records`` (no data,
+    or a fail-closed allow-set) scrubs every figure. Pure; never raises on
+    ``str`` input.
+    """
+    if not text:
+        return GlucoseCitationOutcome(text or "", 0, 0, 0, 0)
+
+    citations = _extract(text)
+    if not citations:
+        return GlucoseCitationOutcome(text, 0, 0, 0, 0)
+
+    referent_pool = set(records if referents is None else referents)
+    single_referent = len(referent_pool) == 1
+    seen = matched = corrected = scrubbed = 0
+    pieces: list[str] = []
+    cursor = 0
+
+    for citation in citations:
+        seen += 1
+        pieces.append(text[cursor : citation.start])
+
+        if _citation_matches(citation, records):
+            pieces.append(text[citation.start : citation.end])
+            matched += 1
+        elif single_referent and not citation.is_range:
+            # One reading to point at: correct the misquote rather than blank it.
+            pieces.append(format_glucose(next(iter(referent_pool)), unit))
+            corrected += 1
+        else:
+            pieces.append(_scrub_replacement(text, citation.start))
+            scrubbed += 1
+
+        cursor = citation.end
+
+    pieces.append(text[cursor:])
+    return GlucoseCitationOutcome("".join(pieces), seen, matched, corrected, scrubbed)
+
+
+def _band_label(unit: GlucoseUnit) -> str:
+    return "0.1 mmol/L" if unit == GlucoseUnit.MMOL else "1 mg/dL"
+
+
+def _display(value: float, unit: GlucoseUnit) -> str:
+    """Render a value already expressed in ``unit`` (mmol to one decimal, mg/dL
+    as a whole number) -- distinct from ``format_glucose_value``, which converts
+    from stored mg/dL."""
+    return f"{value:.1f}" if unit == GlucoseUnit.MMOL else f"{value:.0f}"
+
+
+def _nearest_record(value_mgdl: float, records: Sequence[int]) -> int:
+    return min(records, key=lambda record: abs(record - value_mgdl))
+
+
+def find_glucose_citation_flags(
+    text: str, records: Sequence[int], unit: GlucoseUnit
+) -> list[FlaggedSuggestion]:
+    """Flag every glucose figure in ``text`` that does not trace to ``records``.
+
+    For the ``validate_ai_suggestion`` / ``ValidationResult`` path. Each mismatch
+    becomes one ``FlaggedSuggestion`` whose reason is unit-correct: it states the
+    spoken value, the nearest reading rendered in the *same* (spoken) unit, and
+    the tolerance band. The numeric ``original_value``/``suggested_value`` carry
+    the spoken value and the nearest reading, both in canonical mg/dL (matching
+    how the ratio/factor flags keep a single unit); ``change_pct`` has no glucose
+    meaning and is left at 0 so it is never read as a factor change.
+    """
+    if not text or not records:
+        return []
+
+    flags: list[FlaggedSuggestion] = []
+    for citation in _extract(text):
+        if _citation_matches(citation, records):
+            continue
+
+        spoken = citation.values[0]
+        spoken_unit = citation.unit
+        spoken_mgdl = (
+            spoken * MGDL_PER_MMOL if spoken_unit == GlucoseUnit.MMOL else spoken
+        )
+        nearest = _nearest_record(spoken_mgdl, records)
+        nearest_display = format_glucose(nearest, spoken_unit)
+        spoken_text = (
+            f"{_display(citation.values[0], spoken_unit)}-"
+            f"{_display(citation.values[1], spoken_unit)} {glucose_unit_label(spoken_unit)}"
+            if citation.is_range
+            else f"{_display(spoken, spoken_unit)} {glucose_unit_label(spoken_unit)}"
+        )
+        flags.append(
+            FlaggedSuggestion(
+                suggestion_type=SuggestionType.GLUCOSE_CITATION,
+                original_value=float(spoken_mgdl),
+                suggested_value=float(nearest),
+                change_pct=0.0,
+                max_allowed_pct=0.0,
+                reason=(
+                    f"AI-stated glucose {spoken_text} does not match any logged "
+                    f"reading (closest: {nearest_display}; tolerance "
+                    f"+/-{_band_label(spoken_unit)})"
+                ),
+            )
+        )
+    return flags

--- a/apps/api/src/services/glucose_citation.py
+++ b/apps/api/src/services/glucose_citation.py
@@ -20,10 +20,13 @@ Design (mirrors ``meal_citation``):
   * Deterministic and pure -- ``re`` extraction + the shared rounding-tolerant
     band (``core.units.glucose_display_matches``: +/-1 mg/dL or +/-0.1 mmol/L,
     never equality). No second LLM call.
-  * The extractor matches a number anchored to glucose by a per-volume unit
-    suffix (``mg/dL`` / ``mmol/L``) and excludes the ``1:X`` ISF / carb-ratio
-    forms and ISF *rates* ("50 mg/dL per unit"), so a correction-factor figure is
-    never mis-flagged as a glucose reading (those are the safety layer's job).
+  * The extractor only acts on a figure presented as the user's *reading*. A
+    number anchored to glucose by a per-volume unit suffix (``mg/dL`` /
+    ``mmol/L``) is a candidate, but ``1:X`` ISF / carb-ratio forms, ISF *rates*
+    ("50 mg/dL per unit"), low-to-high ranges, and threshold/directive figures
+    (targets, alert levels, "call if below 3.9 mmol/L") are passed through
+    untouched -- they are not readings, and correcting or scrubbing them would
+    fabricate or strip a level the user might act on.
   * Two consumption models share one extraction + match core:
       - rewrite (``verify_glucose_citations``): correct-or-scrub the reply text,
         for the chat handlers and the daily brief -- consistent with the carb
@@ -62,15 +65,16 @@ from src.services.safety_validation import (
 )
 
 # ── Extraction regexes ──
-# A glucose citation is a number (single value or low-to-high range) immediately
-# carrying a per-volume glucose unit. Requiring the ``/dL`` // ``/L`` denominator
-# excludes a bare "mg"/"mmol" (the abbreviated ISF suffix) and a carb "g/dL"
-# concentration. 1-4 integer digits so a hallucinated out-of-range value
-# (e.g. "1200 mg/dL") is still caught and flagged rather than silently skipped;
-# optional comma-grouped thousands and an optional decimal written with a dot OR
-# a comma -- mmol/L users (and European-locale model output) routinely write
-# "6,7 mmol/L", and the whole token must be captured, never half-read as "7".
-# ``_to_float`` normalizes the separators.
+# A candidate is a number immediately carrying a per-volume glucose unit.
+# Requiring the ``/dL`` // ``/L`` denominator excludes a bare "mg"/"mmol" (the
+# abbreviated ISF suffix) and a carb "g/dL" concentration. 1-4 integer digits so
+# a hallucinated out-of-range value (e.g. "1200 mg/dL") is still caught and
+# flagged rather than silently skipped; optional comma-grouped thousands and an
+# optional decimal written with a dot OR a comma -- mmol/L users (and
+# European-locale model output) routinely write "6,7 mmol/L", and the whole token
+# must be captured, never half-read as "7" (``_to_float`` normalizes them). The
+# optional range group lets a "X to Y unit" span match (and be skipped) as one
+# unit, so its trailing endpoint isn't half-extracted as a lone reading.
 _NUM = r"\d{1,4}(?:,\d{3})*(?:[.,]\d+)?"
 # Range separator: hyphen, en/em dash, or "to". Spaces/tabs only (not ``\s``) so
 # it cannot span newlines; a flat alternation with no nested quantifier.
@@ -97,17 +101,36 @@ _RATE_AFTER = re.compile(
 # value after the colon is never treated as a glucose reading.
 _ONE_TO_X = re.compile(r"1\s*:\s*\d+(?:\.\d+)?")
 
+# A figure governed by a directive / threshold word is a target or alert level
+# the model was told to state, NOT the user's reading -- e.g. "call if below
+# 3.9 mmol/L", "keep above 5.0", "target is 6.7", "severe low is 54 mg/dL".
+# Correcting such a figure to the current reading would fabricate a wrong
+# threshold a user might act on, so it is passed through untouched. The window is
+# short so only a directly-governing word counts (a far-away "if" in the same
+# sentence must not exempt a genuine "your glucose is N" reading); the tail
+# forbids a sentence terminator or another digit between the word and the number.
+_DIRECTIVE_BEFORE_RE = re.compile(
+    r"\b(?:below|above|under|over|if|call|treat|target|keep|stay|aim|alert|"
+    r"less\s+than|greater\s+than|severe\s+low|low\s+is|high\s+is)\b[^.;!?\d\n]*$",
+    re.IGNORECASE,
+)
+_DIRECTIVE_LOOKBACK = 16
+
 
 @dataclass(frozen=True)
 class _Citation:
-    """One extracted glucose-figure span (``values`` holds 1 value, or 2 for a
-    range), tagged with the unit its suffix named."""
+    """One extracted single-value glucose *reading* span, tagged with its unit.
+
+    Only a figure presented as the user's reading is extracted. Ranges and
+    threshold/directive figures (targets, alerts, "call if below N") are not
+    readings -- correcting or scrubbing them would fabricate or strip a level the
+    user might act on -- so they are never extracted and pass through untouched.
+    """
 
     start: int
     end: int
-    values: tuple[float, ...]
+    value: float
     unit: GlucoseUnit
-    is_range: bool
 
 
 @dataclass(frozen=True)
@@ -185,14 +208,11 @@ def verify_glucose_citation(
     )
 
 
-def _value_matches_any(value: float, unit: GlucoseUnit, records: Sequence[int]) -> bool:
-    return any(glucose_display_matches(record, value, unit) for record in records)
-
-
 def _citation_matches(citation: _Citation, records: Sequence[int]) -> bool:
-    """A citation verifies iff every endpoint traces to some allowed reading."""
-    return all(
-        _value_matches_any(value, citation.unit, records) for value in citation.values
+    """A citation verifies iff its value traces to some allowed reading."""
+    return any(
+        glucose_display_matches(record, citation.value, citation.unit)
+        for record in records
     )
 
 
@@ -223,11 +243,19 @@ def _is_excluded(start: int, end: int, excluded: list[tuple[int, int]]) -> bool:
     return any(s_start <= start < s_end for s_start, s_end in excluded)
 
 
-def _extract(text: str) -> list[_Citation]:
-    """Return non-overlapping glucose-figure spans, sorted by position.
+def _directive_before(text: str, start: int) -> bool:
+    window = text[max(0, start - _DIRECTIVE_LOOKBACK) : start]
+    return bool(_DIRECTIVE_BEFORE_RE.search(window))
 
-    Drops candidates that are ISF/carb-ratio figures or ISF rates, then resolves
-    overlaps left-to-right so each figure is verified exactly once.
+
+def _extract(text: str) -> list[_Citation]:
+    """Return non-overlapping glucose-*reading* spans, sorted by position.
+
+    Drops anything that is not a reading the verifier should act on: ISF/
+    carb-ratio figures and ISF rates (left to ``safety_validation``), low-to-high
+    ranges and threshold/directive figures (targets/alerts the model was told to
+    state -- never the user's reading). Then resolves overlaps left-to-right so
+    each reading is verified exactly once.
     """
     excluded = _excluded_spans(text)
     candidates: list[_Citation] = []
@@ -236,21 +264,26 @@ def _extract(text: str) -> list[_Citation]:
             continue
         if _RATE_AFTER.match(text, match.end()):
             continue
-        unit = _unit_from_suffix(match.group("unit"))
-        low = _to_float(match.group("low"))
-        high = match.group("high")
-        values = (low,) if high is None else (low, _to_float(high))
+        # A range ("70 to 180 mg/dL", "3.9-10.0") states bounds, not a reading.
+        if match.group("high") is not None:
+            continue
+        # A figure governed by a threshold/directive word is a target/alert level.
+        if _directive_before(text, match.start()):
+            continue
         candidates.append(
             _Citation(
                 start=match.start(),
                 end=match.end(),
-                values=values,
-                unit=unit,
-                is_range=high is not None,
+                value=_to_float(match.group("low")),
+                unit=_unit_from_suffix(match.group("unit")),
             )
         )
 
     # Resolve overlaps left-to-right: earliest start wins, longer span on a tie.
+    # Candidates are sorted by start, so a span overlaps the kept set iff its
+    # start falls before the furthest end kept so far -- an O(n) running-max
+    # check rather than rescanning every kept span, keeping the pass linear in
+    # the reading count for adversarially long output.
     candidates.sort(key=lambda c: (c.start, -(c.end - c.start)))
     kept: list[_Citation] = []
     max_end = 0
@@ -310,7 +343,7 @@ def verify_glucose_citations(
         if _citation_matches(citation, records):
             pieces.append(text[citation.start : citation.end])
             matched += 1
-        elif single_referent and not citation.is_range:
+        elif single_referent:
             # One reading to point at: correct the misquote rather than blank it.
             pieces.append(format_glucose(next(iter(referent_pool)), unit))
             corrected += 1
@@ -360,7 +393,7 @@ def find_glucose_citation_flags(
         if _citation_matches(citation, records):
             continue
 
-        spoken = citation.values[0]
+        spoken = citation.value
         spoken_unit = citation.unit
         spoken_mgdl = (
             spoken * MGDL_PER_MMOL if spoken_unit == GlucoseUnit.MMOL else spoken
@@ -368,10 +401,7 @@ def find_glucose_citation_flags(
         nearest = _nearest_record(spoken_mgdl, records)
         nearest_display = format_glucose(nearest, spoken_unit)
         spoken_text = (
-            f"{_display(citation.values[0], spoken_unit)}-"
-            f"{_display(citation.values[1], spoken_unit)} {glucose_unit_label(spoken_unit)}"
-            if citation.is_range
-            else f"{_display(spoken, spoken_unit)} {glucose_unit_label(spoken_unit)}"
+            f"{_display(spoken, spoken_unit)} {glucose_unit_label(spoken_unit)}"
         )
         flags.append(
             FlaggedSuggestion(

--- a/apps/api/src/services/meal_analysis.py
+++ b/apps/api/src/services/meal_analysis.py
@@ -26,6 +26,7 @@ from src.schemas.meal_analysis import MealPeriodData
 from src.services.ai_client import get_ai_client
 from src.services.diabetes_context import (
     PumpProfileSummary,
+    build_allowed_glucose,
     format_pump_profile_for_prompt,
     get_pump_profile_summary,
 )
@@ -362,8 +363,39 @@ async def generate_meal_analysis(
     )
 
     # Safety validation (Story 5.6). Unit-agnostic: the regexes accept either
-    # suffix and the ±20% check is unit-relative once a suffix matches.
-    safety_result = validate_ai_suggestion(ai_response.content, "meal_analysis")
+    # suffix and the ±20% check is unit-relative once a suffix matches. Any
+    # glucose figure the model spoke is also flagged if it doesn't trace to the
+    # period's readings; a failed allow-set fails open (no glucose flag) rather
+    # than break the analysis, matching the pump-profile fetch above. ``extra``
+    # admits the derived figures this prompt renders -- the spike threshold and
+    # each period's average peak / 2hr post-meal glucose -- so restating them is
+    # not mis-flagged as an unverifiable reading.
+    allowed_glucose: list[int] = []
+    try:
+        allow = await build_allowed_glucose(
+            db,
+            user.id,
+            window_start=period_start,
+            window_end=period_end,
+            extra=[
+                SPIKE_THRESHOLD,
+                *(mp.avg_peak_glucose for mp in meal_periods),
+                *(mp.avg_2hr_glucose for mp in meal_periods),
+            ],
+        )
+        allowed_glucose = allow.match
+    except Exception:
+        logger.warning(
+            "Failed to build glucose allow-set for meal analysis",
+            user_id=str(user.id),
+            exc_info=True,
+        )
+    safety_result = validate_ai_suggestion(
+        ai_response.content,
+        "meal_analysis",
+        records=allowed_glucose,
+        unit=unit,
+    )
 
     # Store the analysis with sanitized text
     analysis = MealAnalysis(

--- a/apps/api/src/services/safety_validation.py
+++ b/apps/api/src/services/safety_validation.py
@@ -6,10 +6,12 @@ ratio/factor changes stay within ±20% limits.
 """
 
 import re
+from collections.abc import Sequence
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.units import GlucoseUnit
 from src.logging_config import get_logger
 from src.models.safety_log import SafetyLog
 from src.schemas.safety_validation import (
@@ -210,6 +212,8 @@ def _extract_isf_changes(text: str) -> list[FlaggedSuggestion]:
 def validate_ai_suggestion(
     ai_text: str,
     suggestion_type: str,
+    records: Sequence[int] | None = None,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
 ) -> ValidationResult:
     """Validate an AI-generated suggestion against safety bounds.
 
@@ -217,14 +221,25 @@ def validate_ai_suggestion(
     1. Dangerous content (e.g., "double your dose")
     2. Carb ratio changes exceeding ±20%
     3. Correction factor changes exceeding ±20%
+    4. Glucose figures that don't trace to a logged reading (when ``records`` is
+       supplied)
 
     Args:
         ai_text: The AI-generated analysis text.
         suggestion_type: Type of analysis ("meal_analysis" or "correction_analysis").
+        records: Canonical mg/dL glucose readings the model was shown. When
+            provided, any spoken glucose figure that doesn't trace to one (within
+            the display-rounding band) is flagged. Omitted by callers that quote
+            no glucose data.
+        unit: The user's configured display unit (for the flag reason rendering).
 
     Returns:
         ValidationResult with status and any flagged items.
     """
+    # Imported lazily so this module can be imported without pulling in
+    # glucose_citation, which imports this module's regex patterns at top level.
+    from src.services.glucose_citation import find_glucose_citation_flags
+
     has_dangerous = _check_dangerous_content(ai_text)
     flagged_items: list[FlaggedSuggestion] = []
 
@@ -232,6 +247,16 @@ def validate_ai_suggestion(
     # (AI might mention both in any analysis)
     flagged_items.extend(_extract_carb_ratio_changes(ai_text))
     flagged_items.extend(_extract_isf_changes(ai_text))
+    if records:
+        # The glucose-citation flag is advisory (it appends a warning; it never
+        # gates output), and the dangerous-content check above is the real
+        # blocker. If the verifier somehow raises, fail open -- drop the advisory
+        # flag and log it -- rather than break the whole validation, matching how
+        # the analysis callers fail open when the allow-set can't be built.
+        try:
+            flagged_items.extend(find_glucose_citation_flags(ai_text, records, unit))
+        except Exception:
+            logger.warning("Glucose citation flagging failed", exc_info=True)
 
     # Determine status
     if has_dangerous:
@@ -254,8 +279,8 @@ def validate_ai_suggestion(
         for item in flagged_items:
             warnings.append(f"- {item.reason}")
         warning_block = (
-            "\n\n**Safety Warning:** The following suggestions exceed "
-            "recommended change limits:\n" + "\n".join(warnings) + "\n"
+            "\n\n**Safety Warning:** The following AI statements were flagged "
+            "by the safety system:\n" + "\n".join(warnings) + "\n"
             "Discuss these with your endocrinologist before making changes."
         )
         sanitized = ai_text + warning_block

--- a/apps/api/src/services/telegram_chat.py
+++ b/apps/api/src/services/telegram_chat.py
@@ -40,6 +40,7 @@ from src.services.chat_history import (
 )
 from src.services.diabetes_context import (
     build_diabetes_context,
+    verify_glucose_reading_citations,
     verify_meal_citations,
 )
 
@@ -268,8 +269,12 @@ async def handle_chat(
         )
 
     # Verify any meal carb figure the model cited against the user's logged
-    # meals before it reaches the user or is persisted.
+    # meals, and any glucose figure against the user's readings, before it
+    # reaches the user or is persisted.
     content = await verify_meal_citations(db, user_id, content, surface="chat")
+    content = await verify_glucose_reading_citations(
+        db, user_id, content, surface="chat"
+    )
 
     # Persist both messages (non-fatal -- still return the AI response on failure)
     try:
@@ -422,8 +427,12 @@ async def handle_chat_web(
         )
 
     # Verify any meal carb figure the model cited against the user's logged
-    # meals before it reaches the user or is persisted.
+    # meals, and any glucose figure against the user's readings, before it
+    # reaches the user or is persisted.
     content = await verify_meal_citations(db, user_id, content, surface="chat_web")
+    content = await verify_glucose_reading_citations(
+        db, user_id, content, surface="chat_web"
+    )
 
     # Persist both messages (non-fatal -- still return the AI response on failure)
     user_msg_id: uuid.UUID | None = None
@@ -629,9 +638,14 @@ async def handle_caregiver_chat(
             "Please try rephrasing your question." + SAFETY_DISCLAIMER
         )
 
-    # Verify cited meal carb figures against the *patient's* logged meals --
-    # the context was built from the patient's data.
+    # Verify cited meal carb figures against the *patient's* logged meals and
+    # glucose figures against the patient's readings -- the context was built
+    # from the patient's data, so the verification (and the patient's unit) is
+    # keyed on ``patient_id``.
     content = await verify_meal_citations(db, patient_id, content, surface="caregiver")
+    content = await verify_glucose_reading_citations(
+        db, patient_id, content, surface="caregiver"
+    )
 
     safe_content = html.escape(content)
 
@@ -738,9 +752,14 @@ async def handle_caregiver_chat_web(
             detail="The AI returned an empty response",
         )
 
-    # Verify cited meal carb figures against the *patient's* logged meals --
-    # the context was built from the patient's data.
+    # Verify cited meal carb figures against the *patient's* logged meals and
+    # glucose figures against the patient's readings -- the context was built
+    # from the patient's data, so the verification (and the patient's unit) is
+    # keyed on ``patient_id``.
     content = await verify_meal_citations(
+        db, patient_id, content, surface="caregiver_web"
+    )
+    content = await verify_glucose_reading_citations(
         db, patient_id, content, surface="caregiver_web"
     )
 

--- a/apps/api/tests/test_diabetes_context.py
+++ b/apps/api/tests/test_diabetes_context.py
@@ -849,7 +849,17 @@ def _mock_db_for_glucose(reading_values, target=None):
 @pytest.mark.asyncio
 class TestBuildAllowedGlucose:
     """The glucose allow-set = real readings + rendered aggregates (avg, target
-    bounds) + surface extras; readings are kept separate as the referent basis."""
+    bounds) + configured pump thresholds + surface extras; readings are kept
+    separate as the referent basis."""
+
+    @pytest.fixture(autouse=True)
+    def _no_pump_profile(self, monkeypatch):
+        # Most cases don't exercise the pump profile; default it to absent so the
+        # readings/avg/target assertions are exact. The dedicated case re-patches.
+        monkeypatch.setattr(
+            "src.services.diabetes_context.get_pump_profile_summary",
+            AsyncMock(return_value=None),
+        )
 
     async def test_includes_readings_avg_and_default_target(self, monkeypatch):
         monkeypatch.setattr(
@@ -925,6 +935,41 @@ class TestBuildAllowedGlucose:
 
         assert allow.readings == []
         assert set(allow.match) == {70, 180}  # defaults only, no avg
+
+    async def test_includes_configured_pump_thresholds(self, monkeypatch):
+        # The model is shown the pump-profile segment targets + CGM alert levels,
+        # so a reply restating one must be matchable (not scrubbed as invented).
+        monkeypatch.setattr(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            AsyncMock(return_value=[]),
+        )
+        profile = _make_summary(
+            segments=[
+                ProfileSegment(
+                    time="00:00",
+                    start_minutes=0,
+                    basal_rate=0.5,
+                    correction_factor=50,
+                    carb_ratio=8,
+                    target_bg=100,
+                )
+            ],
+            cgm_high_alert_mgdl=200,
+            cgm_low_alert_mgdl=60,
+        )
+        monkeypatch.setattr(
+            "src.services.diabetes_context.get_pump_profile_summary",
+            AsyncMock(return_value=profile),
+        )
+        db = _mock_db_for_glucose([120])
+
+        allow = await build_allowed_glucose(
+            db, uuid.uuid4(), window_start=datetime.now(UTC) - timedelta(hours=6)
+        )
+
+        # segment target 100, CGM high 200, CGM low 60 all land in match.
+        assert {100, 200, 60} <= set(allow.match)
+        assert allow.readings == [120]  # thresholds are not reading referents
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_diabetes_context.py
+++ b/apps/api/tests/test_diabetes_context.py
@@ -12,10 +12,12 @@ from src.core.units import GlucoseUnit
 from src.services.diabetes_context import (
     MEAL_CONTEXT_HOURS,
     MEAL_DESCRIPTION_MAX_LEN,
+    GlucoseAllowSet,
     ProfileSegment,
     PumpProfileSummary,
     _sanitize_for_prompt,
     build_allowed_carbs,
+    build_allowed_glucose,
     build_diabetes_context,
     build_meals_section,
     build_pump_profile_section,
@@ -24,6 +26,7 @@ from src.services.diabetes_context import (
     format_meals_for_brief,
     format_pump_profile_for_prompt,
     get_pump_profile_summary,
+    verify_glucose_reading_citations,
     verify_meal_citations,
 )
 from src.services.meal_citation import SCRUB_TEMPLATE
@@ -830,3 +833,159 @@ class TestVerifyMealCitationsGate:
 
         assert "999" not in result
         assert "~60-80g carbs" in result
+
+
+def _mock_db_for_glucose(reading_values, target=None):
+    """Mock a db whose two execute calls return the glucose readings then the
+    target-range row (``build_allowed_glucose`` queries readings, then target)."""
+    db = AsyncMock()
+    readings_result = [(value,) for value in reading_values]
+    target_result = MagicMock()
+    target_result.scalar_one_or_none.return_value = target
+    db.execute = AsyncMock(side_effect=[readings_result, target_result])
+    return db
+
+
+@pytest.mark.asyncio
+class TestBuildAllowedGlucose:
+    """The glucose allow-set = real readings + rendered aggregates (avg, target
+    bounds) + surface extras; readings are kept separate as the referent basis."""
+
+    async def test_includes_readings_avg_and_default_target(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            AsyncMock(return_value=[]),
+        )
+        db = _mock_db_for_glucose([100, 140])  # avg 120, no target row
+
+        allow = await build_allowed_glucose(
+            db, uuid.uuid4(), window_start=datetime.now(UTC) - timedelta(hours=6)
+        )
+
+        assert allow.readings == [100, 140]
+        # readings + avg(120) + default target bounds 70/180
+        assert set(allow.match) == {100, 140, 120, 70, 180}
+
+    async def test_filters_out_of_range_readings(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            AsyncMock(return_value=[]),
+        )
+        db = _mock_db_for_glucose([19, 20, 500, 501, 120])
+
+        allow = await build_allowed_glucose(
+            db, uuid.uuid4(), window_start=datetime.now(UTC) - timedelta(hours=6)
+        )
+
+        # 19 and 501 dropped; 20 and 500 are inclusive boundaries.
+        assert allow.readings == [20, 120, 500]
+
+    async def test_configured_target_bounds_used(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            AsyncMock(return_value=[]),
+        )
+        target = SimpleNamespace(low_target=80.0, high_target=160.0)
+        db = _mock_db_for_glucose([120], target=target)
+
+        allow = await build_allowed_glucose(
+            db, uuid.uuid4(), window_start=datetime.now(UTC) - timedelta(hours=6)
+        )
+
+        assert 80 in allow.match and 160 in allow.match
+
+    async def test_extra_figures_added_to_match_not_readings(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            AsyncMock(return_value=[]),
+        )
+        db = _mock_db_for_glucose([120])
+
+        allow = await build_allowed_glucose(
+            db,
+            uuid.uuid4(),
+            window_start=datetime.now(UTC) - timedelta(hours=6),
+            extra=[145.0, 0.0],  # a derived figure; the 0.0 placeholder is skipped
+        )
+
+        assert 145 in allow.match
+        assert 0 not in allow.match
+        assert allow.readings == [120]  # extras never count as referents
+
+    async def test_empty_readings_still_returns_target_bounds(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            AsyncMock(return_value=[]),
+        )
+        db = _mock_db_for_glucose([])
+
+        allow = await build_allowed_glucose(
+            db, uuid.uuid4(), window_start=datetime.now(UTC) - timedelta(hours=6)
+        )
+
+        assert allow.readings == []
+        assert set(allow.match) == {70, 180}  # defaults only, no avg
+
+
+@pytest.mark.asyncio
+class TestVerifyGlucoseReadingCitations:
+    """The chat/brief choke-point: corrects-or-scrubs, fails closed, PHI-free."""
+
+    async def test_empty_content_passthrough(self):
+        db = AsyncMock()
+        result = await verify_glucose_reading_citations(
+            db, uuid.uuid4(), "", surface="chat", unit=GlucoseUnit.MGDL
+        )
+        assert result == ""
+        db.execute.assert_not_called()
+
+    async def test_corrects_against_single_referent(self, monkeypatch):
+        # Match set padded with target bounds, single real reading referent 120.
+        monkeypatch.setattr(
+            "src.services.diabetes_context.build_allowed_glucose",
+            AsyncMock(
+                return_value=GlucoseAllowSet(match=[70, 120, 180], readings=[120])
+            ),
+        )
+        result = await verify_glucose_reading_citations(
+            AsyncMock(),
+            uuid.uuid4(),
+            "Your glucose is 200 mg/dL now.",
+            surface="chat",
+            unit=GlucoseUnit.MGDL,
+        )
+        assert "200" not in result
+        assert "120 mg/dL" in result
+
+    async def test_unit_auto_resolved_when_not_passed(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.glucose_unit.resolve_glucose_unit",
+            AsyncMock(return_value=GlucoseUnit.MMOL),
+        )
+        monkeypatch.setattr(
+            "src.services.diabetes_context.build_allowed_glucose",
+            AsyncMock(return_value=GlucoseAllowSet(match=[120], readings=[120])),
+        )
+        result = await verify_glucose_reading_citations(
+            AsyncMock(),
+            uuid.uuid4(),
+            "Your glucose is 9.9 mmol/L now.",
+            surface="chat",
+        )
+        # Corrected into the resolved unit (mmol): 120 mg/dL -> 6.7 mmol/L.
+        assert "6.7 mmol/L" in result
+
+    async def test_fail_closed_scrubs_when_allow_set_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.diabetes_context.build_allowed_glucose",
+            AsyncMock(side_effect=RuntimeError("db down")),
+        )
+        result = await verify_glucose_reading_citations(
+            AsyncMock(),
+            uuid.uuid4(),
+            "Your glucose is 120 mg/dL.",
+            surface="chat",
+            unit=GlucoseUnit.MGDL,
+        )
+        assert "120" not in result
+        assert "can't verify" in result

--- a/apps/api/tests/test_glucose_citation.py
+++ b/apps/api/tests/test_glucose_citation.py
@@ -76,15 +76,14 @@ class TestExtractor:
 
     def test_extracts_mgdl_and_mmol(self):
         cites = _extract("BG was 120 mg/dL, now 6.7 mmol/L")
-        assert [(c.values, c.unit) for c in cites] == [
-            ((120.0,), GlucoseUnit.MGDL),
-            ((6.7,), GlucoseUnit.MMOL),
+        assert [(c.value, c.unit) for c in cites] == [
+            (120.0, GlucoseUnit.MGDL),
+            (6.7, GlucoseUnit.MMOL),
         ]
 
-    def test_extracts_range(self):
-        (cite,) = _extract("ranged from 70 to 180 mg/dL")
-        assert cite.values == (70.0, 180.0)
-        assert cite.is_range
+    def test_range_not_extracted_passes_through(self):
+        # A range states bounds (a target/summary), not a reading -> pass through.
+        assert _extract("ranged from 70 to 180 mg/dL") == []
 
     def test_ignores_isf_one_to_x(self):
         assert _extract("Adjust ISF from 1:50 to 1:45 mg/dL") == []
@@ -134,7 +133,7 @@ class TestCommaSeparators:
     def test_thousands_comma_parses_whole(self):
         # "1,025" is 1025 (out of range) -> not the orphan "1,120".
         cites = _extract("Reading was 1,025 mg/dL.")
-        assert cites[0].values == (1025.0,)
+        assert cites[0].value == 1025.0
 
     def test_comma_decimal_flag_reason_is_clean(self):
         (flag,) = find_glucose_citation_flags(
@@ -154,7 +153,7 @@ class TestIsfExclusionPrecision:
         )
         cites = _extract(text)
         # Only the real reading 250 is a glucose citation; the ISF figures are not.
-        assert [c.values for c in cites] == [(250.0,)]
+        assert [c.value for c in cites] == [250.0]
 
     def test_hallucinated_reading_beside_isf_keyword_is_corrected(self):
         text = "correction factor note: BG 250 mg/dL today, move 50 to 45 mg/dL"
@@ -202,19 +201,37 @@ class TestRewrite:
         assert "can't verify" in outcome.text
         assert outcome.citations_scrubbed == 1
 
-    def test_range_mismatch_scrubbed_not_corrected(self):
-        # A range can't be corrected to a single referent, so it is scrubbed.
-        outcome = verify_glucose_citations(
-            "ranged 40 to 300 mg/dL", [120], GlucoseUnit.MGDL
-        )
-        assert outcome.citations_scrubbed == 1
-        assert "300" not in outcome.text
-
-    def test_range_within_data_matched(self):
-        text = "ranged 70 to 180 mg/dL"
-        outcome = verify_glucose_citations(text, [70, 120, 180], GlucoseUnit.MGDL)
+    def test_range_passes_through_untouched(self):
+        # A range states bounds, not a reading, so it is never corrected/scrubbed
+        # -- even one that doesn't trace to the data is left exactly as written.
+        text = "ranged 40 to 300 mg/dL"
+        outcome = verify_glucose_citations(text, [120], GlucoseUnit.MGDL)
         assert outcome.text == text
-        assert outcome.citations_matched == 1
+        assert outcome.citations_seen == 0
+
+    def test_directive_threshold_passes_through(self):
+        # A hypo-treatment threshold must never be "corrected" to the reading.
+        for text, unit in [
+            ("Call if below 3.9 mmol/L.", GlucoseUnit.MMOL),
+            ("Severe low is 54 mg/dL.", GlucoseUnit.MGDL),
+            ("Keep above 5.0 mmol/L.", GlucoseUnit.MMOL),
+            ("Your target is 6.7 mmol/L.", GlucoseUnit.MMOL),
+        ]:
+            outcome = verify_glucose_citations(text, [120], unit)
+            assert outcome.text == text
+            assert outcome.citations_seen == 0
+
+    def test_reading_still_acted_on_beside_a_threshold(self):
+        # A genuine reading misquote is still corrected even when the same reply
+        # also states a (passed-through) threshold.
+        outcome = verify_glucose_citations(
+            "Your glucose is 200 mg/dL; call if below 3.9 mmol/L.",
+            [120],
+            GlucoseUnit.MGDL,
+        )
+        assert "120 mg/dL" in outcome.text  # the reading is corrected
+        assert "below 3.9 mmol/L" in outcome.text  # the threshold is untouched
+        assert outcome.citations_corrected == 1
 
     def test_empty_records_scrubs_every_figure(self):
         outcome = verify_glucose_citations(

--- a/apps/api/tests/test_glucose_citation.py
+++ b/apps/api/tests/test_glucose_citation.py
@@ -1,0 +1,391 @@
+"""Tests for output-side glucose-citation verification.
+
+Covers the single-value verifier, the free-text extractor (which must tell a
+glucose reading apart from an ISF / carb-ratio figure), the correct-or-scrub
+rewrite, and the flag path -- in both mg/dL and mmol/L, plus the round-trip
+safety property over the whole [20, 500] range.
+"""
+
+import pytest
+
+from src.core.units import (
+    MGDL_PER_MMOL,
+    GlucoseUnit,
+    format_glucose_value,
+)
+from src.schemas.safety_validation import SuggestionType
+from src.services.glucose_citation import (
+    GLUCOSE_VALUE_PATTERN,
+    _extract,
+    find_glucose_citation_flags,
+    verify_glucose_citation,
+    verify_glucose_citations,
+)
+
+
+class TestSingleValueVerifier:
+    """`verify_glucose_citation` applies the rounding-tolerant band, not equality."""
+
+    def test_mgdl_within_one_passes(self):
+        assert verify_glucose_citation(120, "mgdl", 120)
+        assert verify_glucose_citation(121, "mgdl", 120)
+        assert verify_glucose_citation(119, "mgdl", 120)
+
+    def test_mgdl_outside_one_fails(self):
+        assert not verify_glucose_citation(122, "mgdl", 120)
+        assert not verify_glucose_citation(118, "mgdl", 120)
+
+    def test_mmol_within_one_tenth_passes(self):
+        assert verify_glucose_citation(6.7, "mmol", 120)
+        assert verify_glucose_citation(6.6, "mmol", 120)
+
+    def test_mmol_outside_one_tenth_fails(self):
+        assert not verify_glucose_citation(6.4, "mmol", 120)
+
+    def test_unit_token_accepts_labels(self):
+        # The token may arrive as a display label, not just the short form.
+        assert verify_glucose_citation(6.7, "mmol/L", 120)
+        assert verify_glucose_citation(120, "mg/dL", 120)
+
+
+class TestRoundingDriftBoundaries:
+    """Conventional anchors: converted-and-rounded display values must verify, a
+    genuinely wrong number must not."""
+
+    def test_99_mgdl_spoken_5_5_mmol_passes(self):
+        assert verify_glucose_citation(5.5, "mmol", 99)
+
+    def test_100_mgdl_spoken_5_6_mmol_passes(self):
+        assert verify_glucose_citation(5.6, "mmol", 100)
+
+    def test_180_mgdl_spoken_10_0_mmol_passes(self):
+        assert verify_glucose_citation(10.0, "mmol", 180)
+
+    def test_record_99_spoken_9_9_mmol_fails(self):
+        # A tenfold misread (5.5 -> 9.9) is the wrong-number case that must fail.
+        assert not verify_glucose_citation(9.9, "mmol", 99)
+
+    def test_uses_consolidated_factor_not_a_local_literal(self):
+        # 100 mg/dL converts to 5.55 mmol with 18.0156; the legacy 18.0182 would
+        # render 5.5, so this pins the consolidated constant.
+        assert round(100 / MGDL_PER_MMOL, 1) == 5.6
+
+
+class TestExtractor:
+    """The extractor pulls glucose figures while leaving ISF / carb-ratio alone."""
+
+    def test_extracts_mgdl_and_mmol(self):
+        cites = _extract("BG was 120 mg/dL, now 6.7 mmol/L")
+        assert [(c.values, c.unit) for c in cites] == [
+            ((120.0,), GlucoseUnit.MGDL),
+            ((6.7,), GlucoseUnit.MMOL),
+        ]
+
+    def test_extracts_range(self):
+        (cite,) = _extract("ranged from 70 to 180 mg/dL")
+        assert cite.values == (70.0, 180.0)
+        assert cite.is_range
+
+    def test_ignores_isf_one_to_x(self):
+        assert _extract("Adjust ISF from 1:50 to 1:45 mg/dL") == []
+
+    def test_ignores_isf_context_keyword(self):
+        assert _extract("change correction factor from 50 to 45 mg/dL") == []
+
+    def test_ignores_carb_ratio(self):
+        # No per-volume suffix at all -- never a glucose citation.
+        assert _extract("carb ratio 1:8 is fine") == []
+
+    def test_ignores_isf_rate(self):
+        assert _extract("your ISF is 50.0 mg/dL per unit") == []
+
+    def test_ignores_bare_grams_and_g_per_dl(self):
+        # A carb concentration ("g/dL") is not a glucose reading suffix.
+        assert _extract("about 80 g of carbs, albumin 4 g/dL") == []
+
+    def test_pattern_requires_per_volume_denominator(self):
+        # A bare "mg" / "mmol" (the abbreviated ISF suffix) is not a reading.
+        assert GLUCOSE_VALUE_PATTERN.search("dose 5 mg now") is None
+        assert GLUCOSE_VALUE_PATTERN.search("120 mg/dL") is not None
+
+
+class TestCommaSeparators:
+    """A comma is a European decimal point or a thousands separator -- the figure
+    must be parsed whole, never half-read (which would turn a correct citation
+    into a mismatch and leave an orphan fragment)."""
+
+    def test_comma_decimal_mmol_matches(self):
+        # 120 mg/dL == 6.66 mmol -> displays "6.7"; "6,7" must read as 6.7.
+        outcome = verify_glucose_citations(
+            "Your glucose was 6,7 mmol/L.", [120], GlucoseUnit.MMOL
+        )
+        assert outcome.text == "Your glucose was 6,7 mmol/L."
+        assert outcome.citations_matched == 1
+
+    def test_comma_decimal_wrong_value_scrubbed_cleanly(self):
+        # A genuinely wrong comma decimal is removed with no orphan "9," left.
+        outcome = verify_glucose_citations(
+            "You spiked to 9,2 mmol/L.", [120, 90], GlucoseUnit.MMOL
+        )
+        assert "9,2" not in outcome.text
+        assert "9," not in outcome.text
+        assert outcome.citations_scrubbed == 1
+
+    def test_thousands_comma_parses_whole(self):
+        # "1,025" is 1025 (out of range) -> not the orphan "1,120".
+        cites = _extract("Reading was 1,025 mg/dL.")
+        assert cites[0].values == (1025.0,)
+
+    def test_comma_decimal_flag_reason_is_clean(self):
+        (flag,) = find_glucose_citation_flags(
+            "You spiked to 9,2 mmol/L.", [120], GlucoseUnit.MMOL
+        )
+        assert "9.2 mmol/L" in flag.reason
+
+
+class TestIsfExclusionPrecision:
+    """A real reading sharing a sentence with an ISF change is still verified --
+    the exclusion covers only the ISF figure, not the prose around it."""
+
+    def test_reading_beside_isf_change_is_extracted(self):
+        text = (
+            "Your correction factor analysis: BG was 250 mg/dL, "
+            "recommend moving from 50 to 45 mg/dL."
+        )
+        cites = _extract(text)
+        # Only the real reading 250 is a glucose citation; the ISF figures are not.
+        assert [c.values for c in cites] == [(250.0,)]
+
+    def test_hallucinated_reading_beside_isf_keyword_is_corrected(self):
+        text = "correction factor note: BG 250 mg/dL today, move 50 to 45 mg/dL"
+        outcome = verify_glucose_citations(text, [120], GlucoseUnit.MGDL)
+        assert "250" not in outcome.text
+        assert "120 mg/dL" in outcome.text  # corrected, not bypassed
+
+    def test_isf_rate_with_drop_word_excluded(self):
+        # The correction-analysis prompt phrases the rate as "X mg/dL drop per unit".
+        assert _extract("observed ISF is 50 mg/dL drop per unit") == []
+
+
+class TestRewrite:
+    """`verify_glucose_citations`: matched unchanged, single referent corrected,
+    ambiguous scrubbed."""
+
+    def test_matched_value_unchanged(self):
+        text = "Your average was 6.7 mmol/L today."
+        outcome = verify_glucose_citations(text, [120], GlucoseUnit.MMOL)
+        assert outcome.text == text
+        assert outcome.citations_matched == 1
+        assert not outcome.changed
+
+    def test_single_referent_corrected_in_user_unit(self):
+        outcome = verify_glucose_citations(
+            "Your glucose is 200 mg/dL now.", [120], GlucoseUnit.MGDL
+        )
+        assert "120 mg/dL" in outcome.text
+        assert "200" not in outcome.text
+        assert outcome.citations_corrected == 1
+
+    def test_single_referent_corrects_into_mmol(self):
+        outcome = verify_glucose_citations(
+            "Your glucose is 9.9 mmol/L now.", [120], GlucoseUnit.MMOL
+        )
+        assert "6.7 mmol/L" in outcome.text
+        assert "9.9" not in outcome.text
+        assert outcome.citations_corrected == 1
+
+    def test_ambiguous_scrubbed(self):
+        outcome = verify_glucose_citations(
+            "You hit 250 mg/dL overnight.", [120, 140, 90], GlucoseUnit.MGDL
+        )
+        assert "250" not in outcome.text
+        assert "can't verify" in outcome.text
+        assert outcome.citations_scrubbed == 1
+
+    def test_range_mismatch_scrubbed_not_corrected(self):
+        # A range can't be corrected to a single referent, so it is scrubbed.
+        outcome = verify_glucose_citations(
+            "ranged 40 to 300 mg/dL", [120], GlucoseUnit.MGDL
+        )
+        assert outcome.citations_scrubbed == 1
+        assert "300" not in outcome.text
+
+    def test_range_within_data_matched(self):
+        text = "ranged 70 to 180 mg/dL"
+        outcome = verify_glucose_citations(text, [70, 120, 180], GlucoseUnit.MGDL)
+        assert outcome.text == text
+        assert outcome.citations_matched == 1
+
+    def test_empty_records_scrubs_every_figure(self):
+        outcome = verify_glucose_citations(
+            "BG 120 mg/dL and 6.7 mmol/L", [], GlucoseUnit.MGDL
+        )
+        assert outcome.citations_scrubbed == 2
+        assert "120" not in outcome.text and "6.7" not in outcome.text
+
+    def test_empty_text_is_noop(self):
+        outcome = verify_glucose_citations("", [120], GlucoseUnit.MGDL)
+        assert outcome.text == ""
+        assert outcome.citations_seen == 0
+
+    def test_does_not_mutate_records(self):
+        records = [120, 140]
+        verify_glucose_citations("BG 999 mg/dL", records, GlucoseUnit.MGDL)
+        assert records == [120, 140]
+
+    def test_bucket_invariant_holds(self):
+        outcome = verify_glucose_citations(
+            "BG 120 mg/dL, then 250 mg/dL, then 90 mg/dL", [120], GlucoseUnit.MGDL
+        )
+        assert outcome.citations_seen == (
+            outcome.citations_matched
+            + outcome.citations_corrected
+            + outcome.citations_scrubbed
+        )
+
+    def test_determiner_scrub_drops_article(self):
+        # "the 250 mg/dL" -> "the glucose value...", not "the a glucose value...".
+        outcome = verify_glucose_citations(
+            "BG reached the 250 mg/dL overnight.", [120, 140, 90], GlucoseUnit.MGDL
+        )
+        assert "the glucose value I can't verify" in outcome.text
+        assert "the a glucose" not in outcome.text
+        assert "250" not in outcome.text
+
+    def test_no_determiner_keeps_article(self):
+        outcome = verify_glucose_citations(
+            "You hit 250 mg/dL.", [120, 140, 90], GlucoseUnit.MGDL
+        )
+        assert "hit a glucose value I can't verify" in outcome.text
+
+    def test_referents_decide_correction_not_padded_match_set(self):
+        # The match set carries padded aggregates (target bounds), but a single
+        # real reading referent still drives a correction rather than a scrub.
+        outcome = verify_glucose_citations(
+            "Your glucose is 200 mg/dL now.",
+            [70, 120, 180],
+            GlucoseUnit.MGDL,
+            referents=[120],
+        )
+        assert "120 mg/dL" in outcome.text
+        assert outcome.citations_corrected == 1
+
+    def test_multiple_referents_scrub(self):
+        outcome = verify_glucose_citations(
+            "Your glucose is 200 mg/dL now.",
+            [70, 120, 180],
+            GlucoseUnit.MGDL,
+            referents=[120, 140],
+        )
+        assert outcome.citations_scrubbed == 1
+
+    def test_multiple_citations_one_line(self):
+        outcome = verify_glucose_citations(
+            "BG went 120 mg/dL then 250 mg/dL same line.", [120], GlucoseUnit.MGDL
+        )
+        assert outcome.citations_seen == 2
+        assert outcome.citations_matched == 1  # 120 matches
+        assert outcome.citations_corrected == 1  # 250 -> single referent 120
+
+
+class TestFlagPath:
+    """`find_glucose_citation_flags` for the validate_ai_suggestion surface."""
+
+    def test_mismatch_flagged_with_unit_correct_reason(self):
+        flags = find_glucose_citation_flags(
+            "You spiked to 9.9 mmol/L.", [99, 120], GlucoseUnit.MMOL
+        )
+        assert len(flags) == 1
+        flag = flags[0]
+        assert flag.suggestion_type == SuggestionType.GLUCOSE_CITATION
+        # Reason states the spoken value and the closest reading in the same unit.
+        assert "9.9 mmol/L" in flag.reason
+        assert "6.7 mmol/L" in flag.reason
+        assert "0.1 mmol/L" in flag.reason
+
+    def test_mgdl_reason_uses_mgdl_band(self):
+        (flag,) = find_glucose_citation_flags(
+            "BG read 200 mg/dL.", [120], GlucoseUnit.MGDL
+        )
+        assert "200 mg/dL" in flag.reason
+        assert "1 mg/dL" in flag.reason
+
+    def test_matched_figures_not_flagged(self):
+        assert (
+            find_glucose_citation_flags(
+                "Your average was 6.7 mmol/L.", [120], GlucoseUnit.MMOL
+            )
+            == []
+        )
+
+    def test_no_records_no_flags(self):
+        assert find_glucose_citation_flags("BG 200 mg/dL", [], GlucoseUnit.MGDL) == []
+
+    def test_change_pct_is_zero_not_a_factor_change(self):
+        (flag,) = find_glucose_citation_flags(
+            "BG read 200 mg/dL.", [120], GlucoseUnit.MGDL
+        )
+        assert flag.change_pct == 0.0
+        assert flag.max_allowed_pct == 0.0
+
+    def test_numeric_fields_both_mgdl(self):
+        # 9.9 mmol ~= 178 mg/dL spoken; nearest record 120 mg/dL. Both fields are
+        # canonical mg/dL so a future consumer can't mistake mmol for mg/dL.
+        (flag,) = find_glucose_citation_flags(
+            "You spiked to 9.9 mmol/L.", [120], GlucoseUnit.MMOL
+        )
+        assert flag.original_value == pytest.approx(9.9 * MGDL_PER_MMOL)
+        assert flag.suggested_value == 120.0
+
+    def test_multiple_mismatches_one_line_each_flagged(self):
+        flags = find_glucose_citation_flags(
+            "your BG went 90 mg/dL to 250 mg/dL", [120], GlucoseUnit.MGDL
+        )
+        # Two distinct single-value hallucinations on one line -> two flags.
+        assert len(flags) == 2
+
+
+class TestRoundTripSafetyProperty:
+    """Round-trip safety property: every integer mg/dL in the safety range,
+    displayed in either unit and then verified against its own record, must pass
+    the band -- a mis-rounded threshold must never read as a mismatch (and must
+    never be scrubbed)."""
+
+    @pytest.mark.parametrize("unit", [GlucoseUnit.MGDL, GlucoseUnit.MMOL])
+    @pytest.mark.parametrize("mgdl", range(20, 501))
+    def test_displayed_value_verifies_against_its_record(self, mgdl, unit):
+        shown = format_glucose_value(mgdl, unit)
+        label = "mmol/L" if unit == GlucoseUnit.MMOL else "mg/dL"
+        unit_token = "mmol" if unit == GlucoseUnit.MMOL else "mgdl"
+
+        # The single-value verifier accepts it.
+        assert verify_glucose_citation(float(shown), unit_token, mgdl)
+
+        # And the full extractor + rewrite + flag path treat it as verified:
+        # not scrubbed, not corrected, not flagged.
+        text = f"Your glucose is {shown} {label}."
+        outcome = verify_glucose_citations(text, [mgdl], unit)
+        assert outcome.text == text
+        assert outcome.citations_matched == 1
+        assert find_glucose_citation_flags(text, [mgdl], unit) == []
+
+    @pytest.mark.parametrize("unit", [GlucoseUnit.MGDL, GlucoseUnit.MMOL])
+    @pytest.mark.parametrize("mgdl", range(20, 501))
+    def test_off_band_value_is_rejected(self, mgdl, unit):
+        # The reject direction swept across the range: a value bumped clearly
+        # outside the band (so display rounding can't pull it back in) must never
+        # verify -- catches a partial band-widening regression a few fixed points
+        # would miss.
+        shown = float(format_glucose_value(mgdl, unit))
+        unit_token = "mmol" if unit == GlucoseUnit.MMOL else "mgdl"
+        bump = 0.5 if unit == GlucoseUnit.MMOL else 2
+        bumped = round(shown + bump, 1)
+
+        assert not verify_glucose_citation(bumped, unit_token, mgdl)
+        label = "mmol/L" if unit == GlucoseUnit.MMOL else "mg/dL"
+        text = f"Your glucose is {bumped} {label}."
+        outcome = verify_glucose_citations(text, [mgdl], unit)
+        # Single referent -> corrected (not matched); flag path emits one flag.
+        assert outcome.citations_matched == 0
+        assert outcome.citations_corrected == 1
+        assert len(find_glucose_citation_flags(text, [mgdl], unit)) == 1

--- a/apps/api/tests/test_safety_validation.py
+++ b/apps/api/tests/test_safety_validation.py
@@ -263,6 +263,90 @@ class TestExtractISFChanges:
         assert isf[0].suggested_value == 2.5
 
 
+class TestGlucoseCitationFlagging:
+    """validate_ai_suggestion flags a spoken glucose figure that doesn't trace to
+    the supplied readings, while staying backward-compatible when none are."""
+
+    def test_no_records_does_not_flag_glucose(self):
+        # Default call (no readings) must behave exactly as before: a stray
+        # glucose figure is not flagged when there's nothing to verify against.
+        text = "Your glucose hit 250 mg/dL overnight."
+        result = validate_ai_suggestion(text, "daily_brief")
+        assert result.status == SafetyStatus.APPROVED
+        assert not any(
+            f.suggestion_type == SuggestionType.GLUCOSE_CITATION
+            for f in result.flagged_items
+        )
+
+    def test_matching_glucose_not_flagged(self):
+        text = "Your average was 6.7 mmol/L today."
+        result = validate_ai_suggestion(
+            text, "daily_brief", records=[120], unit=GlucoseUnit.MMOL
+        )
+        assert result.status == SafetyStatus.APPROVED
+        assert result.flagged_items == []
+
+    def test_mismatched_glucose_flagged(self):
+        text = "You spiked to 9.9 mmol/L last night."
+        result = validate_ai_suggestion(
+            text, "daily_brief", records=[99, 120], unit=GlucoseUnit.MMOL
+        )
+        assert result.status == SafetyStatus.FLAGGED
+        glucose_flags = [
+            f
+            for f in result.flagged_items
+            if f.suggestion_type == SuggestionType.GLUCOSE_CITATION
+        ]
+        assert len(glucose_flags) == 1
+        # The unit-correct reason is surfaced in the sanitized output.
+        assert "9.9 mmol/L" in result.sanitized_text
+
+    def test_glucose_flag_coexists_with_isf_flag(self):
+        text = (
+            "Your glucose read 9.9 mmol/L. Also move correction factor "
+            "from 1:60 to 1:40 mg/dL."
+        )
+        result = validate_ai_suggestion(
+            text, "correction_analysis", records=[120], unit=GlucoseUnit.MMOL
+        )
+        types = {f.suggestion_type for f in result.flagged_items}
+        assert SuggestionType.GLUCOSE_CITATION in types
+        assert SuggestionType.CORRECTION_FACTOR in types
+
+    def test_mgdl_glucose_flag_reason(self):
+        text = "Your reading was 250 mg/dL."
+        result = validate_ai_suggestion(
+            text, "meal_analysis", records=[120], unit=GlucoseUnit.MGDL
+        )
+        (flag,) = [
+            f
+            for f in result.flagged_items
+            if f.suggestion_type == SuggestionType.GLUCOSE_CITATION
+        ]
+        assert "250 mg/dL" in flag.reason
+        assert "1 mg/dL" in flag.reason
+
+    def test_glucose_flagging_failure_fails_open(self):
+        # The advisory glucose flag must never break validation: if the verifier
+        # raises, validation still completes without the glucose flag, and the
+        # dangerous-content gate is unaffected.
+        with patch(
+            "src.services.glucose_citation.find_glucose_citation_flags",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = validate_ai_suggestion(
+                "Your reading was 250 mg/dL.",
+                "meal_analysis",
+                records=[120],
+                unit=GlucoseUnit.MGDL,
+            )
+        assert result.status == SafetyStatus.APPROVED
+        assert not any(
+            f.suggestion_type == SuggestionType.GLUCOSE_CITATION
+            for f in result.flagged_items
+        )
+
+
 class TestValidateAISuggestion:
     """Tests for validate_ai_suggestion."""
 

--- a/apps/api/tests/test_safety_validation.py
+++ b/apps/api/tests/test_safety_validation.py
@@ -326,6 +326,23 @@ class TestGlucoseCitationFlagging:
         assert "250 mg/dL" in flag.reason
         assert "1 mg/dL" in flag.reason
 
+    def test_rendered_derived_figures_not_flagged(self):
+        # An analysis restating its own rendered figures (peak / 2hr post-meal
+        # glucose) must not be flagged: those are in the match-set via `extra`.
+        # Guards a regression that passes records=allow.readings (raw readings
+        # only) instead of allow.match (readings + aggregates + extras).
+        match = [110, 120, 140, 180]  # readings + peak 180 + 2hr 140 (extras)
+        result = validate_ai_suggestion(
+            "Average peak was 180 mg/dL and 2hr post-meal was 140 mg/dL.",
+            "meal_analysis",
+            records=match,
+            unit=GlucoseUnit.MGDL,
+        )
+        assert not any(
+            f.suggestion_type == SuggestionType.GLUCOSE_CITATION
+            for f in result.flagged_items
+        )
+
     def test_glucose_flagging_failure_fails_open(self):
         # The advisory glucose flag must never break validation: if the verifier
         # raises, validation still completes without the glucose flag, and the


### PR DESCRIPTION
## Summary

Adds output-side glucose-citation verification: any glucose number the AI states in a chat reply, daily brief, or analysis is checked against the user's real readings in a unit-aware, rounding-tolerant way (±1 mg/dL / ±0.1 mmol/L band, never equality). Enabling mmol/L display can no longer let a converted-and-rounded figure read as a mismatch, nor let a genuinely wrong number through.

The hard comparison core (`glucose_display_matches`, the single `MGDL_PER_MMOL` constant) already shipped with the AI-text unit work; this PR adds the extractor, verifier assembly, and wiring.

## What it does

- New pure `services/glucose_citation.py` (sibling of `meal_citation.py`): extracts glucose figures by their per-volume unit suffix, excludes ISF/carb-ratio (`1:X`) forms and ISF rates, and is comma-decimal aware. It either **corrects-or-scrubs** the reply text or emits **flagged suggestions**.
- All surfaces covered:
  - Chat (4 handlers) and the daily brief correct-or-scrub the reply, mirroring the existing carb verifier at the same call sites, and log PHI-free counts.
  - Correction and meal analyses surface mismatches through the existing `validate_ai_suggestion` / `ValidationResult` path as a new `GLUCOSE_CITATION` flagged suggestion.
- The allow-set is what the model was shown: the user's real readings plus the rendered aggregates (window average, target bounds, and each surface's rendered figures).
- The verifier is read-only and never persists a converted value; all comparison math stays in canonical mg/dL.

## Safety

- Convert-once, round-last, tolerance band (never equality), so rounding drift (99 mg/dL shown as 5.5 mmol/L; 100 as 5.6) passes while a wrong number fails. Round-trip property test over the full 20-500 mg/dL range in both units, both directions.
- The 20-500 mg/dL safety invariant and the dosing-safety checks are untouched.
- Chat/brief fail closed (a read failure scrubs every figure); the advisory analysis flag fails open.

## Testing

- New `tests/test_glucose_citation.py`, plus additions to `tests/test_safety_validation.py` and `tests/test_diabetes_context.py` (extractor exclusions, comma separators, correct/scrub/match/referents, flag path, async allow-set builder and wrapper, fail-open/fail-closed).
- Full affected suite green; ruff lint and format clean.

Closes #762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added glucose citation safety validation that checks glucose figures mentioned in AI outputs against allowed logged readings, correcting or scrubbing unsupported values.
  * Improved guidance for non-matching glucose citations with clearer semantics for how spoken glucose is compared to nearest logged readings.

* **Bug Fixes**
  * Enhanced safety validation to be unit-aware and more consistent about how mismatches are evaluated and reported.

* **Tests**
  * Added comprehensive test coverage for glucose citation parsing, rewrite/flagging behavior, and integration within safety validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->