### PR TITLE
test: verify cross-surface glucose-unit consistency and document units

### DIFF
--- a/apps/api/tests/test_alert_notifier.py
+++ b/apps/api/tests/test_alert_notifier.py
@@ -1,5 +1,6 @@
 """Story 7.2: Tests for alert delivery via Telegram."""
 
+import inspect
 import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -115,6 +116,52 @@ class TestTrendDescription:
         result = trend_description(-3.0)
         assert "falling" in result
         assert "fast" not in result
+
+
+def _trend_line(message: str) -> str:
+    """Pull the single ``Trend:`` line out of a rendered alert message."""
+    lines = [line for line in message.splitlines() if "Trend:" in line]
+    assert lines, f"no Trend line in message: {message!r}"
+    return lines[0]
+
+
+def _glucose_line(message: str) -> str:
+    """Pull the single ``Glucose:`` line out of a rendered alert message."""
+    lines = [line for line in message.splitlines() if "Glucose:" in line]
+    assert lines, f"no Glucose line in message: {message!r}"
+    return lines[0]
+
+
+class TestTrendIsUnitIndependent:
+    """The trend arrow/description is bucketed from a mg/dL/min rate and carries
+    no unit -- so switching a patient between mg/dL and mmol/L must never flip
+    the arrow, even though the glucose number beside it changes."""
+
+    def test_trend_description_signature_has_no_unit(self):
+        # The contract that locks "the arrow never flips with the unit": the
+        # function simply has no unit parameter to vary on, so it cannot branch
+        # on the patient's display preference.
+        params = list(inspect.signature(trend_description).parameters)
+        assert params == ["trend_rate"]
+
+    def test_alert_trend_line_is_byte_identical_across_units(self):
+        # Same alert, two units: the Glucose line converts (120 -> 6.7 mmol/L),
+        # but the Trend line is the same arrow + words in both renderings.
+        alert = make_alert(
+            AlertType.HIGH_WARNING,
+            AlertSeverity.WARNING,
+            current_value=120.0,
+            trend_rate=-2.0,
+        )
+        mgdl_msg = format_alert_message(alert, GlucoseUnit.MGDL)
+        mmol_msg = format_alert_message(alert, GlucoseUnit.MMOL)
+
+        assert _trend_line(mgdl_msg) == _trend_line(mmol_msg)
+        # ...while the glucose number genuinely differs (so the test isn't
+        # trivially comparing two identical messages).
+        assert "120 mg/dL" in _glucose_line(mgdl_msg)
+        assert "6.7 mmol/L" in _glucose_line(mmol_msg)
+        assert _glucose_line(mgdl_msg) != _glucose_line(mmol_msg)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_glucose_units.py
+++ b/apps/api/tests/test_glucose_units.py
@@ -149,6 +149,45 @@ class TestPromptInstruction:
         assert "one decimal" in text
 
 
+# The shared cross-surface fixture: a stored mg/dL value and the exact mmol/L
+# string every client must render for it. This list is mirrored byte-for-byte in
+# the web (``formatGlucose(x, "mmol")`` -> ``toFixed(1)``), the phone
+# (``GlucoseFormat.format(x, MMOL)`` -> ``String.format("%.1f")``), and the watch
+# (``GlucoseDisplayUtils.formatGlucose(x, MMOL)``) test suites -- the duplicate
+# copies are deliberate cross-language anchors, so a drift on any one surface
+# fails there. (The same-factor pure-division property is already proven by
+# ``TestRoundTripNoDrift.test_anchors_are_pure_division_of_the_one_factor``; this
+# table instead pins the exact shared strings.) None of the 8 lands on a ``.x5``
+# mmol tie, so JS round-half-away, Java round-half-up, and Python round-half-even
+# all agree -- the strings are identical across languages.
+CROSS_SURFACE_MMOL = {
+    54: "3.0",
+    70: "3.9",
+    99: "5.5",
+    100: "5.6",
+    120: "6.7",
+    180: "10.0",
+    250: "13.9",
+    400: "22.2",
+}
+
+
+class TestCrossSurfaceContract:
+    """The one fixture proving every surface renders the same stored mg/dL value
+    the same way -- a reading can never read 6.7 mmol/L on the phone and 6.6 on
+    the web for the same 120 mg/dL."""
+
+    @pytest.mark.parametrize("mgdl,expected", CROSS_SURFACE_MMOL.items())
+    def test_mmol_string_matches_the_cross_surface_fixture(self, mgdl, expected):
+        assert format_glucose_value(mgdl, GlucoseUnit.MMOL) == expected
+
+    @pytest.mark.parametrize("mgdl", CROSS_SURFACE_MMOL)
+    def test_mgdl_string_stays_the_whole_number(self, mgdl):
+        # mg/dL renders the raw integer on every surface; only the displayed
+        # number, never the stored value, changes with the unit.
+        assert format_glucose_value(mgdl, GlucoseUnit.MGDL) == str(mgdl)
+
+
 class TestResolveGlucoseUnit:
     """The by-user_id resolver used by the alert/escalation/command paths."""
 

