### PR TITLE
fix(food-records): return 404 when a record is deleted mid common-food promotion

### DIFF
--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -408,6 +408,13 @@ async def save_record_as_common_food(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
         ) from exc
+    except common_food_service.RecordGoneError as exc:
+        # The record was deleted out from under the promotion (concurrent delete
+        # during the unique-constraint race fallback): 404, matching how a
+        # missing record signals not-found elsewhere in this router.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
     return CommonFoodResponse.model_validate(common_food)
 
 

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -62,6 +62,10 @@ class DuplicateCommonFoodError(CommonFoodError):
     """A common food with the same (normalized) name already exists."""
 
 
+class RecordGoneError(CommonFoodError):
+    """The food record was concurrently deleted mid-promotion (re-fetch found nothing)."""
+
+
 async def correct_food_record(
     db: AsyncSession,
     record: FoodRecord,
@@ -243,9 +247,17 @@ async def promote_to_common_food(
     if not normalized:
         raise CarbValidationError("Common food name must not be empty.")
 
+    # Capture the record's identifiers before the flush below. The unique-constraint
+    # race fallback rolls the session back, which expires ``record``; reading an
+    # expired column afterwards (``record.id`` / ``record.user_id``) triggers a lazy
+    # reload, and on a concurrently-deleted row that reload fails outright before we
+    # could null-check it. Holding the ids in locals keeps the fallback reload-free.
+    record_id = record.id
+    user_id = record.user_id
+
     existing = await db.scalar(
         select(CommonFood).where(
-            CommonFood.user_id == record.user_id,
+            CommonFood.user_id == user_id,
             CommonFood.normalized_name == normalized,
         )
     )
@@ -257,7 +269,7 @@ async def promote_to_common_food(
         common_food.nutrition_json = nutrition
     else:
         common_food = CommonFood(
-            user_id=record.user_id,
+            user_id=user_id,
             name=name.strip(),
             normalized_name=normalized,
             carbs_low=low,
@@ -273,14 +285,20 @@ async def promote_to_common_food(
         await db.rollback()
         common_food = await db.scalar(
             select(CommonFood).where(
-                CommonFood.user_id == record.user_id,
+                CommonFood.user_id == user_id,
                 CommonFood.normalized_name == normalized,
             )
         )
         if common_food is None:  # pragma: no cover - defensive
             raise
-        # Re-bind the record (the rollback expired it) before linking below.
-        record = await db.get(FoodRecord, record.id)
+        # Re-bind the record (the rollback expired it) before linking below. A
+        # concurrent delete between the initial fetch and here leaves nothing to
+        # re-bind; fail cleanly instead of dereferencing None into a 500.
+        record = await db.get(FoodRecord, record_id)
+        if record is None:
+            raise RecordGoneError(
+                "The food record was deleted before it could be saved as a common food."
+            )
         common_food.name = name.strip()
         common_food.carbs_low = low
         common_food.carbs_high = high
@@ -296,7 +314,7 @@ async def promote_to_common_food(
     # baseline. Best-effort -- an indexing failure must not fail the promotion. The
     # gate read is intentionally outside the try: a flag-resolution error fails
     # closed (surfaces) rather than silently running the gated indexing.
-    if await is_meal_intelligence_enabled(db, record.user_id):
+    if await is_meal_intelligence_enabled(db, user_id):
         try:
             await meal_rag.index_common_food(common_food)
             await meal_rag.index_food_record(record)

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -27,6 +27,7 @@ from src.models.ai_provider import (
     AIProviderType,
 )
 from src.models.food_record import FoodRecord, FoodRecordSource
+from src.services import common_food as common_food_service
 from src.services import food_image, food_vision
 from src.vision import carb_contract
 
@@ -1248,6 +1249,88 @@ class TestCommonFoods:
         assert body["carbs_low"] == 70
         # _estimate_json seeds AI nutrition {"protein_grams": 12, "calories": 520}.
         assert body["nutrition_json"] == {"protein_grams": 12, "calories": 520}
+
+    async def test_promote_concurrent_delete_raises_record_gone(self):
+        # Real-DB exercise of the unique-constraint race fallback. That path rolls the
+        # session back, which EXPIRES the committed in-session record; the re-fetch must
+        # use the ids captured before the rollback, otherwise reloading the expired
+        # (and concurrently-deleted) row blows up (greenlet/IO error) before the
+        # null-check. A mocked or uncommitted in-memory record can't reproduce that
+        # post-rollback expiry, so this is the test that actually guards the fix.
+        #
+        # Dedicated sessions (not the db_session fixture) keep the in-test rollback and
+        # the out-of-band delete on this loop. The record is loaded persistent into the
+        # promotion session, then deleted in a separate committed transaction (a true
+        # concurrent delete); the committed winner baseline survives the rollback as the
+        # "lost the race" winner.
+        from sqlalchemy import delete
+        from sqlalchemy.exc import IntegrityError
+
+        from src.database import get_session_maker
+        from src.models.common_food import CommonFood
+
+        session_maker = get_session_maker()
+        async with session_maker() as db:
+            user = await _new_user(db, "race")
+            db.add(
+                CommonFood(
+                    user_id=user.id,
+                    name="Bagel",
+                    normalized_name="bagel",
+                    carbs_low=40,
+                    carbs_high=55,
+                )
+            )
+            record = FoodRecord(
+                user_id=user.id,
+                filename="m.png",
+                file_type="image/png",
+                file_size_bytes=10,
+                storage_path="x",
+                carbs_low=40,
+                carbs_high=55,
+                nutrition_json={"protein_grams": 12, "calories": 520},
+            )
+            db.add(record)
+            await db.commit()
+            await db.refresh(record)  # record is now persistent + live in this session
+            record_id = record.id
+
+            # A concurrent request deletes the record after it was loaded here but
+            # before the promotion's fallback re-fetch.
+            async with session_maker() as concurrent:
+                await concurrent.execute(
+                    delete(FoodRecord).where(FoodRecord.id == record_id)
+                )
+                await concurrent.commit()
+
+            # Force the unique-constraint race fallback. Only the explicit flush is
+            # patched; autoflush goes through the sync session, so lookups still run.
+            with (
+                patch.object(
+                    db,
+                    "flush",
+                    AsyncMock(side_effect=IntegrityError("dup", {}, Exception())),
+                ),
+                pytest.raises(common_food_service.RecordGoneError),
+            ):
+                await common_food_service.promote_to_common_food(db, record, "Bagel")
+
+    async def test_save_as_common_food_record_gone_returns_404(self, auth_client):
+        # The router maps a concurrent-delete RecordGoneError to a clean 404, the way
+        # a missing record reads elsewhere in this router (never a 500).
+        client, _ = auth_client
+        record_id = (await _create_record(client))["id"]
+        with patch.object(
+            common_food_service,
+            "promote_to_common_food",
+            AsyncMock(side_effect=common_food_service.RecordGoneError("gone")),
+        ):
+            resp = await client.post(
+                f"/api/food-records/{record_id}/save-as-common-food",
+                json={"name": "Bagel"},
+            )
+        assert resp.status_code == 404, resp.text
 
     async def test_update_rejects_partial_carb_range(self, auth_client):
         client, _ = auth_client


### PR DESCRIPTION
## Summary

Fixes a latent HTTP 500 in the "save a meal as a common food" flow when the food record is deleted concurrently mid-promotion. Flagged by Sentry's bug-prediction on the develop→main promotion PR (#796).

## The bug

`promote_to_common_food` dedupes per user on the normalized name. On a unique-constraint race it rolls the session back and re-fetches the record before linking it to the winning baseline. The rollback **expires** the in-session record, so any later attribute access (`record.id`, `record.user_id`) triggers a lazy reload — and if the row was concurrently deleted in that window, the reload raises (and the re-fetch can return `None`), surfacing as an uncaught 500 instead of a clean client error.

## The fix

- Capture the record's `id` and owner id into locals **before** the flush/rollback, so the fallback re-fetch and the winner lookup never dereference the expired instance.
- Null-check the re-fetched record and raise a new `RecordGoneError`, which the router maps to a clean **404** — consistent with how a missing record reads elsewhere in this router.

## Tests

- `test_promote_concurrent_delete_raises_record_gone` — real-DB test driving the genuine rollback + concurrent-delete path (mutation-verified: reverting the capture reintroduces the failure).
- `test_save_as_common_food_record_gone_returns_404` — asserts the router maps `RecordGoneError` to 404.

No behavior change to the normal promote/dedupe path; no dosing or safety surface touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for a rare race condition when saving a food record as a common food item.
  * If the record is removed during processing, the app now returns a clear 404 response instead of an unexpected server error.
  * Made promotion handling more reliable during concurrent updates, reducing failures in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->