### PR TITLE
fix(medtronic-connect): drop ambiguous mmol/L follower glucose as a gap

### DIFF
--- a/apps/api/src/services/integrations/medtronic/connect_mapper.py
+++ b/apps/api/src/services/integrations/medtronic/connect_mapper.py
@@ -25,9 +25,11 @@ These are follow-ups gated on a live active-Medtronic-pump validator.
 
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from src.core.units import MGDL_PER_MMOL, GlucoseUnit
 from src.models.pump_data import PumpEventType
 
 from .carelink_mapper import SOURCE, MappedGlucose, MappedPumpEvent, MappedRecords
@@ -54,18 +56,35 @@ _MAX_SKEW_HOURS = 26
 #
 # Unit safety (mmol/L): CarePartner RecentData carries NO unit field -- ``sg`` and
 # marker BG values reflect whatever unit the pump's locale is configured for, which
-# CAN be mmol/L on European pumps. This feed gives no per-record or profile unit hint
-# to detect or convert against, so values are ASSUMED mg/dL. The 20-500 clamp is the
-# only mmol guard available: the bulk of the mmol/L range (~2-19) falls below 20 and
-# is dropped, so a unit-confused follower value mostly becomes a gap rather than a
-# wrong reading. The residual gap is a very high real reading of ~20-27.8 mmol/L being
-# stored as a 20-27 "mg/dL" false low -- unavoidable here without unit metadata.
-# TODO: if CarePartner ever exposes a unit hint, detect mmol/L and skip (mirroring the
-# CareLink CSV path's header-based skip) rather than store, and only convert against a
-# confirmed real sample. Unlike the CareLink export -- which names the unit in its
-# column header -- this feed exposes no signal to branch on today.
+# CAN be mmol/L on European pumps. The feed gives no per-record or profile unit hint
+# to detect or convert against, so the wire value is ASSUMED mg/dL and the only
+# signal available is the data owner's own glucose-unit preference (resolved by the
+# follower-sync orchestrator and threaded in as ``glucose_unit``).
+#
+# Most of the mmol/L range (~2-19) falls below the 20 mg/dL floor and is already
+# dropped, so a unit-confused value mostly becomes a gap rather than a wrong
+# reading. The residual hazard is a real high of ~20.0-27.8 mmol/L arriving as a
+# bare 20-28 that passes the 20-500 mg/dL bound and is stored as a 20-28 "mg/dL"
+# false SEVERE LOW -- the most dangerous possible misread. To fail safe, when the
+# user's preference is mmol/L we DROP any glucose value in that ambiguous overlap
+# window (a gap, never a false low); mg/dL and unknown-preference users stay
+# byte-identical to before. We never CONVERT here: the preference is only a display
+# setting, not proof the pump reports mmol/L, so converting could corrupt a
+# genuinely mg/dL value. This mirrors the CareLink CSV import, which DROPS glucose
+# in a detected mmol/L section rather than store it -- there the unit is named in
+# the column header; here the feed exposes no such signal, so the user preference
+# is the closest available proxy. Follow-up (GLY-59): an explicit, user-confirmed
+# "my pump displays mmol/L" opt-in could convert(x18.0156)+clamp instead of
+# dropping -- deferred, as it needs a new confirmed user signal + UI.
 _SG_MIN_MGDL = 20
 _SG_MAX_MGDL = 500
+
+# Upper edge of the mmol/L-ambiguity window (see "Unit safety" above): the mmol/L
+# physiologic ceiling expressed back in mg/dL units, ceil(500 / 18.0156) = 28. A
+# bare follower value at or below this could be a real high-end mmol/L reading
+# (<= ~27.8 mmol/L); above it no physiologic mmol/L reading exists, so the value
+# can only be mg/dL and is kept even for a mmol/L-preference user.
+_MMOL_AMBIGUOUS_MAX_MGDL = math.ceil(_SG_MAX_MGDL / MGDL_PER_MMOL)
 
 # Sanity bound on the scheduled basal RATE (U/h). A real basal rate is a few
 # U/h; reject an implausible value rather than store a U/h rate the rate-based