--- a/apps/api/tests/test_telegram_chat.py
+++ b/apps/api/tests/test_telegram_chat.py
@@ -31,6 +31,7 @@ from src.services.telegram_chat import (
     _resolve_max_tokens_for_user,
     _truncate_response,
     handle_caregiver_chat,
+    handle_caregiver_chat_web,
     handle_chat,
 )
 
@@ -1254,6 +1255,36 @@ class TestCaregiverChatPatientUnit:
         db.execute.return_value = mock_result
 
         await handle_caregiver_chat(db, uuid.uuid4(), patient.id, "How is my patient?")
+
+        mock_context.assert_awaited_once()
+        args, kwargs = mock_context.call_args
+        assert args[1] == patient.id  # context built for the patient
+        assert kwargs["unit"] == GlucoseUnit.MMOL  # in the patient's unit
+
+    @pytest.mark.asyncio
+    @patch("src.services.telegram_chat.build_diabetes_context", new_callable=AsyncMock)
+    @patch("src.services.telegram_chat.get_ai_client", new_callable=AsyncMock)
+    async def test_web_context_built_in_patient_unit(
+        self, mock_get_client, mock_context
+    ):
+        """The web caregiver chat builds context in the PATIENT's unit too --
+        the seam where the dashboard caregiver view resolves the patient's
+        preference, distinct from the Telegram path above."""
+        mock_context.return_value = "[Glucose]\n- Current: 6.7 mmol/L (stable)"
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = make_ai_response("Looks stable.")
+        mock_get_client.return_value = mock_client
+
+        patient = make_user()
+        patient.glucose_unit = GlucoseUnit.MMOL
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = patient
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        await handle_caregiver_chat_web(
+            db, uuid.uuid4(), patient.id, "How is my patient?"
+        )
 
         mock_context.assert_awaited_once()
         args, kwargs = mock_context.call_args

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/format/GlucoseFormatTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/format/GlucoseFormatTest.kt
@@ -108,6 +108,30 @@ class GlucoseFormatTest {
     }
 
     @Test
