### PR TITLE
fix: support browser selection in connect helper

### DIFF
--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -2220,7 +2220,10 @@ curl -fsSL -H "X-Connect-Pair-Token: $PAIR" "$API/api/integrations/medtronic/con
 chmod +x "$BIN"
 
 echo "Launching browser; sign in to CareLink to complete setup."
-"$BIN" --api "$API" --pair "$PAIR" --username "$USERNAME" --region "$REGION"
+# "$@" forwards any extra flags the user appended (e.g. `bash -s -- --browser
+# /path/to/browser` for a custom-install Chromium-family browser). The browser
+# path stays entirely on the user's machine -- it never reaches the server.
+"$BIN" --api "$API" --pair "$PAIR" --username "$USERNAME" --region "$REGION" "$@"
 """
 
 
@@ -2245,7 +2248,10 @@ Write-Host "Downloading helper for $OS/$ARCH from $API..."
 Invoke-WebRequest -Headers @{{ 'X-Connect-Pair-Token' = $PAIR }} -Uri "$API/api/integrations/medtronic/connect/helper-binary?os=$OS&arch=$ARCH" -OutFile $BIN -UseBasicParsing
 
 Write-Host 'Launching browser; sign in to CareLink to complete setup.'
-& $BIN --api $API --pair $PAIR --username $USERNAME --region $REGION
+# @args forwards any extra flags the caller passed (e.g. invoking the script
+# block with --browser to point at a custom browser install). The browser
+# path stays on the user's machine -- it never reaches the server.
+& $BIN --api $API --pair $PAIR --username $USERNAME --region $REGION @args
 """
 
 

--- a/apps/api/tests/test_connect_helper_endpoints.py
+++ b/apps/api/tests/test_connect_helper_endpoints.py
@@ -128,6 +128,8 @@ async def test_helper_sh_renders_with_substituted_values():
     assert "helper-binary?os=$OS&arch=$ARCH" in body
     assert "helper-binary?os=$OS&arch=$ARCH&pair=" not in body
     assert '-H "X-Connect-Pair-Token: $PAIR"' in body
+    # Extra flags (e.g. `bash -s -- --browser /path`) forward to the helper.
+    assert '--region "$REGION" "$@"' in body
     # Caches must not serve a stale tokenised script.
     assert r.headers.get("cache-control") == "no-store"
 
@@ -216,6 +218,8 @@ async def test_helper_ps1_renders_with_powershell_quoting():
     # Binary download carries the pair token in a header, never the URL.
     assert "helper-binary?os=$OS&arch=$ARCH" in body
     assert "-Headers @{ 'X-Connect-Pair-Token' = $PAIR }" in body
+    # Extra flags (e.g. invoking the script block with --browser) forward on.
+    assert "--region $REGION @args" in body
 
 
 # --- helper-binary: gating + os/arch allowlist + missing-file 404 ---
@@ -352,6 +356,9 @@ async def test_install_sh_renders_bundle_values():
     assert f"PAIR='{data['pairing_token']}'" in body
     assert "USERNAME='u@x.test'" in body
     assert "REGION='US'" in body
+    # The endpoint the web card actually uses must also forward extra flags
+    # (e.g. `bash -s -- --browser /path`) through to the helper.
+    assert '--region "$REGION" "$@"' in body
     assert r.headers.get("cache-control") == "no-store"
 
 
@@ -370,6 +377,8 @@ async def test_install_ps1_renders_bundle_values_with_ps_quoting():
     assert "$REGION = 'EU'" in body
     # PowerShell single-quote escape: ' -> ''
     assert "$USERNAME = 'evil''; Remove-Item C:\\'" in body
+    # The install endpoint must forward extra flags (--browser) to the helper.
+    assert "--region $REGION @args" in body
 
 
 async def test_install_sh_404_on_unknown_handle():