@@ -183,9 +202,31 @@ def _bg_value(m: dict) -> int | None:
         return None
 
 
-def map_recent_data(recent: dict) -> MappedRecords:
+def _is_mmol_ambiguous_glucose(value: float, glucose_unit: GlucoseUnit) -> bool:
+    """Whether a bare glucose value must be dropped as a mmol/L false low.
+
+    The follower feed exposes no unit, so for a user whose preference is mmol/L a
+    bare value in the overlap window ``[20, _MMOL_AMBIGUOUS_MAX_MGDL]`` could be a
+    real ~20.0-27.8 mmol/L high that would otherwise be stored as a 20-28 "mg/dL"
+    severe low. Dropping it fails safe (a gap, never a false low). mg/dL and
+    unknown-preference users always return False, so they are unchanged. See the
+    "Unit safety (mmol/L)" note above."""
+    return (
+        glucose_unit == GlucoseUnit.MMOL
+        and _SG_MIN_MGDL <= value <= _MMOL_AMBIGUOUS_MAX_MGDL
+    )
+
+
+def map_recent_data(
+    recent: dict, *, glucose_unit: GlucoseUnit = GlucoseUnit.MGDL
+) -> MappedRecords:
     """Map a ``RecentData`` (display/message ``patientData``) dict to records.
-    Glucose values here are in mg/dL."""
+
+    Glucose values on the wire are ASSUMED mg/dL (the feed carries no unit).
+    ``glucose_unit`` is the data owner's resolved display preference; when it is
+    mmol/L, glucose values in the mmol/L-ambiguity window are dropped to fail safe
+    (see ``_is_mmol_ambiguous_glucose`` and the "Unit safety (mmol/L)" note).
+    Defaults to mg/dL so callers without user context are unchanged."""
     records = MappedRecords()
     if not isinstance(recent, dict):
         return records
@@ -199,11 +240,13 @@ def map_recent_data(recent: dict) -> MappedRecords:
         dt = _shift(_parse_dt(sg.get("datetime")), skew)
         # Drop physiologically implausible readings rather than feed them to
         # TIR/alerts/AI -- a corrupt/unit-confused follower value is worse than
-        # a gap, and this feed can't be validated live.
+        # a gap, and this feed can't be validated live. Plus the mmol/L-ambiguity
+        # drop for mmol/L-preference users (see _is_mmol_ambiguous_glucose).
         if (
             dt is not None
             and isinstance(value, (int, float))
             and _SG_MIN_MGDL <= value <= _SG_MAX_MGDL
+            and not _is_mmol_ambiguous_glucose(value, glucose_unit)
         ):
             records.glucose.append(
                 MappedGlucose(timestamp=dt, value_mgdl=int(value), source=SOURCE)
@@ -221,8 +264,13 @@ def map_recent_data(recent: dict) -> MappedRecords:
             bg = _bg_value(m)
             # Apply the same physiologic clamp as sensor glucose -- a finger BG
             # is a glucose value too, and a corrupt/unit-confused one would
-            # poison TIR/alerts/AI context just the same.
-            if bg and _SG_MIN_MGDL <= bg <= _SG_MAX_MGDL:
+            # poison TIR/alerts/AI context just the same. Includes the same
+            # mmol/L-ambiguity drop for a mmol/L-preference user.
+            if (
+                bg
+                and _SG_MIN_MGDL <= bg <= _SG_MAX_MGDL
+                and not _is_mmol_ambiguous_glucose(bg, glucose_unit)
+            ):
                 records.pump_events.append(
                     MappedPumpEvent(PumpEventType.BG_READING, dt, bg_at_event=bg)
                 )

--- a/apps/api/src/services/integrations/medtronic/connect_sync.py
+++ b/apps/api/src/services/integrations/medtronic/connect_sync.py
@@ -33,6 +33,7 @@ from src.models.medtronic_connect_state import (
     STATUS_ERROR,
     MedtronicConnectState,
 )
+from src.services.glucose_unit import resolve_glucose_unit
 
 from .connect_auth import ConnectTokenError, ConnectTokenProvider, get_region
 from .connect_client import CareLinkConnectClient, ConnectAuthError, ConnectError
@@ -158,7 +159,13 @@ async def _sync_connect_for_user_locked(
             patient_id=patient_id,
         ) as client:
             recent = await client.get_recent_data()
-        records = map_recent_data(recent)
+        # The CarePartner feed carries no unit; a mmol/L-configured EU pump returns
+        # bare mmol/L numbers. Thread the data owner's glucose-unit preference into
+        # the mapper so a mmol/L user's ambiguous high (~20-27.8 mmol/L) is dropped
+        # rather than stored as a false mg/dL severe low (GLY-59). mg/dL and
+        # unknown-preference users are unaffected.
+        glucose_unit = await resolve_glucose_unit(db, state.user_id)
+        records = map_recent_data(recent, glucose_unit=glucose_unit)
         # commit=False: defer to the single final commit below so glucose +
         # events + the connected-state update land atomically.
         store = await store_carelink_records(

--- a/apps/api/src/services/tandem_sync.py
+++ b/apps/api/src/services/tandem_sync.py
@@ -403,7 +403,13 @@ def _normalize_pump_event(event, _seen_ids: set | None = None) -> dict | None:
     if "IOB" in d:
         d["iob"] = _float("IOB")
 
-    # Normalize BG from pump (event ID 16: LidBgReadingTaken)
+    # Normalize BG from pump (event ID 16: LidBgReadingTaken). Tandem t:connect
+    # reports glucose in canonical mg/dL (the t:slim X2 stores and transmits BG in
+    # mg/dL), so no unit conversion is applied here -- parity with the Medtronic
+    # CareLink/Connect mappers, which document the same mg/dL invariant. (Unlike
+    # the Medtronic CarePartner follower feed, the Tandem API is not known to emit
+    # mmol/L, so there is no unit-ambiguity guard to mirror; revisit if a mmol/L
+    # Tandem source is ever confirmed.)
     if "BG" in d:
         d["bg"] = _int("BG")
 

--- a/apps/api/tests/test_connect_mapper.py
+++ b/apps/api/tests/test_connect_mapper.py
@@ -5,10 +5,13 @@ The payload shapes mirror xDrip's ``cgm/carelinkfollow`` message classes
 CarePartner ``display/message`` endpoint returns.
 """
 