+    fun `mmol fixture matches the cross-surface contract`() {
+        // The shared mg/dL -> mmol/L fixture every surface must render the same
+        // way: here, the web (formatGlucose -> toFixed(1)), the watch
+        // (GlucoseDisplayUtils.formatGlucose), and the API (format_glucose_value).
+        // Each string is round(x / 18.0156, 1); none of the 8 lands on a .x5
+        // mmol tie, so %.1f, JS toFixed, and Python round all agree.
+        val crossSurface = linkedMapOf(
+            54 to "3.0",
+            70 to "3.9",
+            99 to "5.5",
+            100 to "5.6",
+            120 to "6.7",
+            180 to "10.0",
+            250 to "13.9",
+            400 to "22.2",
+        )
+        for ((mgDl, expected) in crossSurface) {
+            assertEquals("$mgDl mg/dL -> mmol", expected, GlucoseFormat.format(mgDl, GlucoseUnit.MMOL))
+            // mg/dL stays the raw integer; only the displayed number changes.
+            assertEquals("$mgDl mg/dL", mgDl.toString(), GlucoseFormat.format(mgDl, GlucoseUnit.MGDL))
+        }
+    }
+
+    @Test
     fun `boundary values format cleanly`() {
         assertEquals("1.1", GlucoseFormat.format(20, GlucoseUnit.MMOL))
         assertEquals("27.8", GlucoseFormat.format(500, GlucoseUnit.MMOL))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/GlucoseHeroTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/GlucoseHeroTest.kt
@@ -1,0 +1,78 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Phone glucose band + trend-arrow regressions for the unit epic.
+ *
+ * Both [glucoseColor] and [trendArrowSymbol] take a stored mg/dL value or a CGM
+ * trend and NO display unit -- the user's mg/dL vs mmol/L preference can never
+ * reach them. These tests pin that: the severity color a reading shows, and the
+ * trend arrow shown beside it, are identical whether the number is displayed as
+ * 65 or 3.6. [GlucoseFormat] (the unit-aware formatter) is exercised here only
+ * to prove the displayed string genuinely differs while the band does not.
+ *
+ * Note: the theme collapses the low and high warning bands to one color
+ * (Yellow500) and the two urgent bands to one (Red500), so a Color assertion
+ * pins the severity a reading shows, not the low-vs-high name. That severity is
+ * exactly what the cross-surface contract needs -- a reading must show the same
+ * severity on the phone, web, and watch. The boundary test below pins the
+ * comparison operators so a band can never silently slip by one mg/dL.
+ */
+class GlucoseHeroTest {
+
+    // Values chosen to land in the SAME band on the phone, web (classifyGlucose),
+    // and watch (bgColor); threshold edges are avoided here because the surfaces
+    // differ by one mg/dL at the boundary.
+    @Test
+    fun `glucoseColor bands the stored mg-dL value, never the displayed one`() {
+        assertEquals(GlucoseColors.UrgentLow, glucoseColor(40))
+        assertEquals(GlucoseColors.Low, glucoseColor(65))
+        assertEquals(GlucoseColors.InRange, glucoseColor(120))
+        assertEquals(GlucoseColors.High, glucoseColor(200))
+        assertEquals(GlucoseColors.UrgentHigh, glucoseColor(300))
+    }
+
+    @Test
+    fun `glucoseColor switches severity exactly at each default threshold`() {
+        // Each transition crosses a DISTINCT color (red->yellow->green->yellow->
+        // red), so these catch an off-by-one or inverted comparison in the band
+        // boundaries (defaults 55 / 70 / 180 / 250).
+        assertEquals(GlucoseColors.UrgentLow, glucoseColor(55))
+        assertEquals(GlucoseColors.Low, glucoseColor(56))
+        assertEquals(GlucoseColors.Low, glucoseColor(70))
+        assertEquals(GlucoseColors.InRange, glucoseColor(71))
+        assertEquals(GlucoseColors.InRange, glucoseColor(179))
+        assertEquals(GlucoseColors.High, glucoseColor(180))
+        assertEquals(GlucoseColors.High, glucoseColor(249))
+        assertEquals(GlucoseColors.UrgentHigh, glucoseColor(250))
+    }
+
+    @Test
+    fun `a low reading stays low even though its displayed number changes with unit`() {
+        // 65 mg/dL shows as "65" or "3.6"; it is a warning (Low) reading in both,
+        // because the band reads the raw mg/dL value, not the formatted string.
+        assertEquals("65", GlucoseFormat.format(65, GlucoseUnit.MGDL))
+        assertEquals("3.6", GlucoseFormat.format(65, GlucoseUnit.MMOL))
+        assertEquals(GlucoseColors.Low, glucoseColor(65))
+    }
+
+    @Test
+    fun `trendArrowSymbol is a pure function of the trend with no unit input`() {
+        // The arrow is derived from the backend trend direction alone; there is
+        // no unit parameter, so switching units can never flip it.
+        assertEquals("⇈", trendArrowSymbol(CgmTrend.DOUBLE_UP))
+        assertEquals("↑", trendArrowSymbol(CgmTrend.SINGLE_UP))
+        assertEquals("↗", trendArrowSymbol(CgmTrend.FORTY_FIVE_UP))
+        assertEquals("→", trendArrowSymbol(CgmTrend.FLAT))
+        assertEquals("↘", trendArrowSymbol(CgmTrend.FORTY_FIVE_DOWN))
+        assertEquals("↓", trendArrowSymbol(CgmTrend.SINGLE_DOWN))
+        assertEquals("⇊", trendArrowSymbol(CgmTrend.DOUBLE_DOWN))
+        assertEquals("?", trendArrowSymbol(CgmTrend.UNKNOWN))
+    }
+}

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtilsTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtilsTest.kt
@@ -221,6 +221,51 @@ class GlucoseDisplayUtilsTest {
     }
 
     @Test
+    fun `mmol fixture matches the cross-surface contract`() {
+        // The shared mg/dL -> mmol/L fixture every surface must render the same
+        // way: here, the phone (GlucoseFormat.format), the web (formatGlucose ->
+        // toFixed(1)), and the API (format_glucose_value). Each string is
+        // round(x / 18.0156, 1); none of the 8 lands on a .x5 tie so %.1f, JS
+        // toFixed, and Python round all agree.
+        val crossSurface = linkedMapOf(
+            54 to "3.0",
+            70 to "3.9",
+            99 to "5.5",
+            100 to "5.6",
+            120 to "6.7",
+            180 to "10.0",
+            250 to "13.9",
+            400 to "22.2",
+        )
+        for ((mgDl, expected) in crossSurface) {
+            assertEquals("$mgDl mg/dL -> mmol", expected, GlucoseDisplayUtils.formatGlucose(mgDl, GlucoseUnit.MMOL))
+            assertEquals("$mgDl mg/dL", mgDl.toString(), GlucoseDisplayUtils.formatGlucose(mgDl, GlucoseUnit.MGDL))
+        }
+    }
+
+    @Test
+    fun `bgColor bands the stored mg-dL value regardless of display unit`() {
+        // bgColor takes thresholds and a stored mg/dL reading but NO unit, so the
+        // user's mmol/L preference cannot reach it. These values land in the same
+        // band on the watch, phone (glucoseColor), and web (classifyGlucose).
+        val red = 0xFFEF4444.toInt()
+        val yellow = 0xFFEAB308.toInt()
+        val green = 0xFF22C55E.toInt()
+        fun band(mgDl: Int) =
+            GlucoseDisplayUtils.bgColor(mgDl, low = 70, high = 180, urgentLow = 55, urgentHigh = 250)
+        assertEquals(red, band(40))
+        assertEquals(yellow, band(65))
+        assertEquals(green, band(120))
+        assertEquals(yellow, band(200))
+        assertEquals(red, band(300))
+        // 65 displays as "65" or "3.6" but is a warning band in both -- the band
+        // reads the raw mg/dL value, never the formatted one.
+        assertEquals("65", GlucoseDisplayUtils.formatGlucose(65, GlucoseUnit.MGDL))
+        assertEquals("3.6", GlucoseDisplayUtils.formatGlucose(65, GlucoseUnit.MMOL))
+        assertEquals(yellow, band(65))
+    }
+
+    @Test
     fun `formatGlucose mmol uses a dot decimal under a comma-decimal locale`() {
         val original = Locale.getDefault()
         try {

--- a/apps/web/__tests__/components/dashboard/glucose-hero.test.tsx
+++ b/apps/web/__tests__/components/dashboard/glucose-hero.test.tsx
@@ -15,6 +15,7 @@ import {
   type TrendDirection,
 } from "../../../src/components/dashboard/glucose-hero";
 import GlucoseHeroDefault from "../../../src/components/dashboard/glucose-hero";
+import { formatGlucose } from "@/lib/glucose-units";
 
 // Mock framer-motion to avoid animation issues in tests
 const mockUseReducedMotion = jest.fn(() => false);
@@ -85,6 +86,35 @@ describe("classifyGlucose", () => {
 
   it('returns "inRange" for null glucose', () => {
     expect(classifyGlucose(null)).toBe("inRange");
+  });
+});
+
+describe("band stays mg/dL regardless of display unit", () => {
+  // The range classifier takes NO unit argument: it bands a stored mg/dL value
+  // and the user's display preference cannot reach it. These values are chosen
+  // to fall in the SAME band on the web, phone (glucoseColor), and watch
+  // (bgColor) so a reading can never read "low" on one surface and "in range"
+  // on another. (55 and the threshold edges are deliberately avoided because the
+  // surfaces differ by one mg/dL on the boundary `<` vs `<=`.)
+  const BANDS: Array<[number, ReturnType<typeof classifyGlucose>]> = [
+    [40, "urgentLow"],
+    [65, "low"],
+    [120, "inRange"],
+    [200, "high"],
+    [300, "urgentHigh"],
+  ];
+
+  it.each(BANDS)("classifies %d mg/dL as %s", (mgdl, band) => {
+    expect(classifyGlucose(mgdl)).toBe(band);
+  });
+
+  it("classifies the raw mg/dL value even though the displayed number changes", () => {
+    // 65 mg/dL displays as "65" or "3.6" depending on the unit, but it is a
+    // "low" reading in BOTH -- the safety band reads the stored value, never the
+    // displayed one.
+    expect(formatGlucose(65, "mgdl")).toBe("65");
+    expect(formatGlucose(65, "mmol")).toBe("3.6");
+    expect(classifyGlucose(65)).toBe("low");
   });
 });
 
@@ -181,6 +211,31 @@ describe("GlucoseHero", () => {
 
         const trendArrow = screen.getByTestId("trend-arrow");
         expect(trendArrow).toHaveTextContent(expectedArrow);
+      }
+    );
+
+    it.each([
+      ["RisingFast", "↑↑"],
+      ["Falling", "↘"],
+      ["Stable", "→"],
+    ] as const)(
+      "renders the same %s arrow whether the unit is mg/dL or mmol/L",
+      (trend: TrendDirection, expectedArrow: string) => {
+        // The arrow comes from the backend trend direction, not the glucose
+        // unit -- so switching units changes the value (180 -> 10.0) but never
+        // flips the arrow.
+        const { unmount } = render(
+          <GlucoseHero {...defaultProps} value={180} trend={trend} unit="mgdl" />
+        );
+        expect(screen.getByTestId("trend-arrow")).toHaveTextContent(expectedArrow);
+        expect(screen.getByTestId("glucose-value")).toHaveTextContent("180");
+        unmount();
+
+        render(
+          <GlucoseHero {...defaultProps} value={180} trend={trend} unit="mmol" />
+        );
+        expect(screen.getByTestId("trend-arrow")).toHaveTextContent(expectedArrow);
+        expect(screen.getByTestId("glucose-value")).toHaveTextContent("10.0");
       }
     );
   });

--- a/apps/web/__tests__/lib/glucose-units.test.ts
+++ b/apps/web/__tests__/lib/glucose-units.test.ts
@@ -20,6 +20,43 @@ describe("glucose-units", () => {
     });
   });
 
