### PR TITLE
feat: seed glucose display unit from region and Nightscout (overridable)

### DIFF
--- a/apps/api/migrations/versions/076_glucose_unit_source.py
+++ b/apps/api/migrations/versions/076_glucose_unit_source.py
@@ -2,8 +2,8 @@
 
 Tracks whether a user's ``glucose_unit`` was set by a smart default (``seed``)
 or an explicit user choice (``user``), so a region/Nightscout seed never
-overrides a manual choice and the one-time confirmation notice never recurs
-(Story 53.10). Nullable: existing rows stay NULL (seed-neutral); no backfill.
+overrides a manual choice and the one-time confirmation notice never recurs.
+Nullable: existing rows stay NULL (seed-neutral); no backfill.
 Display-preference only -- no stored glucose value or bound changes.
 
 Revision ID: 076_glucose_unit_source

--- a/apps/api/migrations/versions/076_glucose_unit_source.py
+++ b/apps/api/migrations/versions/076_glucose_unit_source.py
@@ -1,0 +1,50 @@
+"""Add glucose unit preference provenance.
+
+Tracks whether a user's ``glucose_unit`` was set by a smart default (``seed``)
+or an explicit user choice (``user``), so a region/Nightscout seed never
+overrides a manual choice and the one-time confirmation notice never recurs
+(Story 53.10). Nullable: existing rows stay NULL (seed-neutral); no backfill.
+Display-preference only -- no stored glucose value or bound changes.
+
+Revision ID: 076_glucose_unit_source
+Revises: 075_user_glucose_unit
+Create Date: 2026-06-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "076_glucose_unit_source"
+down_revision: str | None = "075_user_glucose_unit"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    glucose_unit_source = postgresql.ENUM(
+        "seed", "user", name="glucoseunitsource"
+    )
+    glucose_unit_source.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "glucose_unit_source",
+            postgresql.ENUM(
+                "seed", "user", name="glucoseunitsource", create_type=False
+            ),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "glucose_unit_source")
+
+    glucose_unit_source = postgresql.ENUM(
+        "seed", "user", name="glucoseunitsource"
+    )
+    glucose_unit_source.drop(op.get_bind(), checkfirst=True)

--- a/apps/api/src/core/units.py
+++ b/apps/api/src/core/units.py
@@ -12,6 +12,22 @@ class GlucoseUnit(str, enum.Enum):
     MMOL = "mmol"
 
 
+class GlucoseUnitSource(str, enum.Enum):
+    """Provenance of a user's stored glucose-unit preference.
+
+    ``SEED`` -- the value was set by a smart default (registration locale or a
+    confidently-mmol Nightscout connection), so it is still overridable and a
+    one-time confirmation notice may be shown. ``USER`` -- the user has made an
+    explicit choice (toggled the unit, or dismissed the seed notice), so the
+    seed must never re-fire and the notice must never recur. The column is
+    nullable: ``NULL`` means a legacy account predating provenance tracking,
+    which is treated as seed-neutral (never seed-owned, never user-confirmed).
+    """
+
+    SEED = "seed"
+    USER = "user"
+
+
 # 1 mmol/L = 18.0156 mg/dL -- the exact glucose mass-to-molarity factor
 # (molar mass 180.156 g/mol / 10) and the ADA / IFCC consensus value. This
 # is the single canonical factor so ingestion, onboarding, and display

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -46,7 +46,7 @@ class User(Base, TimestampMixin):
         glucose_unit_source: Provenance of glucose_unit (seed | user | NULL).
             A smart default writes ``seed``; an explicit user choice (toggle or
             dismissed notice) writes ``user``; NULL is a legacy account. Gates
-            re-seeding and the one-time confirmation notice (see Story 53.10).
+            re-seeding and the one-time confirmation notice.
         last_login_at: Timestamp of last successful login
     """
 
@@ -107,7 +107,7 @@ class User(Base, TimestampMixin):
     # Provenance of glucose_unit. Nullable so legacy accounts (and the column's
     # pre-seed state) read as seed-neutral. A smart default sets ``seed``; the
     # PATCH and the dismiss-ack set ``user`` so the seed never re-fires and the