--- a/apps/web/__tests__/components/integrations/medtronic-connect-command.test.ts
+++ b/apps/web/__tests__/components/integrations/medtronic-connect-command.test.ts
@@ -1,0 +1,94 @@
+/**
+ * buildHelperCommand — the copy-paste command builder for the Medtronic
+ * CarePartner Connect helper. Covers the optional --browser passthrough and its
+ * per-shell quoting (issue #815: let custom-install Brave/Edge/Chromium users
+ * point the helper at their own binary from the web flow).
+ */
+
+import { buildHelperCommand } from "@/components/integrations/medtronic-connect-card";
+
+const SH_URL = "https://gly.example.com/api/integrations/medtronic/connect/install/abcd.sh";
+const PS_URL = "https://gly.example.com/api/integrations/medtronic/connect/install/abcd.ps1";
+
+describe("buildHelperCommand", () => {
+  describe("no custom browser (default auto-detect)", () => {
+    it("bash: pipes the install script straight into bash", () => {
+      expect(buildHelperCommand(SH_URL, "linux-mac", "")).toBe(
+        `curl -fsSL '${SH_URL}' | bash`
+      );
+    });
+
+    it("PowerShell: pipes the install script into iex", () => {
+      expect(buildHelperCommand(PS_URL, "windows", "")).toBe(
+        `iwr '${PS_URL}' -UseBasicParsing | iex`
+      );
+    });
+
+    it("treats a whitespace-only path as no custom browser", () => {
+      expect(buildHelperCommand(SH_URL, "linux-mac", "   ")).toBe(
+        `curl -fsSL '${SH_URL}' | bash`
+      );
+    });
+  });
+
+  describe("custom browser passthrough", () => {
+    it("bash: forwards --browser via `bash -s --`", () => {
+      expect(buildHelperCommand(SH_URL, "linux-mac", "/usr/bin/brave-browser")).toBe(
+        `curl -fsSL '${SH_URL}' | bash -s -- --browser '/usr/bin/brave-browser'`
+      );
+    });
+
+    it("bash: single-quotes a path containing spaces (macOS app bundle)", () => {
+      const macBrave =
+        "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser";
+      expect(buildHelperCommand(SH_URL, "linux-mac", macBrave)).toBe(
+        `curl -fsSL '${SH_URL}' | bash -s -- --browser '${macBrave}'`
+      );
+    });
+
+    it("bash: escapes an embedded single quote with the POSIX '\\'' idiom", () => {
+      const tricky = "/opt/o'brien/chrome";
+      const cmd = buildHelperCommand(SH_URL, "linux-mac", tricky);
+      expect(cmd).toBe(
+        `curl -fsSL '${SH_URL}' | bash -s -- --browser '/opt/o'\\''brien/chrome'`
+      );
+    });
+
+    it("PowerShell: runs a script block so trailing args reach the helper", () => {
+      const winBrave =
+        "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe";
+      expect(buildHelperCommand(PS_URL, "windows", winBrave)).toBe(
+        `& ([scriptblock]::Create((iwr '${PS_URL}' -UseBasicParsing).Content)) --browser '${winBrave}'`
+      );
+    });
+
+    it("PowerShell: doubles an embedded single quote (full command pinned)", () => {
+      const tricky = "C:\\o'brien\\brave.exe";
+      expect(buildHelperCommand(PS_URL, "windows", tricky)).toBe(
+        `& ([scriptblock]::Create((iwr '${PS_URL}' -UseBasicParsing).Content)) --browser 'C:\\o''brien\\brave.exe'`
+      );
+    });
+
+    it("trims surrounding whitespace from the path before quoting", () => {
+      expect(buildHelperCommand(SH_URL, "linux-mac", "  /usr/bin/chromium  ")).toBe(
+        `curl -fsSL '${SH_URL}' | bash -s -- --browser '/usr/bin/chromium'`
+      );
+    });
+  });
+
+  describe("URL quoting (the instance URL is a user-editable field)", () => {
+    it("bash: POSIX-escapes a single quote in the URL", () => {
+      const url = "https://exa'mple.com/api/integrations/medtronic/connect/install/abcd.sh";
+      expect(buildHelperCommand(url, "linux-mac", "")).toBe(
+        `curl -fsSL 'https://exa'\\''mple.com/api/integrations/medtronic/connect/install/abcd.sh' | bash`
+      );
+    });
+
+    it("PowerShell: doubles a single quote in the URL", () => {
+      const url = "https://exa'mple.com/api/integrations/medtronic/connect/install/abcd.ps1";
+      expect(buildHelperCommand(url, "windows", "")).toBe(
+        `iwr 'https://exa''mple.com/api/integrations/medtronic/connect/install/abcd.ps1' -UseBasicParsing | iex`
+      );
+    });
+  });
+});

--- a/apps/web/src/components/integrations/medtronic-connect-card.tsx
+++ b/apps/web/src/components/integrations/medtronic-connect-card.tsx
@@ -46,6 +46,42 @@ function detectOS(): HelperOS {
   return ua.includes("win") ? "windows" : "linux-mac";
 }
 
