### PR TITLE
feat(mobile): render phone glucose display in the user's unit (mg/dL or mmol/L)

### DIFF
--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/AppSettingsStoreGlucoseUnitTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/AppSettingsStoreGlucoseUnitTest.kt
@@ -1,0 +1,101 @@
+package com.glycemicgpt.mobile.data.local
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Storage-layer coverage for the per-account glucose display unit. The ViewModel tests mock
+ * [AppSettingsStore], so the real EncryptedSharedPreferences round-trip and the reactive
+ * [AppSettingsStore.glucoseUnitFlow] live here.
+ *
+ * The flow case is load-bearing: the dashboard re-renders glucose surfaces the instant the unit
+ * changes by collecting [AppSettingsStore.glucoseUnitFlow], which only re-emits if the encrypted
+ * prefs change listener reports the *plaintext* key. This pins that contract -- a security-crypto
+ * change that started delivering encrypted keys would fail here instead of silently freezing the UI.
+ *
+ * Instrumented (needs the real Android keystore): run with `./gradlew :app:connectedDebugAndroidTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class AppSettingsStoreGlucoseUnitTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private lateinit var store: AppSettingsStore
+
+    @Before
+    fun setUp() {
+        clearEncryptedPrefs()
+        store = AppSettingsStore(context)
+    }
+
+    @After
+    fun tearDown() {
+        clearEncryptedPrefs()
+    }
+
+    @Test
+    fun glucoseUnit_defaultsToMgdl_whenUnset() {
+        assertEquals(GlucoseUnit.MGDL, store.glucoseUnit)
+    }
+
+    @Test
+    fun glucoseUnit_roundTripsThroughEncryptedStorage() {
+        store.glucoseUnit = GlucoseUnit.MMOL
+
+        assertEquals(GlucoseUnit.MMOL, store.glucoseUnit)
+        // The stored value is visible to another store instance (the per-account singleton contract).
+        assertEquals(GlucoseUnit.MMOL, AppSettingsStore(context).glucoseUnit)
+    }
+
+    @Test
+    fun glucoseUnitFlow_emitsCurrentValueThenReEmitsAfterChange() = runBlocking {
+        store.glucoseUnit = GlucoseUnit.MGDL
+        val emissions = Channel<GlucoseUnit>(Channel.UNLIMITED)
+        val collector = launch(Dispatchers.Default) {
+            store.glucoseUnitFlow().collect { emissions.send(it) }
+        }
+        try {
+            // Seed emission also confirms the collector has subscribed.
+            assertEquals(GlucoseUnit.MGDL, withTimeout(TIMEOUT_MS) { emissions.receive() })
+            // The change listener is registered right after the seed (no suspension point between
+            // the two in the callbackFlow body); a short grace lets that registration win the race
+            // against the write under any scheduling.
+            delay(REGISTRATION_GRACE_MS)
+            store.glucoseUnit = GlucoseUnit.MMOL
+            // Drain to the post-write value instead of asserting the very next emission, so a
+            // duplicate (e.g. a key == null listener fire) can't flip the result. The timeout is
+            // the real failsafe if the listener never re-emits.
+            val reEmitted = withTimeout(TIMEOUT_MS) {
+                var value = emissions.receive()
+                while (value != GlucoseUnit.MMOL) value = emissions.receive()
+                value
+            }
+            assertEquals(GlucoseUnit.MMOL, reEmitted)
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    /** Resets the encrypted settings file so default/round-trip assertions are deterministic. */
+    private fun clearEncryptedPrefs() {
+        // The file name is the storage contract (mirrors AppSettingsStore's private
+        // ENCRYPTED_PREFS_NAME); deleting it returns the store to a pristine state between tests.
+        context.deleteSharedPreferences("app_settings_encrypted")
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 5_000L
+        const val REGISTRATION_GRACE_MS = 250L
+    }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseUnitDisplayUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseUnitDisplayUiTest.kt
@@ -1,18 +1,18 @@
 package com.glycemicgpt.mobile.presentation.home
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.click
-import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.glycemicgpt.mobile.domain.model.CgmReading
@@ -21,6 +21,7 @@ import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.TimeInRangeData
 import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -136,52 +137,59 @@ class GlucoseUnitDisplayUiTest {
     }
 
     @Test
-    fun glucoseTrendChart_mmol_convertsTooltipAndKeepsMgdlPlotGeometry() {
-        // The chart's Y-axis labels are drawn straight onto the Canvas (no semantics node), so the
-        // tooltip -- which renders through the same GlucoseFormat path -- is the queryable proxy for
-        // "this surface converts to the user's unit". Its vertical placement is derived from the
-        // mg/dL geometry (CHART_Y_MIN..CHART_Y_MAX), so it also guards against a regression that
-        // rescaled the plot by the display unit.
-        val reading = CgmReading(
-            glucoseMgDl = 180,
-            trendArrow = CgmTrend.FLAT,
-            timestamp = Instant.now(),
+    fun glucoseTrendChart_displayUnitConvertsAxisLabelsButNotPlotGeometry() {
+        // The Y-axis labels are the only unit-dependent thing the chart draws: the target band, grid
+        // lines, and glucose dots are all positioned from canonical mg/dL. So the same readings
+        // rendered in mg/dL and in mmol/L must produce identical pixels in the plot area and differ
+        // only in the left label gutter. The labels are drawn onto the Canvas (no semantics node),
+        // so a pixel diff is the only way to assert them. (The exact 180 -> 10.0 numeric conversion
+        // is covered by GlucoseFormatTest.)
+        val now = Instant.now()
+        val readings = listOf(
+            CgmReading(glucoseMgDl = 150, trendArrow = CgmTrend.FLAT, timestamp = now.minusSeconds(2 * 3600)),
+            CgmReading(glucoseMgDl = 200, trendArrow = CgmTrend.FLAT, timestamp = now.minusSeconds(3600)),
+            CgmReading(glucoseMgDl = 250, trendArrow = CgmTrend.FLAT, timestamp = now.minusSeconds(120)),
         )
         compose.setContent {
             GlycemicGptTheme {
-                GlucoseTrendChart(
-                    readings = listOf(reading),
-                    iobReadings = emptyList(),
-                    basalReadings = emptyList(),
-                    bolusEvents = emptyList(),
-                    selectedPeriod = ChartPeriod.THREE_HOURS,
-                    onPeriodSelected = {},
-                    glucoseUnit = GlucoseUnit.MMOL,
-                    isDetailMode = true,
-                    showPeriodSelector = false,
-                    modifier = Modifier.fillMaxWidth().height(360.dp),
-                )
+                Column {
+                    listOf(GlucoseUnit.MGDL, GlucoseUnit.MMOL).forEach { unit ->
+                        GlucoseTrendChart(
+                            readings = readings,
+                            iobReadings = emptyList(),
+                            basalReadings = emptyList(),
+                            bolusEvents = emptyList(),
+                            selectedPeriod = ChartPeriod.THREE_HOURS,
+                            onPeriodSelected = {},
+                            glucoseUnit = unit,
+                            isDetailMode = true,
+                            showPeriodSelector = false,
+                            modifier = Modifier.fillMaxWidth().height(200.dp),
+                        )
+                    }
+                }
             }
         }
 
-        // Tap the right edge (= the most recent reading, at "now") to surface the tooltip. The
-        // hit-test maps x to a timestamp, so the y coordinate is irrelevant here.
-        compose.onNodeWithTag("glucose_chart").performTouchInput {
-            click(Offset(width - 1f, centerY))
+        val mgdl = compose.onAllNodesWithTag("glucose_chart")[0].captureToImage().toPixelMap()
+        val mmol = compose.onAllNodesWithTag("glucose_chart")[1].captureToImage().toPixelMap()
+        assertEquals(mgdl.width, mmol.width)
+        assertEquals(mgdl.height, mmol.height)
+
+        // Left ~40% is the label gutter. The bottom fifth is the time axis, where each chart samples
+        // its own "now", so exclude it. Everything else is the plot and must be identical per unit.
+        val gutterEnd = (mgdl.width * 0.4f).toInt()
+        val plotBottom = mgdl.height * 4 / 5
+        var plotDiffs = 0
+        var labelDiffs = 0
+        for (y in 0 until plotBottom) {
+            for (x in 0 until mgdl.width) {
+                if (mgdl[x, y] != mmol[x, y]) {
+                    if (x >= gutterEnd) plotDiffs++ else labelDiffs++
+                }
+            }
         }
-
-        // (a) 180 mg/dL renders as 10.0 mmol/L with the converted label.
-        compose.onNodeWithText("10.0 mmol/L").assertIsDisplayed()
-
-        // (b) 180 sits high on the 40-300 mg/dL axis, so its tooltip lands in the upper half of the
-        // chart. A bug that plotted the converted value (10.0) against the mg/dL axis would clamp to
-        // the floor and push the tooltip to the bottom.
-        val chart = compose.onNodeWithTag("glucose_chart").getUnclippedBoundsInRoot()
-        val tooltip = compose.onNodeWithText("10.0 mmol/L").getUnclippedBoundsInRoot()
-        assertTrue(
-            "Tooltip for 180 mg/dL must sit in the upper half of the chart (mg/dL geometry), " +
-                "not be rescaled by the display unit",
-            (tooltip.top - chart.top) < (chart.bottom - chart.top) / 2,
-        )
+        assertEquals("Plot geometry must not change with the display unit", 0, plotDiffs)
+        assertTrue("Y-axis labels must convert to the display unit", labelDiffs > 0)
     }
 }

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseUnitDisplayUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseUnitDisplayUiTest.kt
@@ -1,11 +1,19 @@
 package com.glycemicgpt.mobile.presentation.home
 
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmStats
@@ -13,6 +21,7 @@ import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.TimeInRangeData
 import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -124,5 +133,55 @@ class GlucoseUnitDisplayUiTest {
         // mean 120 -> 6.7 mmol/L; GMI stays a percentage (6.2%).
         compose.onNodeWithText("6.7 mmol/L").assertIsDisplayed()
         compose.onNodeWithText("6.2%").assertIsDisplayed()
+    }
+
+    @Test
+    fun glucoseTrendChart_mmol_convertsTooltipAndKeepsMgdlPlotGeometry() {
+        // The chart's Y-axis labels are drawn straight onto the Canvas (no semantics node), so the
+        // tooltip -- which renders through the same GlucoseFormat path -- is the queryable proxy for
+        // "this surface converts to the user's unit". Its vertical placement is derived from the
+        // mg/dL geometry (CHART_Y_MIN..CHART_Y_MAX), so it also guards against a regression that
+        // rescaled the plot by the display unit.
+        val reading = CgmReading(
+            glucoseMgDl = 180,
+            trendArrow = CgmTrend.FLAT,
+            timestamp = Instant.now(),
+        )
+        compose.setContent {
+            GlycemicGptTheme {
+                GlucoseTrendChart(
+                    readings = listOf(reading),
+                    iobReadings = emptyList(),
+                    basalReadings = emptyList(),
+                    bolusEvents = emptyList(),
+                    selectedPeriod = ChartPeriod.THREE_HOURS,
+                    onPeriodSelected = {},
+                    glucoseUnit = GlucoseUnit.MMOL,
+                    isDetailMode = true,
+                    showPeriodSelector = false,
+                    modifier = Modifier.fillMaxWidth().height(360.dp),
+                )
+            }
+        }
+
+        // Tap the right edge (= the most recent reading, at "now") to surface the tooltip. The
+        // hit-test maps x to a timestamp, so the y coordinate is irrelevant here.
+        compose.onNodeWithTag("glucose_chart").performTouchInput {
+            click(Offset(width - 1f, centerY))
+        }
+
+        // (a) 180 mg/dL renders as 10.0 mmol/L with the converted label.
+        compose.onNodeWithText("10.0 mmol/L").assertIsDisplayed()
+
+        // (b) 180 sits high on the 40-300 mg/dL axis, so its tooltip lands in the upper half of the
+        // chart. A bug that plotted the converted value (10.0) against the mg/dL axis would clamp to
+        // the floor and push the tooltip to the bottom.
+        val chart = compose.onNodeWithTag("glucose_chart").getUnclippedBoundsInRoot()
+        val tooltip = compose.onNodeWithText("10.0 mmol/L").getUnclippedBoundsInRoot()
+        assertTrue(
+            "Tooltip for 180 mg/dL must sit in the upper half of the chart (mg/dL geometry), " +
+                "not be rescaled by the display unit",
+            (tooltip.top - chart.top) < (chart.bottom - chart.top) / 2,
+        )
     }
 }

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseUnitDisplayUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseUnitDisplayUiTest.kt
@@ -1,0 +1,128 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmStats
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import com.glycemicgpt.mobile.domain.model.TimeInRangeData
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.Instant
+
+/**
+ * On-device rendering of the dashboard glucose surfaces in both units. Confirms the
+ * displayed number, label, and the spoken (TalkBack) accessibility string convert for
+ * mmol/L users while the color/threshold logic keeps reading raw mg/dL.
+ */
+@RunWith(AndroidJUnit4::class)
+class GlucoseUnitDisplayUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val reading = CgmReading(
+        glucoseMgDl = 120,
+        trendArrow = CgmTrend.FLAT,
+        timestamp = Instant.now(),
+    )
+
+    @Test
+    fun glucoseHero_mgdl_showsRawValueAndLabel() {
+        compose.setContent {
+            GlycemicGptTheme {
+                GlucoseHero(
+                    cgm = reading,
+                    iob = null,
+                    basalRate = null,
+                    battery = null,
+                    reservoir = null,
+                    glucoseUnit = GlucoseUnit.MGDL,
+                )
+            }
+        }
+
+        compose.onNodeWithTag("glucose_hero_value").assertTextEquals("120")
+        compose.onNodeWithText("mg/dL").assertIsDisplayed()
+        compose.onNodeWithContentDescription("milligrams per deciliter", substring = true)
+            .assertExists()
+    }
+
+    @Test
+    fun glucoseHero_mmol_convertsValueLabelAndSpokenUnit() {
+        compose.setContent {
+            GlycemicGptTheme {
+                GlucoseHero(
+                    cgm = reading,
+                    iob = null,
+                    basalRate = null,
+                    battery = null,
+                    reservoir = null,
+                    glucoseUnit = GlucoseUnit.MMOL,
+                )
+            }
+        }
+
+        // 120 mg/dL -> 6.7 mmol/L
+        compose.onNodeWithTag("glucose_hero_value").assertTextEquals("6.7")
+        compose.onNodeWithText("mmol/L").assertIsDisplayed()
+        compose.onNodeWithContentDescription("6.7 millimoles per liter", substring = true)
+            .assertExists()
+    }
+
+    @Test
+    fun timeInRangeBar_mmol_convertsTargetLabel() {
+        compose.setContent {
+            GlycemicGptTheme {
+                TimeInRangeBar(
+                    data = TimeInRangeData(
+                        urgentLowPercent = 1f,
+                        lowPercent = 4f,
+                        inRangePercent = 80f,
+                        highPercent = 10f,
+                        urgentHighPercent = 5f,
+                        totalReadings = 288,
+                    ),
+                    selectedPeriod = TirPeriod.TWENTY_FOUR_HOURS,
+                    onPeriodSelected = {},
+                    glucoseUnit = GlucoseUnit.MMOL,
+                )
+            }
+        }
+
+        // Default thresholds 70-180 mg/dL -> 3.9-10.0 mmol/L
+        compose.onNodeWithTag("tir_target_range").assertTextEquals("Target: 3.9-10.0 mmol/L")
+    }
+
+    @Test
+    fun cgmStatsCard_mmol_convertsMeanButKeepsGmiPercent() {
+        compose.setContent {
+            GlycemicGptTheme {
+                CgmStatsCard(
+                    stats = CgmStats(
+                        meanGlucose = 120f,
+                        stdDev = 36f,
+                        cvPercent = 30f,
+                        gmi = 6.18f,
+                        readingsCount = 288,
+                    ),
+                    selectedPeriod = TirPeriod.TWENTY_FOUR_HOURS,
+                    onPeriodSelected = {},
+                    glucoseUnit = GlucoseUnit.MMOL,
+                )
+            }
+        }
+
+        // mean 120 -> 6.7 mmol/L; GMI stays a percentage (6.2%).
+        compose.onNodeWithText("6.7 mmol/L").assertIsDisplayed()
+        compose.onNodeWithText("6.2%").assertIsDisplayed()
+    }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
@@ -25,6 +25,7 @@ import com.glycemicgpt.mobile.data.remote.dto.CommonFoodResponse
 import com.glycemicgpt.mobile.data.remote.dto.CommonFoodUpdateRequest
 import com.glycemicgpt.mobile.data.remote.dto.DeviceRegistrationRequest
 import com.glycemicgpt.mobile.data.remote.dto.EstimateDispersionResponse
+import com.glycemicgpt.mobile.data.remote.dto.GlucoseUnitUpdateRequest
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordCorrectionRequest
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordIdentityRequest
 import com.glycemicgpt.mobile.data.remote.dto.FoodRecordListResponse
@@ -320,6 +321,8 @@ private class FakeMealApi : GlycemicGptApi {
     override suspend fun unregisterDevice(deviceToken: String) = notUsed()
     override suspend fun getPendingAlerts() = notUsed()
     override suspend fun acknowledgeAlert(alertId: String) = notUsed()
+    override suspend fun getGlucoseUnit() = notUsed()
+    override suspend fun patchGlucoseUnit(request: GlucoseUnitUpdateRequest) = notUsed()
     override suspend fun getGlucoseRange() = notUsed()
     override suspend fun getSafetyLimits() = notUsed()
     override suspend fun getAnalyticsConfig() = notUsed()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -4,8 +4,12 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.presentation.theme.ThemeMode
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -126,6 +130,36 @@ class AppSettingsStore @Inject constructor(
             prefs.edit().putString(KEY_THEME_MODE, value.name).apply()
         }
 
+    /**
+     * User-selected glucose display unit. The unit is a *per-account* preference
+     * (PATCHed to the backend and reconciled from it); this stored value is only
+     * an offline cache / pre-sync fallback. Stored as the enum name, mirroring the
+     * [themeMode] string-stored pattern, and defaults to [GlucoseUnit.MGDL] before
+     * the first backend sync.
+     */
+    var glucoseUnit: GlucoseUnit
+        get() = GlucoseUnit.fromName(prefs.getString(KEY_GLUCOSE_UNIT, GlucoseUnit.MGDL.name))
+        set(value) {
+            prefs.edit().putString(KEY_GLUCOSE_UNIT, value.name).apply()
+        }
+
+    /**
+     * Emits the current [glucoseUnit] and re-emits whenever it changes, so display
+     * surfaces update live when the user toggles the unit or a backend reconcile
+     * writes the cache. Uses the same change-listener mechanism the activity relies
+     * on for live theme switching.
+     */
+    fun glucoseUnitFlow(): Flow<GlucoseUnit> = callbackFlow {
+        trySend(glucoseUnit)
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_GLUCOSE_UNIT || key == null) {
+                trySend(glucoseUnit)
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+
     // Watch face config persistence
     var watchFaceShowIoB: Boolean
         get() = prefs.getBoolean(KEY_WATCHFACE_SHOW_IOB, true)
@@ -202,6 +236,7 @@ class AppSettingsStore @Inject constructor(
         private const val KEY_DEVICE_TOKEN = "device_token"
         private const val KEY_SHOW_PUMP_LABELS = "show_pump_labels"
         internal const val KEY_THEME_MODE = "theme_mode"
+        internal const val KEY_GLUCOSE_UNIT = "glucose_unit"
         const val DEFAULT_RETENTION_DAYS = 7
         const val MIN_RETENTION_DAYS = 1
         const val MAX_RETENTION_DAYS = 30

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -11,6 +11,8 @@ import com.glycemicgpt.mobile.data.remote.dto.DeviceRegistrationRequest
 import com.glycemicgpt.mobile.data.remote.dto.DeviceRegistrationResponse
 import com.glycemicgpt.mobile.data.remote.dto.PluginDeclarationRequest
 import com.glycemicgpt.mobile.data.remote.dto.GlucoseRangeResponse
+import com.glycemicgpt.mobile.data.remote.dto.GlucoseUnitResponse
+import com.glycemicgpt.mobile.data.remote.dto.GlucoseUnitUpdateRequest
 import com.glycemicgpt.mobile.data.remote.dto.SafetyLimitsResponse
 import com.glycemicgpt.mobile.data.remote.dto.HealthResponse
 import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
@@ -78,6 +80,13 @@ interface GlycemicGptApi {
 
     @POST("/api/v1/alerts/{alertId}/acknowledge")
     suspend fun acknowledgeAlert(@Path("alertId") alertId: String): Response<AcknowledgeResponse>
+
+    // Glucose display unit preference (per-account; backend exposes both GET and PATCH)
+    @GET("/api/settings/glucose-unit")
+    suspend fun getGlucoseUnit(): Response<GlucoseUnitResponse>
+
+    @PATCH("/api/settings/glucose-unit")
+    suspend fun patchGlucoseUnit(@Body request: GlucoseUnitUpdateRequest): Response<GlucoseUnitResponse>
 
     // Glucose range settings
     @GET("/api/settings/target-glucose-range")

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
@@ -114,6 +114,17 @@ data class GlucoseRangeResponse(
     @Json(name = "urgent_high") val urgentHigh: Float,
 )
 
+/** Per-account glucose display unit preference. [glucoseUnit] is the backend enum wire value ("mgdl"/"mmol"). */
+@JsonClass(generateAdapter = true)
+data class GlucoseUnitResponse(
+    @Json(name = "glucose_unit") val glucoseUnit: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class GlucoseUnitUpdateRequest(
+    @Json(name = "glucose_unit") val glucoseUnit: String,
+)
+
 @JsonClass(generateAdapter = true)
 data class SafetyLimitsResponse(
     @Json(name = "min_glucose_mgdl") val minGlucoseMgDl: Int,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import com.glycemicgpt.mobile.BuildConfig
 import com.glycemicgpt.mobile.data.auth.AuthManager
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpProfileStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.GlucoseUnitUpdateRequest
 import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertStreamService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlin.coroutines.cancellation.CancellationException
@@ -35,6 +38,7 @@ class AuthRepository @Inject constructor(
     private val safetyLimitsStore: SafetyLimitsStore,
     private val analyticsSettingsStore: AnalyticsSettingsStore,
     private val pumpProfileStore: PumpProfileStore,
+    private val appSettingsStore: AppSettingsStore,
     private val api: GlycemicGptApi,
     private val deviceRepository: DeviceRepository,
     private val authManager: AuthManager,
@@ -94,6 +98,7 @@ class AuthRepository @Inject constructor(
                 }
                 scope.launch { fetchGlucoseRange() }
                 scope.launch { fetchSafetyLimits() }
+                scope.launch { fetchGlucoseUnit() }
                 AlertStreamService.start(appContext)
 
                 LoginResult(success = true, email = body.user.email)
@@ -122,6 +127,9 @@ class AuthRepository @Inject constructor(
         safetyLimitsStore.clear()
         analyticsSettingsStore.clear()
         pumpProfileStore.clear()
+        // The glucose unit is a per-account preference; reset to the neutral default so a stale
+        // unit can't carry over to the next account before its reconcile lands.
+        appSettingsStore.glucoseUnit = GlucoseUnit.MGDL
         authManager.onLogout()
         scope.launch {
             deviceRepository.unregisterDevice()
@@ -171,6 +179,36 @@ class AuthRepository @Inject constructor(
         fetchSafetyLimits()
     }
 
+    /** Reconcile the cached glucose display unit from the backend (the account is the source of truth). */
+    suspend fun refreshGlucoseUnit() {
+        fetchGlucoseUnit()
+    }
+
+    /**
+     * Write the user's glucose display unit to the account (`PATCH /api/settings/glucose-unit`)
+     * and reconcile the local cache to whatever the server returns. The unit is a per-account
+     * preference, so this -- not the local cache -- is what makes it consistent across web,
+     * phone, watch, and AI text. On failure the optimistic local cache is left intact (the next
+     * reconcile will correct it); the [Result] lets the caller surface a transient error.
+     */
+    suspend fun updateGlucoseUnit(unit: GlucoseUnit): Result<GlucoseUnit> {
+        return try {
+            val response = api.patchGlucoseUnit(GlucoseUnitUpdateRequest(glucoseUnit = unit.wireValue))
+            if (response.isSuccessful) {
+                val resolved = response.body()?.let { GlucoseUnit.fromWire(it.glucoseUnit) } ?: unit
+                appSettingsStore.glucoseUnit = resolved
+                Result.success(resolved)
+            } else {
+                Result.failure(Exception("Server responded with HTTP ${response.code()}"))
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to update glucose unit")
+            Result.failure(e)
+        }
+    }
+
     private suspend fun fetchGlucoseRange() {
         try {
             val response = api.getGlucoseRange()
@@ -193,6 +231,23 @@ class AuthRepository @Inject constructor(
             throw e
         } catch (e: Exception) {
             Timber.w(e, "Failed to fetch glucose range settings")
+        }
+    }
+
+    private suspend fun fetchGlucoseUnit() {
+        try {
+            val response = api.getGlucoseUnit()
+            if (response.isSuccessful) {
+                response.body()?.let { body ->
+                    appSettingsStore.glucoseUnit = GlucoseUnit.fromWire(body.glucoseUnit)
+                    Timber.d("Glucose unit reconciled: %s", body.glucoseUnit)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Keep the cached unit (ultimately MGDL) on any failure.
+            Timber.w(e, "Failed to fetch glucose unit preference")
         }
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/format/GlucoseFormat.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/format/GlucoseFormat.kt
@@ -1,0 +1,88 @@
+package com.glycemicgpt.mobile.domain.format
+
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import java.util.Locale
+
+/**
+ * The single client-side choke-point that turns a stored mg/dL glucose value into
+ * the number and label a user reads in their preferred unit.
+ *
+ * Pure Kotlin (no Android dependencies) so the watch surface can mirror it. mg/dL
+ * output is byte-identical to the legacy hand-written strings (integer, `mg/dL`
+ * label); mmol/L converts from the most-precise mg/dL source ONCE and rounds to
+ * one decimal LAST, so the threshold anchors land on their conventional values
+ * (70 -> 3.9, 180 -> 10.0, 120 -> 6.7, 100 -> 5.6). All formatting uses
+ * [Locale.US] so the decimal separator is always a dot -- both for cross-surface
+ * consistency and so the mmol output still matches the release log scrubber.
+ */
+object GlucoseFormat {
+
+    /**
+     * 1 mmol/L = 18.0156 mg/dL -- the exact glucose mass-to-molarity factor and the
+     * single canonical constant. Mirrors the backend `MGDL_PER_MMOL` in
+     * `src/core/units.py` and the web `MGDL_PER_MMOL`. Never introduce a second
+     * value (18.02 / 18.0182); a drift here desyncs the client from the server.
+     */
+    const val MGDL_PER_MMOL: Double = 18.0156
+
+    /** User-facing unit label: `"mg/dL"` / `"mmol/L"`. */
+    fun label(unit: GlucoseUnit): String = when (unit) {
+        GlucoseUnit.MGDL -> "mg/dL"
+        GlucoseUnit.MMOL -> "mmol/L"
+    }
+
+    /** Spoken (accessibility) unit name (US spelling, matching the mg/dL "deciliter"). */
+    fun spokenUnit(unit: GlucoseUnit): String = when (unit) {
+        GlucoseUnit.MGDL -> "milligrams per deciliter"
+        GlucoseUnit.MMOL -> "millimoles per liter"
+    }
+
+    /** The one mg/dL -> mmol/L divide, unrounded (round LAST). Mirrors the backend `mgdl_to_mmol`. */
+    private fun mgdlToMmol(valueMgDl: Double): Double = valueMgDl / MGDL_PER_MMOL
+
+    /**
+     * Convert a stored mg/dL glucose value to the display unit, without rounding
+     * (round LAST at the display edge). mg/dL returns the value verbatim.
+     */
+    fun convertValue(mgDl: Int, unit: GlucoseUnit): Double = when (unit) {
+        GlucoseUnit.MGDL -> mgDl.toDouble()
+        GlucoseUnit.MMOL -> mgdlToMmol(mgDl.toDouble())
+    }
+
+    /**
+     * Convert a glucose *spread* (a standard deviation or any difference of two
+     * glucose values) to mmol/L. Offset-free divide-by-factor, deliberately
+     * distinct from [convertValue]: a spread has no zero-anchor and, in mg/dL,
+     * keeps a decimal where a value is shown as an integer. Reusing the value
+     * converter for a spread is a bug.
+     */
+    fun convertSpread(mgDl: Double): Double = mgdlToMmol(mgDl)
+
+    /** A bare glucose number in [unit] -- integer for mg/dL, one decimal for mmol/L. */
+    fun format(mgDl: Int, unit: GlucoseUnit): String = when (unit) {
+        GlucoseUnit.MGDL -> mgDl.toString()
+        GlucoseUnit.MMOL -> String.format(Locale.US, "%.1f", convertValue(mgDl, unit))
+    }
+
+    /** A glucose number with its unit label, e.g. `"120 mg/dL"` / `"6.7 mmol/L"`. */
+    fun formatWithLabel(mgDl: Int, unit: GlucoseUnit): String =
+        "${format(mgDl, unit)} ${label(unit)}"
+
+    /**
+     * Format a mean glucose (a `Float` already in mg/dL): an integer for mg/dL --
+     * byte-identical to the legacy `"%.0f"` -- and one decimal for mmol/L.
+     */
+    fun formatMean(meanMgDl: Float, unit: GlucoseUnit): String = when (unit) {
+        GlucoseUnit.MGDL -> String.format(Locale.US, "%.0f", meanMgDl)
+        GlucoseUnit.MMOL -> String.format(Locale.US, "%.1f", mgdlToMmol(meanMgDl.toDouble()))
+    }
+
+    /**
+     * Format a glucose spread (a `Float` standard deviation in mg/dL): one decimal
+     * in either unit. mmol/L goes through [convertSpread], never [convertValue].
+     */
+    fun formatSpread(spreadMgDl: Float, unit: GlucoseUnit): String = when (unit) {
+        GlucoseUnit.MGDL -> String.format(Locale.US, "%.1f", spreadMgDl)
+        GlucoseUnit.MMOL -> String.format(Locale.US, "%.1f", convertSpread(spreadMgDl.toDouble()))
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/GlucoseUnit.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/model/GlucoseUnit.kt
@@ -1,0 +1,35 @@
+package com.glycemicgpt.mobile.domain.model
+
+/**
+ * User-facing glucose display unit.
+ *
+ * Storage, transport, every threshold comparison, alert detection, and the
+ * platform-wide 20-500 safety invariant all stay canonical mg/dL. This enum only
+ * selects how a glucose number is *shown* (and spoken) to the user.
+ *
+ * [wireValue] mirrors the backend `GlucoseUnit` enum's JSON serialization
+ * (`"mgdl"` / `"mmol"`); [name] (`MGDL` / `MMOL`) is what we persist in
+ * SharedPreferences, matching the existing string-stored-enum pattern.
+ */
+enum class GlucoseUnit(val wireValue: String) {
+    MGDL("mgdl"),
+    MMOL("mmol"),
+    ;
+
+    companion object {
+        /** Parse a backend JSON value (`"mgdl"`/`"mmol"`); unknown/null falls back to [MGDL]. */
+        fun fromWire(value: String?): GlucoseUnit =
+            entries.firstOrNull { it.wireValue.equals(value, ignoreCase = true) } ?: MGDL
+
+        /**
+         * Parse a persisted enum name (SharedPreferences); unknown/null/corrupt falls back to
+         * [MGDL]. Mirrors the `themeMode` try/catch-valueOf storage pattern and never throws.
+         */
+        fun fromName(value: String?): GlucoseUnit =
+            try {
+                valueOf(value ?: MGDL.name)
+            } catch (_: IllegalArgumentException) {
+                MGDL
+            }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -51,6 +53,7 @@ fun AlertsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val alerts by viewModel.alerts.collectAsState()
+    val glucoseUnit by viewModel.glucoseUnit.collectAsState()
 
     PullToRefreshBox(
         isRefreshing = uiState.isLoading,
@@ -70,6 +73,7 @@ fun AlertsScreen(
                 items(alerts, key = { it.serverId }) { alert ->
                     AlertCard(
                         alert = alert,
+                        glucoseUnit = glucoseUnit,
                         onAcknowledge = { viewModel.acknowledgeAlert(alert.serverId) },
                     )
                 }
@@ -111,6 +115,7 @@ private fun EmptyAlertsState() {
 @Composable
 private fun AlertCard(
     alert: AlertEntity,
+    glucoseUnit: GlucoseUnit,
     onAcknowledge: () -> Unit,
 ) {
     val severityColor = when (alert.severity) {
@@ -162,7 +167,7 @@ private fun AlertCard(
                     )
                     Spacer(Modifier.width(8.dp))
                     Text(
-                        text = "${alert.currentValue.toInt()} mg/dL",
+                        text = GlucoseFormat.formatWithLabel(alert.currentValue.toInt(), glucoseUnit),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                     )

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -2,8 +2,10 @@ package com.glycemicgpt.mobile.presentation.alerts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.repository.AlertRepository
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,6 +26,7 @@ data class AlertsUiState(
 class AlertsViewModel @Inject constructor(
     private val alertRepository: AlertRepository,
     private val alertNotificationManager: AlertNotificationManager,
+    private val appSettingsStore: AppSettingsStore,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AlertsUiState())
@@ -31,6 +34,10 @@ class AlertsViewModel @Inject constructor(
 
     val alerts: StateFlow<List<AlertEntity>> = alertRepository.observeRecentAlerts()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** The user's glucose display unit, for rendering alert values. Alert detection stays mg/dL. */
+    val glucoseUnit: StateFlow<GlucoseUnit> = appSettingsStore.glucoseUnitFlow()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), appSettingsStore.glucoseUnit)
 
     init {
         viewModelScope.launch { alertRepository.cleanupOldAlerts() }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/ChartDetailScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/detail/ChartDetailScreen.kt
@@ -65,6 +65,7 @@ fun ChartDetailScreen(
     val selectedPeriod by viewModel.selectedPeriod.collectAsState()
     val thresholds by viewModel.glucoseThresholds.collectAsState()
     val categoryLabels by viewModel.categoryLabels.collectAsState()
+    val glucoseUnit by viewModel.glucoseUnit.collectAsState()
     val retentionDays by viewModel.dataRetentionDays.collectAsState()
     val safeRetention = retentionDays.coerceAtLeast(1)
     val availablePeriods = ChartPeriod.entries.filter { it.hours / 24 <= safeRetention }
@@ -128,6 +129,7 @@ fun ChartDetailScreen(
             onPeriodSelected = { viewModel.onPeriodSelected(it) },
             thresholds = thresholds,
             categoryLabels = categoryLabels,
+            glucoseUnit = glucoseUnit,
             isDetailMode = true,
             showPeriodSelector = false,
             modifier = Modifier

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/CgmStatsCard.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/CgmStatsCard.kt
@@ -25,7 +25,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.CgmStats
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
 
 private val CgmStatsPeriods = listOf(
@@ -39,6 +41,7 @@ fun CgmStatsCard(
     stats: CgmStats?,
     selectedPeriod: TirPeriod,
     onPeriodSelected: (TirPeriod) -> Unit,
+    glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     maxRetentionDays: Int = AppSettingsStore.DEFAULT_RETENTION_DAYS,
     modifier: Modifier = Modifier,
 ) {
@@ -53,10 +56,14 @@ fun CgmStatsCard(
     val a11yDescription = if (stats != null) {
         val (cvLabel, _) = cvAssessment(stats.cvPercent)
         val (activeLabel, _) = cgmActiveAssessment(stats.cgmActivePercent)
-        ("CGM statistics: mean glucose %.0f mg/dL, std dev %.1f mg/dL, " +
+        val spokenUnit = GlucoseFormat.spokenUnit(glucoseUnit)
+        val meanSpoken = "${GlucoseFormat.formatMean(stats.meanGlucose, glucoseUnit)} $spokenUnit"
+        val stdDevSpoken = "${GlucoseFormat.formatSpread(stats.stdDev, glucoseUnit)} $spokenUnit"
+        // GMI stays a % computed from the RAW mg/dL mean -- never converted.
+        ("CGM statistics: mean glucose %s, std dev %s, " +
             "CV %.1f%% %s, GMI %.1f%%, CGM active %.0f%% %s, %d readings").format(
-            stats.meanGlucose,
-            stats.stdDev,
+            meanSpoken,
+            stdDevSpoken,
             stats.cvPercent,
             cvLabel,
             stats.gmi,
@@ -131,14 +138,15 @@ fun CgmStatsCard(
                 ) {
                     StatColumn(
                         label = "Mean Glucose",
-                        value = "%.0f mg/dL".format(stats.meanGlucose),
+                        value = "${GlucoseFormat.formatMean(stats.meanGlucose, glucoseUnit)} " +
+                            GlucoseFormat.label(glucoseUnit),
                         valueColor = MaterialTheme.colorScheme.onSurface,
                     )
                     StatColumn(
                         label = "Std Dev",
-                        value = "%.1f".format(stats.stdDev),
+                        value = GlucoseFormat.formatSpread(stats.stdDev, glucoseUnit),
                         valueColor = MaterialTheme.colorScheme.onSurface,
-                        subtitle = "mg/dL",
+                        subtitle = GlucoseFormat.label(glucoseUnit),
                     )
                     val (cvLabel, cvColor) = cvAssessment(stats.cvPercent)
                     StatColumn(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseHero.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseHero.kt
@@ -22,10 +22,12 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.model.ReservoirReading
@@ -79,11 +81,15 @@ fun GlucoseHero(
     battery: BatteryStatus?,
     reservoir: ReservoirReading?,
     thresholds: GlucoseThresholds = GlucoseThresholds(),
+    glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     modifier: Modifier = Modifier,
 ) {
     val a11yDescription = if (cgm != null) {
         buildString {
-            append("Glucose ${cgm.glucoseMgDl} milligrams per deciliter, ")
+            append(
+                "Glucose ${GlucoseFormat.format(cgm.glucoseMgDl, glucoseUnit)} " +
+                    "${GlucoseFormat.spokenUnit(glucoseUnit)}, ",
+            )
             append(cgm.trendArrow.name.lowercase().replace('_', ' '))
             if (iob != null) append(", insulin on board %.2f units".format(iob.iob))
             if (basalRate != null) append(", basal rate %.2f units per hour".format(basalRate.rate))
@@ -117,7 +123,7 @@ fun GlucoseHero(
                     horizontalArrangement = Arrangement.Center,
                 ) {
                     Text(
-                        text = "${cgm.glucoseMgDl}",
+                        text = GlucoseFormat.format(cgm.glucoseMgDl, glucoseUnit),
                         fontSize = 64.sp,
                         fontWeight = FontWeight.Bold,
                         color = color,
@@ -135,7 +141,7 @@ fun GlucoseHero(
                 }
 
                 Text(
-                    text = "mg/dL",
+                    text = GlucoseFormat.label(glucoseUnit),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -194,7 +200,7 @@ fun GlucoseHero(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
-                    text = "mg/dL",
+                    text = GlucoseFormat.label(glucoseUnit),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseTrendChart.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseTrendChart.kt
@@ -56,10 +56,12 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.glycemicgpt.mobile.domain.compute.DashboardComputations
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BolusEvent
 import com.glycemicgpt.mobile.domain.model.BolusType
 import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.presentation.theme.BolusTypeColors
@@ -115,6 +117,7 @@ fun GlucoseTrendChart(
     onPeriodSelected: (ChartPeriod) -> Unit,
     thresholds: GlucoseThresholds = GlucoseThresholds(),
     categoryLabels: Map<String, String> = emptyMap(),
+    glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     onClick: (() -> Unit)? = null,
     isDetailMode: Boolean = false,
     showPeriodSelector: Boolean = true,
@@ -130,6 +133,7 @@ fun GlucoseTrendChart(
             onPeriodSelected = onPeriodSelected,
             thresholds = thresholds,
             categoryLabels = categoryLabels,
+            glucoseUnit = glucoseUnit,
             onClick = onClick,
             isDetailMode = isDetailMode,
             showPeriodSelector = showPeriodSelector,
@@ -162,6 +166,7 @@ private fun GlucoseTrendChartContent(
     onPeriodSelected: (ChartPeriod) -> Unit,
     thresholds: GlucoseThresholds,
     categoryLabels: Map<String, String>,
+    glucoseUnit: GlucoseUnit,
     onClick: (() -> Unit)?,
     isDetailMode: Boolean,
     showPeriodSelector: Boolean = true,
@@ -384,6 +389,7 @@ private fun GlucoseTrendChartContent(
                         gridColor = gridColor,
                         iobColor = iobColor,
                         thresholds = thresholds,
+                        glucoseUnit = glucoseUnit,
                         categoryLabels = categoryLabels,
                     )
                 }
@@ -416,7 +422,7 @@ private fun GlucoseTrendChartContent(
                     ) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Text(
-                                text = "${tt.reading.glucoseMgDl} mg/dL",
+                                text = GlucoseFormat.formatWithLabel(tt.reading.glucoseMgDl, glucoseUnit),
                                 style = MaterialTheme.typography.labelLarge,
                                 color = color,
                             )
@@ -551,6 +557,7 @@ private fun DrawScope.drawGlucoseChart(
     gridColor: Color,
     iobColor: Color,
     thresholds: GlucoseThresholds = GlucoseThresholds(),
+    glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     categoryLabels: Map<String, String> = emptyMap(),
 ) {
     // Guard against zero-span viewport (prevents division by zero throughout)
@@ -592,12 +599,13 @@ private fun DrawScope.drawGlucoseChart(
         )
     }
 
-    // Y-axis labels (left: glucose)
+    // Y-axis labels (left: glucose). Geometry above stays mg/dL; only the rendered
+    // string converts to the user's unit.
     val yLabelValues = listOf(thresholds.low, thresholds.high, thresholds.urgentHigh)
     val labelStyle = TextStyle(fontSize = 10.sp, color = axisLabelColor)
     for (value in yLabelValues) {
         val y = topPadding + chartHeight * (1f - (value - yMin) / yRange)
-        val textResult = textMeasurer.measure("$value", labelStyle)
+        val textResult = textMeasurer.measure(GlucoseFormat.format(value, glucoseUnit), labelStyle)
         drawText(
             textResult,
             topLeft = Offset(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -98,6 +98,7 @@ fun HomeScreen(
     val pumpLabelMap by viewModel.pumpLabelMap.collectAsState()
     val showPumpLabels by viewModel.showPumpLabels.collectAsState()
     val retentionDays by viewModel.dataRetentionDays.collectAsState()
+    val glucoseUnit by viewModel.glucoseUnit.collectAsState()
 
     PullToRefreshBox(
         isRefreshing = isRefreshing,
@@ -128,6 +129,7 @@ fun HomeScreen(
                 battery = battery,
                 reservoir = reservoir,
                 thresholds = thresholds,
+                glucoseUnit = glucoseUnit,
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -148,6 +150,7 @@ fun HomeScreen(
                 onPeriodSelected = { viewModel.onPeriodSelected(it) },
                 thresholds = thresholds,
                 categoryLabels = categoryLabels,
+                glucoseUnit = glucoseUnit,
                 onClick = onNavigateToChartDetail,
             )
 
@@ -159,6 +162,7 @@ fun HomeScreen(
                 selectedPeriod = selectedTirPeriod,
                 onPeriodSelected = { viewModel.onTirPeriodSelected(it) },
                 thresholds = thresholds,
+                glucoseUnit = glucoseUnit,
                 maxRetentionDays = retentionDays,
             )
 
@@ -169,6 +173,7 @@ fun HomeScreen(
                 stats = cgmStats,
                 selectedPeriod = selectedCgmStatsPeriod,
                 onPeriodSelected = { viewModel.onCgmStatsPeriodSelected(it) },
+                glucoseUnit = glucoseUnit,
                 maxRetentionDays = retentionDays,
             )
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -20,8 +20,8 @@ import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmStats
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.EnrichedBolusEvent
-import com.glycemicgpt.mobile.domain.model.InsulinSummary
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import com.glycemicgpt.mobile.domain.model.InsulinSummary
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.plugin.DevicePlugin
 import com.glycemicgpt.mobile.domain.plugin.asBolusCategoryProvider
@@ -161,10 +161,14 @@ class HomeViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), appSettingsStore.glucoseUnit)
 
     init {
-        // Refresh glucose range + display-unit preference from backend on screen load if stale (15 min)
+        // The display unit is a per-account preference with no local staleness clock, so reconcile
+        // it from the backend on every load (a cheap GET). It used to piggyback the glucose-range
+        // staleness gate, which meant a unit change made on another device wouldn't propagate on a
+        // cold open while the range was still fresh.
+        viewModelScope.launch { authRepository.refreshGlucoseUnit() }
+        // Refresh glucose range from backend on screen load if stale (15 min)
         if (glucoseRangeStore.isStale(maxAgeMs = RANGE_REFRESH_INTERVAL_MS)) {
             viewModelScope.launch { refreshGlucoseRange() }
-            viewModelScope.launch { authRepository.refreshGlucoseUnit() }
         }
         // Refresh safety limits from backend if stale (1 hour)
         if (safetyLimitsStore.isStale()) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -21,6 +21,7 @@ import com.glycemicgpt.mobile.domain.model.CgmStats
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.EnrichedBolusEvent
 import com.glycemicgpt.mobile.domain.model.InsulinSummary
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.plugin.DevicePlugin
 import com.glycemicgpt.mobile.domain.plugin.asBolusCategoryProvider
@@ -151,10 +152,19 @@ class HomeViewModel @Inject constructor(
     private val _dataRetentionDays = MutableStateFlow(appSettingsStore.dataRetentionDays)
     val dataRetentionDays: StateFlow<Int> = _dataRetentionDays.asStateFlow()
 
+    /**
+     * The user's glucose display unit. Reactive so the dashboard re-renders the moment
+     * the unit changes in Settings or a backend reconcile writes the cache. All glucose
+     * math/color/threshold logic stays mg/dL; only the displayed number + label convert.
+     */
+    val glucoseUnit: StateFlow<GlucoseUnit> = appSettingsStore.glucoseUnitFlow()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), appSettingsStore.glucoseUnit)
+
     init {
-        // Refresh glucose range from backend on screen load if stale (15 min)
+        // Refresh glucose range + display-unit preference from backend on screen load if stale (15 min)
         if (glucoseRangeStore.isStale(maxAgeMs = RANGE_REFRESH_INTERVAL_MS)) {
             viewModelScope.launch { refreshGlucoseRange() }
+            viewModelScope.launch { authRepository.refreshGlucoseUnit() }
         }
         // Refresh safety limits from backend if stale (1 hour)
         if (safetyLimitsStore.isStale()) {
@@ -340,6 +350,7 @@ class HomeViewModel @Inject constructor(
             try {
                 // Refresh settings concurrently -- don't block BLE reads
                 launch { refreshGlucoseRange() }
+                launch { authRepository.refreshGlucoseUnit() }
                 launch { refreshAnalyticsConfig() }
                 launch { refreshPumpProfile() }
                 // If backend call fails, refreshSafetyLimits re-reads the store's

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBar.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBar.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.TimeInRangeData
 import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
 
@@ -64,23 +66,26 @@ fun TimeInRangeBar(
     selectedPeriod: TirPeriod,
     onPeriodSelected: (TirPeriod) -> Unit,
     thresholds: GlucoseThresholds = GlucoseThresholds(),
+    glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     maxRetentionDays: Int = AppSettingsStore.DEFAULT_RETENTION_DAYS,
     modifier: Modifier = Modifier,
 ) {
     val safeRetention = maxRetentionDays.coerceAtLeast(1)
     val availablePeriods = TirPeriod.entries.filter { it.hours / 24 <= safeRetention }
     val effectivePeriod = if (selectedPeriod in availablePeriods) selectedPeriod else availablePeriods.first()
+    val bucketLabels = tirBucketLabels(thresholds, glucoseUnit)
     val a11yDescription = if (data != null && data.totalReadings > 0) {
+        val targetSpoken = "${GlucoseFormat.format(thresholds.low, glucoseUnit)}-" +
+            "${GlucoseFormat.format(thresholds.high, glucoseUnit)} ${GlucoseFormat.spokenUnit(glucoseUnit)}"
         ("Time in range: %.0f%% urgent low, %.0f%% low, %.0f%% in range, " +
             "%.0f%% high, %.0f%% urgent high, " +
-            "target %d-%d mg/dL, %d readings over %s").format(
+            "target %s, %d readings over %s").format(
                 data.urgentLowPercent,
                 data.lowPercent,
                 data.inRangePercent,
                 data.highPercent,
                 data.urgentHighPercent,
-                thresholds.low,
-                thresholds.high,
+                targetSpoken,
                 data.totalReadings,
                 effectivePeriod.label,
             )
@@ -180,17 +185,17 @@ fun TimeInRangeBar(
                 ) {
                     LegendEntry(
                         color = ColorUrgentLow,
-                        label = "<${thresholds.urgentLow}",
+                        label = bucketLabels[0],
                         percent = data.urgentLowPercent,
                     )
                     LegendEntry(
                         color = ColorLow,
-                        label = "${thresholds.urgentLow}-${thresholds.low}",
+                        label = bucketLabels[1],
                         percent = data.lowPercent,
                     )
                     LegendEntry(
                         color = ColorInRange,
-                        label = "${thresholds.low}-${thresholds.high}",
+                        label = bucketLabels[2],
                         percent = data.inRangePercent,
                     )
                 }
@@ -201,12 +206,12 @@ fun TimeInRangeBar(
                 ) {
                     LegendEntry(
                         color = ColorHigh,
-                        label = "${thresholds.high}-${thresholds.urgentHigh}",
+                        label = bucketLabels[3],
                         percent = data.highPercent,
                     )
                     LegendEntry(
                         color = ColorUrgentHigh,
-                        label = ">${thresholds.urgentHigh}",
+                        label = bucketLabels[4],
                         percent = data.urgentHighPercent,
                     )
                 }
@@ -215,7 +220,7 @@ fun TimeInRangeBar(
 
                 // Target range
                 Text(
-                    text = "Target: ${thresholds.low}-${thresholds.high} mg/dL",
+                    text = tirTargetLabel(thresholds, glucoseUnit),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
@@ -310,6 +315,27 @@ private fun LegendEntry(
         )
     }
 }
+
+/**
+ * The five stacked-bar legend bucket-boundary labels (`<55`, `55-70`, ...) rendered in the
+ * user's unit. The bucket COUNTS / TIR percentages stay SQL-computed in mg/dL; only these
+ * boundary strings convert.
+ */
+internal fun tirBucketLabels(thresholds: GlucoseThresholds, unit: GlucoseUnit): List<String> {
+    fun v(value: Int) = GlucoseFormat.format(value, unit)
+    return listOf(
+        "<${v(thresholds.urgentLow)}",
+        "${v(thresholds.urgentLow)}-${v(thresholds.low)}",
+        "${v(thresholds.low)}-${v(thresholds.high)}",
+        "${v(thresholds.high)}-${v(thresholds.urgentHigh)}",
+        ">${v(thresholds.urgentHigh)}",
+    )
+}
+
+/** The "Target: low-high mg/dL" caption rendered in the user's unit. */
+internal fun tirTargetLabel(thresholds: GlucoseThresholds, unit: GlucoseUnit): String =
+    "Target: ${GlucoseFormat.format(thresholds.low, unit)}-" +
+        "${GlucoseFormat.format(thresholds.high, unit)} ${GlucoseFormat.label(unit)}"
 
 internal fun qualityAssessment(inRangePercent: Float): Pair<String, Color> = when {
     inRangePercent >= 70f -> "Excellent" to ColorInRange

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -79,6 +79,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.glycemicgpt.mobile.data.local.AlertSoundCategory
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
 import com.glycemicgpt.mobile.presentation.plugin.PluginSettingsRenderer
@@ -273,6 +275,14 @@ fun SettingsScreen(
         ThemeSection(
             currentTheme = state.themeMode,
             onThemeChange = settingsViewModel::setThemeMode,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        GlucoseUnitsSection(
+            currentUnit = state.glucoseUnit,
+            syncError = state.glucoseUnitSyncError,
+            onUnitChange = settingsViewModel::setGlucoseUnit,
         )
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -2184,6 +2194,67 @@ private fun BatteryOptimizationCard(
                     .testTag("disable_battery_optimization_button"),
             ) {
                 Text("Disable Battery Optimization")
+            }
+        }
+    }
+}
+
+@Composable
+private fun GlucoseUnitsSection(
+    currentUnit: GlucoseUnit,
+    syncError: String?,
+    onUnitChange: (GlucoseUnit) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Text(
+                text = "Glucose Units",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                text = "Choose how glucose values are displayed across the app",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                GlucoseUnit.entries.forEach { unit ->
+                    val testTag = when (unit) {
+                        GlucoseUnit.MGDL -> "glucose_unit_mgdl"
+                        GlucoseUnit.MMOL -> "glucose_unit_mmol"
+                    }
+                    OutlinedButton(
+                        onClick = { onUnitChange(unit) },
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag(testTag),
+                        colors = if (currentUnit == unit) {
+                            ButtonDefaults.outlinedButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        } else {
+                            ButtonDefaults.outlinedButtonColors()
+                        },
+                    ) {
+                        Text(GlucoseFormat.label(unit), style = MaterialTheme.typography.labelMedium)
+                    }
+                }
+            }
+            if (syncError != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = syncError,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
             }
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -2075,8 +2075,10 @@ private fun WatchDataTelemetryCard(
                 )
             } else {
                 TelemetryRow(
-                    label = "Last BG sent",
-                    value = telemetry.lastBgMgDl?.let { "$it mg/dL" },
+                    // The watch is always sent the canonical mg/dL wire value, regardless of the
+                    // user's display unit; label it so this reads as a diagnostic, not a UI value.
+                    label = "Last BG sent (wire, mg/dL)",
+                    value = telemetry.lastBgMgDl?.toString(),
                     timestampMs = telemetry.lastBgTimestampMs,
                 )
                 TelemetryRow(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -1185,19 +1185,29 @@ class SettingsViewModel @Inject constructor(
      * Set the glucose display unit. The unit is a per-account preference, so this does an
      * optimistic local-cache set for instant feedback AND a backend PATCH so the choice
      * propagates to web, watch, and AI text. (Unlike [setThemeMode], which is per-device.)
-     * On PATCH failure the optimistic value stays and a transient error is surfaced; the next
-     * `/api/settings/glucose-unit` reconcile corrects it rather than reverting mid-session.
+     * On success the selector reflects whatever unit the server resolved to (in case it ever
+     * coerces the value); on PATCH failure the optimistic value stays and a transient error is
+     * surfaced; the next `/api/settings/glucose-unit` reconcile corrects it rather than reverting
+     * mid-session.
      */
     fun setGlucoseUnit(unit: GlucoseUnit) {
         appSettingsStore.glucoseUnit = unit
         _uiState.value = _uiState.value.copy(glucoseUnit = unit, glucoseUnitSyncError = null)
         viewModelScope.launch {
-            authRepository.updateGlucoseUnit(unit).onFailure { e ->
-                Timber.w(e, "Failed to sync glucose unit to backend")
-                _uiState.value = _uiState.value.copy(
-                    glucoseUnitSyncError = "Couldn't save to your account. It will retry on next sign-in.",
-                )
-            }
+            authRepository.updateGlucoseUnit(unit)
+                .onSuccess { resolved ->
+                    // Fold the server-resolved unit back into the selector so it self-corrects if
+                    // the backend ever returns a different value than we optimistically applied.
+                    if (resolved != _uiState.value.glucoseUnit) {
+                        _uiState.value = _uiState.value.copy(glucoseUnit = resolved)
+                    }
+                }
+                .onFailure { e ->
+                    Timber.w(e, "Failed to sync glucose unit to backend")
+                    _uiState.value = _uiState.value.copy(
+                        glucoseUnitSyncError = "Couldn't save to your account. It will retry on next sign-in.",
+                    )
+                }
         }
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -24,6 +24,7 @@ import com.glycemicgpt.mobile.data.local.PumpCredentialStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import com.glycemicgpt.mobile.data.update.AppUpdateChecker
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
 import com.glycemicgpt.mobile.service.AlertStreamService
 import com.glycemicgpt.mobile.service.PumpConnectionService
@@ -201,6 +202,9 @@ data class SettingsUiState(
     // Appearance
     val themeMode: com.glycemicgpt.mobile.presentation.theme.ThemeMode =
         com.glycemicgpt.mobile.presentation.theme.ThemeMode.System,
+    // Glucose display unit (per-account preference)
+    val glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
+    val glucoseUnitSyncError: String? = null,
 )
 
 private const val AUTO_DISMISS_MS = 5_000L
@@ -320,6 +324,7 @@ class SettingsViewModel @Inject constructor(
             runtimePlugins = pluginRegistry.runtimePlugins.value,
             showPumpLabels = appSettingsStore.showPumpLabels,
             themeMode = appSettingsStore.themeMode,
+            glucoseUnit = appSettingsStore.glucoseUnit,
             watchFaceConfig = loadPersistedWatchFaceConfig(),
         ).withActivePumpFields()
 
@@ -1174,6 +1179,26 @@ class SettingsViewModel @Inject constructor(
     fun setThemeMode(mode: com.glycemicgpt.mobile.presentation.theme.ThemeMode) {
         appSettingsStore.themeMode = mode
         _uiState.value = _uiState.value.copy(themeMode = mode)
+    }
+
+    /**
+     * Set the glucose display unit. The unit is a per-account preference, so this does an
+     * optimistic local-cache set for instant feedback AND a backend PATCH so the choice
+     * propagates to web, watch, and AI text. (Unlike [setThemeMode], which is per-device.)
+     * On PATCH failure the optimistic value stays and a transient error is surfaced; the next
+     * `/api/settings/glucose-unit` reconcile corrects it rather than reverting mid-session.
+     */
+    fun setGlucoseUnit(unit: GlucoseUnit) {
+        appSettingsStore.glucoseUnit = unit
+        _uiState.value = _uiState.value.copy(glucoseUnit = unit, glucoseUnitSyncError = null)
+        viewModelScope.launch {
+            authRepository.updateGlucoseUnit(unit).onFailure { e ->
+                Timber.w(e, "Failed to sync glucose unit to backend")
+                _uiState.value = _uiState.value.copy(
+                    glucoseUnitSyncError = "Couldn't save to your account. It will retry on next sign-in.",
+                )
+            }
+        }
     }
 
     fun setOverrideSilentForLow(enabled: Boolean) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
@@ -16,7 +16,10 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.glycemicgpt.mobile.data.local.AlertSoundCategory
 import com.glycemicgpt.mobile.data.local.AlertSoundStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.presentation.MainActivity
 import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
@@ -27,6 +30,7 @@ import javax.inject.Singleton
 class AlertNotificationManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val alertSoundStore: AlertSoundStore,
+    private val appSettingsStore: AppSettingsStore,
 ) {
     companion object {
         private const val GROUP_KEY = "com.glycemicgpt.ALERTS"
@@ -368,14 +372,22 @@ class AlertNotificationManager @Inject constructor(
         }
     }
 
-    private fun buildTitle(alert: AlertEntity): String {
-        val prefix = when (alert.severity) {
-            "emergency" -> "EMERGENCY"
-            "urgent" -> "URGENT"
-            "warning" -> "Warning"
-            else -> "Info"
-        }
-        val patientSuffix = alert.patientName?.let { " - $it" } ?: ""
-        return "$prefix: ${alert.currentValue.toInt()} mg/dL$patientSuffix"
+    private fun buildTitle(alert: AlertEntity): String =
+        formatAlertTitle(alert, appSettingsStore.glucoseUnit)
+}
+
+/**
+ * Builds a notification title (`"EMERGENCY: 320 mg/dL - Alice"`) with the glucose value rendered
+ * in [unit]. Pure -- no Android dependencies -- so it can be exercised directly in unit tests.
+ * Alert detection and the stored [AlertEntity.currentValue] stay canonical mg/dL.
+ */
+internal fun formatAlertTitle(alert: AlertEntity, unit: GlucoseUnit): String {
+    val prefix = when (alert.severity) {
+        "emergency" -> "EMERGENCY"
+        "urgent" -> "URGENT"
+        "warning" -> "Warning"
+        else -> "Info"
     }
+    val patientSuffix = alert.patientName?.let { " - $it" } ?: ""
+    return "$prefix: ${GlucoseFormat.formatWithLabel(alert.currentValue.toInt(), unit)}$patientSuffix"
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -1,8 +1,10 @@
 package com.glycemicgpt.mobile.service
 
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.data.local.dao.RawHistoryLogDao
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.data.local.entity.RawHistoryLogEntity
 import com.glycemicgpt.mobile.data.repository.PumpDataRepository
@@ -45,6 +47,7 @@ class PumpPollingOrchestrator @Inject constructor(
     private val glucoseRangeStore: GlucoseRangeStore,
     private val safetyLimitsStore: SafetyLimitsStore,
     private val historyLogParser: HistoryLogParser,
+    private val appSettingsStore: AppSettingsStore,
 ) {
 
     /** Set by PumpConnectionService to trigger immediate sync after enqueue. */
@@ -251,6 +254,10 @@ class PumpPollingOrchestrator @Inject constructor(
             pumpDriver.getCgmStatus()
                 .onSuccess {
                     repository.saveCgm(it)
+                    // We send the raw mg/dL value plus a per-account unit flag so the watch can
+                    // render in the user's unit once it consumes the flag (watch-side rendering is
+                    // a follow-up; the watch still shows mg/dL today). The wire value stays mg/dL.
+                    val glucoseUnit = appSettingsStore.glucoseUnit
                     try {
                         wearDataSender.sendCgm(
                             mgDl = it.glucoseMgDl,
@@ -260,12 +267,13 @@ class PumpPollingOrchestrator @Inject constructor(
                             high = glucoseRangeStore.high,
                             urgentLow = glucoseRangeStore.urgentLow,
                             urgentHigh = glucoseRangeStore.urgentHigh,
+                            unit = glucoseUnit,
                         )
                     } catch (e: Exception) {
                         Timber.w(e, "Failed to send CGM to watch")
                     }
 
-                    // Alert threshold detection for watch (uses dynamic thresholds)
+                    // Alert threshold detection for watch (uses dynamic thresholds, stays mg/dL)
                     val alertType = detectAlertForCgm(it.glucoseMgDl)
                     try {
                         if (alertType != null && alertType != previousAlertType) {
@@ -273,7 +281,8 @@ class PumpPollingOrchestrator @Inject constructor(
                                 type = alertType,
                                 bgValue = it.glucoseMgDl,
                                 timestampMs = it.timestamp.toEpochMilli(),
-                                message = "${alertLabel(alertType)} ${it.glucoseMgDl} mg/dL",
+                                message = "${alertLabel(alertType)} " +
+                                    GlucoseFormat.formatWithLabel(it.glucoseMgDl, glucoseUnit),
                             )
                             previousAlertType = alertType
                         } else if (alertType == null && previousAlertType != null) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
@@ -25,6 +25,8 @@ object WearDataContract {
     const val KEY_CGM_MG_DL = "cgm_mgdl"
     const val KEY_CGM_TREND = "cgm_trend"
     const val KEY_CGM_TIMESTAMP = "cgm_ts"
+    // Per-account glucose display unit ("mgdl"/"mmol"); value stays raw mg/dL, watch formats.
+    const val KEY_GLUCOSE_UNIT = "glucose_unit"
     const val KEY_GLUCOSE_LOW = "glucose_low"
     const val KEY_GLUCOSE_HIGH = "glucose_high"
     const val KEY_GLUCOSE_URGENT_LOW = "glucose_urg_low"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataSender.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataSender.kt
@@ -1,6 +1,7 @@
 package com.glycemicgpt.mobile.wear
 
 import android.content.Context
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -41,12 +42,14 @@ class WearDataSender @Inject constructor(
         high: Int,
         urgentLow: Int,
         urgentHigh: Int,
+        unit: GlucoseUnit,
     ) {
         try {
             val request = PutDataMapRequest.create(WearDataContract.CGM_PATH).apply {
                 dataMap.putInt(WearDataContract.KEY_CGM_MG_DL, mgDl)
                 dataMap.putString(WearDataContract.KEY_CGM_TREND, trend)
                 dataMap.putLong(WearDataContract.KEY_CGM_TIMESTAMP, timestampMs)
+                dataMap.putString(WearDataContract.KEY_GLUCOSE_UNIT, unit.wireValue)
                 dataMap.putInt(WearDataContract.KEY_GLUCOSE_LOW, low)
                 dataMap.putInt(WearDataContract.KEY_GLUCOSE_HIGH, high)
                 dataMap.putInt(WearDataContract.KEY_GLUCOSE_URGENT_LOW, urgentLow)

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.glycemicgpt.mobile.data.repository
 
 import android.content.Context
 import com.glycemicgpt.mobile.data.auth.AuthManager
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
@@ -9,9 +10,11 @@ import com.glycemicgpt.mobile.data.local.PumpProfileStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.GlucoseRangeResponse
+import com.glycemicgpt.mobile.data.remote.dto.GlucoseUnitResponse
 import com.glycemicgpt.mobile.data.remote.dto.HealthResponse
 import com.glycemicgpt.mobile.data.remote.dto.LoginResponse
 import com.glycemicgpt.mobile.data.remote.dto.UserDto
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -42,13 +45,14 @@ class AuthRepositoryTest {
     private val safetyLimitsStore = mockk<SafetyLimitsStore>(relaxed = true)
     private val analyticsSettingsStore = mockk<AnalyticsSettingsStore>(relaxed = true)
     private val pumpProfileStore = mockk<PumpProfileStore>(relaxed = true)
+    private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true)
     private val api = mockk<GlycemicGptApi>()
     private val deviceRepository = mockk<DeviceRepository>(relaxed = true)
     private val authManager = mockk<AuthManager>(relaxed = true)
 
     private val repository = AuthRepository(
         appContext, authTokenStore, glucoseRangeStore, safetyLimitsStore,
-        analyticsSettingsStore, pumpProfileStore, api, deviceRepository, authManager,
+        analyticsSettingsStore, pumpProfileStore, appSettingsStore, api, deviceRepository, authManager,
     )
 
     private val testScope = TestScope(UnconfinedTestDispatcher())
@@ -199,6 +203,7 @@ class AuthRepositoryTest {
         verify { safetyLimitsStore.clear() }
         verify { analyticsSettingsStore.clear() }
         verify { pumpProfileStore.clear() }
+        verify { appSettingsStore.glucoseUnit = GlucoseUnit.MGDL }
         verify { authManager.onLogout() }
     }
 
@@ -217,5 +222,49 @@ class AuthRepositoryTest {
     @Test
     fun `isValidUrl rejects malformed URL`() {
         assertFalse(repository.isValidUrl("not-a-url"))
+    }
+
+    @Test
+    fun `updateGlucoseUnit PATCHes the account and caches the server value`() = runTest {
+        coEvery { api.patchGlucoseUnit(any()) } returns Response.success(
+            GlucoseUnitResponse(glucoseUnit = "mmol"),
+        )
+
+        val result = repository.updateGlucoseUnit(GlucoseUnit.MMOL)
+
+        assertTrue(result.isSuccess)
+        assertEquals(GlucoseUnit.MMOL, result.getOrNull())
+        coVerify { api.patchGlucoseUnit(match { it.glucoseUnit == "mmol" }) }
+        verify { appSettingsStore.glucoseUnit = GlucoseUnit.MMOL }
+    }
+
+    @Test
+    fun `updateGlucoseUnit returns failure and leaves cache untouched on HTTP error`() = runTest {
+        coEvery { api.patchGlucoseUnit(any()) } returns Response.error(500, "boom".toResponseBody())
+
+        val result = repository.updateGlucoseUnit(GlucoseUnit.MMOL)
+
+        assertTrue(result.isFailure)
+        verify(exactly = 0) { appSettingsStore.glucoseUnit = any() }
+    }
+
+    @Test
+    fun `refreshGlucoseUnit writes the backend value into the cache`() = runTest {
+        coEvery { api.getGlucoseUnit() } returns Response.success(
+            GlucoseUnitResponse(glucoseUnit = "mmol"),
+        )
+
+        repository.refreshGlucoseUnit()
+
+        verify { appSettingsStore.glucoseUnit = GlucoseUnit.MMOL }
+    }
+
+    @Test
+    fun `refreshGlucoseUnit leaves cache untouched when the backend call fails`() = runTest {
+        coEvery { api.getGlucoseUnit() } throws java.io.IOException("offline")
+
+        repository.refreshGlucoseUnit()
+
+        verify(exactly = 0) { appSettingsStore.glucoseUnit = any() }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/compute/DashboardComputationsTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/compute/DashboardComputationsTest.kt
@@ -95,6 +95,20 @@ class DashboardComputationsTest {
     }
 
     @Test
+    fun `GMI is derived from the raw mgdl mean, never a display-converted value`() {
+        // GMI must keep eating the mg/dL mean even when the dashboard shows the mean in mmol/L.
+        // Feeding the mmol mean (120 / 18.0156 = 6.66) into the formula would give ~3.47 -- guard it.
+        val stats = DashboardComputations.computeCgmStats(listOf(cgm(120), cgm(120)))!!
+        val mmolMean = 120f / 18.0156f
+        val gmiFromMmolMean = 3.31f + 0.02392f * mmolMean
+        assertEquals(6.18f, stats.gmi, 0.01f)
+        assertTrue(
+            "GMI must not be computed from the mmol-converted mean",
+            kotlin.math.abs(stats.gmi - gmiFromMmolMean) > 0.5f,
+        )
+    }
+
+    @Test
     fun `computeCgmStats computes non-zero stdDev`() {
         val readings = listOf(cgm(100), cgm(200), cgm(150))
         val stats = DashboardComputations.computeCgmStats(readings)!!

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/format/GlucoseFormatTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/format/GlucoseFormatTest.kt
@@ -1,0 +1,117 @@
+package com.glycemicgpt.mobile.domain.format
+
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.After
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * Tests for the single client-side glucose formatter. The clinical anchors
+ * (70 -> 3.9, 180 -> 10.0, 120 -> 6.7, 100 -> 5.6) are the load-bearing cases:
+ * they pin the conversion constant and the round-LAST rule, and must match the
+ * backend / web rendering of the same stored mg/dL values.
+ */
+class GlucoseFormatTest {
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(savedLocale)
+    }
+
+    private val savedLocale: Locale = Locale.getDefault()
+
+    @Test
+    fun `constant is the single canonical factor`() {
+        assertEquals(18.0156, GlucoseFormat.MGDL_PER_MMOL, 0.0)
+    }
+
+    @Test
+    fun `mgdl value formats as integer with no conversion`() {
+        assertEquals("120", GlucoseFormat.format(120, GlucoseUnit.MGDL))
+        assertEquals("70", GlucoseFormat.format(70, GlucoseUnit.MGDL))
+        assertEquals("250", GlucoseFormat.format(250, GlucoseUnit.MGDL))
+    }
+
+    @Test
+    fun `mmol value renders the clinical anchors`() {
+        assertEquals("3.9", GlucoseFormat.format(70, GlucoseUnit.MMOL))
+        assertEquals("10.0", GlucoseFormat.format(180, GlucoseUnit.MMOL))
+        assertEquals("6.7", GlucoseFormat.format(120, GlucoseUnit.MMOL))
+        assertEquals("5.6", GlucoseFormat.format(100, GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `formatWithLabel pairs value and unit label`() {
+        assertEquals("120 mg/dL", GlucoseFormat.formatWithLabel(120, GlucoseUnit.MGDL))
+        assertEquals("6.7 mmol/L", GlucoseFormat.formatWithLabel(120, GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `labels and spoken units are unit-correct`() {
+        assertEquals("mg/dL", GlucoseFormat.label(GlucoseUnit.MGDL))
+        assertEquals("mmol/L", GlucoseFormat.label(GlucoseUnit.MMOL))
+        assertEquals("milligrams per deciliter", GlucoseFormat.spokenUnit(GlucoseUnit.MGDL))
+        assertEquals("millimoles per liter", GlucoseFormat.spokenUnit(GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `convertValue divides by the factor for mmol and is identity for mgdl`() {
+        assertEquals(120.0, GlucoseFormat.convertValue(120, GlucoseUnit.MGDL), 0.0)
+        assertEquals(120 / 18.0156, GlucoseFormat.convertValue(120, GlucoseUnit.MMOL), 1e-9)
+    }
+
+    @Test
+    fun `convertSpread is offset-free divide-by-factor`() {
+        // A spread of 18.0156 mg/dL is exactly 1.0 mmol/L -- no anchor, no offset.
+        assertEquals(1.0, GlucoseFormat.convertSpread(18.0156), 1e-9)
+        assertEquals(0.0, GlucoseFormat.convertSpread(0.0), 0.0)
+    }
+
+    @Test
+    fun `mean formats as integer for mgdl and one decimal for mmol`() {
+        assertEquals("117", GlucoseFormat.formatMean(117.4f, GlucoseUnit.MGDL))
+        assertEquals("6.5", GlucoseFormat.formatMean(117.4f, GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `std-dev formats one decimal in either unit via the spread converter`() {
+        assertEquals("23.4", GlucoseFormat.formatSpread(23.42f, GlucoseUnit.MGDL))
+        // 36 mg/dL spread -> 36 / 18.0156 = 1.998 -> 2.0 mmol/L
+        assertEquals("2.0", GlucoseFormat.formatSpread(36f, GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `round-trips through mmol stay within one display step`() {
+        // Rounding mmol to 1 dp introduces at most 0.05 mmol/L of error, i.e. ~0.9 mg/dL when
+        // converted back. A looser bound would let a real conversion bug slip through.
+        val maxDriftMgDl = 0.05 * GlucoseFormat.MGDL_PER_MMOL + 1e-6
+        for (mgDl in 40..400 step 1) {
+            val mmol = GlucoseFormat.format(mgDl, GlucoseUnit.MMOL).toDouble()
+            val backToMgDl = mmol * GlucoseFormat.MGDL_PER_MMOL
+            assertTrue(
+                "round-trip for $mgDl mg/dL drifted too far: $mmol mmol/L -> $backToMgDl",
+                kotlin.math.abs(backToMgDl - mgDl) <= maxDriftMgDl,
+            )
+        }
+    }
+
+    @Test
+    fun `mmol uses a dot separator regardless of device locale`() {
+        // A comma-decimal locale (e.g. Germany) must NOT produce "5,6" -- the log
+        // scrubber and cross-surface consistency both require a dot.
+        Locale.setDefault(Locale.GERMANY)
+        assertEquals("5.6", GlucoseFormat.format(100, GlucoseUnit.MMOL))
+        assertEquals("6.7 mmol/L", GlucoseFormat.formatWithLabel(120, GlucoseUnit.MMOL))
+        assertEquals("6.5", GlucoseFormat.formatMean(117.4f, GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `boundary values format cleanly`() {
+        assertEquals("1.1", GlucoseFormat.format(20, GlucoseUnit.MMOL))
+        assertEquals("27.8", GlucoseFormat.format(500, GlucoseUnit.MMOL))
+        assertEquals("20", GlucoseFormat.format(20, GlucoseUnit.MGDL))
+        assertEquals("500", GlucoseFormat.format(500, GlucoseUnit.MGDL))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/model/GlucoseUnitTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/model/GlucoseUnitTest.kt
@@ -1,0 +1,45 @@
+package com.glycemicgpt.mobile.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Parsing + default behaviour for [GlucoseUnit]. [fromName] is exactly the logic the
+ * [com.glycemicgpt.mobile.data.local.AppSettingsStore] cache getter delegates to, so these
+ * cover the "default mg/dL, fall back on unparseable" guarantee without an Android context.
+ */
+class GlucoseUnitTest {
+
+    @Test
+    fun `wire values mirror the backend enum`() {
+        assertEquals("mgdl", GlucoseUnit.MGDL.wireValue)
+        assertEquals("mmol", GlucoseUnit.MMOL.wireValue)
+    }
+
+    @Test
+    fun `fromWire parses backend json values`() {
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire("mgdl"))
+        assertEquals(GlucoseUnit.MMOL, GlucoseUnit.fromWire("mmol"))
+        assertEquals(GlucoseUnit.MMOL, GlucoseUnit.fromWire("MMOL"))
+    }
+
+    @Test
+    fun `fromWire falls back to mgdl on unknown or null`() {
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire(null))
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire(""))
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire("gibberish"))
+    }
+
+    @Test
+    fun `fromName parses stored enum names`() {
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromName("MGDL"))
+        assertEquals(GlucoseUnit.MMOL, GlucoseUnit.fromName("MMOL"))
+    }
+
+    @Test
+    fun `fromName falls back to mgdl on unknown or null`() {
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromName(null))
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromName("mmol")) // wire value is not a valid name
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromName("nonsense"))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/logging/ReleaseTreeTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/logging/ReleaseTreeTest.kt
@@ -1,5 +1,7 @@
 package com.glycemicgpt.mobile.logging
 
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -41,6 +43,21 @@ class ReleaseTreeTest {
         val msg = "Reading: 5.4 mmol/L"
         val result = ReleaseTree.scrubSensitiveData(msg)
         assertEquals("Reading: [BG]", result)
+    }
+
+    @Test
+    fun `scrubs mmol values produced by the glucose formatter`() {
+        // The mmol format chosen for display must still match BG_MMOL_PATTERN so it cannot
+        // bypass the release log scrubber (AC: log scrubber still works).
+        for (mgDl in listOf(70, 100, 120, 180, 250)) {
+            val rendered = GlucoseFormat.formatWithLabel(mgDl, GlucoseUnit.MMOL)
+            val msg = "Current reading: $rendered"
+            assertEquals(
+                "mmol output '$rendered' should be scrubbed",
+                "Current reading: [BG]",
+                ReleaseTree.scrubSensitiveData(msg),
+            )
+        }
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -1,7 +1,9 @@
 package com.glycemicgpt.mobile.presentation.alerts
 
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.repository.AlertRepository
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -11,6 +13,7 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -32,6 +35,7 @@ class AlertsViewModelTest {
     private val alertsFlow = MutableStateFlow<List<AlertEntity>>(emptyList())
     private lateinit var repository: AlertRepository
     private lateinit var notificationManager: AlertNotificationManager
+    private lateinit var appSettingsStore: AppSettingsStore
 
     @Before
     fun setUp() {
@@ -41,6 +45,10 @@ class AlertsViewModelTest {
             coEvery { fetchPendingAlerts() } returns Result.success(emptyList())
         }
         notificationManager = mockk(relaxed = true)
+        appSettingsStore = mockk(relaxed = true) {
+            every { glucoseUnit } returns GlucoseUnit.MGDL
+            every { glucoseUnitFlow() } returns flowOf(GlucoseUnit.MGDL)
+        }
     }
 
     @After
@@ -48,7 +56,7 @@ class AlertsViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = AlertsViewModel(repository, notificationManager)
+    private fun createViewModel() = AlertsViewModel(repository, notificationManager, appSettingsStore)
 
     private fun makeAlert(
         serverId: String = "alert-1",
@@ -91,6 +99,24 @@ class AlertsViewModelTest {
 
         assertEquals(1, vm.alerts.value.size)
         assertEquals("alert-1", vm.alerts.value[0].serverId)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `glucoseUnit seeds from the cache and propagates flow emissions`() = runTest {
+        val unitFlow = MutableStateFlow(GlucoseUnit.MGDL)
+        every { appSettingsStore.glucoseUnit } returns GlucoseUnit.MGDL
+        every { appSettingsStore.glucoseUnitFlow() } returns unitFlow
+        val vm = createViewModel()
+
+        val job = backgroundScope.launch(testDispatcher) { vm.glucoseUnit.collect { } }
+        advanceUntilIdle()
+        assertEquals(GlucoseUnit.MGDL, vm.glucoseUnit.value)
+
+        unitFlow.value = GlucoseUnit.MMOL
+        advanceUntilIdle()
+        assertEquals(GlucoseUnit.MMOL, vm.glucoseUnit.value)
 
         job.cancel()
     }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -471,6 +471,16 @@ class HomeViewModelTest {
         coVerify(atLeast = 1) { authRepository.refreshSafetyLimits() }
     }
 
+    @Test
+    fun `init reconciles the glucose unit even when the glucose range is fresh`() = runTest {
+        // The unit reconcile is decoupled from range staleness so a unit change made on another
+        // device propagates on a cold open even while the range cache is still fresh.
+        every { glucoseRangeStore.isStale(any()) } returns false
+        createViewModel()
+        advanceTimeBy(10_000); runCurrent()
+        coVerify(atLeast = 1) { authRepository.refreshGlucoseUnit() }
+    }
+
     // -- Plugin cards ----------------------------------------------------------
 
     // -- CGM Stats state ------------------------------------------------------

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -16,6 +16,7 @@ import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.BolusEvent
 import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.domain.model.ReservoirReading
@@ -129,6 +130,8 @@ class HomeViewModelTest {
     private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true) {
         every { showPumpLabels } returns false
         every { dataRetentionDays } returns 7
+        every { glucoseUnit } returns GlucoseUnit.MGDL
+        every { glucoseUnitFlow() } returns flowOf(GlucoseUnit.MGDL)
     }
 
     private val authRepository = mockk<AuthRepository>(relaxed = true)
@@ -230,6 +233,26 @@ class HomeViewModelTest {
         advanceTimeBy(10_000); runCurrent()
 
         assertFalse(vm.isRefreshing.value)
+    }
+
+    @Test
+    fun `glucoseUnit seeds from the cache and propagates flow emissions`() = runTest {
+        val unitFlow = MutableStateFlow(GlucoseUnit.MGDL)
+        every { appSettingsStore.glucoseUnit } returns GlucoseUnit.MGDL
+        every { appSettingsStore.glucoseUnitFlow() } returns unitFlow
+        val vm = createViewModel()
+
+        // Subscribe so the WhileSubscribed stateIn starts collecting upstream.
+        val collected = mutableListOf<GlucoseUnit>()
+        val job = backgroundScope.launch(testDispatcher) { vm.glucoseUnit.collect { collected.add(it) } }
+        runCurrent()
+        assertEquals(GlucoseUnit.MGDL, vm.glucoseUnit.value)
+
+        unitFlow.value = GlucoseUnit.MMOL
+        runCurrent()
+        assertEquals(GlucoseUnit.MMOL, vm.glucoseUnit.value)
+
+        job.cancel()
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBarTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/TimeInRangeBarTest.kt
@@ -1,6 +1,7 @@
 package com.glycemicgpt.mobile.presentation.home
 
 import com.glycemicgpt.mobile.data.local.dao.TimeInRangeCounts
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.TimeInRangeData
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -121,30 +122,47 @@ class TimeInRangeBarTest {
         assertEquals("100%", formatTirPercent(100f))
     }
 
-    // -- Dynamic target range label -------------------------------------------
+    // -- Dynamic target range label (calls real production function) ------------
 
     @Test
-    fun `target range label uses default thresholds`() {
-        val thresholds = GlucoseThresholds()
-        val label = "Target: ${thresholds.low}-${thresholds.high} mg/dL"
-        assertEquals("Target: 70-180 mg/dL", label)
+    fun `target range label uses default thresholds in mgdl`() {
+        assertEquals(
+            "Target: 70-180 mg/dL",
+            tirTargetLabel(GlucoseThresholds(), GlucoseUnit.MGDL),
+        )
     }
 
     @Test
-    fun `target range label uses custom thresholds`() {
+    fun `target range label uses custom thresholds in mgdl`() {
         val thresholds = GlucoseThresholds(urgentLow = 60, low = 90, high = 230, urgentHigh = 330)
-        val label = "Target: ${thresholds.low}-${thresholds.high} mg/dL"
-        assertEquals("Target: 90-230 mg/dL", label)
+        assertEquals("Target: 90-230 mg/dL", tirTargetLabel(thresholds, GlucoseUnit.MGDL))
     }
 
     @Test
-    fun `legend labels reflect custom thresholds`() {
+    fun `target range label converts to mmol`() {
+        // 70 -> 3.9, 180 -> 10.0
+        assertEquals(
+            "Target: 3.9-10.0 mmol/L",
+            tirTargetLabel(GlucoseThresholds(), GlucoseUnit.MMOL),
+        )
+    }
+
+    @Test
+    fun `legend labels reflect custom thresholds in mgdl`() {
         val thresholds = GlucoseThresholds(urgentLow = 60, low = 90, high = 230, urgentHigh = 330)
-        assertEquals("<60", "<${thresholds.urgentLow}")
-        assertEquals("60-90", "${thresholds.urgentLow}-${thresholds.low}")
-        assertEquals("90-230", "${thresholds.low}-${thresholds.high}")
-        assertEquals("230-330", "${thresholds.high}-${thresholds.urgentHigh}")
-        assertEquals(">330", ">${thresholds.urgentHigh}")
+        assertEquals(
+            listOf("<60", "60-90", "90-230", "230-330", ">330"),
+            tirBucketLabels(thresholds, GlucoseUnit.MGDL),
+        )
+    }
+
+    @Test
+    fun `legend labels convert to mmol`() {
+        // 55 -> 3.1, 70 -> 3.9, 180 -> 10.0, 250 -> 13.9
+        assertEquals(
+            listOf("<3.1", "3.1-3.9", "3.9-10.0", "10.0-13.9", ">13.9"),
+            tirBucketLabels(GlucoseThresholds(), GlucoseUnit.MMOL),
+        )
     }
 
     // -- Helper: mirrors repository logic for percentage math tests -----------

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -16,6 +16,7 @@ import com.glycemicgpt.mobile.data.repository.LoginResult
 import com.glycemicgpt.mobile.data.update.AppUpdateChecker
 import com.glycemicgpt.mobile.data.update.DownloadResult
 import com.glycemicgpt.mobile.data.update.UpdateCheckResult
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.data.update.UpdateInfo
 import com.glycemicgpt.mobile.data.update.WearAppUpdateChecker
 import com.glycemicgpt.mobile.wear.WatchFacePusher
@@ -47,6 +48,7 @@ import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -64,6 +66,7 @@ class SettingsViewModelTest {
     private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true) {
         every { backendSyncEnabled } returns true
         every { dataRetentionDays } returns 7
+        every { glucoseUnit } returns GlucoseUnit.MGDL
         every { watchFaceShowIoB } returns true
         every { watchFaceShowGraph } returns true
         every { watchFaceShowAlert } returns true
@@ -137,6 +140,40 @@ class SettingsViewModelTest {
         assertFalse(state.isPumpPaired)
         assertTrue(state.backendSyncEnabled)
         assertEquals(7, state.dataRetentionDays)
+    }
+
+    @Test
+    fun `loadState reads the cached glucose unit`() {
+        every { appSettingsStore.glucoseUnit } returns GlucoseUnit.MMOL
+        val vm = createViewModel()
+
+        assertEquals(GlucoseUnit.MMOL, vm.uiState.value.glucoseUnit)
+    }
+
+    @Test
+    fun `setGlucoseUnit optimistically caches locally and PATCHes the account`() = runTest {
+        coEvery { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) } returns
+            Result.success(GlucoseUnit.MMOL)
+        val vm = createViewModel()
+
+        vm.setGlucoseUnit(GlucoseUnit.MMOL)
+
+        verify { appSettingsStore.glucoseUnit = GlucoseUnit.MMOL }
+        coVerify { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) }
+        assertEquals(GlucoseUnit.MMOL, vm.uiState.value.glucoseUnit)
+        assertNull(vm.uiState.value.glucoseUnitSyncError)
+    }
+
+    @Test
+    fun `setGlucoseUnit keeps the optimistic value and surfaces an error on PATCH failure`() = runTest {
+        coEvery { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) } returns
+            Result.failure(RuntimeException("offline"))
+        val vm = createViewModel()
+
+        vm.setGlucoseUnit(GlucoseUnit.MMOL)
+
+        assertEquals(GlucoseUnit.MMOL, vm.uiState.value.glucoseUnit)
+        assertNotNull(vm.uiState.value.glucoseUnitSyncError)
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -165,6 +165,20 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `setGlucoseUnit folds the server-resolved unit back into state`() = runTest {
+        // Optimistically applied MMOL, but the server resolves to MGDL; the selector must reflect
+        // whatever the backend returned rather than the optimistic value.
+        coEvery { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) } returns
+            Result.success(GlucoseUnit.MGDL)
+        val vm = createViewModel()
+
+        vm.setGlucoseUnit(GlucoseUnit.MMOL)
+
+        assertEquals(GlucoseUnit.MGDL, vm.uiState.value.glucoseUnit)
+        assertNull(vm.uiState.value.glucoseUnitSyncError)
+    }
+
+    @Test
     fun `setGlucoseUnit keeps the optimistic value and surfaces an error on PATCH failure`() = runTest {
         coEvery { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) } returns
             Result.failure(RuntimeException("offline"))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertNotificationManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertNotificationManagerTest.kt
@@ -1,6 +1,7 @@
 package com.glycemicgpt.mobile.service
 
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -94,29 +95,43 @@ class AlertNotificationManagerTest {
     @Test
     fun `notification title includes severity prefix and glucose value`() {
         val alert = makeAlert(severity = "emergency", currentValue = 320.0)
-        val title = buildTitle(alert)
+        val title = formatAlertTitle(alert, GlucoseUnit.MGDL)
         assertEquals("EMERGENCY: 320 mg/dL", title)
     }
 
     @Test
     fun `notification title includes patient name for caregivers`() {
         val alert = makeAlert(severity = "urgent", currentValue = 55.0, patientName = "Alice")
-        val title = buildTitle(alert)
+        val title = formatAlertTitle(alert, GlucoseUnit.MGDL)
         assertEquals("URGENT: 55 mg/dL - Alice", title)
     }
 
     @Test
     fun `warning title uses mixed case`() {
         val alert = makeAlert(severity = "warning", currentValue = 200.0)
-        val title = buildTitle(alert)
+        val title = formatAlertTitle(alert, GlucoseUnit.MGDL)
         assertEquals("Warning: 200 mg/dL", title)
     }
 
     @Test
     fun `info title uses mixed case`() {
         val alert = makeAlert(severity = "info", currentValue = 180.0)
-        val title = buildTitle(alert)
+        val title = formatAlertTitle(alert, GlucoseUnit.MGDL)
         assertEquals("Info: 180 mg/dL", title)
+    }
+
+    @Test
+    fun `notification title renders glucose value in mmol when selected`() {
+        val alert = makeAlert(severity = "emergency", currentValue = 320.0)
+        // 320 / 18.0156 = 17.76 -> 17.8 mmol/L
+        assertEquals("EMERGENCY: 17.8 mmol/L", formatAlertTitle(alert, GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `mmol notification title keeps the patient suffix`() {
+        val alert = makeAlert(severity = "urgent", currentValue = 55.0, patientName = "Alice")
+        // 55 / 18.0156 = 3.05 -> 3.1 mmol/L
+        assertEquals("URGENT: 3.1 mmol/L - Alice", formatAlertTitle(alert, GlucoseUnit.MMOL))
     }
 
     // --- Stable notification ID tests ---
@@ -260,17 +275,6 @@ class AlertNotificationManagerTest {
     }
 
     // --- Helper mirrors for testing without Android context ---
-
-    private fun buildTitle(alert: AlertEntity): String {
-        val prefix = when (alert.severity) {
-            "emergency" -> "EMERGENCY"
-            "urgent" -> "URGENT"
-            "warning" -> "Warning"
-            else -> "Info"
-        }
-        val patientSuffix = alert.patientName?.let { " - $it" } ?: ""
-        return "$prefix: ${alert.currentValue.toInt()} mg/dL$patientSuffix"
-    }
 
     private fun stableNotificationId(alert: AlertEntity): Int {
         val key = "${alert.alertType}|${alert.patientName ?: ""}"

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -1,5 +1,6 @@
 package com.glycemicgpt.mobile.service
 
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.data.local.dao.RawHistoryLogDao
@@ -11,6 +12,7 @@ import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.model.PumpActivityMode
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.model.ReservoirReading
@@ -78,6 +80,9 @@ class PumpPollingOrchestratorTest {
     }
     private val safetyLimitsStore = mockk<SafetyLimitsStore>(relaxed = true)
     private val historyLogParser = mockk<HistoryLogParser>(relaxed = true)
+    private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true) {
+        every { glucoseUnit } returns GlucoseUnit.MGDL
+    }
 
     /**
      * Time to advance past the fast loop's initial delay + stagger + margin.
@@ -101,7 +106,7 @@ class PumpPollingOrchestratorTest {
     /** Alias for tests that only need fast loop data. */
     private val SETTLE_TIME_MS = FAST_SETTLE_MS
 
-    private fun createOrchestrator() = PumpPollingOrchestrator(pumpDriver, repository, syncEnqueuer, rawHistoryLogDao, wearDataSender, glucoseRangeStore, safetyLimitsStore, historyLogParser)
+    private fun createOrchestrator() = PumpPollingOrchestrator(pumpDriver, repository, syncEnqueuer, rawHistoryLogDao, wearDataSender, glucoseRangeStore, safetyLimitsStore, historyLogParser, appSettingsStore)
 
     @Test
     fun `does not poll when disconnected`() = runTest {
@@ -336,6 +341,30 @@ class PumpPollingOrchestratorTest {
         advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
 
         coVerify(exactly = 1) { wearDataSender.sendAlert("low", 65, any(), any()) }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `watch CGM and alert render in the user's mmol unit`() = runTest {