-    # one-time notice never recurs (Story 53.10). Display-preference only --
+    # one-time notice never recurs. Display-preference only --
     # this never affects stored values or the 20-500 mg/dL invariant.
     glucose_unit_source: Mapped[GlucoseUnitSource | None] = mapped_column(
         Enum(

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -11,7 +11,7 @@ from sqlalchemy import DateTime, Enum, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from src.core.units import GlucoseUnit
+from src.core.units import GlucoseUnit, GlucoseUnitSource
 from src.models.base import Base, TimestampMixin
 
 
@@ -43,6 +43,10 @@ class User(Base, TimestampMixin):
             (NULL until first acknowledged). A mismatch with the current
             DISCLAIMER_VERSION re-prompts the user; see src.core.disclaimer.
         glucose_unit: User's preferred glucose display unit
+        glucose_unit_source: Provenance of glucose_unit (seed | user | NULL).
+            A smart default writes ``seed``; an explicit user choice (toggle or
+            dismissed notice) writes ``user``; NULL is a legacy account. Gates
+            re-seeding and the one-time confirmation notice (see Story 53.10).
         last_login_at: Timestamp of last successful login
     """
 
@@ -99,6 +103,21 @@ class User(Base, TimestampMixin):
         nullable=False,
         default=GlucoseUnit.MGDL,
         server_default=GlucoseUnit.MGDL.value,
+    )
+    # Provenance of glucose_unit. Nullable so legacy accounts (and the column's
+    # pre-seed state) read as seed-neutral. A smart default sets ``seed``; the
+    # PATCH and the dismiss-ack set ``user`` so the seed never re-fires and the
+    # one-time notice never recurs (Story 53.10). Display-preference only --
+    # this never affects stored values or the 20-500 mg/dL invariant.
+    glucose_unit_source: Mapped[GlucoseUnitSource | None] = mapped_column(
+        Enum(
+            GlucoseUnitSource,
+            name="glucoseunitsource",
+            create_type=False,
+            values_callable=lambda e: [member.value for member in e],
+        ),
+        nullable=True,
+        default=None,
     )
     display_name: Mapped[str | None] = mapped_column(
         String(100),

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -28,6 +28,7 @@ from src.core.token_blacklist import (
     blacklist_token,
     consume_token_once,
 )
+from src.core.units import GlucoseUnitSource
 from src.database import get_db
 from src.deployment_check import request_is_insecure_http
 from src.logging_config import get_logger
@@ -46,6 +47,7 @@ from src.schemas.auth import (
     UserRegistrationResponse,
     UserResponse,
 )
+from src.services.glucose_unit_seed import glucose_unit_for_locale
 
 logger = get_logger(__name__)
 
@@ -107,6 +109,7 @@ async def _blacklist_current_token(request: Request) -> None:
 )
 async def register_user(
     request: UserRegistrationRequest,
+    http_request: Request,
     db: AsyncSession = Depends(get_db),
 ) -> UserRegistrationResponse:
     """Register a new user account.
@@ -115,8 +118,16 @@ async def register_user(
     Password is hashed using bcrypt before storage.
     New users are assigned the 'diabetic' role by default.
 
+    Seeds an overridable glucose display unit from the request's
+    ``Accept-Language`` region (Story 53.10): an mmol-region locale starts the
+    account in mmol/L, everything else in mg/dL (today's default). The seed is
+    a display-preference-only best guess marked ``source=seed`` so the manual
+    toggle always wins and a one-time notice can offer a correction; canonical
+    storage is untouched.
+
     Args:
         request: Registration request with email and password
+        http_request: The HTTP request (for the ``Accept-Language`` locale seed)
         db: Database session
 
     Returns:
@@ -140,6 +151,11 @@ async def register_user(
             detail="Registration failed. Please try again or contact support.",
         )
 
+    # Smart-default the glucose display unit from the request locale. This is a
+    # best guess, not a detector -- marked ``source=seed`` so the manual toggle
+    # always overrides it and the one-time notice can offer a correction.
+    seeded_unit = glucose_unit_for_locale(http_request.headers.get("Accept-Language"))
+
     # Create new user
     user = User(
         email=request.email.lower(),
@@ -148,6 +164,8 @@ async def register_user(
         is_active=True,
         email_verified=False,
         disclaimer_acknowledged=False,
+        glucose_unit=seeded_unit,
+        glucose_unit_source=GlucoseUnitSource.SEED,
     )
 
     try:

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -119,7 +119,7 @@ async def register_user(
     New users are assigned the 'diabetic' role by default.
 
     Seeds an overridable glucose display unit from the request's
-    ``Accept-Language`` region (Story 53.10): an mmol-region locale starts the
+    ``Accept-Language`` region: an mmol-region locale starts the
     account in mmol/L, everything else in mg/dL (today's default). The seed is
     a display-preference-only best guess marked ``source=seed`` so the manual
     toggle always wins and a one-time notice can offer a correction; canonical

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -986,7 +986,7 @@ async def apply_onboarding(  # noqa: PLR0912, PLR0915  -- linear, readable orche
         conn.initial_sync_window_days = request.initial_sync_window_days
         applied["initial_sync_window_days"] = True
 
-    # ---- smart-default glucose unit (Story 53.10) -----------------------
+    # ---- smart-default glucose unit -------------------------------------
     # A confidently-mmol Nightscout (units_converted is True only for a
     # classified-mmol source -- never for an unknown or mg/dL one) is a strong
     # signal the user thinks in mmol/L. Seed the *display* preference only,

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import DiabeticOrAdminUser
 from src.core.encryption import decrypt_credential, encrypt_credential
+from src.core.units import GlucoseUnit, GlucoseUnitSource
 from src.database import get_db
 from src.logging_config import get_logger
 from src.models.glucose import GlucoseReading
@@ -984,6 +985,21 @@ async def apply_onboarding(  # noqa: PLR0912, PLR0915  -- linear, readable orche
     if request.initial_sync_window_days is not None:
         conn.initial_sync_window_days = request.initial_sync_window_days
         applied["initial_sync_window_days"] = True
+
+    # ---- smart-default glucose unit (Story 53.10) -----------------------
+    # A confidently-mmol Nightscout (units_converted is True only for a
+    # classified-mmol source -- never for an unknown or mg/dL one) is a strong
+    # signal the user thinks in mmol/L. Seed the *display* preference only,
+    # leaving canonical mg/dL storage and the derivation untouched. Stay
+    # override-safe: never overwrite an explicit user choice, never re-seed an
+    # account already in mmol, and no-op on units_unknown / mg/dL profiles.
+    if (
+        derivation.units_converted
+        and current_user.glucose_unit_source != GlucoseUnitSource.USER
+        and current_user.glucose_unit != GlucoseUnit.MMOL
+    ):
+        current_user.glucose_unit = GlucoseUnit.MMOL
+        current_user.glucose_unit_source = GlucoseUnitSource.SEED
 
     # Commit all settings changes BEFORE the first sync runs so
     # that a sync timeout doesn't unwind the user's confirmed

--- a/apps/api/src/routers/settings.py
+++ b/apps/api/src/routers/settings.py
@@ -128,7 +128,7 @@ async def get_glucose_unit(
     """Get the current user's glucose display unit preference.
 
     Includes the provenance (``glucose_unit_source``) so clients can show the
-    one-time smart-default notice (Story 53.10). The phone reconciles its unit
+    one-time smart-default notice. The phone reconciles its unit
     from this endpoint -- not ``/api/auth/me`` -- so the source is exposed here
     as well as on ``UserResponse``.
     """
@@ -152,7 +152,7 @@ async def patch_glucose_unit(
 
     An explicit choice marks the preference ``source=user`` so a region or
     Nightscout seed can never override it and the smart-default notice never
-    recurs (Story 53.10).
+    recurs.
     """
     user.glucose_unit = body.glucose_unit
     user.glucose_unit_source = GlucoseUnitSource.USER
@@ -177,7 +177,7 @@ async def acknowledge_glucose_unit_seed(
 
     Dismissing the one-time notice means "treat the seeded unit as my choice":
     it stamps ``source=user`` (leaving the unit value untouched) so the notice
-    never recurs and a later seed never re-fires (Story 53.10). Idempotent --
+    never recurs and a later seed never re-fires. Idempotent --
     a re-ack on an already-user-owned preference is a no-op write.
     """
     user.glucose_unit_source = GlucoseUnitSource.USER

--- a/apps/api/src/routers/settings.py
+++ b/apps/api/src/routers/settings.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import get_current_user, require_diabetic_or_admin
+from src.core.units import GlucoseUnitSource
 from src.database import get_db
 from src.logging_config import get_logger
 from src.models.user import User
@@ -124,8 +125,17 @@ router = APIRouter(prefix="/api/settings", tags=["settings"])
 async def get_glucose_unit(
     user: User = Depends(get_current_user),
 ) -> GlucoseUnitPreferenceResponse:
-    """Get the current user's glucose display unit preference."""
-    return GlucoseUnitPreferenceResponse(glucose_unit=user.glucose_unit)
+    """Get the current user's glucose display unit preference.
+
+    Includes the provenance (``glucose_unit_source``) so clients can show the
+    one-time smart-default notice (Story 53.10). The phone reconciles its unit
+    from this endpoint -- not ``/api/auth/me`` -- so the source is exposed here
+    as well as on ``UserResponse``.
+    """
+    return GlucoseUnitPreferenceResponse(
+        glucose_unit=user.glucose_unit,
+        glucose_unit_source=user.glucose_unit_source,
+    )
 
 
 @router.patch(
@@ -138,11 +148,45 @@ async def patch_glucose_unit(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> GlucoseUnitPreferenceResponse:
-    """Update the current user's glucose display unit preference."""
+    """Update the current user's glucose display unit preference.
+
+    An explicit choice marks the preference ``source=user`` so a region or
+    Nightscout seed can never override it and the smart-default notice never
+    recurs (Story 53.10).
+    """
     user.glucose_unit = body.glucose_unit
+    user.glucose_unit_source = GlucoseUnitSource.USER
     await db.commit()
     await db.refresh(user)
-    return GlucoseUnitPreferenceResponse(glucose_unit=user.glucose_unit)
+    return GlucoseUnitPreferenceResponse(
+        glucose_unit=user.glucose_unit,
+        glucose_unit_source=user.glucose_unit_source,
+    )
+
+
+@router.post(
+    "/glucose-unit/acknowledge",
+    response_model=GlucoseUnitPreferenceResponse,
+    dependencies=[Depends(require_diabetic_or_admin)],
+)
+async def acknowledge_glucose_unit_seed(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> GlucoseUnitPreferenceResponse:
+    """Acknowledge the smart-default glucose-unit notice without changing it.
+
+    Dismissing the one-time notice means "treat the seeded unit as my choice":
+    it stamps ``source=user`` (leaving the unit value untouched) so the notice
+    never recurs and a later seed never re-fires (Story 53.10). Idempotent --
+    a re-ack on an already-user-owned preference is a no-op write.
+    """
+    user.glucose_unit_source = GlucoseUnitSource.USER
+    await db.commit()
+    await db.refresh(user)
+    return GlucoseUnitPreferenceResponse(
+        glucose_unit=user.glucose_unit,
+        glucose_unit_source=user.glucose_unit_source,
+    )
 
 
 @router.get(

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
 
 from src.core.disclaimer import has_acknowledged_current
-from src.core.units import GlucoseUnit
+from src.core.units import GlucoseUnit, GlucoseUnitSource
 from src.models.user import UserRole
 
 
@@ -73,6 +73,14 @@ class UserResponse(BaseModel):
     glucose_unit: GlucoseUnit = Field(
         default=GlucoseUnit.MGDL,
         description="Preferred glucose display unit: mgdl or mmol",
+    )
+    glucose_unit_source: GlucoseUnitSource | None = Field(
+        default=None,
+        description=(
+            "Provenance of glucose_unit: 'seed' (smart default, overridable),"
+            " 'user' (explicit choice), or null (legacy). Drives the one-time"
+            " smart-default notice (Story 53.10)."
+        ),
     )
     created_at: datetime
 

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -79,7 +79,7 @@ class UserResponse(BaseModel):
         description=(
             "Provenance of glucose_unit: 'seed' (smart default, overridable),"
             " 'user' (explicit choice), or null (legacy). Drives the one-time"
-            " smart-default notice (Story 53.10)."
+            " smart-default notice."
         ),
     )
     created_at: datetime

--- a/apps/api/src/schemas/glucose_unit.py
+++ b/apps/api/src/schemas/glucose_unit.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from src.core.units import GlucoseUnit
+from src.core.units import GlucoseUnit, GlucoseUnitSource
 
 
 class GlucoseUnitPreferenceResponse(BaseModel):
@@ -10,6 +10,14 @@ class GlucoseUnitPreferenceResponse(BaseModel):
 
     glucose_unit: GlucoseUnit = Field(
         ..., description="Preferred glucose display unit: mgdl or mmol"
+    )
+    glucose_unit_source: GlucoseUnitSource | None = Field(
+        default=None,
+        description=(
+            "Provenance of the preference: 'seed' (smart default, overridable),"
+            " 'user' (explicit choice), or null (legacy). Drives the one-time"
+            " confirmation notice."
+        ),
     )
 
 

--- a/apps/api/src/services/glucose_unit_seed.py
+++ b/apps/api/src/services/glucose_unit_seed.py
@@ -1,0 +1,114 @@
+"""Smart-default glucose-unit seeding.
+
+The platform stores every glucose value in canonical mg/dL and defaults every
+new account to an ``mgdl`` *display* preference. For users in mmol/L regions
+that default is wrong, and there is no honest way to auto-*detect* the unit on
+mobile (all inbound glucose is canonical mg/dL ``int`` -- there is no mmol
+stream to key off). The only available signals are weak proxies usable as a
+one-time, overridable *seed*: the registration request's locale/region and a
+connected Nightscout's classified display unit.
+
+This module owns the locale->unit mapping. It is a best-guess **default**, not
+a detector: the manual per-account toggle always wins, and a visible one-time
+notice (gated on a still-seed-owned non-mgdl value) lets the user correct a
+wrong guess. Nothing here touches stored values, conversion, or the 20-500
+mg/dL safety invariant.
+"""
+
+from __future__ import annotations
+
+import re
+
+from src.core.units import GlucoseUnit
+
+# ISO 3166-1 alpha-2 regions where blood glucose is conventionally reported in
+# mmol/L. Curated best-guess, not exhaustive: the Anglosphere (minus the US),
+# the Nordics, and the other commonly-mmol European / rest-of-world markets.
+# A region absent from this set -- including the US and the mg/dL-reporting
+# parts of Europe (DE, FR, ES, IT, PT) and Asia -- falls back to mg/dL, which
+# is today's behavior. The user can always override; this only sets the
+# starting point so mmol-region users aren't silently defaulted to mg/dL.
+MMOL_REGIONS: frozenset[str] = frozenset(
+    {
+        # Anglosphere (mmol/L) -- US deliberately excluded (mg/dL).
+        "GB",  # United Kingdom
+        "IE",  # Ireland
+        "AU",  # Australia
+        "NZ",  # New Zealand
+        "CA",  # Canada
+        # Nordics
+        "SE",  # Sweden
+        "NO",  # Norway
+        "FI",  # Finland
+        "DK",  # Denmark
+        "IS",  # Iceland
+        # Other commonly-mmol European markets
+        "NL",  # Netherlands
+        "CH",  # Switzerland
+        "CZ",  # Czechia
+        "SK",  # Slovakia
+        "HR",  # Croatia
+        "EE",  # Estonia
+        "LV",  # Latvia
+        "LT",  # Lithuania
+        # Rest of world
+        "CN",  # China (mainland)
+        "HK",  # Hong Kong
+        "RU",  # Russia
+        "UA",  # Ukraine
+        "BY",  # Belarus
+        "KZ",  # Kazakhstan
+        "ZA",  # South Africa
+        "MY",  # Malaysia
+    }
+)
+
+# A BCP-47 region subtag is exactly two ASCII letters (e.g. ``GB`` in
+# ``en-GB``) or three digits (a UN M.49 area code, which we do not map).
+# Script subtags are four letters and language subtags lead, so a 2-letter
+# subtag in any position after the first is the region.
+_REGION_SUBTAG = re.compile(r"^[A-Za-z]{2}$")
+
+
+def _region_from_language_tag(tag: str) -> str | None:
+    """Extract the upper-cased region from one BCP-47 language tag.
+
+    Handles ``en-GB`` -> ``GB``, ``zh-Hans-CN`` -> ``CN`` (the 4-letter script
+    subtag is skipped), and ``en`` / ``*`` -> ``None`` (no region present).
+    """
+    subtags = tag.strip().split("-")
+    for subtag in subtags[1:]:
+        if _REGION_SUBTAG.match(subtag):
+            return subtag.upper()
+    return None
+
+
+def glucose_unit_for_locale(accept_language: str | None) -> GlucoseUnit:
+    """Map an ``Accept-Language`` header to a seeded glucose display unit.
+
+    Decides from the user's highest-priority *regional* preference: the first
+    language tag (in the header's listed order, which clients send
+    most-preferred-first) that carries a region subtag wins. Its region maps to
+    ``MMOL`` if it is a known mmol region, else ``MGDL``. A region-less leading
+    tag (e.g. bare ``en``) is skipped in favor of the next regional tag. An
+    absent, malformed, or wholly region-less header falls back to ``MGDL``
+    (today's default). Quality values (``;q=...``) are ignored beyond list
+    order, which is sufficient for a best-guess default.
+
+    Deciding on the *first regional* tag -- not the first *mmol* tag anywhere in
+    the list -- means a US-primary user with a UK fallback (``en-US,en-GB``)
+    correctly seeds mg/dL rather than being pulled to mmol by a lower-priority
+    locale.
+    """
+    if not accept_language:
+        return GlucoseUnit.MGDL
+
+    for entry in accept_language.split(","):
+        # Drop any ``;q=`` weight; we honor list order, not the weight value.
+        tag = entry.split(";", 1)[0].strip()
+        if not tag or tag == "*":
+            continue
+        region = _region_from_language_tag(tag)
+        if region is not None:
+            return GlucoseUnit.MMOL if region in MMOL_REGIONS else GlucoseUnit.MGDL
+    return GlucoseUnit.MGDL

--- a/apps/api/tests/test_glucose_unit_preference.py
+++ b/apps/api/tests/test_glucose_unit_preference.py
@@ -49,11 +49,20 @@ async def test_glucose_unit_preference_round_trips_to_auth_me(client):
     me_response = await client.get("/api/auth/me", cookies=cookies)
 
     assert default_response.status_code == 200
-    assert default_response.json() == {"glucose_unit": "mgdl"}
+    # A fresh account's unit is a smart default (registration locale), so its
+    # provenance is "seed"; an explicit PATCH flips it to "user".
+    assert default_response.json() == {
+        "glucose_unit": "mgdl",
+        "glucose_unit_source": "seed",
+    }
     assert update_response.status_code == 200
-    assert update_response.json() == {"glucose_unit": "mmol"}
+    assert update_response.json() == {
+        "glucose_unit": "mmol",
+        "glucose_unit_source": "user",
+    }
     assert me_response.status_code == 200
     assert me_response.json()["glucose_unit"] == "mmol"
+    assert me_response.json()["glucose_unit_source"] == "user"
 
 
 async def test_glucose_unit_preference_rejects_unknown_value(client):
@@ -97,6 +106,115 @@ async def test_glucose_unit_requires_authentication(client):
 
     assert get_response.status_code == 401
     assert patch_response.status_code == 401
+
+
+async def _register(client, *, accept_language: str | None = None) -> dict:
+    """Register a fresh account (optionally with an Accept-Language header) and
+    return the auth cookies."""
+    email = unique_email("seed")
+    password = "SecurePass123"
+    headers = {"Accept-Language": accept_language} if accept_language else {}
+    await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+        headers=headers,
+    )
+    login_response = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    return {
+        settings.jwt_cookie_name: login_response.cookies.get(settings.jwt_cookie_name)
+    }
+
+
+async def test_registration_seeds_mmol_for_mmol_region_locale(client):
+    cookies = await _register(client, accept_language="en-GB,en;q=0.9")
+
+    response = await client.get("/api/settings/glucose-unit", cookies=cookies)
+
+    assert response.status_code == 200
+    assert response.json() == {"glucose_unit": "mmol", "glucose_unit_source": "seed"}
+
+
+async def test_registration_seeds_mgdl_for_us_locale(client):
+    cookies = await _register(client, accept_language="en-US,en;q=0.9")
+
+    response = await client.get("/api/settings/glucose-unit", cookies=cookies)
+
+    assert response.status_code == 200
+    # US is mg/dL: seeded value matches today's default, provenance still "seed".
+    assert response.json() == {"glucose_unit": "mgdl", "glucose_unit_source": "seed"}
+
+
+async def test_auth_me_exposes_seed_provenance_for_a_seeded_account(client):
+    """The web seed notice gates on `glucose_unit_source` read from /api/auth/me,
+    so the UserResponse serializer must carry the 'seed' value -- a separate path
+    from the settings GET asserted elsewhere."""
+    cookies = await _register(client, accept_language="en-GB")
+
+    response = await client.get("/api/auth/me", cookies=cookies)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["glucose_unit"] == "mmol"
+    assert body["glucose_unit_source"] == "seed"
+
+
+async def test_registration_seeds_mgdl_without_accept_language(client):
+    cookies = await _register(client, accept_language=None)
+
+    response = await client.get("/api/settings/glucose-unit", cookies=cookies)
+
+    assert response.status_code == 200
+    assert response.json()["glucose_unit"] == "mgdl"
+
+
+async def test_registration_seed_leaves_canonical_settings_in_mgdl(client):
+    """The mmol display seed must not convert canonical mg/dL settings."""
+    cookies = await _register(client, accept_language="en-GB")
+
+    unit_response = await client.get("/api/settings/glucose-unit", cookies=cookies)
+    range_response = await client.get(
+        "/api/settings/target-glucose-range", cookies=cookies
+    )
+
+    assert unit_response.json()["glucose_unit"] == "mmol"
+    # Default target range stays canonical mg/dL (70/180), NOT mmol-converted.
+    body = range_response.json()
+    assert body["low_target"] == 70.0
+    assert body["high_target"] == 180.0
+
+
+async def test_acknowledge_flips_seed_to_user_without_changing_unit(client):
+    cookies = await _register(client, accept_language="en-GB")
+
+    before = await client.get("/api/settings/glucose-unit", cookies=cookies)
+    ack = await client.post("/api/settings/glucose-unit/acknowledge", cookies=cookies)
+    after = await client.get("/api/settings/glucose-unit", cookies=cookies)
+
+    assert before.json() == {"glucose_unit": "mmol", "glucose_unit_source": "seed"}
+    assert ack.status_code == 200
+    # Dismiss = "treat the seeded unit as my choice": unit unchanged, source=user.
+    assert ack.json() == {"glucose_unit": "mmol", "glucose_unit_source": "user"}
+    assert after.json() == {"glucose_unit": "mmol", "glucose_unit_source": "user"}
+
+
+async def test_acknowledge_is_idempotent(client):
+    cookies = await _register(client, accept_language="en-GB")
+
+    first = await client.post("/api/settings/glucose-unit/acknowledge", cookies=cookies)
+    second = await client.post(
+        "/api/settings/glucose-unit/acknowledge", cookies=cookies
+    )
+
+    assert first.json() == {"glucose_unit": "mmol", "glucose_unit_source": "user"}
+    assert second.json() == {"glucose_unit": "mmol", "glucose_unit_source": "user"}
+
+
+async def test_acknowledge_requires_authentication(client):
+    response = await client.post("/api/settings/glucose-unit/acknowledge")
+    assert response.status_code == 401
 
 
 async def test_glucose_unit_forbidden_for_caregiver(client, db_session):

--- a/apps/api/tests/test_glucose_unit_seed.py
+++ b/apps/api/tests/test_glucose_unit_seed.py
@@ -1,0 +1,74 @@
+"""Unit tests for the locale -> glucose-unit seed mapping (Story 53.10).
+
+Covers the pure ``glucose_unit_for_locale`` mapping: the mmol-region set, the
+mg/dL miss/absent fallback, and BCP-47 tag parsing edge cases. The seed is a
+display-preference best guess, not a detector, so the contract under test is
+"recognized mmol region -> mmol; everything else -> mg/dL".
+"""
+
+import pytest
+
+from src.core.units import GlucoseUnit
+from src.services.glucose_unit_seed import (
+    MMOL_REGIONS,
+    glucose_unit_for_locale,
+)
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "en-GB",
+        "en-GB,en;q=0.9",
+        "en-IE",
+        "en-AU,en;q=0.8",
+        "en-NZ",
+        "en-CA,fr-CA;q=0.7",
+        "sv-SE",
+        "nl-NL",
+        "zh-Hans-CN",  # script subtag is skipped; region CN is mmol
+        "ru-RU",
+        "EN-gb",  # case-insensitive region match
+    ],
+)
+def test_mmol_region_locales_seed_mmol(header):
+    assert glucose_unit_for_locale(header) == GlucoseUnit.MMOL
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "en-US",
+        "en-US,en;q=0.9",
+        "de-DE",  # Germany reports mg/dL -- deliberately excluded
+        "fr-FR",
+        "es-ES",
+        "ja-JP",
+        "pt-BR",
+        "en",  # language only, no region
+        "*",
+        "",
+        "   ",
+        "xx-ZZ",  # unknown region
+    ],
+)
+def test_non_mmol_or_regionless_locales_seed_mgdl(header):
+    assert glucose_unit_for_locale(header) == GlucoseUnit.MGDL
+
+
+def test_absent_header_seeds_mgdl():
+    assert glucose_unit_for_locale(None) == GlucoseUnit.MGDL
+
+
+def test_first_recognized_region_in_list_order_wins():
+    # Lower-priority mmol region behind a higher-priority mg/dL one: list order
+    # is honored, so the leading mg/dL tag (US) decides -> mg/dL.
+    assert glucose_unit_for_locale("en-US,en-GB;q=0.5") == GlucoseUnit.MGDL
+    # A leading region-less tag is skipped; the next tag (GB) decides.
+    assert glucose_unit_for_locale("en,en-GB;q=0.5") == GlucoseUnit.MMOL
+
+
+def test_us_excluded_and_anglosphere_included():
+    assert "US" not in MMOL_REGIONS
+    for region in ("GB", "IE", "AU", "NZ", "CA"):
+        assert region in MMOL_REGIONS

--- a/apps/api/tests/test_glucose_unit_seed.py
+++ b/apps/api/tests/test_glucose_unit_seed.py
@@ -1,4 +1,4 @@
-"""Unit tests for the locale -> glucose-unit seed mapping (Story 53.10).
+"""Unit tests for the locale -> glucose-unit seed mapping.
 
 Covers the pure ``glucose_unit_for_locale`` mapping: the mmol-region set, the
 mg/dL miss/absent fallback, and BCP-47 tag parsing edge cases. The seed is a

--- a/apps/api/tests/test_nightscout_apply_onboarding.py
+++ b/apps/api/tests/test_nightscout_apply_onboarding.py
@@ -17,8 +17,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import delete
+from sqlalchemy import delete, select, update
 
+from src.core.units import GlucoseUnit, GlucoseUnitSource
 from src.database import get_session_maker
 from src.main import app
 from src.models.insulin_config import InsulinConfig
@@ -1025,5 +1026,181 @@ async def test_apply_no_imports_returns_skipped(http_client):
         assert body["insulin_config"] is None
         assert body["pump_profile_id"] is None
         assert all(v is False for v in body["applied"].values())
+    finally:
+        await _cleanup([email])
+
+
+# ---------------------------------------------------------------------------
+# Smart-default glucose-unit seed (Story 53.10)
+# ---------------------------------------------------------------------------
+
+
+async def _read_user_unit(email: str) -> tuple[GlucoseUnit, GlucoseUnitSource | None]:
+    """Return the (glucose_unit, glucose_unit_source) for an account by email."""
+    async with get_session_maker()() as db:
+        user = (await db.execute(select(User).where(User.email == email))).scalar_one()
+        return user.glucose_unit, user.glucose_unit_source
+
+
+@pytest.mark.asyncio
+async def test_apply_seeds_mmol_unit_from_confident_mmol_nightscout(http_client):
+    """Connecting a confidently-mmol Nightscout flips the display preference to
+    mmol (source=seed) -- even with no settings imported -- while canonical
+    storage stays mg/dL."""
+    email = _unique_email("ns_seed_mmol")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id, user_email=email, units="mmol"
+        )
+
+        # Sanity: a fresh US-test-client account starts mg/dL via the seed default.
+        unit_before, source_before = await _read_user_unit(email)
+        assert unit_before == GlucoseUnit.MGDL
+        assert source_before == GlucoseUnitSource.SEED
+
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={},
+            )
+        assert resp.status_code == 200, resp.text
+
+        unit_after, source_after = await _read_user_unit(email)
+        assert unit_after == GlucoseUnit.MMOL
+        assert source_after == GlucoseUnitSource.SEED
+
+        # Canonical settings untouched: default target range stays mg/dL.
+        range_resp = await http_client.get(
+            "/api/settings/target-glucose-range", cookies=cookies
+        )
+        body = range_resp.json()
+        assert body["low_target"] == 70.0
+        assert body["high_target"] == 180.0
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_units_unknown_does_not_seed_unit(http_client):
+    """An unclassifiable source unit is NOT a confident mmol signal -> no seed."""
+    email = _unique_email("ns_seed_unknown")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id, user_email=email, units="weird_unit"
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={},  # no glucose-domain import -> no units_unknown 409 gate
+            )
+        assert resp.status_code == 200, resp.text
+
+        unit_after, source_after = await _read_user_unit(email)
+        assert unit_after == GlucoseUnit.MGDL
+        assert source_after == GlucoseUnitSource.SEED
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_confident_mgdl_does_not_seed_mmol(http_client):
+    """A confidently-mg/dL Nightscout must not seed mmol (units_unknown==False
+    is NOT sufficient -- only a confident mmol signal seeds)."""
+    email = _unique_email("ns_seed_mgdl")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id, user_email=email, units="mg/dl"
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={},
+            )
+        assert resp.status_code == 200, resp.text
+
+        unit_after, source_after = await _read_user_unit(email)
+        assert unit_after == GlucoseUnit.MGDL
+        assert source_after == GlucoseUnitSource.SEED
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_does_not_override_explicit_user_unit_choice(http_client):
+    """An explicit user choice (source=user) is never overridden by a mmol
+    Nightscout connect, even when the chosen unit is mg/dL."""
+    email = _unique_email("ns_seed_userset")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        # User explicitly chooses mg/dL -> source=user.
+        patch_resp = await http_client.patch(
+            "/api/settings/glucose-unit",
+            cookies=cookies,
+            json={"glucose_unit": "mgdl"},
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["glucose_unit_source"] == "user"
+
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id, user_email=email, units="mmol"
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={},
+            )
+        assert resp.status_code == 200, resp.text
+
+        unit_after, source_after = await _read_user_unit(email)
+        assert unit_after == GlucoseUnit.MGDL
+        assert source_after == GlucoseUnitSource.USER
+    finally:
+        await _cleanup([email])
+
+
+@pytest.mark.asyncio
+async def test_apply_does_not_re_seed_an_account_already_in_mmol(http_client):
+    """AC3 'never re-fire': a confident-mmol connect must not re-stamp an account
+    already in mmol. A legacy mmol account with NULL provenance must keep its NULL
+    source -- re-stamping it 'seed' would spuriously re-trigger the one-time notice."""
+    email = _unique_email("ns_seed_already_mmol")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        # Simulate a legacy account: mmol display unit, provenance never recorded.
+        async with get_session_maker()() as db:
+            await db.execute(
+                update(User)
+                .where(User.email == email)
+                .values(glucose_unit=GlucoseUnit.MMOL, glucose_unit_source=None)
+            )
+            await db.commit()
+
+        connection_id = await _create_conn(http_client, cookies)
+        await _seed_snapshot(
+            connection_id=connection_id, user_email=email, units="mmol"
+        )
+        with _patch_sync_ok():
+            resp = await http_client.post(
+                f"/api/integrations/nightscout/{connection_id}/apply-onboarding",
+                cookies=cookies,
+                json={},
+            )
+        assert resp.status_code == 200, resp.text
+
+        # Untouched: still mmol, provenance NOT re-stamped to SEED.
+        unit_after, source_after = await _read_user_unit(email)
+        assert unit_after == GlucoseUnit.MMOL
+        assert source_after is None
     finally:
         await _cleanup([email])

--- a/apps/api/tests/test_nightscout_apply_onboarding.py
+++ b/apps/api/tests/test_nightscout_apply_onboarding.py
@@ -22,6 +22,7 @@ from sqlalchemy import delete, select, update
 from src.core.units import GlucoseUnit, GlucoseUnitSource
 from src.database import get_session_maker
 from src.main import app
+from src.models.glucose import GlucoseReading, TrendDirection
 from src.models.insulin_config import InsulinConfig
 from src.models.nightscout_connection import (
     NightscoutConnection,
@@ -66,6 +67,9 @@ async def _cleanup(emails: list[str]) -> None:
         result = await db.execute(User.__table__.select().where(User.email.in_(emails)))
         ids = [row.id for row in result.fetchall()]
         if ids:
+            await db.execute(
+                delete(GlucoseReading).where(GlucoseReading.user_id.in_(ids))
+            )
             # Snapshots first (FK to connection AND user).
             await db.execute(
                 delete(NightscoutProfileSnapshot).where(
@@ -1031,7 +1035,7 @@ async def test_apply_no_imports_returns_skipped(http_client):
 
 
 # ---------------------------------------------------------------------------
-# Smart-default glucose-unit seed (Story 53.10)
+# Smart-default glucose-unit seed
 # ---------------------------------------------------------------------------
 
 
@@ -1040,6 +1044,36 @@ async def _read_user_unit(email: str) -> tuple[GlucoseUnit, GlucoseUnitSource | 
     async with get_session_maker()() as db:
         user = (await db.execute(select(User).where(User.email == email))).scalar_one()
         return user.glucose_unit, user.glucose_unit_source
+
+
+async def _seed_glucose_reading(email: str, value_mgdl: int) -> uuid.UUID:
+    """Persist one canonical mg/dL glucose reading for the account; return its id."""
+    async with get_session_maker()() as db:
+        user_id = (
+            await db.execute(select(User.id).where(User.email == email))
+        ).scalar_one()
+        reading = GlucoseReading(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            value=value_mgdl,
+            reading_timestamp=datetime.now(UTC),
+            trend=TrendDirection.FLAT,
+            received_at=datetime.now(UTC),
+            source="test",
+        )
+        db.add(reading)
+        await db.commit()
+        return reading.id
+
+
+async def _read_glucose_value(reading_id: uuid.UUID) -> int:
+    """Return the stored mg/dL value of a glucose reading by id."""
+    async with get_session_maker()() as db:
+        return (
+            await db.execute(
+                select(GlucoseReading.value).where(GlucoseReading.id == reading_id)
+            )
+        ).scalar_one()
 
 
 @pytest.mark.asyncio
@@ -1054,6 +1088,9 @@ async def test_apply_seeds_mmol_unit_from_confident_mmol_nightscout(http_client)
         await _seed_snapshot(
             connection_id=connection_id, user_email=email, units="mmol"
         )
+
+        # A pre-existing canonical mg/dL reading must survive the seed untouched.
+        reading_id = await _seed_glucose_reading(email, 123)
 
         # Sanity: a fresh US-test-client account starts mg/dL via the seed default.
         unit_before, source_before = await _read_user_unit(email)
@@ -1071,6 +1108,10 @@ async def test_apply_seeds_mmol_unit_from_confident_mmol_nightscout(http_client)
         unit_after, source_after = await _read_user_unit(email)
         assert unit_after == GlucoseUnit.MMOL
         assert source_after == GlucoseUnitSource.SEED
+
+        # Safety invariant: the display seed must not rewrite any stored glucose
+        # value. The reading stays the exact canonical mg/dL integer it was.
+        assert await _read_glucose_value(reading_id) == 123
 
         # Canonical settings untouched: default target range stays mg/dL.
         range_resp = await http_client.get(
@@ -1171,7 +1212,7 @@ async def test_apply_does_not_override_explicit_user_unit_choice(http_client):
 
 @pytest.mark.asyncio
 async def test_apply_does_not_re_seed_an_account_already_in_mmol(http_client):
-    """AC3 'never re-fire': a confident-mmol connect must not re-stamp an account
+    """'never re-fire': a confident-mmol connect must not re-stamp an account
     already in mmol. A legacy mmol account with NULL provenance must keep its NULL
     source -- re-stamping it 'seed' would spuriously re-trigger the one-time notice."""
     email = _unique_email("ns_seed_already_mmol")

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
@@ -323,6 +323,7 @@ private class FakeMealApi : GlycemicGptApi {
     override suspend fun acknowledgeAlert(alertId: String) = notUsed()
     override suspend fun getGlucoseUnit() = notUsed()
     override suspend fun patchGlucoseUnit(request: GlucoseUnitUpdateRequest) = notUsed()
+    override suspend fun acknowledgeGlucoseUnitSeed() = notUsed()
     override suspend fun getGlucoseRange() = notUsed()
     override suspend fun getSafetyLimits() = notUsed()
     override suspend fun getAnalyticsConfig() = notUsed()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -144,6 +144,20 @@ class AppSettingsStore @Inject constructor(
         }
 
     /**
+     * Whether the current [glucoseUnit] is a still-unconfirmed smart default
+     * (server provenance "seed") with a non-mgdl value, so Settings should show
+     * the one-time confirmation notice (Story 53.10). Reconciled from
+     * `GET /api/settings/glucose-unit`; cleared when the user confirms (toggles
+     * the unit or dismisses the notice) and reset on logout. Local cache only --
+     * the account value remains the source of truth.
+     */
+    var glucoseUnitSeedPending: Boolean
+        get() = prefs.getBoolean(KEY_GLUCOSE_UNIT_SEED_PENDING, false)
+        set(value) {
+            prefs.edit().putBoolean(KEY_GLUCOSE_UNIT_SEED_PENDING, value).apply()
+        }
+
+    /**
      * Emits the current [glucoseUnit] and re-emits whenever it changes, so display
      * surfaces update live when the user toggles the unit or a backend reconcile
      * writes the cache. Uses the same change-listener mechanism the activity relies
@@ -237,6 +251,7 @@ class AppSettingsStore @Inject constructor(
         private const val KEY_SHOW_PUMP_LABELS = "show_pump_labels"
         internal const val KEY_THEME_MODE = "theme_mode"
         internal const val KEY_GLUCOSE_UNIT = "glucose_unit"
+        internal const val KEY_GLUCOSE_UNIT_SEED_PENDING = "glucose_unit_seed_pending"
         const val DEFAULT_RETENTION_DAYS = 7
         const val MIN_RETENTION_DAYS = 1
         const val MAX_RETENTION_DAYS = 30

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -146,7 +146,7 @@ class AppSettingsStore @Inject constructor(
     /**
      * Whether the current [glucoseUnit] is a still-unconfirmed smart default
      * (server provenance "seed") with a non-mgdl value, so Settings should show
-     * the one-time confirmation notice (Story 53.10). Reconciled from
+     * the one-time confirmation notice. Reconciled from
      * `GET /api/settings/glucose-unit`; cleared when the user confirms (toggles
      * the unit or dismisses the notice) and reset on logout. Local cache only --
      * the account value remains the source of truth.

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -88,7 +88,7 @@ interface GlycemicGptApi {
     @PATCH("/api/settings/glucose-unit")
     suspend fun patchGlucoseUnit(@Body request: GlucoseUnitUpdateRequest): Response<GlucoseUnitResponse>
 
-    // Acknowledge the smart-default unit notice without changing the unit (Story 53.10):
+    // Acknowledge the smart-default unit notice without changing the unit:
     // stamps source=user server-side so the notice never recurs.
     @POST("/api/settings/glucose-unit/acknowledge")
     suspend fun acknowledgeGlucoseUnitSeed(): Response<GlucoseUnitResponse>

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -88,6 +88,11 @@ interface GlycemicGptApi {
     @PATCH("/api/settings/glucose-unit")
     suspend fun patchGlucoseUnit(@Body request: GlucoseUnitUpdateRequest): Response<GlucoseUnitResponse>
 
+    // Acknowledge the smart-default unit notice without changing the unit (Story 53.10):
+    // stamps source=user server-side so the notice never recurs.
+    @POST("/api/settings/glucose-unit/acknowledge")
+    suspend fun acknowledgeGlucoseUnitSeed(): Response<GlucoseUnitResponse>
+
     // Glucose range settings
     @GET("/api/settings/target-glucose-range")
     suspend fun getGlucoseRange(): Response<GlucoseRangeResponse>

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
@@ -117,7 +117,7 @@ data class GlucoseRangeResponse(
 /**
  * Per-account glucose display unit preference. [glucoseUnit] is the backend enum wire value
  * ("mgdl"/"mmol"). [glucoseUnitSource] is the provenance ("seed"/"user"/null) -- "seed" with a
- * non-mgdl unit drives the one-time smart-default confirmation notice (Story 53.10). Nullable so an
+ * non-mgdl unit drives the one-time smart-default confirmation notice. Nullable so an
  * older API that predates provenance is parsed safely.
  */
 @JsonClass(generateAdapter = true)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
@@ -114,10 +114,16 @@ data class GlucoseRangeResponse(
     @Json(name = "urgent_high") val urgentHigh: Float,
 )
 
-/** Per-account glucose display unit preference. [glucoseUnit] is the backend enum wire value ("mgdl"/"mmol"). */
+/**
+ * Per-account glucose display unit preference. [glucoseUnit] is the backend enum wire value
+ * ("mgdl"/"mmol"). [glucoseUnitSource] is the provenance ("seed"/"user"/null) -- "seed" with a
+ * non-mgdl unit drives the one-time smart-default confirmation notice (Story 53.10). Nullable so an
+ * older API that predates provenance is parsed safely.
+ */
 @JsonClass(generateAdapter = true)
 data class GlucoseUnitResponse(
     @Json(name = "glucose_unit") val glucoseUnit: String,
+    @Json(name = "glucose_unit_source") val glucoseUnitSource: String? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -217,7 +217,7 @@ class AuthRepository @Inject constructor(
     }
 
     /**
-     * Acknowledge the smart-default glucose-unit notice without changing the unit (Story 53.10).
+     * Acknowledge the smart-default glucose-unit notice without changing the unit.
      * Stamps provenance `source=user` server-side -- so the notice never recurs and a later seed
      * never re-fires -- and clears the local pending flag. Used when the user dismisses the notice
      * without picking a unit; picking one goes through [updateGlucoseUnit], which already confirms.
@@ -272,7 +272,7 @@ class AuthRepository @Inject constructor(
                     val unit = GlucoseUnit.fromWire(body.glucoseUnit)
                     appSettingsStore.glucoseUnit = unit
                     // A still-seed-owned non-mgdl preference drives the one-time smart-default
-                    // confirmation notice in Settings (Story 53.10). Reconcile clears it once the
+                    // confirmation notice in Settings. Reconcile clears it once the
                     // account provenance is "user" (the user confirmed elsewhere).
                     appSettingsStore.glucoseUnitSeedPending =
                         body.glucoseUnitSource == GLUCOSE_UNIT_SOURCE_SEED &&

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -24,6 +24,9 @@ import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/** Backend glucose-unit provenance wire value flagging a still-unconfirmed smart default. */
+private const val GLUCOSE_UNIT_SOURCE_SEED = "seed"
+
 data class LoginResult(
     val success: Boolean,
     val email: String? = null,
@@ -130,6 +133,7 @@ class AuthRepository @Inject constructor(
         // The glucose unit is a per-account preference; reset to the neutral default so a stale
         // unit can't carry over to the next account before its reconcile lands.
         appSettingsStore.glucoseUnit = GlucoseUnit.MGDL
+        appSettingsStore.glucoseUnitSeedPending = false
         authManager.onLogout()
         scope.launch {
             deviceRepository.unregisterDevice()
@@ -197,6 +201,9 @@ class AuthRepository @Inject constructor(
             if (response.isSuccessful) {
                 val resolved = response.body()?.let { GlucoseUnit.fromWire(it.glucoseUnit) } ?: unit
                 appSettingsStore.glucoseUnit = resolved
+                // An explicit choice confirms the preference, so the one-time smart-default
+                // notice must not show (the backend also flips provenance to "user").
+                appSettingsStore.glucoseUnitSeedPending = false
                 Result.success(resolved)
             } else {
                 Result.failure(Exception("Server responded with HTTP ${response.code()}"))
@@ -205,6 +212,29 @@ class AuthRepository @Inject constructor(
             throw e
         } catch (e: Exception) {
             Timber.w(e, "Failed to update glucose unit")
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Acknowledge the smart-default glucose-unit notice without changing the unit (Story 53.10).
+     * Stamps provenance `source=user` server-side -- so the notice never recurs and a later seed
+     * never re-fires -- and clears the local pending flag. Used when the user dismisses the notice
+     * without picking a unit; picking one goes through [updateGlucoseUnit], which already confirms.
+     */
+    suspend fun acknowledgeGlucoseUnitSeed(): Result<Unit> {
+        return try {
+            val response = api.acknowledgeGlucoseUnitSeed()
+            if (response.isSuccessful) {
+                appSettingsStore.glucoseUnitSeedPending = false
+                Result.success(Unit)
+            } else {
+                Result.failure(Exception("Server responded with HTTP ${response.code()}"))
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to acknowledge glucose unit seed")
             Result.failure(e)
         }
     }
@@ -239,8 +269,19 @@ class AuthRepository @Inject constructor(
             val response = api.getGlucoseUnit()
             if (response.isSuccessful) {
                 response.body()?.let { body ->
-                    appSettingsStore.glucoseUnit = GlucoseUnit.fromWire(body.glucoseUnit)
-                    Timber.d("Glucose unit reconciled: %s", body.glucoseUnit)
+                    val unit = GlucoseUnit.fromWire(body.glucoseUnit)
+                    appSettingsStore.glucoseUnit = unit
+                    // A still-seed-owned non-mgdl preference drives the one-time smart-default
+                    // confirmation notice in Settings (Story 53.10). Reconcile clears it once the
+                    // account provenance is "user" (the user confirmed elsewhere).
+                    appSettingsStore.glucoseUnitSeedPending =
+                        body.glucoseUnitSource == GLUCOSE_UNIT_SOURCE_SEED &&
+                        unit != GlucoseUnit.MGDL
+                    Timber.d(
+                        "Glucose unit reconciled: %s (source=%s)",
+                        body.glucoseUnit,
+                        body.glucoseUnitSource,
+                    )
                 }
             }
         } catch (e: CancellationException) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -2227,7 +2227,7 @@ private fun GlucoseUnitsSection(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             if (seedNeedsConfirm) {
-                // One-time smart-default notice (Story 53.10): the unit was guessed from the
+                // One-time smart-default notice: the unit was guessed from the
                 // user's region or Nightscout and hasn't been confirmed. Never blocks the UI.
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -282,7 +282,9 @@ fun SettingsScreen(
         GlucoseUnitsSection(
             currentUnit = state.glucoseUnit,
             syncError = state.glucoseUnitSyncError,
+            seedNeedsConfirm = state.seedNeedsConfirm,
             onUnitChange = settingsViewModel::setGlucoseUnit,
+            onDismissSeedNotice = settingsViewModel::dismissGlucoseUnitSeedNotice,
         )
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -2205,7 +2207,9 @@ private fun BatteryOptimizationCard(
 private fun GlucoseUnitsSection(
     currentUnit: GlucoseUnit,
     syncError: String?,
+    seedNeedsConfirm: Boolean,
     onUnitChange: (GlucoseUnit) -> Unit,
+    onDismissSeedNotice: () -> Unit,
 ) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(
@@ -2222,6 +2226,38 @@ private fun GlucoseUnitsSection(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            if (seedNeedsConfirm) {
+                // One-time smart-default notice (Story 53.10): the unit was guessed from the
+                // user's region or Nightscout and hasn't been confirmed. Never blocks the UI.
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("glucose_unit_seed_notice"),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Info,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "We set this to ${GlucoseFormat.label(currentUnit)} based on your " +
+                            "region or your Nightscout. Change it anytime below.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    TextButton(
+                        onClick = onDismissSeedNotice,
+                        modifier = Modifier.testTag("glucose_unit_seed_dismiss"),
+                    ) {
+                        Text("Got it")
+                    }
+                }
+            }
             Spacer(modifier = Modifier.height(12.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -205,6 +205,9 @@ data class SettingsUiState(
     // Glucose display unit (per-account preference)
     val glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     val glucoseUnitSyncError: String? = null,
+    // One-time smart-default notice: the unit was seeded (region / Nightscout) and not yet
+    // confirmed (Story 53.10). Cleared when the user picks a unit or dismisses the notice.
+    val seedNeedsConfirm: Boolean = false,
 )
 
 private const val AUTO_DISMISS_MS = 5_000L
@@ -325,6 +328,7 @@ class SettingsViewModel @Inject constructor(
             showPumpLabels = appSettingsStore.showPumpLabels,
             themeMode = appSettingsStore.themeMode,
             glucoseUnit = appSettingsStore.glucoseUnit,
+            seedNeedsConfirm = appSettingsStore.glucoseUnitSeedPending,
             watchFaceConfig = loadPersistedWatchFaceConfig(),
         ).withActivePumpFields()
 
@@ -339,6 +343,15 @@ class SettingsViewModel @Inject constructor(
             }
             if (safetyLimitsStore.isStale()) {
                 viewModelScope.launch { authRepository.refreshSafetyLimits() }
+            }
+            // Reconcile the per-account glucose unit so the seed-confirmation notice
+            // reflects the latest account provenance when Settings opens.
+            viewModelScope.launch {
+                authRepository.refreshGlucoseUnit()
+                _uiState.value = _uiState.value.copy(
+                    glucoseUnit = appSettingsStore.glucoseUnit,
+                    seedNeedsConfirm = appSettingsStore.glucoseUnitSeedPending,
+                )
             }
         }
         if (pumpCredentialStore.isPaired()) {
@@ -1192,7 +1205,13 @@ class SettingsViewModel @Inject constructor(
      */
     fun setGlucoseUnit(unit: GlucoseUnit) {
         appSettingsStore.glucoseUnit = unit
-        _uiState.value = _uiState.value.copy(glucoseUnit = unit, glucoseUnitSyncError = null)
+        // Picking a unit confirms the preference, so dismiss the smart-default notice. The backend
+        // PATCH (and the optimistic local clear in updateGlucoseUnit) flip provenance to "user".
+        _uiState.value = _uiState.value.copy(
+            glucoseUnit = unit,
+            glucoseUnitSyncError = null,
+            seedNeedsConfirm = false,
+        )
         viewModelScope.launch {
             authRepository.updateGlucoseUnit(unit)
                 .onSuccess { resolved ->
@@ -1208,6 +1227,21 @@ class SettingsViewModel @Inject constructor(
                         glucoseUnitSyncError = "Couldn't save to your account. It will retry on next sign-in.",
                     )
                 }
+        }
+    }
+
+    /**
+     * Dismiss the one-time smart-default glucose-unit notice without changing the unit
+     * (Story 53.10). Hides it immediately, then acknowledges server-side so it never recurs
+     * (the backend stamps provenance "user"). Best-effort: a failed ack leaves the local flag
+     * cleared for this session and the next reconcile re-checks provenance.
+     */
+    fun dismissGlucoseUnitSeedNotice() {
+        appSettingsStore.glucoseUnitSeedPending = false
+        _uiState.value = _uiState.value.copy(seedNeedsConfirm = false)
+        viewModelScope.launch {
+            authRepository.acknowledgeGlucoseUnitSeed()
+                .onFailure { e -> Timber.w(e, "Failed to acknowledge glucose unit seed notice") }
         }
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -206,7 +206,7 @@ data class SettingsUiState(
     val glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
     val glucoseUnitSyncError: String? = null,
     // One-time smart-default notice: the unit was seeded (region / Nightscout) and not yet
-    // confirmed (Story 53.10). Cleared when the user picks a unit or dismisses the notice.
+    // confirmed. Cleared when the user picks a unit or dismisses the notice.
     val seedNeedsConfirm: Boolean = false,
 )
 
@@ -1231,8 +1231,8 @@ class SettingsViewModel @Inject constructor(
     }
 
     /**
-     * Dismiss the one-time smart-default glucose-unit notice without changing the unit
-     * (Story 53.10). Hides it immediately, then acknowledges server-side so it never recurs
+     * Dismiss the one-time smart-default glucose-unit notice without changing the unit.
+     * Hides it immediately, then acknowledges server-side so it never recurs
      * (the backend stamps provenance "user"). Best-effort: a failed ack leaves the local flag
      * cleared for this session and the next reconcile re-checks provenance.
      */

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -267,4 +267,75 @@ class AuthRepositoryTest {
 
         verify(exactly = 0) { appSettingsStore.glucoseUnit = any() }
     }
+
+    @Test
+    fun `refreshGlucoseUnit flags seed-pending for a seed-owned mmol preference`() = runTest {
+        coEvery { api.getGlucoseUnit() } returns Response.success(
+            GlucoseUnitResponse(glucoseUnit = "mmol", glucoseUnitSource = "seed"),
+        )
+
+        repository.refreshGlucoseUnit()
+
+        verify { appSettingsStore.glucoseUnit = GlucoseUnit.MMOL }
+        verify { appSettingsStore.glucoseUnitSeedPending = true }
+    }
+
+    @Test
+    fun `refreshGlucoseUnit does not flag seed-pending for a seed-owned mgdl preference`() =
+        runTest {
+            coEvery { api.getGlucoseUnit() } returns Response.success(
+                GlucoseUnitResponse(glucoseUnit = "mgdl", glucoseUnitSource = "seed"),
+            )
+
+            repository.refreshGlucoseUnit()
+
+            verify { appSettingsStore.glucoseUnitSeedPending = false }
+        }
+
+    @Test
+    fun `refreshGlucoseUnit does not flag seed-pending once the user has chosen`() = runTest {
+        coEvery { api.getGlucoseUnit() } returns Response.success(
+            GlucoseUnitResponse(glucoseUnit = "mmol", glucoseUnitSource = "user"),
+        )
+
+        repository.refreshGlucoseUnit()
+
+        verify { appSettingsStore.glucoseUnitSeedPending = false }
+    }
+
+    @Test
+    fun `updateGlucoseUnit clears seed-pending on success`() = runTest {
+        coEvery { api.patchGlucoseUnit(any()) } returns Response.success(
+            GlucoseUnitResponse(glucoseUnit = "mmol", glucoseUnitSource = "user"),
+        )
+
+        repository.updateGlucoseUnit(GlucoseUnit.MMOL)
+
+        verify { appSettingsStore.glucoseUnitSeedPending = false }
+    }
+
+    @Test
+    fun `acknowledgeGlucoseUnitSeed clears seed-pending and succeeds`() = runTest {
+        coEvery { api.acknowledgeGlucoseUnitSeed() } returns Response.success(
+            GlucoseUnitResponse(glucoseUnit = "mmol", glucoseUnitSource = "user"),
+        )
+
+        val result = repository.acknowledgeGlucoseUnitSeed()
+
+        assertTrue(result.isSuccess)
+        coVerify { api.acknowledgeGlucoseUnitSeed() }
+        verify { appSettingsStore.glucoseUnitSeedPending = false }
+    }
+
+    @Test
+    fun `acknowledgeGlucoseUnitSeed returns failure and leaves cache untouched on HTTP error`() =
+        runTest {
+            coEvery { api.acknowledgeGlucoseUnitSeed() } returns
+                Response.error(500, "boom".toResponseBody())
+
+            val result = repository.acknowledgeGlucoseUnitSeed()
+
+            assertTrue(result.isFailure)
+            verify(exactly = 0) { appSettingsStore.glucoseUnitSeedPending = any() }
+        }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -289,6 +289,7 @@ class AuthRepositoryTest {
 
             repository.refreshGlucoseUnit()
 
+            verify { appSettingsStore.glucoseUnit = GlucoseUnit.MGDL }
             verify { appSettingsStore.glucoseUnitSeedPending = false }
         }
 
@@ -300,6 +301,7 @@ class AuthRepositoryTest {
 
         repository.refreshGlucoseUnit()
 
+        verify { appSettingsStore.glucoseUnit = GlucoseUnit.MMOL }
         verify { appSettingsStore.glucoseUnitSeedPending = false }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -191,6 +191,65 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `loadState exposes the seed-confirm flag from the store`() {
+        every { appSettingsStore.glucoseUnitSeedPending } returns true
+
+        val vm = createViewModel()
+
+        assertTrue(vm.uiState.value.seedNeedsConfirm)
+    }
+
+    @Test
+    fun `loadState leaves seed-confirm false when the store flag is unset`() {
+        every { appSettingsStore.glucoseUnitSeedPending } returns false
+
+        val vm = createViewModel()
+
+        assertFalse(vm.uiState.value.seedNeedsConfirm)
+    }
+
+    @Test
+    fun `setGlucoseUnit dismisses the seed-confirm notice`() = runTest {
+        // Picking a unit confirms the preference, so the one-time notice must clear immediately.
+        every { appSettingsStore.glucoseUnitSeedPending } returns true
+        coEvery { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) } returns
+            Result.success(GlucoseUnit.MMOL)
+        val vm = createViewModel()
+        assertTrue(vm.uiState.value.seedNeedsConfirm)
+
+        vm.setGlucoseUnit(GlucoseUnit.MMOL)
+
+        assertFalse(vm.uiState.value.seedNeedsConfirm)
+    }
+
+    @Test
+    fun `dismissGlucoseUnitSeedNotice hides the notice, clears the flag, and acks the server`() =
+        runTest {
+            every { appSettingsStore.glucoseUnitSeedPending } returns true
+            coEvery { authRepository.acknowledgeGlucoseUnitSeed() } returns Result.success(Unit)
+            val vm = createViewModel()
+            assertTrue(vm.uiState.value.seedNeedsConfirm)
+
+            vm.dismissGlucoseUnitSeedNotice()
+
+            assertFalse(vm.uiState.value.seedNeedsConfirm)
+            verify { appSettingsStore.glucoseUnitSeedPending = false }
+            coVerify { authRepository.acknowledgeGlucoseUnitSeed() }
+        }
+
+    @Test
+    fun `dismissGlucoseUnitSeedNotice keeps the notice hidden even if the ack fails`() = runTest {
+        every { appSettingsStore.glucoseUnitSeedPending } returns true
+        coEvery { authRepository.acknowledgeGlucoseUnitSeed() } returns
+            Result.failure(RuntimeException("offline"))
+        val vm = createViewModel()
+
+        vm.dismissGlucoseUnitSeedNotice()
+
+        assertFalse(vm.uiState.value.seedNeedsConfirm)
+    }
+
+    @Test
     fun `loadState restores user email when logged in`() {
         every { authRepository.hasActiveSession() } returns true
         every { authRepository.getUserEmail() } returns "saved@test.com"

--- a/apps/web/__tests__/dashboard/glucose-unit-seed-notice.test.tsx
+++ b/apps/web/__tests__/dashboard/glucose-unit-seed-notice.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Story 53.10: GlucoseUnitSeedNotice tests.
+ *
+ * The one-time smart-default notice must appear ONLY for a still-seed-owned
+ * non-mgdl preference, never for an mg/dL default or an explicit user choice,
+ * and dismissing it must acknowledge the seed server-side so it doesn't recur.
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("lucide-react", () => ({
+  Info: ({ className }: { className?: string }) => (
+    <span data-testid="info-icon" className={className} />
+  ),
+  X: ({ className }: { className?: string }) => (
+    <span data-testid="x-icon" className={className} />
+  ),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const mockUseUserContext = jest.fn();
+jest.mock("@/providers", () => ({
+  useUserContext: () => mockUseUserContext(),
+}));
+
+const mockAcknowledgeGlucoseUnitSeed = jest.fn();
+jest.mock("@/lib/api", () => ({
+  acknowledgeGlucoseUnitSeed: (...args: unknown[]) =>
+    mockAcknowledgeGlucoseUnitSeed(...args),
+}));
+
+import { GlucoseUnitSeedNotice } from "@/components/dashboard/glucose-unit-seed-notice";
+
+function mockUser(user: Record<string, unknown> | null, refreshUser = jest.fn()) {
+  mockUseUserContext.mockReturnValue({
+    user,
+    isLoading: false,
+    error: null,
+    refreshUser,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAcknowledgeGlucoseUnitSeed.mockResolvedValue(undefined);
+});
+
+describe("GlucoseUnitSeedNotice - visibility gate", () => {
+  it("shows the notice for a seed-owned mmol preference", () => {
+    mockUser({ glucose_unit: "mmol", glucose_unit_source: "seed" });
+    render(<GlucoseUnitSeedNotice />);
+    expect(
+      screen.getByTestId("glucose-unit-seed-notice")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/We set your glucose unit to mmol\/L/)
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT show for an mg/dL-defaulted account (even if seed-owned)", () => {
+    mockUser({ glucose_unit: "mgdl", glucose_unit_source: "seed" });
+    render(<GlucoseUnitSeedNotice />);
+    expect(
+      screen.queryByTestId("glucose-unit-seed-notice")
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show once the user has explicitly chosen (source=user)", () => {
+    mockUser({ glucose_unit: "mmol", glucose_unit_source: "user" });
+    render(<GlucoseUnitSeedNotice />);
+    expect(
+      screen.queryByTestId("glucose-unit-seed-notice")
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show when the source field is absent (deploy skew)", () => {
+    mockUser({ glucose_unit: "mmol" });
+    render(<GlucoseUnitSeedNotice />);
+    expect(
+      screen.queryByTestId("glucose-unit-seed-notice")
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show while the user is null", () => {
+    mockUser(null);
+    render(<GlucoseUnitSeedNotice />);
+    expect(
+      screen.queryByTestId("glucose-unit-seed-notice")
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("GlucoseUnitSeedNotice - dismiss", () => {
+  it("acknowledges the seed and refreshes the user, then hides", async () => {
+    const refreshUser = jest.fn().mockResolvedValue(undefined);
+    mockUser({ glucose_unit: "mmol", glucose_unit_source: "seed" }, refreshUser);
+
+    render(<GlucoseUnitSeedNotice />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Dismiss glucose unit notice" })
+    );
+
+    await waitFor(() => {
+      expect(mockAcknowledgeGlucoseUnitSeed).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(refreshUser).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      screen.queryByTestId("glucose-unit-seed-notice")
+    ).not.toBeInTheDocument();
+  });
+
+  it("still hides when the acknowledge call fails (best-effort)", async () => {
+    mockAcknowledgeGlucoseUnitSeed.mockRejectedValue(new Error("network"));
+    mockUser({ glucose_unit: "mmol", glucose_unit_source: "seed" });
+
+    render(<GlucoseUnitSeedNotice />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Dismiss glucose unit notice" })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("glucose-unit-seed-notice")
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/__tests__/dashboard/glucose-unit-seed-notice.test.tsx
+++ b/apps/web/__tests__/dashboard/glucose-unit-seed-notice.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Story 53.10: GlucoseUnitSeedNotice tests.
+ * GlucoseUnitSeedNotice tests.
  *
  * The one-time smart-default notice must appear ONLY for a still-seed-owned
  * non-mgdl preference, never for an mg/dL default or an explicit user choice,

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -41,6 +41,7 @@ import {
   InsulinSummaryStats,
   BolusReviewTable,
   DataSourcesFreshnessCard,
+  GlucoseUnitSeedNotice,
   PERIOD_LABELS,
 } from "@/components/dashboard";
 import { useGlucoseStreamContext, useUserContext } from "@/providers";
@@ -220,6 +221,9 @@ export default function DashboardPage() {
         errorMessage={error?.message}
         onReconnect={reconnect}
       />
+
+      {/* One-time smart-default glucose-unit notice - Story 53.10 */}
+      <GlucoseUnitSeedNotice />
 
       {/* Page header - using div instead of header to avoid banner role confusion inside main */}
       <AnimatedCard>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -222,7 +222,7 @@ export default function DashboardPage() {
         onReconnect={reconnect}
       />
 
-      {/* One-time smart-default glucose-unit notice - Story 53.10 */}
+      {/* One-time smart-default glucose-unit notice */}
       <GlucoseUnitSeedNotice />
 
       {/* Page header - using div instead of header to avoid banner role confusion inside main */}

--- a/apps/web/src/components/dashboard/glucose-unit-seed-notice.tsx
+++ b/apps/web/src/components/dashboard/glucose-unit-seed-notice.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * GlucoseUnitSeedNotice Component
+ *
+ * Story 53.10: a one-time, dismissible notice shown when the account's glucose
+ * unit was set by a smart default (registration locale or a confidently-mmol
+ * Nightscout) and is still seed-owned and non-mgdl. It is the visible safety
+ * valve for an overridable best guess -- it never blocks the UI and never
+ * appears for mg/dL-defaulted users.
+ *
+ * Dismissing it acknowledges the preference server-side (`source=user`) so it
+ * never recurs; changing the unit in Settings flips the source the same way.
+ */
+
+import { Info, X } from "lucide-react";
+import clsx from "clsx";
+import { useState } from "react";
+import Link from "next/link";
+import { useUserContext } from "@/providers";
+import { acknowledgeGlucoseUnitSeed } from "@/lib/api";
+import { unitLabel } from "@/lib/glucose-units";
+
+export function GlucoseUnitSeedNotice() {
+  const { user, refreshUser } = useUserContext();
+  // Optimistic local hide so the notice disappears immediately on dismiss,
+  // independent of the best-effort server acknowledgment below.
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  const unit = user?.glucose_unit ?? "mgdl";
+  const isSeeded = user?.glucose_unit_source === "seed" && unit !== "mgdl";
+
+  if (!isSeeded || isDismissed) {
+    return null;
+  }
+
+  const handleDismiss = async () => {
+    setIsDismissed(true);
+    try {
+      // Persist the acknowledgment so the notice doesn't return on next load,
+      // then refresh the shared user context so `source` flips to "user".
+      await acknowledgeGlucoseUnitSeed();
+      await refreshUser();
+    } catch {
+      // Non-fatal: it stays hidden for this session and the server can be
+      // acknowledged again on a later dismiss if this call failed.
+    }
+  };
+
+  return (
+    <div
+      className={clsx(
+        "rounded-lg border px-4 py-3 flex items-center justify-between gap-3",
+        "bg-sky-500/20 border-sky-500"
+      )}
+      role="status"
+      aria-live="polite"
+      data-testid="glucose-unit-seed-notice"
+    >
+      <div className="flex items-center gap-3">
+        <Info className="h-5 w-5 text-sky-400 shrink-0" aria-hidden="true" />
+        <span className="text-sm font-medium text-sky-300">
+          We set your glucose unit to {unitLabel(unit)} based on your region or
+          your Nightscout.{" "}
+          <Link
+            href="/dashboard/settings/profile"
+            className="underline hover:text-sky-200"
+          >
+            Change anytime in Settings
+          </Link>
+          .
+        </span>
+      </div>
+
+      <button
+        onClick={handleDismiss}
+        className="p-1 rounded-md transition-colors hover:bg-slate-700/50 text-sky-300 shrink-0"
+        type="button"
+        aria-label="Dismiss glucose unit notice"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+export default GlucoseUnitSeedNotice;

--- a/apps/web/src/components/dashboard/glucose-unit-seed-notice.tsx
+++ b/apps/web/src/components/dashboard/glucose-unit-seed-notice.tsx
@@ -3,8 +3,8 @@
 /**
  * GlucoseUnitSeedNotice Component
  *
- * Story 53.10: a one-time, dismissible notice shown when the account's glucose
- * unit was set by a smart default (registration locale or a confidently-mmol
+ * A one-time, dismissible notice shown when the account's glucose unit was set
+ * by a smart default (registration locale or a confidently-mmol
  * Nightscout) and is still seed-owned and non-mgdl. It is the visible safety
  * valve for an overridable best guess -- it never blocks the UI and never
  * appears for mg/dL-defaulted users.

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -50,6 +50,8 @@ export {
   type ConnectionStatusBannerProps,
 } from "./connection-status-banner";
 
+export { GlucoseUnitSeedNotice } from "./glucose-unit-seed-notice";
+
 export {
   AIInsightCard,
   type AIInsightCardProps,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1308,8 +1308,8 @@ export async function updateGlucoseUnit(
 }
 
 /**
- * Acknowledge the smart-default glucose-unit notice without changing the unit
- * (Story 53.10). Stamps the preference `source=user` server-side so the notice
+ * Acknowledge the smart-default glucose-unit notice without changing the unit.
+ * Stamps the preference `source=user` server-side so the notice
  * never recurs and a later seed never re-fires. Used when the user dismisses
  * the dashboard notice without going to Settings; changing the unit there
  * already flips the source via `updateGlucoseUnit`.

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,7 +7,7 @@
  * Glucose unit preference on the current user + update endpoint
  */
 
-import type { GlucoseUnit } from "./glucose-units";
+import type { GlucoseUnit, GlucoseUnitSource } from "./glucose-units";
 
 /**
  * Resolve the API base URL.
@@ -1220,6 +1220,13 @@ export interface CurrentUserResponse {
    * `useGlucoseUnit`) so existing mg/dL behavior is preserved.
    */
   glucose_unit?: GlucoseUnit;
+  /**
+   * Provenance of `glucose_unit`. `"seed"` means a smart default (registration
+   * locale / confident Nightscout) that the user hasn't confirmed yet; the
+   * dashboard shows a one-time notice when it is `"seed"` and the unit is
+   * non-mgdl. Optional for deploy skew against an older API.
+   */
+  glucose_unit_source?: GlucoseUnitSource;
   created_at: string;
 }
 
@@ -1298,6 +1305,31 @@ export async function updateGlucoseUnit(
   }
 
   return response.json();
+}
+
+/**
+ * Acknowledge the smart-default glucose-unit notice without changing the unit
+ * (Story 53.10). Stamps the preference `source=user` server-side so the notice
+ * never recurs and a later seed never re-fires. Used when the user dismisses
+ * the dashboard notice without going to Settings; changing the unit there
+ * already flips the source via `updateGlucoseUnit`.
+ *
+ * Fire-and-forget: the caller refreshes the user context to pick up the new
+ * provenance, so this resolves to void rather than returning the (unused)
+ * acknowledged preference body.
+ */
+export async function acknowledgeGlucoseUnitSeed(): Promise<void> {
+  const response = await apiFetch(
+    `${API_BASE_URL}/api/settings/glucose-unit/acknowledge`,
+    { method: "POST" }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error.detail || `Failed to acknowledge glucose unit: ${response.status}`
+    );
+  }
 }
 
 /**

--- a/apps/web/src/lib/glucose-units.ts
+++ b/apps/web/src/lib/glucose-units.ts
@@ -18,6 +18,14 @@
 export type GlucoseUnit = "mgdl" | "mmol";
 
 /**
+ * Provenance of a stored glucose-unit preference. Mirrors the backend
+ * `GlucoseUnitSource` enum. `"seed"` is a smart default (registration locale or
+ * a confidently-mmol Nightscout) that is still overridable; `"user"` is an
+ * explicit choice. Drives the one-time smart-default notice (Story 53.10).
+ */
+export type GlucoseUnitSource = "seed" | "user";
+
+/**
  * The ONE canonical conversion factor: 1 mmol/L = 18.0156 mg/dL — the exact
  * glucose mass-to-molarity factor. Mirrors the backend's
  * `src/core/units.py` `MGDL_PER_MMOL`. Do NOT introduce a second value

--- a/apps/web/src/lib/glucose-units.ts
+++ b/apps/web/src/lib/glucose-units.ts
@@ -21,7 +21,7 @@ export type GlucoseUnit = "mgdl" | "mmol";
  * Provenance of a stored glucose-unit preference. Mirrors the backend
  * `GlucoseUnitSource` enum. `"seed"` is a smart default (registration locale or
  * a confidently-mmol Nightscout) that is still overridable; `"user"` is an
- * explicit choice. Drives the one-time smart-default notice (Story 53.10).
+ * explicit choice. Drives the one-time smart-default notice.
  */
 export type GlucoseUnitSource = "seed" | "user";
 


### PR DESCRIPTION
## Summary

New accounts and Nightscout connections now start in the glucose unit the user most likely expects, instead of defaulting everyone to mg/dL — and the guess is always overridable, with a one-time notice as the safety valve.

This is a **display/input preference only**. Canonical mg/dL storage, the 20–500 mg/dL safety invariant, and every alert/threshold/TIR/GMI computation are untouched.

## What changed

**Seeding (backend)**
- Registration seeds the display unit from the request's `Accept-Language` region: mmol-region locales start in mmol/L, everything else (including the US and unrecognized/absent locales) stays mg/dL. Decided on the user's highest-priority *regional* tag, so `en-US,en-GB` correctly resolves to mg/dL.
- Connecting a confidently-mmol Nightscout seeds mmol/L (gated on the already-classified, persisted source unit — no re-fetch).
- A nullable `users.glucose_unit_source` (`seed` | `user`) tracks provenance so a manual choice always wins and a seed never re-fires or overrides one. Registration stamps `seed`; the existing `PATCH /api/settings/glucose-unit` and a new `POST /api/settings/glucose-unit/acknowledge` stamp `user`.

**One-time notice (clients)**
- Provenance is exposed on both `/api/auth/me` (web) and `GET /api/settings/glucose-unit` (phone).
- Web: a dismissible dashboard banner shown only when `glucose_unit_source == 'seed'` and the unit is non-mgdl. Dismissing it (or changing the unit in Settings) acknowledges the preference so it never recurs.
- Phone: a one-time notice in the Settings "Glucose Units" section with the same gate and acknowledge behavior; reconciled from the account on login/foreground, reset on logout.

**Scope guard:** no seeding from Dexcom or Glooko (neither exposes a user-facing display-unit signal). The seed sources are exactly registration locale and a confident Nightscout.

## Migration

`076_glucose_unit_source` — a single additive nullable column off `075_user_glucose_unit`. Single-head and downgrade/upgrade round-trip verified.

## Testing

- **API:** locale→unit mapping table (incl. adversarial/fail-safe headers), registration seed, acknowledge idempotency, NS seed / `units_unknown`-no-seed / confident-mgdl-no-seed / never-override-user-choice / never-re-fire, provenance on both read endpoints, and assertions that no stored glucose value or bound changed.
- **Web:** banner gate + dismiss behavior (jest); full suite green.
- **Mobile:** repository reconcile/acknowledge matrix and ViewModel notice state/dismiss (unit tests); full suite green.
- **Visual:** verified end-to-end on web and the phone emulator — the notice shows for a seeded mmol account, dismiss flips provenance to `user` (unit unchanged) and the notice does not recur, and mg/dL accounts see nothing.
- Security review and a Sentry-enabled validation run of the changed paths both passed with no issues attributable to this change.

Closes #801


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Glucose unit preference now uses locale-based smart defaults at registration and during Nightscout onboarding, with a one-time confirmation notice when mmol is auto-set.
  * The app now exposes whether the glucose unit was auto-seeded (“seed”) or explicitly chosen (“user”).
  * Added a one-tap “Got it”/dismiss action in Settings, dashboard, and mobile to acknowledge the notice without changing the unit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->