+/** POSIX single-quote (close, escaped quote, reopen) for safe bash embedding. */
+function shSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/** PowerShell single-quote (double any embedded quote) for safe embedding. */
+function psSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Assemble the copy-paste command that downloads and runs the helper installer
+ * from `url`. Exported and pure so the shell-quoting is unit-testable. Both the
+ * URL and the optional --browser path are single-quoted for the target shell, so
+ * a value with a space or quote can't break out. A custom browser is forwarded
+ * via `bash -s --` / a PowerShell script block (a plain `| iex` can't pass
+ * arguments); it stays in the pasted command and never reaches the server.
+ */
+export function buildHelperCommand(
+  url: string,
+  os: HelperOS,
+  browserPath: string
+): string {
+  const customBrowser = browserPath.trim();
+  if (os === "windows") {
+    if (customBrowser) {
+      return `& ([scriptblock]::Create((iwr ${psSingleQuote(url)} -UseBasicParsing).Content)) --browser ${psSingleQuote(customBrowser)}`;
+    }
+    return `iwr ${psSingleQuote(url)} -UseBasicParsing | iex`;
+  }
+  if (customBrowser) {
+    return `curl -fsSL ${shSingleQuote(url)} | bash -s -- --browser ${shSingleQuote(customBrowser)}`;
+  }
+  return `curl -fsSL ${shSingleQuote(url)} | bash`;
+}
+
 export function MedtronicConnectCard({ isOffline }: { isOffline: boolean }) {
   const [status, setStatus] = useState<MedtronicConnectStatus | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -85,6 +121,11 @@ export function MedtronicConnectCard({ isOffline }: { isOffline: boolean }) {
     typeof window !== "undefined" ? window.location.origin : ""
   );
   const [selectedOS, setSelectedOS] = useState<HelperOS>(() => detectOS());
+
+  // Optional explicit browser path for the helper's --browser flag, for users
+  // whose Chrome/Edge/Brave/Chromium is installed somewhere auto-detection
+  // can't find. Stays in the copy-paste command; never sent to the server.
+  const [browserPath, setBrowserPath] = useState<string>("");
 
   useEffect(() => {
     let cancelled = false;
@@ -178,12 +219,8 @@ export function MedtronicConnectCard({ isOffline }: { isOffline: boolean }) {
     } catch {
       return "";
     }
-    if (selectedOS === "windows") {
-      // PowerShell single-quoted; the URL has no ' so no doubling needed.
-      return `iwr '${url}' -UseBasicParsing | iex`;
-    }
-    return `curl -fsSL '${url}' | bash`;
-  }, [pairing, instanceUrl, selectedOS]);
+    return buildHelperCommand(url, selectedOS, browserPath);
+  }, [pairing, instanceUrl, selectedOS, browserPath]);
 
   // Non-empty but unparseable instance URL -> show an inline error instead of
   // silently rendering no command (and never throw during render).