+import math
 from datetime import UTC, datetime, timedelta, timezone
 
+from src.core.units import MGDL_PER_MMOL, GlucoseUnit
 from src.models.pump_data import PumpEventType
 from src.services.integrations.medtronic.connect_mapper import (
+    _MMOL_AMBIGUOUS_MAX_MGDL,
     SOURCE,
     map_recent_data,
 )
@@ -367,3 +370,145 @@ def test_non_numeric_amounts_fail_soft():
         )
     )
     assert rec.pump_events == []
+
+
+# ── mmol/L follower-feed fail-safe guard (GLY-59 / #808) ──
+#
+# See the mapper's "Unit safety (mmol/L)" note for the rationale. In short: for a
+# mmol/L-preference user a bare value in [20, _MMOL_AMBIGUOUS_MAX_MGDL] is dropped
+# (a gap, not a false mg/dL low); mg/dL and default users are unchanged.
+
+# Each bare follower value paired with whether a mmol/L-preference user keeps it.
+# 19 is below the 20 floor (dropped for everyone); 20 and 28 are the inclusive
+# window edges (dropped only for mmol/L); 29..500 sit above the window (kept);
+# 501 is above the mg/dL ceiling (dropped for everyone).
+_AMBIGUOUS_DROP = (20, 24, 27, 28)  # mmol/L user: dropped as ambiguous
+_KEPT_FOR_MMOL = (29, 80, 120, 180, 500)  # mmol/L user: kept (cannot be mmol/L)
+
+
+def test_ambiguous_window_ceiling_is_mmol_equivalent_of_500():
+    # The window's upper edge is the platform glucose ceiling expressed in mmol/L
+    # units: ceil(500 / 18.0156) = 28. Pin it so the derivation can't silently
+    # drift (a wrong factor or direction would move the safety boundary).
+    assert _MMOL_AMBIGUOUS_MAX_MGDL == 28
+    assert math.ceil(500 / MGDL_PER_MMOL) == _MMOL_AMBIGUOUS_MAX_MGDL
+
+
+def test_mmol_user_drops_ambiguous_sensor_glucose():
+    rec = map_recent_data(
+        _recent(
+            sgs=[
+                {"sg": v, "datetime": f"2025-01-31T12:{i:02d}:00-05:00"}
+                for i, v in enumerate(_AMBIGUOUS_DROP)
+            ]
+        ),
+        glucose_unit=GlucoseUnit.MMOL,
+    )
+    # Every value in the ambiguity window is dropped -> a gap, not a false low.
+    assert rec.glucose == []
+
+
+def test_mmol_user_keeps_sensor_glucose_above_window():
+    rec = map_recent_data(
+        _recent(
+            sgs=[
+                {"sg": v, "datetime": f"2025-01-31T12:{i:02d}:00-05:00"}
+                for i, v in enumerate(_KEPT_FOR_MMOL)
+            ]
+        ),
+        glucose_unit=GlucoseUnit.MMOL,
+    )
+    # Above the window a value cannot be a physiologic mmol/L reading, so it is
+    # kept as mg/dL unchanged.
+    assert [g.value_mgdl for g in rec.glucose] == list(_KEPT_FOR_MMOL)
+
+
+def test_mmol_user_drops_float_value_just_below_ceiling():
+    # A fractional SG of 27.7 mmol/L (the high end of the hazard) is dropped.
+    rec = map_recent_data(
+        _recent(sgs=[{"sg": 27.7, "datetime": "2025-01-31T12:00:00-05:00"}]),
+        glucose_unit=GlucoseUnit.MMOL,
+    )
+    assert rec.glucose == []
+
+
+def test_mgdl_user_keeps_full_window_byte_identical():
+    # mg/dL preference: the ambiguity guard never fires -- the same 20-500 range
+    # (including 20-28) is kept exactly as before this story.
+    sgs = [
+        {"sg": v, "datetime": f"2025-01-31T12:{i:02d}:00-05:00"}
+        for i, v in enumerate(_AMBIGUOUS_DROP + _KEPT_FOR_MMOL)
+    ]
+    rec = map_recent_data(_recent(sgs=sgs), glucose_unit=GlucoseUnit.MGDL)
+    assert [g.value_mgdl for g in rec.glucose] == list(_AMBIGUOUS_DROP + _KEPT_FOR_MMOL)
+
+
+def test_default_glucose_unit_is_mgdl_and_unchanged():
+    # No glucose_unit argument (callers without user context) -> mg/dL behavior,
+    # so a 20-28 value is still kept exactly as the legacy mapper did.
+    rec = map_recent_data(
+        _recent(sgs=[{"sg": 22, "datetime": "2025-01-31T12:00:00-05:00"}])
+    )
+    assert [g.value_mgdl for g in rec.glucose] == [22]
+
+
+def test_mmol_user_drops_ambiguous_bg_marker():
+    rec = map_recent_data(
+        _recent(
+            markers=[
+                {
+                    "type": "BG_READING",
+                    "displayTime": "2025-01-31T12:00:00-05:00",
+                    "value": 22,
+                }
+            ]
+        ),
+        glucose_unit=GlucoseUnit.MMOL,
+    )
+    # A finger-BG marker is a glucose value too -> same drop for mmol/L users.
+    assert _events_of(rec, PumpEventType.BG_READING) == []
+
+
+def test_mmol_user_keeps_bg_marker_above_window():
+    rec = map_recent_data(
+        _recent(
+            markers=[
+                {
+                    "type": "BG_READING",
+                    "displayTime": "2025-01-31T12:00:00-05:00",
+                    "value": 110,
+                }
+            ]
+        ),
+        glucose_unit=GlucoseUnit.MMOL,
+    )
+    bgs = _events_of(rec, PumpEventType.BG_READING)
+    assert [b.bg_at_event for b in bgs] == [110]
+
+
+def test_mmol_guard_does_not_touch_insulin_or_carbs():
+    # The guard is glucose-only: insulin (units) and carbs (grams) are not glucose
+    # and must be mapped for a mmol/L user exactly as for a mg/dL user. A bolus of
+    # 22 U and 24 g of carbs sit numerically inside the glucose window but must NOT
+    # be dropped.
+    rec = map_recent_data(
+        _recent(
+            markers=[
+                {
+                    "type": "INSULIN",
+                    "displayTime": "2025-01-31T12:00:00-05:00",
+                    "deliveredFastAmount": 22.0,
+                },
+                {
+                    "type": "MEAL",
+                    "displayTime": "2025-01-31T12:05:00-05:00",
+                    "amount": 24.0,
+                },
+            ]
+        ),
+        glucose_unit=GlucoseUnit.MMOL,
+    )
+    bolus = _events_of(rec, PumpEventType.BOLUS)
+    carbs = _events_of(rec, PumpEventType.CARBS)
+    assert [b.units for b in bolus] == [22.0]
+    assert [c.cob_at_event for c in carbs] == [24.0]