+        every { appSettingsStore.glucoseUnit } returns GlucoseUnit.MMOL
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(SETTLE_TIME_MS) // initial poll: 120 mg/dL = normal
+
+        // Raw mg/dL stays on the wire; the unit flag tells the watch how to render it.
+        coVerify(atLeast = 1) {
+            wearDataSender.sendCgm(120, any(), any(), any(), any(), any(), any(), GlucoseUnit.MMOL)
+        }
+
+        // Drop to a low reading -> the pre-formatted watch alert message is in mmol/L (65 -> 3.6)
+        coEvery { pumpDriver.getCgmStatus() } returns Result.success(
+            CgmReading(glucoseMgDl = 65, trendArrow = CgmTrend.SINGLE_DOWN, timestamp = Instant.now()),
+        )
+        advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
+
+        coVerify(exactly = 1) { wearDataSender.sendAlert("low", 65, any(), "LOW 3.6 mmol/L") }
         orchestrator.stop()
     }
 

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
@@ -25,6 +25,8 @@ object WearDataContract {
     const val KEY_CGM_MG_DL = "cgm_mgdl"
     const val KEY_CGM_TREND = "cgm_trend"
     const val KEY_CGM_TIMESTAMP = "cgm_ts"
+    // Per-account glucose display unit ("mgdl"/"mmol"); value stays raw mg/dL, watch formats.
+    const val KEY_GLUCOSE_UNIT = "glucose_unit"
     const val KEY_GLUCOSE_LOW = "glucose_low"
     const val KEY_GLUCOSE_HIGH = "glucose_high"
     const val KEY_GLUCOSE_URGENT_LOW = "glucose_urg_low"


### PR DESCRIPTION
## Summary
Adds a per-account glucose unit preference (mg/dL or mmol/L) to the Android phone app (Epic 53, #758). The phone is fundamentally a display surface: only the shown/spoken number and unit label convert — every comparison, alert detection, color, threshold, GMI, chart geometry, and the 20-500 mg/dL safety invariant stay canonical mg/dL.

## Changes
- **Format helper:** new `GlucoseUnit` enum + `GlucoseFormat` (single `18.0156` constant matching the backend/web; round-last; locale-independent dot separator; `convertValue` vs an offset-free `convertSpread` for std-dev). Pure Kotlin so the watch can mirror it.
- **Per-account preference:** a "Glucose Units" selector in Settings does an optimistic local-cache set + `PATCH /api/settings/glucose-unit`. `AuthRepository` reconciles the cache from `GET /api/settings/glucose-unit` on login and on stale refresh, and resets it to the default on logout. The local store is a cache only — the account value is the source of truth.
- **Display surfaces:** home hero, trend-chart axis labels + tooltip, time-in-range legend/target, CGM stats (mean + std-dev), the alerts list, and notifications render in the user's unit. GMI keeps eating the raw mg/dL mean; chart geometry stays mg/dL.
- **Wear:** the CGM data item carries a unit flag (added to both contract mirrors) alongside the raw mg/dL value; the watch-side render is a follow-up.
- **a11y:** the spoken unit converts (e.g. "millimoles per liter") and the mmol format still matches the release log scrubber.

## Testing
- 708 unit tests pass — clinical anchors (70→3.9, 180→10.0, 120→6.7, 100→5.6), locale-independence, a GMI-from-raw-mean guard, log-scrubber round-trip, per-account PATCH/reconcile/logout-reset, and flow propagation.
- On-device Compose test (`GlucoseUnitDisplayUiTest`, 4/4 on the Android 15 emulator) renders the hero, time-in-range, and CGM stats in both units.
- Lint + `:app`/`:wear-device` assemble all green.

Closes #758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - **Glucose unit preference:** Choose mg/dL or mmol/L in Settings (Appearance). Values across the Home screen, charts, alerts, stats, and Time in Range update accordingly.
  - **Backend + watch sync:** The selected unit is saved per account and sent to the watch so notifications and CGM formatting stay consistent.
- **Accessibility & UI**
  - Unit labels, tooltips, and spoken/readout text are now unit-aware.
- **Tests**
  - Expanded automated coverage for conversion accuracy, UI rendering consistency, and accessibility across both units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->