@@ -202,11 +239,10 @@ export function MedtronicConnectCard({ isOffline }: { isOffline: boolean }) {
   // download a binary -- same backend endpoints, same flow, just heavier deps.
   const pythonCommand = useMemo(() => {
     if (!pairing) return "";
-    const q = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
-    const api = q(instanceUrl || "https://your-glycemicgpt-instance");
-    const user = q(username.trim());
-    const pair = q(pairing.pairing_token);
-    const region = q(regionCode);
+    const api = shSingleQuote(instanceUrl || "https://your-glycemicgpt-instance");
+    const user = shSingleQuote(username.trim());
+    const pair = shSingleQuote(pairing.pairing_token);
+    const region = shSingleQuote(regionCode);
     return [
       "uv run tools/medtronic-connect-login/medtronic_connect_login.py \\",
       `  --api ${api} \\`,
@@ -428,11 +464,41 @@ export function MedtronicConnectCard({ isOffline }: { isOffline: boolean }) {
                 ))}
               </div>
 
+              {/* Optional --browser path for installs auto-detect can't find. */}
+              <div>
+                <label
+                  htmlFor="connect-browser-path"
+                  className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1"
+                >
+                  Browser path (optional)
+                </label>
+                <input
+                  id="connect-browser-path"
+                  type="text"
+                  value={browserPath}
+                  onChange={(e) => setBrowserPath(e.target.value)}
+                  className={clsx(inputClass, "max-w-md")}
+                  spellCheck={false}
+                  placeholder={
+                    selectedOS === "windows"
+                      ? "e.g. C:\\Program Files\\BraveSoftware\\...\\brave.exe"
+                      : "e.g. /Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+                  }
+                />
+                <p className="mt-1 text-xs text-slate-500">
+                  Only if the helper can&apos;t find your browser on its own —
+                  point it at a Chrome, Edge, Brave, or Chromium executable.
+                </p>
+              </div>
+
               <p className="text-xs text-slate-500">
                 Paste this one line into a terminal on your computer. It runs
                 a small one-time connector from your own GlycemicGPT, opens
                 your browser to CareLink, and connects automatically. No
-                installs; requires Chrome, Edge, Brave, or Chromium.
+                installs; requires Chrome, Edge, Brave, or Chromium (auto-detected,
+                or set a path above for a custom install). No Chromium-family
+                browser at all? The Advanced → Python CLI below works on its own
+                — it uses a bundled browser engine.
               </p>
 
               <pre className="overflow-x-auto rounded-md border border-slate-700 bg-slate-950 p-3 text-xs text-slate-200">
@@ -469,8 +535,10 @@ export function MedtronicConnectCard({ isOffline }: { isOffline: boolean }) {
                   {pythonCommand}
                 </pre>
                 <p className="mt-1">
-                  Equivalent flow using the in-tree Python helper. Useful for
-                  devs / Firefox-only users; otherwise prefer the one-liner above.
+                  Equivalent flow using the in-tree Python helper. It runs the
+                  login through a bundled browser engine, so it works even with
+                  no Chromium-family browser installed (handy for Firefox/Safari
+                  users and devs); otherwise prefer the one-liner above.
                 </p>
               </details>
 

--- a/docs/daily-use/connecting-medtronic.md
+++ b/docs/daily-use/connecting-medtronic.md
@@ -32,7 +32,7 @@ This keeps GlycemicGPT updated automatically. After a one-time setup, a backgrou
 >
 > - A Medtronic pump + CGM whose data shows up in Medtronic's **CareLink / CarePartner** (the MiniMed Mobile or CareLink app already uploading your pump to Medtronic's cloud)
 > - Your CareLink username and password
-> - A desktop browser installed (Chrome, Edge, Brave, or Chromium)
+> - A desktop **Chromium-family browser** installed — Chrome, Edge, Brave, or Chromium (Firefox and Safari can't be driven this way; see the fallback note below)
 > - GlycemicGPT running and you signed in
 
 ### What it pulls
@@ -54,6 +54,8 @@ In your GlycemicGPT dashboard:
 4. GlycemicGPT shows a **one-time setup command**. Copy it and run it in a terminal on your own computer (macOS/Linux) or PowerShell (Windows). It downloads a small helper **from your own GlycemicGPT instance** — there's no third-party download.
 5. The helper opens your browser to Medtronic's sign-in. **Sign in and solve the captcha.**
 6. That's it. The helper hands the resulting login back to GlycemicGPT and exits. Your screen will show the connection as active.
+
+> **Browser not found, or installed somewhere unusual?** The helper auto-detects Chrome, Edge, Brave, and Chromium in their normal locations. If yours is in a custom spot, type its path into the **Browser path (optional)** field before you copy the command — the command then points the helper straight at that binary (it stays on your machine; the path is never sent to GlycemicGPT). If you have **no Chromium-family browser at all** (e.g. only Firefox or Safari, which can't be driven this way), use the **Advanced → Python CLI** fallback shown under the command — it runs the login through its own bundled browser engine, so it doesn't need a browser installed.
 
 Under the hood, GlycemicGPT stores an encrypted **refresh token** (never your password) and uses it to keep itself authorized. If Medtronic's sign-in ever expires, the connection shows as **Disconnected** and you re-run the one-time setup.
 

--- a/tools/connect-helper/README.md
+++ b/tools/connect-helper/README.md
@@ -68,8 +68,8 @@ go test ./...
 Chrome, Edge, Brave, or Chromium installed locally. The helper auto-detects
 common executable names and app bundle locations. If your browser is installed
 somewhere custom, pass `--browser /path/to/browser` (or a command on your
-`PATH`). Firefox-only users get a clear error message; Firefox support (via
-Marionette) is a follow-up.
+`PATH`). If you only have Firefox or Safari, use the Python/Playwright fallback
+(`tools/medtronic-connect-login/`) for the login flow.
 
 ## Scope (v1)
 

--- a/tools/connect-helper/README.md
+++ b/tools/connect-helper/README.md
@@ -61,11 +61,15 @@ go test ./...
 | `--region`   | `US`       | `US`, or `EU` for any non-US account (UK/EU/AU/ZA/…). |
 | `--timeout`  | `5m`       | How long to wait for the human to finish the browser login. |
 | `--headless` | off        | Don't use — CarePartner requires a captcha. |
+| `--browser`  | auto       | Optional browser executable path or command when auto-detection cannot find your Chrome, Edge, Brave, or Chromium install. |
 
 ## Browser requirement
 
-Chrome, Edge, Brave, or Chromium installed locally. Firefox-only users get a
-clear error message; Firefox support (via Marionette) is a follow-up.
+Chrome, Edge, Brave, or Chromium installed locally. The helper auto-detects
+common executable names and app bundle locations. If your browser is installed
+somewhere custom, pass `--browser /path/to/browser` (or a command on your
+`PATH`). Firefox-only users get a clear error message; Firefox support (via
+Marionette) is a follow-up.
 
 ## Scope (v1)
 

--- a/tools/connect-helper/main.go
+++ b/tools/connect-helper/main.go
@@ -251,13 +251,15 @@ func captureRedirect(ctx context.Context, authorizeURL string, headless bool, br
 	}
 	defer os.RemoveAll(tmp)
 
-	browserPath, err := findBrowserExecPath(browser)
-	if err != nil {
+	var opts []chromedp.ExecAllocatorOption
+	if browserPath, err := findBrowserExecPath(browser); err == nil {
+		opts = append(opts, chromedp.ExecPath(browserPath))
+	} else if browser != "" {
 		return "", err
 	}
 
-	opts := append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.ExecPath(browserPath),
+	opts = append(opts, chromedp.DefaultExecAllocatorOptions[:]...)
+	opts = append(opts,
 		chromedp.Flag("headless", headless),
 		chromedp.UserDataDir(tmp),
 		chromedp.NoFirstRun,

--- a/tools/connect-helper/main.go
+++ b/tools/connect-helper/main.go
@@ -164,11 +164,24 @@ func getAuthorize(ctx context.Context, f *flags) (*authorizeResponse, error) {
 	return &out, nil
 }
 
+// browserExecCandidates returns the ordered list of Chromium-family browser
+// executables to probe when the user did not pass --browser. It reads the real
+// host environment; the pure logic lives in browserExecCandidatesFor so each
+// OS branch can be table-tested from a single-platform runner.
 func browserExecCandidates() []string {
-	switch runtime.GOOS {
+	home, _ := os.UserHomeDir()
+	return browserExecCandidatesFor(runtime.GOOS, home, os.Getenv)
+}
+
+// browserExecCandidatesFor is the pure core of browserExecCandidates: no direct
+// os calls, so the darwin/windows branches (unreachable when `go test` runs on
+// Linux) can still be asserted in unit tests. `home` is the user's home dir ("",
+// if unknown) and `getenv` resolves Windows install-root variables.
+func browserExecCandidatesFor(goos, home string, getenv func(string) string) []string {
+	switch goos {
 	case "darwin":
 		homes := []string{"/Applications"}
-		if home, err := os.UserHomeDir(); err == nil {
+		if home != "" {
 			homes = append(homes, filepath.Join(home, "Applications"))
 		}
 		apps := []string{
@@ -178,15 +191,15 @@ func browserExecCandidates() []string {
 			"Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
 		}
 		out := make([]string, 0, len(homes)*len(apps)+4)
-		for _, home := range homes {
+		for _, h := range homes {
 			for _, app := range apps {
-				out = append(out, filepath.Join(home, app))
+				out = append(out, filepath.Join(h, app))
 			}
 		}
 		return append(out, "google-chrome", "chromium", "brave-browser", "microsoft-edge")
 	case "windows":
 		var out []string
-		for _, base := range []string{os.Getenv("LOCALAPPDATA"), os.Getenv("PROGRAMFILES"), os.Getenv("PROGRAMFILES(X86)")} {
+		for _, base := range []string{getenv("LOCALAPPDATA"), getenv("PROGRAMFILES"), getenv("PROGRAMFILES(X86)")} {
 			if base == "" {
 				continue
 			}
@@ -207,11 +220,15 @@ func browserExecCandidates() []string {
 	}
 }
 
+// executablePath resolves a --browser value (or an auto-detect candidate) to a
+// concrete executable. A value containing a path separator is treated as a
+// filesystem path and stat'd directly (rejecting directories); a bare name is
+// looked up on PATH. The bool reports whether a usable executable was found.
 func executablePath(candidate string) (string, bool) {
 	if candidate == "" {
 		return "", false
 	}
-	if filepath.IsAbs(candidate) || strings.ContainsAny(candidate, `/\\`) {
+	if filepath.IsAbs(candidate) || strings.ContainsAny(candidate, `/\`) {
 		info, err := os.Stat(candidate)
 		if err == nil && !info.IsDir() {
 			return candidate, true
@@ -224,6 +241,10 @@ func executablePath(candidate string) (string, bool) {
 	return "", false
 }
 
+// findBrowserExecPath resolves which browser to drive. An explicit --browser
+// that can't be resolved is a hard error (the user named a specific binary);
+// with no request it probes the per-OS candidates and returns an actionable
+// error naming the supported browsers and the --browser escape hatch.
 func findBrowserExecPath(requested string) (string, error) {
 	if requested != "" {
 		if path, ok := executablePath(requested); ok {
@@ -255,8 +276,15 @@ func captureRedirect(ctx context.Context, authorizeURL string, headless bool, br
 	if browserPath, err := findBrowserExecPath(browser); err == nil {
 		opts = append(opts, chromedp.ExecPath(browserPath))
 	} else if browser != "" {
+		// An explicit --browser we couldn't resolve is fatal: never silently
+		// launch a different browser than the one the user named.
 		return "", err
 	}
+	// If auto-detection found nothing (browser == "" and no candidate matched),
+	// fall through WITHOUT an ExecPath on purpose: chromedp's own findExecPath
+	// covers a few targets our candidate list omits (headless_shell, the Chrome
+	// beta/unstable channels, some absolute/snap paths). If that also fails, the
+	// actionable error surfaces at the network.Enable() call below.
 
 	opts = append(opts, chromedp.DefaultExecAllocatorOptions[:]...)
 	opts = append(opts,
@@ -303,7 +331,10 @@ func captureRedirect(ctx context.Context, authorizeURL string, headless bool, br
 
 	// Enable the Network domain so the events above actually fire.
 	if err := chromedp.Run(browserCtx, network.Enable()); err != nil {
-		return "", fmt.Errorf("enabling DevTools network events (is Chrome/Edge installed?): %w", err)
+		// network.Enable is the first command that actually launches the
+		// browser, so a failure here almost always means no Chromium-family
+		// browser could be started -- not that DevTools itself is broken.
+		return "", fmt.Errorf("could not start a Chromium-family browser (Chrome, Edge, Brave, or Chromium); if yours is installed in a custom location, pass --browser /path/to/browser: %w", err)
 	}
 
 	// Initial navigation: don't fail the run on a transient error (the post-

--- a/tools/connect-helper/main.go
+++ b/tools/connect-helper/main.go
@@ -3,15 +3,16 @@
 // authorization code to a GlycemicGPT instance over its API.
 //
 // WHY THIS EXISTS
-//   Medtronic's CarePartner login can only be completed interactively in a
-//   browser, and on success Auth0 redirects to a *mobile-app* URL scheme
-//   (com.medtronic.carepartner:/sso?code=...) that no web app and no server
-//   can receive. So a tiny native helper on the user's machine drives the
-//   login in their own installed Chrome (or Edge / Brave / Chromium -- any
-//   Chromium-protocol-compatible browser), intercepts that 302 at the
-//   DevTools-Protocol layer, and POSTs the code to the user's GlycemicGPT
-//   backend. The backend does the actual Auth0 code -> refresh-token exchange
-//   server-side, so the refresh token NEVER reaches this binary.
+//
+//	Medtronic's CarePartner login can only be completed interactively in a
+//	browser, and on success Auth0 redirects to a *mobile-app* URL scheme
+//	(com.medtronic.carepartner:/sso?code=...) that no web app and no server
+//	can receive. So a tiny native helper on the user's machine drives the
+//	login in their own installed Chrome (or Edge / Brave / Chromium -- any
+//	Chromium-protocol-compatible browser), intercepts that 302 at the
+//	DevTools-Protocol layer, and POSTs the code to the user's GlycemicGPT
+//	backend. The backend does the actual Auth0 code -> refresh-token exchange
+//	server-side, so the refresh token NEVER reaches this binary.
 //
 // WHAT IT NEVER SEES
 //   - The user's CareLink password (typed directly into Medtronic's page).
@@ -35,6 +36,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -65,6 +69,7 @@ type flags struct {
 	region   string
 	timeout  time.Duration
 	headless bool
+	browser  string
 }
 
 // parseFlags is split out so it can be unit-tested without a running browser.
@@ -77,6 +82,7 @@ func parseFlags(args []string) (*flags, error) {
 		region   = fs.String("region", "US", "CarePartner region: US, or EU for non-US (UK/EU/AU/ZA/...)")
 		timeout  = fs.Duration("timeout", 5*time.Minute, "How long to wait for you to finish the browser login")
 		headless = fs.Bool("headless", false, "Run the browser headless (NOT recommended -- you must solve a captcha)")
+		browser  = fs.String("browser", "", "Optional browser executable path or command (Chrome, Edge, Brave, or Chromium)")
 	)
 	if err := fs.Parse(args); err != nil {
 		return nil, err
@@ -91,6 +97,7 @@ func parseFlags(args []string) (*flags, error) {
 		region:   strings.ToUpper(*region),
 		timeout:  *timeout,
 		headless: *headless,
+		browser:  strings.TrimSpace(*browser),
 	}, nil
 }
 
@@ -157,10 +164,85 @@ func getAuthorize(ctx context.Context, f *flags) (*authorizeResponse, error) {
 	return &out, nil
 }
 
+func browserExecCandidates() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		homes := []string{"/Applications"}
+		if home, err := os.UserHomeDir(); err == nil {
+			homes = append(homes, filepath.Join(home, "Applications"))
+		}
+		apps := []string{
+			"Google Chrome.app/Contents/MacOS/Google Chrome",
+			"Chromium.app/Contents/MacOS/Chromium",
+			"Brave Browser.app/Contents/MacOS/Brave Browser",
+			"Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+		}
+		out := make([]string, 0, len(homes)*len(apps)+4)
+		for _, home := range homes {
+			for _, app := range apps {
+				out = append(out, filepath.Join(home, app))
+			}
+		}
+		return append(out, "google-chrome", "chromium", "brave-browser", "microsoft-edge")
+	case "windows":
+		var out []string
+		for _, base := range []string{os.Getenv("LOCALAPPDATA"), os.Getenv("PROGRAMFILES"), os.Getenv("PROGRAMFILES(X86)")} {
+			if base == "" {
+				continue
+			}
+			out = append(out,
+				filepath.Join(base, "Google", "Chrome", "Application", "chrome.exe"),
+				filepath.Join(base, "Microsoft", "Edge", "Application", "msedge.exe"),
+				filepath.Join(base, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+			)
+		}
+		return append(out, "chrome.exe", "msedge.exe", "brave.exe", "chromium.exe")
+	default:
+		return []string{
+			"google-chrome", "google-chrome-stable", "chrome",
+			"chromium", "chromium-browser",
+			"brave-browser", "brave",
+			"microsoft-edge", "microsoft-edge-stable", "msedge",
+		}
+	}
+}
+
+func executablePath(candidate string) (string, bool) {
+	if candidate == "" {
+		return "", false
+	}
+	if filepath.IsAbs(candidate) || strings.ContainsAny(candidate, `/\\`) {
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return candidate, true
+		}
+		return "", false
+	}
+	if path, err := exec.LookPath(candidate); err == nil {
+		return path, true
+	}
+	return "", false
+}
+
+func findBrowserExecPath(requested string) (string, error) {
+	if requested != "" {
+		if path, ok := executablePath(requested); ok {
+			return path, nil
+		}
+		return "", fmt.Errorf("browser %q was not found or is not executable", requested)
+	}
+	for _, candidate := range browserExecCandidates() {
+		if path, ok := executablePath(candidate); ok {
+			return path, nil
+		}
+	}
+	return "", errors.New("no supported Chromium-family browser found (install Chrome, Edge, Brave, or Chromium, or pass --browser /path/to/browser)")
+}
+
 // captureRedirect launches the user's installed Chromium-family browser at the
 // supplied authorize_url, lets the user complete the CareLink login + captcha,
 // and returns the captured 302 Location (custom-scheme URL carrying the code).
-func captureRedirect(ctx context.Context, authorizeURL string, headless bool) (string, error) {
+func captureRedirect(ctx context.Context, authorizeURL string, headless bool, browser string) (string, error) {
 	// Use a fresh temporary user-data dir so we don't touch the user's normal
 	// browser profile.
 	tmp, err := os.MkdirTemp("", "glycemicgpt-connect-*")
@@ -169,7 +251,13 @@ func captureRedirect(ctx context.Context, authorizeURL string, headless bool) (s
 	}
 	defer os.RemoveAll(tmp)
 
+	browserPath, err := findBrowserExecPath(browser)
+	if err != nil {
+		return "", err
+	}
+
 	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.ExecPath(browserPath),
 		chromedp.Flag("headless", headless),
 		chromedp.UserDataDir(tmp),
 		chromedp.NoFirstRun,
@@ -303,7 +391,7 @@ func run() error {
 	}
 
 	fmt.Println("  [2/3]  Opening your browser  -  sign in to CareLink (solve the captcha if it appears)")
-	redirect, err := captureRedirect(ctx, start.AuthorizeURL, cli.headless)
+	redirect, err := captureRedirect(ctx, start.AuthorizeURL, cli.headless, cli.browser)
 	if err != nil {
 		return err
 	}

--- a/tools/connect-helper/main_test.go
+++ b/tools/connect-helper/main_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestIsCaptureRedirect_MatchesCarePartnerWithCode(t *testing.T) {
 	for _, status := range []int{301, 302, 303, 307, 308} {
@@ -82,12 +86,16 @@ func TestParseFlags_NormalisesRegionUpper(t *testing.T) {
 		"--pair", "tok",
 		"--username", "u",
 		"--region", "eu",
+		"--browser", "brave-browser",
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if got.region != "EU" {
 		t.Errorf("region upper: %q", got.region)
+	}
+	if got.browser != "brave-browser" {
+		t.Errorf("browser flag: %q", got.browser)
 	}
 }
 
@@ -102,5 +110,38 @@ func TestParseFlags_RejectsMissingRequired(t *testing.T) {
 		if _, err := parseFlags(c); err == nil {
 			t.Errorf("expected err for %v", c)
 		}
+	}
+}
+
+func TestBrowserExecCandidates_IncludeEdgeAndBrave(t *testing.T) {
+	joined := strings.Join(browserExecCandidates(), "\n")
+	for _, want := range []string{"brave", "edge"} {
+		if !strings.Contains(strings.ToLower(joined), want) {
+			t.Errorf("browser candidates should include %s; got %q", want, joined)
+		}
+	}
+}
+
+func TestFindBrowserExecPath_AcceptsExplicitExecutable(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	got, err := findBrowserExecPath(exe)
+	if err != nil {
+		t.Fatalf("findBrowserExecPath(%q): %v", exe, err)
+	}
+	if got != exe {
+		t.Errorf("explicit executable path: got %q want %q", got, exe)
+	}
+}
+
+func TestFindBrowserExecPath_RejectsMissingExplicitBrowser(t *testing.T) {
+	_, err := findBrowserExecPath("/definitely/not/a/browser")
+	if err == nil {
+		t.Fatal("expected missing browser error")
+	}
+	if !strings.Contains(err.Error(), "was not found") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/tools/connect-helper/main_test.go
+++ b/tools/connect-helper/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -143,5 +145,139 @@ func TestFindBrowserExecPath_RejectsMissingExplicitBrowser(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "was not found") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBrowserExecCandidatesFor_Linux(t *testing.T) {
+	got := browserExecCandidatesFor("linux", "/home/u", func(string) string { return "" })
+	want := []string{
+		"google-chrome", "google-chrome-stable", "chrome",
+		"chromium", "chromium-browser",
+		"brave-browser", "brave",
+		"microsoft-edge", "microsoft-edge-stable", "msedge",
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("linux candidates:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestBrowserExecCandidatesFor_Darwin(t *testing.T) {
+	got := browserExecCandidatesFor("darwin", "/Users/jo", func(string) string { return "" })
+	joined := strings.Join(got, "\n")
+	for _, want := range []string{
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/Applications/Chromium.app/Contents/MacOS/Chromium",
+		"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+		"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+		"/Users/jo/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+		"brave-browser", "microsoft-edge",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("darwin candidates missing %q\ngot %q", want, joined)
+		}
+	}
+	// With no home dir, only the system /Applications prefix should appear.
+	for _, c := range browserExecCandidatesFor("darwin", "", func(string) string { return "" }) {
+		if strings.HasPrefix(c, "/Users") {
+			t.Errorf("unexpected per-user path with empty home: %q", c)
+		}
+	}
+}
+
+func TestBrowserExecCandidatesFor_Windows(t *testing.T) {
+	env := map[string]string{
+		"LOCALAPPDATA":      `C:\Users\jo\AppData\Local`,
+		"PROGRAMFILES":      `C:\Program Files`,
+		"PROGRAMFILES(X86)": `C:\Program Files (x86)`,
+	}
+	got := browserExecCandidatesFor("windows", "", func(k string) string { return env[k] })
+	joined := strings.Join(got, "\n")
+	for _, base := range []string{env["LOCALAPPDATA"], env["PROGRAMFILES"], env["PROGRAMFILES(X86)"]} {
+		for _, want := range []string{
+			filepath.Join(base, "Google", "Chrome", "Application", "chrome.exe"),
+			filepath.Join(base, "Microsoft", "Edge", "Application", "msedge.exe"),
+			filepath.Join(base, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+		} {
+			if !strings.Contains(joined, want) {
+				t.Errorf("windows candidates missing %q\ngot %q", want, joined)
+			}
+		}
+	}
+	for _, want := range []string{"chrome.exe", "msedge.exe", "brave.exe", "chromium.exe"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("windows bare fallback missing %q", want)
+		}
+	}
+	// Empty install-root vars must be skipped, not joined into bogus paths.
+	none := browserExecCandidatesFor("windows", "", func(string) string { return "" })
+	if strings.Join(none, ",") != "chrome.exe,msedge.exe,brave.exe,chromium.exe" {
+		t.Errorf("windows with no env should yield only bare names; got %q", none)
+	}
+}
+
+func TestExecutablePath_LookPathBranch(t *testing.T) {
+	dir := t.TempDir()
+	full := filepath.Join(dir, "fake-browser")
+	if err := os.WriteFile(full, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake browser: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	got, ok := executablePath("fake-browser")
+	if !ok {
+		t.Fatal("expected bare command to resolve via PATH")
+	}
+	if got != full {
+		t.Errorf("LookPath result: got %q want %q", got, full)
+	}
+}
+
+func TestExecutablePath_RejectsDirectoryAndMissing(t *testing.T) {
+	if _, ok := executablePath(t.TempDir()); ok {
+		t.Error("a directory must not resolve as an executable")
+	}
+	if _, ok := executablePath("/no/such/browser/binary"); ok {
+		t.Error("a missing absolute path must not resolve")
+	}
+	if _, ok := executablePath(""); ok {
+		t.Error("empty candidate must not resolve")
+	}
+}
+
+func TestFindBrowserExecPath_AutoDetectResolvesOnPath(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("auto-detect candidate names are OS-specific; PATH-injection test is linux-only")
+	}
+	dir := t.TempDir()
+	full := filepath.Join(dir, "google-chrome") // first linux candidate
+	if err := os.WriteFile(full, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake browser: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	got, err := findBrowserExecPath("")
+	if err != nil {
+		t.Fatalf("auto-detect should resolve a browser on PATH: %v", err)
+	}
+	if got != full {
+		t.Errorf("auto-detect path: got %q want %q", got, full)
+	}
+}
+
+// Asserts findBrowserExecPath's own contract. Note captureRedirect deliberately
+// swallows this error on auto-detect (browser == "") and falls through to
+// chromedp's findExecPath; the message a no-browser user actually sees comes
+// from the reworded network.Enable() error in captureRedirect.
+func TestFindBrowserExecPath_NoBrowserReturnsActionableError(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("relies on linux candidates being bare PATH names; other OSes probe absolute paths")
+	}
+	t.Setenv("PATH", t.TempDir()) // empty dir: no candidate resolves
+	_, err := findBrowserExecPath("")
+	if err == nil {
+		t.Fatal("expected no-browser error")
+	}
+	for _, want := range []string{"no supported Chromium-family browser", "--browser"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err.Error(), want)
+		}
 	}
 }


### PR DESCRIPTION
## 📋 Summary

Adds explicit Chromium-family browser selection for the Medtronic CareLink Connect helper so users with Edge or Brave installs are no longer blocked by chromedp's narrower default Chrome/Chromium discovery.

## 🔗 Related Issues

Fixes #815

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [x] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

- Added cross-platform auto-detection candidates for Chrome, Chromium, Brave, and Microsoft Edge.
- Added a `--browser` CLI flag for users with custom browser install paths or command names.
- Routed the resolved browser executable through `chromedp.ExecPath` before launching the login flow.
- Documented the new flag and browser auto-detection behavior.
- Added unit coverage for parsing the browser flag, Brave/Edge candidates, explicit executable paths, and missing explicit browser errors.

## 🧪 Test Plan

- [x] `cd tools/connect-helper && go test ./...` → passed
- [x] `cd tools/connect-helper && go build -o /tmp/glycemicgpt-connect .` → passed
- [x] `/tmp/glycemicgpt-connect --help` → shows the new `--browser` flag
- [x] `git diff --check` → passed
- [x] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [x] Self-review completed
- [x] Code follows project style guidelines
- [x] No hardcoded secrets, API keys, or credentials
- [x] Changes generate no new warnings
- [x] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `--browser` flag (default `auto`) to select a specific Chromium-family browser executable/command.
  * Updated the Medtronic integration UI with an optional “Browser path” field and safer copy-paste command generation that forwards the selection.
  * Installer/helper scripts now forward extra command-line flags to the Go helper.
* **Bug Fixes**
  * Improved the “browser can’t start” error with clearer guidance to use `--browser /path/to/browser`.
* **Documentation**
  * Clarified Chromium-family browser requirements and the Firefox/Safari fallback guidance.
* **Tests**
  * Expanded test coverage for browser discovery, argument forwarding, and command quoting/escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->