--- a/apps/api/tests/test_connect_sync.py
+++ b/apps/api/tests/test_connect_sync.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 import pytest
 
 from src.core.encryption import decrypt_credential, encrypt_credential
+from src.core.units import GlucoseUnit
 from src.models.medtronic_connect_state import (
     STATUS_CONNECTED,
     STATUS_DISCONNECTED,
@@ -87,9 +88,22 @@ def patched(monkeypatch):
             return {"sgs": [{"sg": 120, "datetime": "2025-01-31T12:00:00-05:00"}]}
 
     monkeypatch.setattr(cs, "CareLinkConnectClient", _FakeClient)
-    monkeypatch.setattr(
-        cs, "map_recent_data", lambda recent: captured.setdefault("recent", recent)
-    )
+
+    def _fake_map(recent, *, glucose_unit):
+        captured["recent"] = recent
+        captured["glucose_unit"] = glucose_unit
+        return recent
+
+    monkeypatch.setattr(cs, "map_recent_data", _fake_map)
+
+    # resolve_glucose_unit hits the DB; the fake DB has no execute(). Patch it to
+    # return a configurable unit (default mg/dL) and capture which user it asked
+    # for, so we can assert the data owner's preference is threaded into the mapper.
+    async def _fake_resolve(db, user_id):
+        captured["resolve_user_id"] = user_id
+        return captured.get("unit", GlucoseUnit.MGDL)
+
+    monkeypatch.setattr(cs, "resolve_glucose_unit", _fake_resolve)
 
     async def _fake_store(db, user_id, records, *, now=None, commit=True):
         return CareLinkStoreResult(
@@ -116,6 +130,30 @@ async def test_success_updates_state(patched):
     # username + cloud host threaded into the client.
     assert patched["client_kwargs"]["username"] == "user@example.com"
     assert "clcloud.minimed.com" in patched["client_kwargs"]["base_url"]
+
+
+async def test_data_owner_unit_preference_is_threaded_into_mapper(patched):
+    # GLY-59: the orchestrator resolves the data owner's glucose-unit preference
+    # and passes it to the mapper so the mmol/L follower-feed guard can fire.
+    state = _state()
+    db = _FakeDB()
+
+    await sync_connect_for_user(db, state, now=datetime(2025, 2, 1, tzinfo=UTC))
+
+    assert patched["resolve_user_id"] == state.user_id
+    assert patched["glucose_unit"] == GlucoseUnit.MGDL
+
+
+async def test_mmol_preference_is_threaded_into_mapper(patched):
+    # When the owner prefers mmol/L, that unit reaches the mapper unchanged so the
+    # fail-safe drop applies on this sync path.
+    patched["unit"] = GlucoseUnit.MMOL
+    state = _state()
+    db = _FakeDB()
+
+    await sync_connect_for_user(db, state, now=datetime(2025, 2, 1, tzinfo=UTC))
+
+    assert patched["glucose_unit"] == GlucoseUnit.MMOL
 
 
 async def test_rotated_refresh_token_is_persisted(patched, monkeypatch):


### PR DESCRIPTION
## Summary

The Medtronic CarePartner ("follower") cloud feed returns bare glucose numbers with no unit field anywhere in the payload. On a European Medtronic pump configured to display mmol/L, a real hyperglycemia of ~20.0–27.8 mmol/L arrives as a bare 20–27, passes the platform 20–500 mg/dL bound unconverted, and is stored as a 20–27 "mg/dL" reading — a false severe low, the most dangerous possible misread. This makes that case fail safe.

## Change

- **Mapper guard (`connect_mapper.py`)** — `map_recent_data` now takes a keyword-only `glucose_unit` (default `mg/dL`). For a user whose preference is mmol/L, glucose values (sensor SG and finger-BG markers) in the ambiguous overlap window `[20, 28]` mg/dL are **dropped as a gap, never stored**. The window ceiling is the mmol/L physiologic max expressed in mg/dL: `ceil(500 / 18.0156) = 28`; values above it can only be mg/dL and are kept.
- **Orchestrator (`connect_sync.py`)** — resolves the data owner's unit via `resolve_glucose_unit(db, state.user_id)` and threads it into the mapper. The pure mapper holds no DB/user context.
- **No conversion** — the preference is a display setting, not proof the pump reports mmol/L, so converting could corrupt a genuinely mg/dL value. mg/dL and unknown-preference users are byte-identical to before.
- **Tandem parity** — added a mg/dL-invariant note to the Tandem BG source, matching the documented invariant on the Medtronic mappers.

## Design decision

The guard is threaded into the **pure mapper** (co-located with the documented hazard and the 20–500 bounds) rather than post-filtered in the orchestrator: this keeps a single source of truth for "what is a valid glucose," keeps the mapper pure and exhaustively unit-testable, and confines the DB lookup to the orchestrator that holds user context.

We **drop, never guess-convert**. The optional convert+clamp opt-in (behind an explicit, user-confirmed "my pump displays mmol/L" signal) is deliberately **deferred**: it needs a new persisted/confirmed user signal plus UI, and converting without that signal would re-introduce exactly the guessing this change removes. No distribution/clustering heuristic is used to infer the unit — too risky for a safety feed.

## Investigation note

We have no EU mmol/L-configured CarePartner account on hand, so a real mmol/L `RecentData` sample could not be captured to rule out an unconsumed top-level unit/metadata key. The fail-safe default (drop, never guess) is correct regardless of whether such a key is found later; if one ever surfaces, it can drive a precise skip/convert as a follow-up.

## Tests

- `test_connect_mapper.py` — window boundary pin (`== 28` plus the `ceil(500 / 18.0156)` derivation), both inclusive edges (20 and 28) dropped only for mmol/L, 29–500 kept, a fractional 27.7 dropped, mg/dL and default-unit users byte-identical, BG-marker parity, and insulin/carbs untouched.
- `test_connect_sync.py` — the data owner's unit is resolved and threaded into the mapper for both mg/dL (default) and mmol/L.

## Verification

- Full API suite green except 5 pre-existing failures unrelated to this change (4 `test_tandem_sync` cases that pass 9/9 in isolation — full-suite ordering pollution; 1 known `test_nightscout_scheduler` Python-3.14 teardown flake).
- Sentry validation gate: a Sentry-enabled run exercised the real connect-sync path (resolve + map + store) for seeded mmol and mg/dL users — ambiguous value dropped for mmol, byte-identical for mg/dL — with no real error issues attributable to the change.

## Out of scope

Per-record conversion without a confirmed unit signal; the Medtronic BLE path (GLY-60 — spec-mandated mg/dL, no change).

Closes #808


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Medtronic glucose data now respects individual user glucose unit preferences (mg/dL vs mmol/L)
  * Enhanced safety validation for mmol/L glucose values to prevent misinterpretation of ambiguous readings

* **Documentation**
  * Clarified glucose unit specifications for pump data reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->