+  describe("cross-surface consistency contract", () => {
+    // The shared fixture every surface must agree on: a stored mg/dL value and
+    // the exact mmol/L string each client renders for it. Asserted identically
+    // here, in the phone (GlucoseFormat.format -> "%.1f"), the watch
+    // (GlucoseDisplayUtils.formatGlucose), and the API (format_glucose_value).
+    // Each string is round(x / 18.0156, 1) to one decimal; a drift in the factor
+    // or the round-LAST rule on any surface breaks its copy of this table. None
+    // of the 8 lands on a .x5 mmol tie, so JS toFixed, Java %.1f, and Python
+    // round all produce the same string.
+    const CROSS_SURFACE_MMOL: Array<[number, string]> = [
+      [54, "3.0"],
+      [70, "3.9"],
+      [99, "5.5"],
+      [100, "5.6"],
+      [120, "6.7"],
+      [180, "10.0"],
+      [250, "13.9"],
+      [400, "22.2"],
+    ];
+
+    it.each(CROSS_SURFACE_MMOL)(
+      "renders %d mg/dL as %s mmol/L on every surface",
+      (mgdl, expected) => {
+        expect(formatGlucose(mgdl, "mmol")).toBe(expected);
+      }
+    );
+
+    it.each(CROSS_SURFACE_MMOL)(
+      "keeps %d mg/dL as the raw integer string in mg/dL mode",
+      (mgdl) => {
+        // Only the displayed number changes with the unit; the stored value
+        // (and its mg/dL rendering) never does.
+        expect(formatGlucose(mgdl, "mgdl")).toBe(String(mgdl));
+      }
+    );
+  });
+
   describe("clinical anchors", () => {
     // 70 / 18.0156 = 3.886 -> 3.9 ; 180 -> 9.99 -> 10.0 ; 120 -> 6.66 -> 6.7
     it("formats 70 mg/dL as 3.9 mmol", () => {
@@ -72,6 +109,18 @@ describe("glucose-units", () => {
       // 3 mg/dL/min / 18.0156 = 0.166 -> 0.17 (1 decimal would collapse to 0.2)
       expect(formatTrendRate(3, "mmol")).toBe("0.17");
       expect(formatTrendRate(1, "mmol")).toBe("0.06");
+    });
+    it("converts the rate offset-free (a rate has no zero anchor)", () => {
+      // A rate divides by 18.0156 with NO offset, unlike a glucose value -- so a
+      // negative rate converts just as cleanly as a positive one. Expected
+      // strings are computed by hand (1/18.0156=0.0555->"0.06",
+      // 3/18.0156=0.1665->"0.17", -1.5/18.0156=-0.0832->"-0.08") so the
+      // assertion is grounded in the offset-free result, not the helper itself.
+      expect(formatTrendRate(1, "mmol")).toBe("0.06");
+      expect(formatTrendRate(3, "mmol")).toBe("0.17");
+      expect(formatTrendRate(-1.5, "mmol")).toBe("-0.08");
+      // mg/dL keeps one decimal and never converts.
+      expect(formatTrendRate(-1.5, "mgdl")).toBe("-1.5");
     });
   });
 

--- a/docs/daily-use/_meta.json
+++ b/docs/daily-use/_meta.json
@@ -2,6 +2,7 @@
   "title": "Daily Use",
   "pages": [
     "dashboard",
+    "glucose-units",
     "integrations",
     "connecting-dexcom",
     "connecting-tandem-cloud",

--- a/docs/daily-use/glucose-units.md
+++ b/docs/daily-use/glucose-units.md
@@ -1,0 +1,51 @@
+---
+title: Glucose Units (mg/dL and mmol/L)
+description: Display your glucose in mg/dL or mmol/L. It's a personal display choice that never changes your data or your safety limits.
+---
+
+GlycemicGPT can show your glucose in either **mg/dL** or **mmol/L**. This is a personal display preference -- pick whichever your country and your care team use. Changing it updates the numbers you read everywhere in the app; it does not change anything about your data or how the app keeps you safe.
+
+> **Switching units is a display choice, not a data change.** Your glucose history, your alerts, and every safety check work exactly the same in either unit. You're only changing the numbers you read on the screen.
+
+## Picking your unit (mg/dL vs mmol/L)
+
+Both units measure the same thing -- they're just two scales:
+
+- **mg/dL** is used in the United States and a few other countries. Values are whole numbers (for example, **120**).
+- **mmol/L** is used in most of the rest of the world. Values have one decimal place (for example, **6.7**).
+
+Choose the one you and your healthcare provider already use. If you're not sure, match whatever your CGM or meter shows.
+
+## On the web dashboard
+
+Go to **Settings → Profile → Glucose Display Unit** and pick **mg/dL** or **mmol/L**. The dashboard updates right away -- your current glucose, charts, alerts, and daily briefs all switch to the unit you chose.
+
+> Your glucose data is always stored in mg/dL; this only changes how it is displayed.
+
+## On the phone app
+
+Open **Settings → Glucose Units** and choose **mg/dL** or **mmol/L**. The change applies across the app -- the home screen, history, and notifications all follow your choice. Your unit is tied to your account, so it stays the same when you sign in on another device.
+
+## On the watch
+
+The watch face doesn't have its own unit setting -- it shows whatever your **phone** is set to. Change the unit on your phone (**Settings → Glucose Units**) and your watch follows automatically the next time it updates.
+
+## Switching units changes only what you see
+
+Behind the scenes, GlycemicGPT always keeps your glucose in one consistent form, and every safety check -- range banding, alert thresholds, and the limits that keep impossible readings out -- runs on that same underlying value. Switching your unit only relabels the numbers you read.
+
+> **The same reading is always classified the same way.** A glucose value that's "low" on your phone is the same "low" on the web dashboard and the watch, no matter which unit you're viewing. The color and the alert never change just because the number on screen is written differently.
+
+## How mmol/L numbers are shown
+
+mmol/L values are shown to **one decimal place** -- the same level of detail your CGM or meter uses. mg/dL values are whole numbers.
+
+When you **type in** a threshold in mmol/L (for example, a low-glucose alert level), the app keeps it on a whole-number scale behind the scenes. You don't need to think about that: the threshold you save is shown back to you exactly as you entered it, and your alert fires at the level you chose. That same behind-the-scenes scale is what keeps every threshold inside the safe range.
+
+## What caregivers see
+
+If you've [linked a caregiver](../caregivers/linking-to-patient.md), they see **your** glucose in **your** unit -- not theirs. A caregiver who personally prefers mg/dL will still read your numbers in mmol/L if that's what you've chosen, so you're both looking at the same numbers when you talk.
+
+## Alerts and briefs from before you switched
+
+Alerts and daily briefs that were already created keep the unit they were written in. Only **new** alerts and briefs use your new unit. So just after switching, your history may show a mix -- older entries in the old unit, newer ones in the new unit. This is expected and clears up as new entries come in.


### PR DESCRIPTION
## Summary

Final QA closeout for the mmol/L glucose-unit work. The display machinery already shipped across web, phone, watch, and the AI/notifier layer; this PR **proves it end-to-end** with net-new cross-surface guard tests and adds the user-facing documentation. **No production code changes, no migrations** — only test files and docs.

## What's added

**Cross-surface consistency tests** — one shared fixture, asserted on every surface, so a stored mg/dL value can never render as two different mmol/L numbers:

- The 8 shared anchors (`54→3.0, 70→3.9, 99→5.5, 100→5.6, 120→6.7, 180→10.0, 250→13.9, 400→22.2`) are pinned byte-for-byte in the web, phone, watch, and API formatter tests. None lands on a `.x5` mmol tie, so JS `toFixed`, Java `%.1f`, and Python `round` agree.
- **Band stays mg/dL** — the range classifiers (`classifyGlucose` / `glucoseColor` / `bgColor`) take no unit argument, so a reading lands in the same severity band regardless of display unit. The cross-surface band table (40/65/120/200/300) was chosen so all three surfaces agree; the phone test additionally pins each default threshold (55/70/180/250) so a comparison operator cannot silently slip.
- **Trend arrows are unit-independent** — web (`TrendArrow` symbol identical across units, rate label converts offset-free at 2 decimals), phone (`trendArrowSymbol`), watch (`trendSymbol`), and the API (`format_alert_message` trend line byte-identical across units; `trend_description` has no unit parameter).
- **Caregiver web chat** builds the patient's diabetes context in the **patient's** unit.

**User doc** — `docs/daily-use/glucose-units.md` (registered in the nav): how to switch units on each surface, that switching changes only what you see (storage + safety math unchanged), what caregivers see, and how mmol/L is shown.

## Verification (verify-only suites; all green)

- AC1 (one 18.0156 factor per platform): API `test_units` + `test_glucose_units` 537; phone `GlucoseFormatTest`; watch `GlucoseDisplayUtilsTest`; web `glucose-units.test.ts` — all pin 18.0156.
- AC4 (caregiver/escalation render the patient's unit): 195 (caregiver_dashboard, escalation_engine, alert_notifier, telegram_chat, telegram_caregiver) + web caregiver page test.
- AC6 (threshold round-trip + bounds): 66 (threshold_unit_round_trip, treatment_safety_models, treatment_validator) + web.
- AC8 (4 threshold paths — alert thresholds, target range, safety limits, onboarding-derived — each round-trip + bounds + the mis-conversion negative `test_hypo_floor_is_not_evaded_by_the_mmol_path`): 53 (threshold_unit_round_trip, units, nightscout_onboarding_derive). Per PM ruling the existing exhaustive 0.1-step sweeps satisfy the property-test intent (no Hypothesis added).
- AC9 (AI-spoken glucose matches the record across chat / brief / correction / meal): 2023 (glucose_citation, safety_validation). Call sites: chat `telegram_chat.py:275/433/646/762`, brief `daily_brief.py:507`, correction `correction_analysis.py:436`, meal `meal_analysis.py:393`.

## Gates

- API: full verify batch 2865 passed; `ruff check` + `ruff format --check` clean.
- Web: 1081 jest passed; `tsc --noEmit` + eslint clean.
- Mobile: `testDebugUnitTest` (phone + watch) + `lintDebug` clean.
- Multi-agent review (adversarial + senior-engineer + security): security clean; 7 quality findings raised and all addressed (doc rounding wording, web rate assertion grounded in literals, phone band boundaries pinned, redundant API test dropped, file renamed).
- CodeRabbit CLI (`--base origin/develop`): 1 minor (strengthened the alert-line test helpers); resolved.
- Medical-Safety gate verified on a throwaway probe: a widened `10..600` clamp and a `3.9`-stored-as-mg/dL line both hard-fail (critical); a pure `formatGlucose(70, "mmol")` display line is correctly not flagged.

**Sentry runtime gate:** not run for this PR — it changes no production code (tests + docs only), so there is no new runtime path to exercise; the mmol runtime surfaces were already Sentry-validated in the merged display stories. No migrations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for glucose unit conversions and display consistency across web, mobile, and wear platforms.

* **Documentation**
  * Added user guide for glucose unit settings (mg/dL and mmol/L), including how to change display preferences on web and mobile apps and clarifying that unit selection is display-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->