### PR TITLE
feat(mobile): render Wear OS glucose in the user's unit (mg/dL or mmol/L)

### DIFF
--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseUnitDisplayUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseUnitDisplayUiTest.kt
@@ -164,6 +164,10 @@ class GlucoseUnitDisplayUiTest {
                             glucoseUnit = unit,
                             isDetailMode = true,
                             showPeriodSelector = false,
+                            // Pin both charts to the same "now" so the x-axis mapping is identical;
+                            // otherwise each chart samples the wall clock at its own composition
+                            // moment and the dots land a sub-pixel apart, failing the plot-diff below.
+                            nowMsOverride = now.toEpochMilli(),
                             modifier = Modifier.fillMaxWidth().height(200.dp),
                         )
                     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseTrendChart.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseTrendChart.kt
@@ -121,6 +121,9 @@ fun GlucoseTrendChart(
     onClick: (() -> Unit)? = null,
     isDetailMode: Boolean = false,
     showPeriodSelector: Boolean = true,
+    // Test seam: pins the chart's "now" so the x-axis mapping is deterministic across
+    // renders (production passes null and samples the wall clock once per data change).
+    nowMsOverride: Long? = null,
     modifier: Modifier = Modifier,
 ) {
     val content: @Composable (Modifier) -> Unit = { innerModifier ->
@@ -137,6 +140,7 @@ fun GlucoseTrendChart(
             onClick = onClick,
             isDetailMode = isDetailMode,
             showPeriodSelector = showPeriodSelector,
+            nowMsOverride = nowMsOverride,
             modifier = innerModifier,
         )
     }
@@ -170,6 +174,7 @@ private fun GlucoseTrendChartContent(
     onClick: (() -> Unit)?,
     isDetailMode: Boolean,
     showPeriodSelector: Boolean = true,
+    nowMsOverride: Long? = null,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -254,8 +259,8 @@ private fun GlucoseTrendChartContent(
             val axisLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
             val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
             val iobColor = MaterialTheme.colorScheme.primary
-            val nowMs = remember(readings, iobReadings, basalReadings, bolusEvents, selectedPeriod) {
-                System.currentTimeMillis()
+            val nowMs = remember(readings, iobReadings, basalReadings, bolusEvents, selectedPeriod, nowMsOverride) {
+                nowMsOverride ?: System.currentTimeMillis()
             }
             val fullPeriodMs = selectedPeriod.hours * 3600_000L
             val fullStartMs = nowMs - fullPeriodMs

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -254,9 +254,9 @@ class PumpPollingOrchestrator @Inject constructor(
             pumpDriver.getCgmStatus()
                 .onSuccess {
                     repository.saveCgm(it)
-                    // We send the raw mg/dL value plus a per-account unit flag so the watch can
-                    // render in the user's unit once it consumes the flag (watch-side rendering is
-                    // a follow-up; the watch still shows mg/dL today). The wire value stays mg/dL.
+                    // We send the raw mg/dL value plus a per-account unit flag so the watch
+                    // renders glucose in the user's unit. The wire value stays canonical mg/dL;
+                    // only the watch's displayed/spoken number converts.
                     val glucoseUnit = appSettingsStore.glucoseUnit
                     try {
                         wearDataSender.sendCgm(

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearDataContractTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearDataContractTest.kt
@@ -22,6 +22,7 @@ class WearDataContractTest {
         assertEquals("cgm_mgdl", WearDataContract.KEY_CGM_MG_DL)
         assertEquals("cgm_trend", WearDataContract.KEY_CGM_TREND)
         assertEquals("cgm_ts", WearDataContract.KEY_CGM_TIMESTAMP)
+        assertEquals("glucose_unit", WearDataContract.KEY_GLUCOSE_UNIT)
         assertEquals("glucose_low", WearDataContract.KEY_GLUCOSE_LOW)
         assertEquals("glucose_high", WearDataContract.KEY_GLUCOSE_HIGH)
         assertEquals("glucose_urg_low", WearDataContract.KEY_GLUCOSE_URGENT_LOW)

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/GlycemicWearDeviceApp.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/GlycemicWearDeviceApp.kt
@@ -6,6 +6,7 @@ import com.glycemicgpt.weardevice.data.WatchVersionPublisher
 import com.glycemicgpt.weardevice.data.WearDataContract
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils.sanitizeThresholds
+import com.glycemicgpt.weardevice.util.GlucoseUnit
 import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.Wearable
 import dagger.hilt.android.HiltAndroidApp
@@ -54,6 +55,13 @@ class GlycemicWearDeviceApp : Application() {
                                 Timber.d("Bootstrapped IoB from DataLayer cache")
                             }
                             WearDataContract.CGM_PATH -> {
+                                // The cached CGM item carries the account-global unit; hydrate it
+                                // alongside the reading so cold start renders in the right unit.
+                                // Skip when the key is absent (e.g. an item cached by a pre-53.3
+                                // phone) so it can't clobber the unit restored from prefs.
+                                dataMap.getString(WearDataContract.KEY_GLUCOSE_UNIT)?.let {
+                                    WatchDataRepository.updateGlucoseUnit(GlucoseUnit.fromWire(it))
+                                }
                                 val mgDl = dataMap.getInt(WearDataContract.KEY_CGM_MG_DL)
                                 if (!GlucoseDisplayUtils.isValidGlucose(mgDl)) {
                                     Timber.w("Rejected invalid cached CGM value during bootstrap")

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/GlycemicWearDeviceApp.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/GlycemicWearDeviceApp.kt
@@ -57,8 +57,8 @@ class GlycemicWearDeviceApp : Application() {
                             WearDataContract.CGM_PATH -> {
                                 // The cached CGM item carries the account-global unit; hydrate it
                                 // alongside the reading so cold start renders in the right unit.
-                                // Skip when the key is absent (e.g. an item cached by a pre-53.3
-                                // phone) so it can't clobber the unit restored from prefs.
+                                // Skip when the key is absent (e.g. an item cached by an older
+                                // phone build) so it can't clobber the unit restored from prefs.
                                 dataMap.getString(WearDataContract.KEY_GLUCOSE_UNIT)?.let {
                                     WatchDataRepository.updateGlucoseUnit(GlucoseUnit.fromWire(it))
                                 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/BgComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/BgComplicationDataSource.kt
@@ -20,9 +20,16 @@ import java.util.concurrent.TimeUnit
 class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
 
     override fun getPreviewData(type: ComplicationType): ComplicationData {
-        val text = PlainComplicationText.Builder("120 \u2192").build()
+        // Show the sample reading in the user's configured unit so the picker preview
+        // matches what they will actually see (defaults to mg/dL before any sync).
+        WatchDataRepository.init(applicationContext)
+        val unit = WatchDataRepository.glucoseUnit.value
+        val sample = GlucoseDisplayUtils.formatGlucose(PREVIEW_MG_DL, unit)
+        val sampleWithLabel = GlucoseDisplayUtils.formatWithLabel(PREVIEW_MG_DL, unit)
+
+        val text = PlainComplicationText.Builder("$sample \u2192").build()
         val title = PlainComplicationText.Builder("BG").build()
-        val description = PlainComplicationText.Builder("Blood Glucose: 120 mg/dL").build()
+        val description = PlainComplicationText.Builder("Blood Glucose: $sampleWithLabel").build()
 
         return when (type) {
             ComplicationType.SHORT_TEXT ->
@@ -31,7 +38,7 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
                     .build()
             ComplicationType.LONG_TEXT ->
                 LongTextComplicationData.Builder(
-                    text = PlainComplicationText.Builder("BG: 120 mg/dL \u2192").build(),
+                    text = PlainComplicationText.Builder("BG: $sampleWithLabel \u2192").build(),
                     contentDescription = description,
                 )
                     .setTitle(title)
@@ -42,17 +49,21 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
 
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData {
         WatchDataRepository.init(applicationContext)
+        val unit = WatchDataRepository.glucoseUnit.value
         val now = System.currentTimeMillis()
         val staleThresholdMs = 15 * 60_000L // 15 minutes
+        // Staleness/validity gates compare the raw mg/dL Int; only the rendered text converts.
         val cgmState = WatchDataRepository.cgm.value?.takeIf {
             val ageMs = now - it.timestampMs
             GlucoseDisplayUtils.isValidGlucose(it.mgDl) &&
                 ageMs in 0 until staleThresholdMs
         }
         val bgText = cgmState?.let {
-            "${it.mgDl} ${GlucoseDisplayUtils.trendSymbol(it.trend)}"
+            "${GlucoseDisplayUtils.formatGlucose(it.mgDl, unit)} ${GlucoseDisplayUtils.trendSymbol(it.trend)}"
         } ?: "--"
-        val descriptionText = cgmState?.let { "Blood Glucose: ${it.mgDl} mg/dL" } ?: "No data"
+        val descriptionText = cgmState?.let {
+            "Blood Glucose: ${GlucoseDisplayUtils.formatWithLabel(it.mgDl, unit)}"
+        } ?: "No data"
 
         val text = PlainComplicationText.Builder(bgText).build()
         val description = PlainComplicationText.Builder(descriptionText).build()
@@ -78,7 +89,8 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
             ComplicationType.LONG_TEXT ->
                 LongTextComplicationData.Builder(
                     text = PlainComplicationText.Builder(
-                        "BG: ${cgmState?.mgDl ?: "--"} mg/dL ${cgmState?.let { GlucoseDisplayUtils.trendSymbol(it.trend) } ?: ""}",
+                        "BG: ${cgmState?.let { GlucoseDisplayUtils.formatWithLabel(it.mgDl, unit) } ?: "--"} " +
+                            (cgmState?.let { GlucoseDisplayUtils.trendSymbol(it.trend) } ?: ""),
                     ).build(),
                     contentDescription = description,
                 )
@@ -86,5 +98,10 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
                     .build()
             else -> NoDataComplicationData()
         }
+    }
+
+    private companion object {
+        /** Representative sample value for the complication picker preview. */
+        const val PREVIEW_MG_DL = 120
     }
 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/GlycemicDataListenerService.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/GlycemicDataListenerService.kt
@@ -10,6 +10,7 @@ import com.glycemicgpt.weardevice.complications.GraphComplicationDataSource
 import com.glycemicgpt.weardevice.complications.IoBComplicationDataSource
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils.sanitizeThresholds
+import com.glycemicgpt.weardevice.util.GlucoseUnit
 import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataMapItem
@@ -157,6 +158,12 @@ class GlycemicDataListenerService : WearableListenerService() {
                 }
 
                 WearDataContract.CGM_PATH -> {
+                    // Account-global display unit rides every CGM push; apply it even if this
+                    // particular reading is rejected below (the value itself stays raw mg/dL).
+                    // Skip when the key is absent so an older phone build can't reset the unit.
+                    dataMap.getString(WearDataContract.KEY_GLUCOSE_UNIT)?.let {
+                        WatchDataRepository.updateGlucoseUnit(GlucoseUnit.fromWire(it))
+                    }
                     val mgDl = dataMap.getInt(WearDataContract.KEY_CGM_MG_DL)
                     if (!GlucoseDisplayUtils.isValidGlucose(mgDl)) {
                         Timber.w("Rejected invalid CGM value from phone")

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WatchDataRepository.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WatchDataRepository.kt
@@ -2,6 +2,7 @@ package com.glycemicgpt.weardevice.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.glycemicgpt.weardevice.util.GlucoseUnit
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,6 +15,7 @@ object WatchDataRepository {
     private const val KEY_CGM_HISTORY = "cgm_history"
     private const val KEY_CURRENT_CGM = "current_cgm"
     private const val KEY_CURRENT_IOB = "current_iob"
+    private const val KEY_CURRENT_GLUCOSE_UNIT = "current_glucose_unit"
 
     private var prefs: SharedPreferences? = null
 
@@ -24,6 +26,7 @@ object WatchDataRepository {
         if (_cgmHistory.value.isEmpty()) restoreCgmHistory()
         if (_cgm.value == null) restoreCurrentCgm()
         if (_iob.value == null) restoreCurrentIoB()
+        restoreGlucoseUnit()
         Timber.d("WatchDataRepository initialized with persisted data")
     }
 
@@ -127,6 +130,14 @@ object WatchDataRepository {
     private val _watchFaceConfig = MutableStateFlow(WatchFaceConfigState())
     val watchFaceConfig: StateFlow<WatchFaceConfigState> = _watchFaceConfig.asStateFlow()
 
+    /**
+     * Per-account glucose display unit. Carried on `CGM_PATH` (not the config
+     * payload), so the wire value stays raw mg/dL and only the rendered number
+     * converts. Standalone state -- never written into [CgmState] or the CGM CSV.
+     */
+    private val _glucoseUnit = MutableStateFlow(GlucoseUnit.MGDL)
+    val glucoseUnit: StateFlow<GlucoseUnit> = _glucoseUnit.asStateFlow()
+
     fun updateIoB(iob: Float, timestampMs: Long) {
         _iob.value = IoBState(iob, timestampMs)
         persistCurrentIoB()
@@ -202,6 +213,17 @@ object WatchDataRepository {
 
     fun updateCategoryLabels(labels: Map<String, String>) {
         _categoryLabels.value = labels
+    }
+
+    /**
+     * Set the per-account display unit (from the unit token on `CGM_PATH`).
+     * Persists so a cold-started watch renders its restored last reading in the
+     * correct unit instead of defaulting to mg/dL until the next push arrives.
+     */
+    fun updateGlucoseUnit(unit: GlucoseUnit) {
+        if (_glucoseUnit.value == unit) return
+        _glucoseUnit.value = unit
+        persistGlucoseUnit()
     }
 
     private val VALID_GRAPH_RANGES = setOf(1, 3, 6)
@@ -356,5 +378,16 @@ object WatchDataRepository {
             Timber.w(e, "Failed to restore current IoB from cache")
             p.edit().remove(KEY_CURRENT_IOB).apply()
         }
+    }
+
+    /** Persist the display unit as its wire token (`"mgdl"`/`"mmol"`). */
+    private fun persistGlucoseUnit() {
+        prefs?.edit()?.putString(KEY_CURRENT_GLUCOSE_UNIT, _glucoseUnit.value.wireValue)?.apply()
+    }
+
+    private fun restoreGlucoseUnit() {
+        val p = prefs ?: return
+        // fromWire never throws and defaults to MGDL on absence/corruption.
+        _glucoseUnit.value = GlucoseUnit.fromWire(p.getString(KEY_CURRENT_GLUCOSE_UNIT, null))
     }
 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
@@ -32,6 +32,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import com.glycemicgpt.weardevice.data.WatchDataRepository
 import com.glycemicgpt.weardevice.messaging.WearMessageSender
+import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
 import kotlinx.coroutines.launch
 
 class AlertsActivity : ComponentActivity() {
@@ -46,6 +47,7 @@ class AlertsActivity : ComponentActivity() {
 @Composable
 private fun WearAlertScreen(onFinish: () -> Unit) {
     val alert by WatchDataRepository.alert.collectAsState()
+    val glucoseUnit by WatchDataRepository.glucoseUnit.collectAsState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var dismissing by remember { mutableStateOf(false) }
@@ -88,10 +90,11 @@ private fun WearAlertScreen(onFinish: () -> Unit) {
                         textAlign = TextAlign.Center,
                     )
 
+                    // Gate compares the raw mg/dL Int; only the rendered text converts to the unit.
                     if (currentAlert.bgValue in 20..500) {
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(
-                            text = "${currentAlert.bgValue} mg/dL",
+                            text = GlucoseDisplayUtils.formatWithLabel(currentAlert.bgValue, glucoseUnit),
                             fontSize = 20.sp,
                             color = alertColor,
                             textAlign = TextAlign.Center,

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/GraphDetailActivity.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/GraphDetailActivity.kt
@@ -41,6 +41,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import com.glycemicgpt.weardevice.data.WatchDataRepository
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
+import com.glycemicgpt.weardevice.util.GlucoseUnit
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -157,6 +158,7 @@ private const val Y_MAX_DEFAULT = 400
 @Composable
 private fun GraphDetailScreen() {
     val config by WatchDataRepository.watchFaceConfig.collectAsState()
+    val glucoseUnit by WatchDataRepository.glucoseUnit.collectAsState()
     val cgmHistory by WatchDataRepository.cgmHistory.collectAsState()
     val basalHistory by WatchDataRepository.basalHistory.collectAsState()
     val bolusHistory by WatchDataRepository.bolusHistory.collectAsState()
@@ -242,7 +244,7 @@ private fun GraphDetailScreen() {
                                         panOffsetPx = panOffsetPx.coerceIn(0f, maxPanPx)
                                     }
                                 }
-                                .pointerInput(readings) {
+                                .pointerInput(readings, glucoseUnit) {
                                     detectTapGestures { offset ->
                                         tooltip = findNearestReading(
                                             tapOffset = offset,
@@ -253,6 +255,7 @@ private fun GraphDetailScreen() {
                                             viewportRangeMs = rangeMs,
                                             dataStartMs = dataStartMs,
                                             nowMs = now,
+                                            unit = glucoseUnit,
                                         )
                                     }
                                 },
@@ -322,6 +325,7 @@ private fun GraphDetailScreen() {
                                 high = high,
                                 graphRect = graphRect,
                                 yPos = ::yPos,
+                                unit = glucoseUnit,
                             )
 
                             // 4. Basal stepped area
@@ -453,6 +457,7 @@ private fun DrawScope.drawThresholdLines(
     high: Int,
     graphRect: Rect,
     yPos: (Int) -> Float,
+    unit: GlucoseUnit,
 ) {
     val dashEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 6f), 0f)
     val lineColor = Color(0x80FFFFFF)
@@ -478,10 +483,20 @@ private fun DrawScope.drawThresholdLines(
         pathEffect = dashEffect,
     )
 
-    // Y-axis threshold labels
+    // Y-axis threshold labels (positions stay mg/dL via yPos; only the printed number converts).
     val canvas = drawContext.canvas.nativeCanvas
-    canvas.drawText(low.toString(), graphRect.left - 4f, lowY + 6f, GraphPaints.thresholdLabel)
-    canvas.drawText(high.toString(), graphRect.left - 4f, highY + 6f, GraphPaints.thresholdLabel)
+    canvas.drawText(
+        GlucoseDisplayUtils.formatGlucose(low, unit),
+        graphRect.left - 4f,
+        lowY + 6f,
+        GraphPaints.thresholdLabel,
+    )
+    canvas.drawText(
+        GlucoseDisplayUtils.formatGlucose(high, unit),
+        graphRect.left - 4f,
+        highY + 6f,
+        GraphPaints.thresholdLabel,
+    )
 }
 
 private fun DrawScope.drawModeBands(
@@ -824,6 +839,7 @@ private fun findNearestReading(
     viewportRangeMs: Long,
     dataStartMs: Long,
     nowMs: Long,
+    unit: GlucoseUnit,
 ): TooltipData? {
     if (readings.isEmpty()) return null
 
@@ -873,7 +889,7 @@ private fun findNearestReading(
     val dotY = yPos(r.mgDl)
     val timeText = tooltipTimeFormat.format(Date(r.timestampMs))
     return TooltipData(
-        text = "${r.mgDl} mg/dL  $timeText",
+        text = "${GlucoseDisplayUtils.formatWithLabel(r.mgDl, unit)}  $timeText",
         x = dotX,
         y = dotY,
     )

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtils.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtils.kt
@@ -1,8 +1,18 @@
 package com.glycemicgpt.weardevice.util
 
 import android.graphics.Color
+import java.util.Locale
 
 object GlucoseDisplayUtils {
+
+    /**
+     * 1 mmol/L = 18.0156 mg/dL -- the exact glucose mass-to-molarity factor and
+     * the single canonical constant. Pinned to match the phone
+     * `GlucoseFormat.MGDL_PER_MMOL` (and the backend `MGDL_PER_MMOL`) exactly:
+     * a drift here would let the watch read a different number than the phone
+     * for the same mg/dL. Never introduce a second value (18.02 / 18.0182).
+     */
+    const val MGDL_PER_MMOL: Double = 18.0156
 
     fun isValidGlucose(mgDl: Int): Boolean = mgDl in 20..500
 
@@ -28,6 +38,32 @@ object GlucoseDisplayUtils {
             else -> 0xFF22C55E.toInt()                                      // Green
         }
     }
+
+    // --- Display-only unit formatting (everything above stays canonical mg/dL) ---
+
+    /** User-facing unit label: `"mg/dL"` / `"mmol/L"`. */
+    fun unitLabel(unit: GlucoseUnit): String = when (unit) {
+        GlucoseUnit.MGDL -> "mg/dL"
+        GlucoseUnit.MMOL -> "mmol/L"
+    }
+
+    /**
+     * Convert a canonical mg/dL Int to the bare number shown in [unit]: the raw
+     * integer for mg/dL, or one-decimal mmol/L (divide by [MGDL_PER_MMOL] once,
+     * round LAST). [Locale.US] keeps the decimal separator a dot, matching the
+     * phone formatter exactly.
+     *
+     * Display-only: never feed the result back into [isValidGlucose], [bgColor],
+     * [sanitizeThresholds], or any plotting geometry -- those all stay mg/dL.
+     */
+    fun formatGlucose(mgDl: Int, unit: GlucoseUnit): String = when (unit) {
+        GlucoseUnit.MGDL -> mgDl.toString()
+        GlucoseUnit.MMOL -> String.format(Locale.US, "%.1f", mgDl / MGDL_PER_MMOL)
+    }
+
+    /** A glucose number with its unit label, e.g. `"120 mg/dL"` / `"6.7 mmol/L"`. */
+    fun formatWithLabel(mgDl: Int, unit: GlucoseUnit): String =
+        "${formatGlucose(mgDl, unit)} ${unitLabel(unit)}"
 
     fun alertColor(type: String): Int {
         return when (type) {

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/GlucoseUnit.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/GlucoseUnit.kt
@@ -1,0 +1,26 @@
+package com.glycemicgpt.weardevice.util
+
+/**
+ * Watch-side mirror of the phone's `GlucoseUnit`
+ * (`app/.../domain/model/GlucoseUnit.kt`). The two live in separate Gradle
+ * modules and cannot share code, so the wire token and parsing are duplicated
+ * here deliberately.
+ *
+ * Display-only: storage, transport, every threshold comparison, and the
+ * platform-wide 20-500 mg/dL safety invariant all stay canonical mg/dL. This
+ * enum only selects how a glucose number is shown (and spoken) to the user.
+ *
+ * [wireValue] is the token carried on `WearDataContract.KEY_GLUCOSE_UNIT`
+ * (`"mgdl"` / `"mmol"`), matching the phone enum and the backend serialization.
+ */
+enum class GlucoseUnit(val wireValue: String) {
+    MGDL("mgdl"),
+    MMOL("mmol"),
+    ;
+
+    companion object {
+        /** Parse the wire token (`"mgdl"`/`"mmol"`); unknown/null falls back to [MGDL]. */
+        fun fromWire(value: String?): GlucoseUnit =
+            entries.firstOrNull { it.wireValue.equals(value, ignoreCase = true) } ?: MGDL
+    }
+}

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WatchDataRepositoryTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WatchDataRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.glycemicgpt.weardevice.data
 
+import com.glycemicgpt.weardevice.util.GlucoseUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -22,6 +23,7 @@ class WatchDataRepositoryTest {
             showIoB = true, showGraph = true, showAlert = true,
             showSeconds = false, graphRangeHours = 3, theme = "dark",
         )
+        WatchDataRepository.updateGlucoseUnit(GlucoseUnit.MGDL)
         WatchDataRepository.clearChat()
     }
 
@@ -192,6 +194,22 @@ class WatchDataRepositoryTest {
     }
 
     // --- clearAlert tests ---
+
+    // --- Glucose unit tests ---
+
+    @Test
+    fun `glucoseUnit is MGDL after reset`() {
+        assertEquals(GlucoseUnit.MGDL, WatchDataRepository.glucoseUnit.value)
+    }
+
+    @Test
+    fun `updateGlucoseUnit updates the glucose unit flow`() {
+        WatchDataRepository.updateGlucoseUnit(GlucoseUnit.MMOL)
+        assertEquals(GlucoseUnit.MMOL, WatchDataRepository.glucoseUnit.value)
+
+        WatchDataRepository.updateGlucoseUnit(GlucoseUnit.MGDL)
+        assertEquals(GlucoseUnit.MGDL, WatchDataRepository.glucoseUnit.value)
+    }
 
     @Test
     fun `clearAlert clears active alert`() {

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WearDataContractTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WearDataContractTest.kt
@@ -65,6 +65,15 @@ class WearDataContractTest {
     }
 
     @Test
+    fun `cgm keys match phone-side contract values`() {
+        assertEquals("cgm_mgdl", WearDataContract.KEY_CGM_MG_DL)
+        assertEquals("cgm_trend", WearDataContract.KEY_CGM_TREND)
+        assertEquals("cgm_ts", WearDataContract.KEY_CGM_TIMESTAMP)
+        // Per-account display unit; must match the phone mirror or the watch can't read it.
+        assertEquals("glucose_unit", WearDataContract.KEY_GLUCOSE_UNIT)
+    }
+
+    @Test
     fun `config keys are defined`() {
         assertEquals("cfg_show_iob", WearDataContract.KEY_CONFIG_SHOW_IOB)
         assertEquals("cfg_show_graph", WearDataContract.KEY_CONFIG_SHOW_GRAPH)

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtilsTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtilsTest.kt
@@ -1,6 +1,7 @@
 package com.glycemicgpt.weardevice.util
 
 import android.graphics.Color
+import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -195,5 +196,50 @@ class GlucoseDisplayUtilsTest {
     fun `sanitizeThresholds high is at least low plus 1`() {
         val t = GlucoseDisplayUtils.sanitizeThresholds(150, 150, 55, 250)
         assertTrue("high > low", t.high > t.low)
+    }
+
+    // --- Display-only unit formatting ---
+
+    @Test
+    fun `MGDL_PER_MMOL is the canonical 18_0156 constant`() {
+        // A drift here desyncs the watch from the phone/backend for the same mg/dL.
+        assertEquals(18.0156, GlucoseDisplayUtils.MGDL_PER_MMOL, 0.0)
+    }
+
+    @Test
+    fun `formatGlucose renders mgdl as the raw integer`() {
+        assertEquals("70", GlucoseDisplayUtils.formatGlucose(70, GlucoseUnit.MGDL))
+        assertEquals("120", GlucoseDisplayUtils.formatGlucose(120, GlucoseUnit.MGDL))
+    }
+
+    @Test
+    fun `formatGlucose converts mmol to conventional clinical anchors`() {
+        assertEquals("3.9", GlucoseDisplayUtils.formatGlucose(70, GlucoseUnit.MMOL))
+        assertEquals("10.0", GlucoseDisplayUtils.formatGlucose(180, GlucoseUnit.MMOL))
+        assertEquals("6.7", GlucoseDisplayUtils.formatGlucose(120, GlucoseUnit.MMOL))
+        assertEquals("5.6", GlucoseDisplayUtils.formatGlucose(100, GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `formatGlucose mmol uses a dot decimal under a comma-decimal locale`() {
+        val original = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.GERMANY)
+            assertEquals("6.7", GlucoseDisplayUtils.formatGlucose(120, GlucoseUnit.MMOL))
+        } finally {
+            Locale.setDefault(original)
+        }
+    }
+
+    @Test
+    fun `unitLabel returns the user-facing label`() {
+        assertEquals("mg/dL", GlucoseDisplayUtils.unitLabel(GlucoseUnit.MGDL))
+        assertEquals("mmol/L", GlucoseDisplayUtils.unitLabel(GlucoseUnit.MMOL))
+    }
+
+    @Test
+    fun `formatWithLabel appends the unit label`() {
+        assertEquals("120 mg/dL", GlucoseDisplayUtils.formatWithLabel(120, GlucoseUnit.MGDL))
+        assertEquals("6.7 mmol/L", GlucoseDisplayUtils.formatWithLabel(120, GlucoseUnit.MMOL))
     }
 }

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseUnitTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseUnitTest.kt
@@ -1,0 +1,33 @@
+package com.glycemicgpt.weardevice.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GlucoseUnitTest {
+
+    @Test
+    fun `fromWire parses the canonical tokens`() {
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire("mgdl"))
+        assertEquals(GlucoseUnit.MMOL, GlucoseUnit.fromWire("mmol"))
+    }
+
+    @Test
+    fun `fromWire is case-insensitive`() {
+        assertEquals(GlucoseUnit.MMOL, GlucoseUnit.fromWire("MMOL"))
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire("MgDl"))
+    }
+
+    @Test
+    fun `fromWire falls back to MGDL for null, empty, or unknown`() {
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire(null))
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire(""))
+        assertEquals(GlucoseUnit.MGDL, GlucoseUnit.fromWire("bogus"))
+    }
+
+    @Test
+    fun `wireValue round-trips through fromWire`() {
+        for (unit in GlucoseUnit.entries) {
+            assertEquals(unit, GlucoseUnit.fromWire(unit.wireValue))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Story 53.4 — the final Wear OS piece of Epic 53 (mmol/L glucose unit support). The watch now renders blood glucose in the user's chosen unit (mg/dL or mmol/L) across the BG complication, alert screen, and detail graph.

This is the release-coupling closer for the unit feature: 53.3 (#807) already sends the per-account unit on every phone→watch CGM push; this story makes the watch **consume and render** it, so phone and watch are unit-consistent.

## What changed (watch-side, display-only)

- New `GlucoseUnit` enum + `GlucoseDisplayUtils.formatGlucose` / `unitLabel` / `formatWithLabel`. Single pinned conversion constant `18.0156` (mirrors the phone `GlucoseFormat.MGDL_PER_MMOL`), `Locale.US` dot decimal, clinical anchors 70→3.9, 180→10.0, 120→6.7, 100→5.6.
- `WatchDataRepository` carries the unit as a standalone, persisted `StateFlow`, restored synchronously on cold start (mirrors the existing CGM-cache idiom, so a restored reading renders in the right unit immediately). It is consumed at both phone→watch CGM read sites — the live data listener and the cold-start DataLayer bootstrap — and an absent key is skipped so an item cached by an older phone build can't reset the unit.
- BG complication (hero / preview / TalkBack contentDescription / LONG_TEXT), the alert hero number, and the graph y-axis threshold labels + tooltip render via the formatter.

## Safety

Storage, transport, all thresholds, alert detection, and the platform-wide 20-500 mg/dL invariant stay canonical mg/dL. Every gate (`isValidGlucose`, the alert `bgValue in 20..500` gate, `sanitizeThresholds`), `bgColor`, and all plotting geometry keep comparing **raw mg/dL Ints** — only the displayed/spoken number and label convert. The value written to `CgmState` and the SharedPreferences CSV stays the raw Int (no CSV migration). A dedicated safety-invariant review pass found 0 violations.

## Testing

- `:wear-device:testDebugUnitTest` green — formatter round-trip with the pinned clinical anchors, an `18.0156` drift guard, a comma-locale dot-decimal guard, `GlucoseUnit.fromWire` fallback coverage, and the repository unit flow.
- `:wear-device:lintDebug`, `:app` contract-mirror test, and both-module `assembleDebug` green.
- Multi-dimension review (adversarial + senior-engineer + safety + completeness, each finding adversarially verified): one LOW finding — the cold-start bootstrap could clobber a restored unit when the key is absent — found and fixed; otherwise clean.

## Visual verification

The Wear OS emulator could not boot on the dev box (root filesystem disk-constrained). The conversion path is pure and exhaustively unit-tested. The AC9 watch-face hero string-fit + ambient pass across both WFF flavors (`digitalFull`, `analogMechanical`) should be run on a capable machine before the develop→main promotion.

Closes #759


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Watch glucose values (alerts, complications, and graphs) now display using the user-selected glucose unit (mg/dL or mmol/L).
  * The watch persists the glucose unit and hydrates/synchronizes it from the phone for consistent rendering.

* **Bug Fixes**
  * Glucose unit updates are applied on incoming CGM updates even when an individual glucose reading is rejected as invalid.

* **Tests**
  * Added/updated tests for glucose unit parsing, unit-aware display formatting (including locale handling), watch data contract keys, and deterministic chart geometry via a time override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->