### PR TITLE
feat(mobile): make the Home "Log a meal" FAB draggable

### DIFF
--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/AppSettingsStoreMealFabTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/AppSettingsStoreMealFabTest.kt
@@ -59,8 +59,21 @@ class AppSettingsStoreMealFabTest {
         assertEquals(22, store.mealFabOffsetYPx)
     }
 
+    @Test
+    fun mealFabOffset_clearReturnsToUnset() {
+        store.setMealFabOffset(120, 340)
+        store.clearMealFabOffset()
+
+        assertEquals(AppSettingsStore.UNSET_FAB_OFFSET, store.mealFabOffsetXPx)
+        assertEquals(AppSettingsStore.UNSET_FAB_OFFSET, store.mealFabOffsetYPx)
+        // The clear is visible to another store instance (the per-device persistence contract).
+        val reread = AppSettingsStore(context)
+        assertEquals(AppSettingsStore.UNSET_FAB_OFFSET, reread.mealFabOffsetXPx)
+        assertEquals(AppSettingsStore.UNSET_FAB_OFFSET, reread.mealFabOffsetYPx)
+    }
+
     /** Resets the encrypted settings file so default/round-trip assertions are deterministic. */
     private fun clearEncryptedPrefs() {
-        context.deleteSharedPreferences("app_settings_encrypted")
+        context.deleteSharedPreferences(AppSettingsStore.ENCRYPTED_PREFS_NAME)
     }
 }

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/AppSettingsStoreMealFabTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/AppSettingsStoreMealFabTest.kt
@@ -1,0 +1,66 @@
+package com.glycemicgpt.mobile.data.local
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Storage-layer coverage for the draggable meal FAB's persisted position. The ViewModel/UI tests
+ * mock [AppSettingsStore], so the real EncryptedSharedPreferences round-trip and the unset-sentinel
+ * default -- the load-bearing part of the "position persists per device" guarantee -- live here.
+ *
+ * Instrumented (needs the real Android keystore): run with `./gradlew :app:connectedDebugAndroidTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class AppSettingsStoreMealFabTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private lateinit var store: AppSettingsStore
+
+    @Before
+    fun setUp() {
+        clearEncryptedPrefs()
+        store = AppSettingsStore(context)
+    }
+
+    @After
+    fun tearDown() {
+        clearEncryptedPrefs()
+    }
+
+    @Test
+    fun mealFabOffset_defaultsToUnset_whenNeverMoved() {
+        assertEquals(AppSettingsStore.UNSET_FAB_OFFSET, store.mealFabOffsetXPx)
+        assertEquals(AppSettingsStore.UNSET_FAB_OFFSET, store.mealFabOffsetYPx)
+    }
+
+    @Test
+    fun mealFabOffset_roundTripsThroughEncryptedStorage() {
+        store.setMealFabOffset(120, 340)
+
+        assertEquals(120, store.mealFabOffsetXPx)
+        assertEquals(340, store.mealFabOffsetYPx)
+        // The stored value is visible to another store instance (the per-device persistence contract).
+        val reread = AppSettingsStore(context)
+        assertEquals(120, reread.mealFabOffsetXPx)
+        assertEquals(340, reread.mealFabOffsetYPx)
+    }
+
+    @Test
+    fun mealFabOffset_keepsAxesDistinct() {
+        // Guards against a copy-paste key collision: X and Y must use separate storage keys.
+        store.setMealFabOffset(11, 22)
+
+        assertEquals(11, store.mealFabOffsetXPx)
+        assertEquals(22, store.mealFabOffsetYPx)
+    }
+
+    /** Resets the encrypted settings file so default/round-trip assertions are deterministic. */
+    private fun clearEncryptedPrefs() {
+        context.deleteSharedPreferences("app_settings_encrypted")
+    }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/DraggableMealFabUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/DraggableMealFabUiTest.kt
@@ -2,6 +2,7 @@ package com.glycemicgpt.mobile.presentation.meal
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -9,6 +10,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -17,6 +20,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipe
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
 import org.junit.Assert.assertEquals
@@ -29,8 +33,10 @@ import org.junit.runner.RunWith
 
 /**
  * Behavioral guard for the draggable "Log a meal" FAB: a tap still navigates (it isn't swallowed by
- * the drag handler), a drag repositions without navigating, the position is clamped on-screen, and a
- * saved position is restored. The tap-vs-drag disambiguation is the case most likely to regress.
+ * the drag handler), a drag repositions without navigating, the position is clamped on-screen (on
+ * restore and after a container shrink), and the accessibility reset action returns it to the
+ * default. The tap-vs-drag disambiguation and the off-screen re-clamp are the cases most likely to
+ * regress.
  */
 @RunWith(AndroidJUnit4::class)
 class DraggableMealFabUiTest {
@@ -40,7 +46,13 @@ class DraggableMealFabUiTest {
 
     private var clicks = 0
     private var settled: FabOffset? = null
+    private var resetCalled = false
+    private var lastContainerPx = IntSize.Zero
 
+    // A test-controlled container side for the shrink/re-clamp case; read in [setSizedContent].
+    private val containerSide = mutableStateOf(DEFAULT_CONTAINER_SIDE)
+
+    /** Full-screen container -- the common case (container == window). */
     private fun setContent(savedOffset: FabOffset? = null) {
         compose.setContent {
             GlycemicGptTheme {
@@ -48,6 +60,33 @@ class DraggableMealFabUiTest {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
+                        .onSizeChanged {
+                            containerSize = it
+                            lastContainerPx = it
+                        },
+                ) {
+                    DraggableMealFab(
+                        containerSizePx = containerSize,
+                        savedOffset = savedOffset,
+                        onClick = { clicks++ },
+                        onOffsetSettled = { settled = it },
+                        onReset = { resetCalled = true },
+                    )
+                }
+            }
+        }
+    }
+
+    /** Container whose size is driven by [containerSide], so a test can shrink it and re-clamp. */
+    private fun setSizedContent(savedOffset: FabOffset?) {
+        compose.setContent {
+            GlycemicGptTheme {
+                val side by containerSide
+                var containerSize by remember { mutableStateOf(IntSize.Zero) }
+                Box(
+                    modifier = Modifier
+                        .size(side)
+                        .testTag(CONTAINER_TAG)
                         .onSizeChanged { containerSize = it },
                 ) {
                     DraggableMealFab(
@@ -55,6 +94,7 @@ class DraggableMealFabUiTest {
                         savedOffset = savedOffset,
                         onClick = { clicks++ },
                         onOffsetSettled = { settled = it },
+                        onReset = { resetCalled = true },
                     )
                 }
             }
@@ -84,8 +124,8 @@ class DraggableMealFabUiTest {
         val fab = fabBounds()
         // With no saved offset the FAB defaults to the bottom-end, not the top-left -- this pins the
         // default-placement wiring (and would catch a never-settling zero-size resolve()).
-        assertTrue("rests near the bottom edge", fab.bottom.value > root.bottom.value - 48f)
-        assertTrue("rests near the end edge", fab.right.value > root.right.value - 48f)
+        assertTrue("rests near the bottom edge", fab.bottom.value > root.bottom.value - EDGE_SLACK)
+        assertTrue("rests near the end edge", fab.right.value > root.right.value - EDGE_SLACK)
     }
 
     @Test
@@ -129,6 +169,7 @@ class DraggableMealFabUiTest {
     @Test
     fun drag_past_the_edge_keeps_the_fab_on_screen() {
         setContent()
+        compose.waitForIdle()
 
         compose.onNodeWithTag(FAB_TAG).performTouchInput {
             // Drag far past the bottom-right corner; the clamp must keep the FAB on-screen.
@@ -142,6 +183,14 @@ class DraggableMealFabUiTest {
         assertTrue("top in bounds", fab.top.value >= root.top.value - POS_EPS)
         assertTrue("right in bounds", fab.right.value <= root.right.value + POS_EPS)
         assertTrue("bottom in bounds", fab.bottom.value <= root.bottom.value + POS_EPS)
+
+        // The *persisted* value must be clamped too, not just the visual bounds -- a drag past the
+        // edge can't store an out-of-range offset that a later restore would have to fix up.
+        val fabPx = compose.onNodeWithTag(FAB_TAG).fetchSemanticsNode().size
+        val s = settled
+        assertNotNull("a drag must settle a position", s)
+        assertTrue("settled x clamped", s!!.x in 0f..(lastContainerPx.width - fabPx.width).toFloat())
+        assertTrue("settled y clamped", s.y in 0f..(lastContainerPx.height - fabPx.height).toFloat())
     }
 
     @Test
@@ -151,12 +200,83 @@ class DraggableMealFabUiTest {
         compose.waitForIdle()
 
         val fab = fabBounds()
-        assertTrue("restored at the top, not bottom-end", fab.top.value < 100f)
-        assertTrue("restored at the start, not bottom-end", fab.left.value < 100f)
+        assertTrue("restored at the top, not bottom-end", fab.top.value < NEAR_EDGE)
+        assertTrue("restored at the start, not bottom-end", fab.left.value < NEAR_EDGE)
+    }
+
+    @Test
+    fun a_stale_out_of_bounds_saved_position_is_reclamped_on_screen() {
+        // A saved offset far outside any container (e.g. from a larger past layout) must be pulled
+        // back on-screen on restore -- this pins the re-clamp path savedOffset -> resolve() -> clamp.
+        setContent(savedOffset = FabOffset(99_999f, 99_999f))
+        compose.waitForIdle()
+
+        val root = compose.onRoot().getUnclippedBoundsInRoot()
+        val fab = fabBounds()
+        assertTrue("left in bounds", fab.left.value >= root.left.value - POS_EPS)
+        assertTrue("top in bounds", fab.top.value >= root.top.value - POS_EPS)
+        assertTrue("right in bounds", fab.right.value <= root.right.value + POS_EPS)
+        assertTrue("bottom in bounds", fab.bottom.value <= root.bottom.value + POS_EPS)
+    }
+
+    @Test
+    fun shrinking_the_container_reclamps_the_fab_on_screen() {
+        // Save the FAB far in the corner of a large container, then shrink (the rotation/resize case):
+        // the re-clamp must pull it back inside the now-smaller bounds.
+        setSizedContent(savedOffset = FabOffset(100_000f, 100_000f))
+        compose.waitForIdle()
+
+        compose.runOnIdle { containerSide.value = SHRUNK_CONTAINER_SIDE }
+        compose.waitForIdle()
+
+        val container = compose.onNodeWithTag(CONTAINER_TAG).getUnclippedBoundsInRoot()
+        val fab = fabBounds()
+        assertTrue("left in bounds", fab.left.value >= container.left.value - POS_EPS)
+        assertTrue("top in bounds", fab.top.value >= container.top.value - POS_EPS)
+        assertTrue("right in bounds", fab.right.value <= container.right.value + POS_EPS)
+        assertTrue("bottom in bounds", fab.bottom.value <= container.bottom.value + POS_EPS)
+    }
+
+    @Test
+    fun accessibility_reset_action_returns_the_fab_to_the_default() {
+        setContent()
+        compose.waitForIdle()
+        // Move it well away from the default first.
+        compose.onNodeWithTag(FAB_TAG).performTouchInput {
+            swipe(start = center, end = Offset(center.x - 200f, center.y - 300f), durationMillis = 200)
+        }
+        compose.waitForIdle()
+
+        val resetAction = compose.onNodeWithTag(FAB_TAG)
+            .fetchSemanticsNode()
+            .config.getOrElseNullable(SemanticsActions.CustomActions) { null }
+            .orEmpty()
+            .firstOrNull { it.label == RESET_FAB_ACTION_LABEL }
+        assertNotNull("a reset accessibility action must be exposed for screen readers", resetAction)
+        compose.runOnUiThread { resetAction!!.action() }
+        compose.waitForIdle()
+
+        assertTrue("reset callback fired", resetCalled)
+        val root = compose.onRoot().getUnclippedBoundsInRoot()
+        val fab = fabBounds()
+        assertTrue("returned to the bottom edge", fab.bottom.value > root.bottom.value - EDGE_SLACK)
+        assertTrue("returned to the end edge", fab.right.value > root.right.value - EDGE_SLACK)
     }
 
     private companion object {
         const val FAB_TAG = "home_meal_fab"
+        const val CONTAINER_TAG = "fab_container"
+
+        // Tolerance for visual-bounds assertions (sub-pixel rounding on getUnclippedBoundsInRoot).
         const val POS_EPS = 2f
+
+        // The default/reset placement rests within this of the bottom-end edge (FAB margin + slack).
+        const val EDGE_SLACK = 48f
+
+        // A restored top-left offset sits within this of the origin.
+        const val NEAR_EDGE = 100f
+
+        val DEFAULT_CONTAINER_SIDE = 600.dp
+        val SHRUNK_CONTAINER_SIDE = 280.dp
     }
 }

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/DraggableMealFabUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/DraggableMealFabUiTest.kt
@@ -1,0 +1,162 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.unit.IntSize
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Behavioral guard for the draggable "Log a meal" FAB: a tap still navigates (it isn't swallowed by
+ * the drag handler), a drag repositions without navigating, the position is clamped on-screen, and a
+ * saved position is restored. The tap-vs-drag disambiguation is the case most likely to regress.
+ */
+@RunWith(AndroidJUnit4::class)
+class DraggableMealFabUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private var clicks = 0
+    private var settled: FabOffset? = null
+
+    private fun setContent(savedOffset: FabOffset? = null) {
+        compose.setContent {
+            GlycemicGptTheme {
+                var containerSize by remember { mutableStateOf(IntSize.Zero) }
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .onSizeChanged { containerSize = it },
+                ) {
+                    DraggableMealFab(
+                        containerSizePx = containerSize,
+                        savedOffset = savedOffset,
+                        onClick = { clicks++ },
+                        onOffsetSettled = { settled = it },
+                    )
+                }
+            }
+        }
+    }
+
+    private fun fabBounds() = compose.onNodeWithTag(FAB_TAG).getUnclippedBoundsInRoot()
+
+    @Test
+    fun tap_navigates_without_repositioning() {
+        setContent()
+
+        compose.onNodeWithTag(FAB_TAG).performClick()
+        compose.waitForIdle()
+
+        assertEquals("a tap must trigger navigation", 1, clicks)
+        // No drag settled, so the position is untouched -- a tap is not a reposition.
+        assertNull("a tap must not settle a new position", settled)
+    }
+
+    @Test
+    fun default_position_rests_at_the_bottom_end() {
+        setContent()
+        compose.waitForIdle()
+
+        val root = compose.onRoot().getUnclippedBoundsInRoot()
+        val fab = fabBounds()
+        // With no saved offset the FAB defaults to the bottom-end, not the top-left -- this pins the
+        // default-placement wiring (and would catch a never-settling zero-size resolve()).
+        assertTrue("rests near the bottom edge", fab.bottom.value > root.bottom.value - 48f)
+        assertTrue("rests near the end edge", fab.right.value > root.right.value - 48f)
+    }
+
+    @Test
+    fun drag_repositions_without_navigating() {
+        setContent()
+        val before = fabBounds()
+
+        compose.onNodeWithTag(FAB_TAG).performTouchInput {
+            swipe(start = center, end = Offset(center.x - 250f, center.y - 350f), durationMillis = 200)
+        }
+        compose.waitForIdle()
+
+        assertEquals("a drag must not navigate", 0, clicks)
+        assertNotNull("a drag must settle a new position", settled)
+        val after = fabBounds()
+        // Dragged up and to the left, so the FAB's top-left moves accordingly.
+        assertTrue("FAB should move up", after.top.value < before.top.value - 1f)
+        assertTrue("FAB should move left", after.left.value < before.left.value - 1f)
+    }
+
+    @Test
+    fun small_drag_follows_the_finger_and_does_not_snap_to_the_origin() {
+        setContent()
+        compose.waitForIdle()
+        val root = compose.onRoot().getUnclippedBoundsInRoot()
+        val before = fabBounds()
+
+        compose.onNodeWithTag(FAB_TAG).performTouchInput {
+            swipe(start = center, end = Offset(center.x - 120f, center.y - 120f), durationMillis = 200)
+        }
+        compose.waitForIdle()
+
+        val after = fabBounds()
+        // A small drag from the bottom-end default nudges the FAB up a little; it must follow the
+        // finger and stay in the lower half -- not collapse to the top-left origin, which clamping
+        // against a stale/zero container size would force.
+        assertTrue("FAB moved up with the finger", after.top.value < before.top.value)
+        assertTrue("FAB stayed in the lower half", after.bottom.value > root.bottom.value / 2)
+    }
+
+    @Test
+    fun drag_past_the_edge_keeps_the_fab_on_screen() {
+        setContent()
+
+        compose.onNodeWithTag(FAB_TAG).performTouchInput {
+            // Drag far past the bottom-right corner; the clamp must keep the FAB on-screen.
+            swipe(start = center, end = Offset(center.x + 5000f, center.y + 5000f), durationMillis = 200)
+        }
+        compose.waitForIdle()
+
+        val root = compose.onRoot().getUnclippedBoundsInRoot()
+        val fab = fabBounds()
+        assertTrue("left in bounds", fab.left.value >= root.left.value - POS_EPS)
+        assertTrue("top in bounds", fab.top.value >= root.top.value - POS_EPS)
+        assertTrue("right in bounds", fab.right.value <= root.right.value + POS_EPS)
+        assertTrue("bottom in bounds", fab.bottom.value <= root.bottom.value + POS_EPS)
+    }
+
+    @Test
+    fun a_saved_position_is_restored() {
+        // A saved top-left position must place the FAB at the top-left, not the default bottom-end.
+        setContent(savedOffset = FabOffset(0f, 0f))
+        compose.waitForIdle()
+
+        val fab = fabBounds()
+        assertTrue("restored at the top, not bottom-end", fab.top.value < 100f)
+        assertTrue("restored at the start, not bottom-end", fab.left.value < 100f)
+    }
+
+    private companion object {
+        const val FAB_TAG = "home_meal_fab"
+        const val POS_EPS = 2f
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -204,6 +204,29 @@ class AppSettingsStore @Inject constructor(
         awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
     }
 
+    /**
+     * Persisted top-left position (px) of the draggable Home "Log a meal" FAB, or [UNSET_FAB_OFFSET]
+     * on an axis the user has never set (fall back to the default bottom-end placement). Per-device
+     * UI state only -- a local placement preference, never synced to the account. Read-only here;
+     * write the pair atomically via [setMealFabOffset]. Bounds are intentionally enforced in the
+     * placement layer (clampFabOffset), not on write, so a stale value self-corrects against the
+     * live container size.
+     */
+    val mealFabOffsetXPx: Int
+        get() = prefs.getInt(KEY_MEAL_FAB_OFFSET_X, UNSET_FAB_OFFSET)
+
+    /** Persisted top-left Y (px) of the draggable Home meal FAB; see [mealFabOffsetXPx]. */
+    val mealFabOffsetYPx: Int
+        get() = prefs.getInt(KEY_MEAL_FAB_OFFSET_Y, UNSET_FAB_OFFSET)
+
+    /** Persist the FAB position (px) as one atomic edit, so an interrupted write can't tear X from Y. */
+    fun setMealFabOffset(x: Int, y: Int) {
+        prefs.edit()
+            .putInt(KEY_MEAL_FAB_OFFSET_X, x)
+            .putInt(KEY_MEAL_FAB_OFFSET_Y, y)
+            .apply()
+    }
+
     // Watch face config persistence
     var watchFaceShowIoB: Boolean
         get() = prefs.getBoolean(KEY_WATCHFACE_SHOW_IOB, true)
@@ -283,6 +306,11 @@ class AppSettingsStore @Inject constructor(
         internal const val KEY_GLUCOSE_UNIT = "glucose_unit"
         internal const val KEY_GLUCOSE_UNIT_SEED_PENDING = "glucose_unit_seed_pending"
         internal const val KEY_MEAL_INTELLIGENCE_ENABLED = "meal_intelligence_enabled"
+        private const val KEY_MEAL_FAB_OFFSET_X = "meal_fab_offset_x"
+        private const val KEY_MEAL_FAB_OFFSET_Y = "meal_fab_offset_y"
+
+        /** Sentinel for a meal-FAB offset the user has never set (use the default position). */
+        const val UNSET_FAB_OFFSET = Int.MIN_VALUE
         const val DEFAULT_RETENTION_DAYS = 7
         const val MIN_RETENTION_DAYS = 1
         const val MAX_RETENTION_DAYS = 30

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -227,6 +227,14 @@ class AppSettingsStore @Inject constructor(
             .apply()
     }
 
+    /** Forget the saved FAB position so it falls back to the default bottom-end placement. */
+    fun clearMealFabOffset() {
+        prefs.edit()
+            .remove(KEY_MEAL_FAB_OFFSET_X)
+            .remove(KEY_MEAL_FAB_OFFSET_Y)
+            .apply()
+    }
+
     // Watch face config persistence
     var watchFaceShowIoB: Boolean
         get() = prefs.getBoolean(KEY_WATCHFACE_SHOW_IOB, true)
@@ -296,7 +304,7 @@ class AppSettingsStore @Inject constructor(
     companion object {
         private val VALID_WATCHFACE_GRAPH_RANGES = listOf(1, 3, 6)
         private const val OLD_PREFS_NAME = "app_settings"
-        private const val ENCRYPTED_PREFS_NAME = "app_settings_encrypted"
+        internal const val ENCRYPTED_PREFS_NAME = "app_settings_encrypted"
         private const val KEY_ONBOARDING_COMPLETE = "onboarding_complete"
         private const val KEY_BACKEND_SYNC_ENABLED = "backend_sync_enabled"
         private const val KEY_DATA_RETENTION_DAYS = "data_retention_days"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModel.kt
@@ -83,6 +83,11 @@ class HomeMealViewModel @Inject constructor(
         appSettingsStore.setMealFabOffset(offset.x.roundToInt(), offset.y.roundToInt())
     }
 
+    /** Forget the saved FAB position so it returns to the default placement (accessibility reset). */
+    fun resetFabOffset() {
+        appSettingsStore.clearMealFabOffset()
+    }
+
     /** Re-fetch the most recent meal; safe to call on Home resume / pull-to-refresh. */
     fun refresh() {
         // The local setting gates the FAB without a round-trip; skip the probe when off.

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModel.kt
@@ -3,9 +3,11 @@ package com.glycemicgpt.mobile.presentation.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore.Companion.UNSET_FAB_OFFSET
 import com.glycemicgpt.mobile.data.meal.FoodRecord
 import com.glycemicgpt.mobile.data.meal.MealException
 import com.glycemicgpt.mobile.data.repository.MealRepository
+import com.glycemicgpt.mobile.presentation.meal.FabOffset
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,6 +16,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 /**
  * Drives the Home meal glance (the camera FAB + Recent-meal card) independently of the pump-data
@@ -59,6 +62,25 @@ class HomeMealViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * The user's saved FAB position (px), or null if they've never moved it (use the default
+     * placement). Read once when Home first composes -- a per-device UI preference, not reactive.
+     */
+    fun savedFabOffset(): FabOffset? {
+        val x = appSettingsStore.mealFabOffsetXPx
+        val y = appSettingsStore.mealFabOffsetYPx
+        return if (x == UNSET_FAB_OFFSET || y == UNSET_FAB_OFFSET) {
+            null
+        } else {
+            FabOffset(x.toFloat(), y.toFloat())
+        }
+    }
+
+    /** Persist the FAB position (px) once a drag settles, so it survives navigation and restarts. */
+    fun persistFabOffset(offset: FabOffset) {
+        appSettingsStore.setMealFabOffset(offset.x.roundToInt(), offset.y.roundToInt())
     }
 
     /** Re-fetch the most recent meal; safe to call on Home resume / pull-to-refresh. */

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -36,12 +36,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
-import com.glycemicgpt.mobile.presentation.meal.MealFab
+import com.glycemicgpt.mobile.presentation.meal.DraggableMealFab
 import com.glycemicgpt.mobile.presentation.meal.RecentMealCard
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.presentation.plugin.PluginDashboardCardRenderer
@@ -71,6 +73,11 @@ fun HomeScreen(
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         if (firstResume) firstResume = false else mealViewModel.refresh()
     }
+    // Draggable meal FAB: the container size feeds the on-screen clamp; the saved placement is read
+    // once here (a per-device UI preference, not a reactive flow) and tracked in state so a drag is
+    // reflected if the FAB is hidden then shown again within this Home session.
+    var containerSizePx by remember { mutableStateOf(IntSize.Zero) }
+    var savedFabOffset by remember { mutableStateOf(mealViewModel.savedFabOffset()) }
     val connectionState by viewModel.connectionState.collectAsState()
     val cgm by viewModel.cgm.collectAsState()
     val iob by viewModel.iob.collectAsState()
@@ -106,7 +113,9 @@ fun HomeScreen(
             viewModel.refreshData()
             mealViewModel.refresh()
         },
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .onSizeChanged { containerSizePx = it },
     ) {
         Column(
             modifier = Modifier
@@ -234,15 +243,18 @@ fun HomeScreen(
             }
         }
 
-        // Extended camera FAB (Epic 50) — overlaid in the pull-to-refresh BoxScope, hidden when
-        // the user's per-account meal-intelligence setting is off (instant on toggle) or the
-        // server reports the feature disabled.
+        // Camera FAB overlaid in the pull-to-refresh BoxScope, hidden when the user's per-account
+        // meal-intelligence setting is off (instant on toggle) or the server reports it disabled.
+        // Draggable so the user can move it off the data underneath; its position persists per device.
         if (mealState.mealLoggingAvailable) {
-            MealFab(
+            DraggableMealFab(
+                containerSizePx = containerSizePx,
+                savedOffset = savedFabOffset,
                 onClick = onNavigateToMealLog,
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp),
+                onOffsetSettled = {
+                    mealViewModel.persistFabOffset(it)
+                    savedFabOffset = it
+                },
             )
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -255,6 +255,10 @@ fun HomeScreen(
                     mealViewModel.persistFabOffset(it)
                     savedFabOffset = it
                 },
+                onReset = {
+                    mealViewModel.resetFabOffset()
+                    savedFabOffset = null
+                },
             )
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealFabPlacement.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealFabPlacement.kt
@@ -1,0 +1,48 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+/**
+ * Pure placement math for the draggable "Log a meal" FAB, kept free of Compose types so it can be
+ * unit-tested on the JVM. All values are pixels relative to the FAB's container.
+ */
+
+/** The FAB's top-left position, in pixels from its container's top-left corner. */
+data class FabOffset(val x: Float, val y: Float)
+
+/**
+ * The FAB's default resting position: the bottom-end of the container, inset by [marginPx] from the
+ * right and bottom edges -- reproducing the original fixed `align(BottomEnd).padding(16.dp)` look.
+ *
+ * The result is not clamped here; callers run it through [clampFabOffset] so a container smaller than
+ * the FAB can't produce a negative resting position.
+ */
+fun defaultFabOffset(
+    fabWidth: Float,
+    fabHeight: Float,
+    containerWidth: Float,
+    containerHeight: Float,
+    marginPx: Float,
+): FabOffset = FabOffset(
+    x = containerWidth - fabWidth - marginPx,
+    y = containerHeight - fabHeight - marginPx,
+)
+
+/**
+ * Clamp [offset] so the FAB stays fully inside the container and can never be stranded off-screen.
+ * The host insets the container for system bars, so container-relative bounds already keep the FAB
+ * out from behind them. When the container is smaller than the FAB, the FAB is pinned to the
+ * top-left rather than allowed to drift to a negative position.
+ */
+fun clampFabOffset(
+    offset: FabOffset,
+    fabWidth: Float,
+    fabHeight: Float,
+    containerWidth: Float,
+    containerHeight: Float,
+): FabOffset {
+    val maxX = (containerWidth - fabWidth).coerceAtLeast(0f)
+    val maxY = (containerHeight - fabHeight).coerceAtLeast(0f)
+    return FabOffset(
+        x = offset.x.coerceIn(0f, maxX),
+        y = offset.y.coerceIn(0f, maxY),
+    )
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHomeComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHomeComponents.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -180,11 +181,12 @@ fun BoxScope.DraggableMealFab(
     // against the *current* bounds -- including after a rotation/resize.
     val container by rememberUpdatedState(containerSizePx)
     // The user's chosen position, or null until they first drag (then use the default placement).
-    // Seeded once from [savedOffset]; the key is intentionally absent so this single MutableState
-    // stays stable for the gesture handler's lifetime (a re-key would strand the drag closures on a
-    // dead state). A new saved value is picked up when the FAB re-enters composition -- e.g. when it
-    // is hidden then shown -- which also re-clamps it to the current bounds.
+    // The key is intentionally absent so this single MutableState stays stable for the gesture
+    // handler's lifetime (a re-key would allocate a new state and strand the drag closures on a dead
+    // one). A changed [savedOffset] -- a late settings load, or a reset -- is synced into that same
+    // stable state below, so the closures keep reading the live value.
     var dragOffset by remember { mutableStateOf(savedOffset) }
+    LaunchedEffect(savedOffset) { dragOffset = savedOffset }
 
     // Resolve to a concrete, clamped, on-screen position from the latest measured sizes. Computed in
     // the placement lambda below (not a LaunchedEffect) so it tracks the current sizes without a

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHomeComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHomeComponents.kt
@@ -38,6 +38,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
@@ -140,8 +143,15 @@ fun MealFab(onClick: () -> Unit, modifier: Modifier = Modifier) {
     )
 }
 
-/** Inset the FAB keeps from the container edges in its default bottom-end resting position. */
+/**
+ * Inset the FAB keeps from the container edges in its *default* resting position. A deliberate drag
+ * may still place the FAB flush to an edge (the clamp uses the full container bounds); this margin
+ * only gives the untouched default placement some breathing room.
+ */
 private val FAB_EDGE_MARGIN = 16.dp
+
+/** TalkBack action label to return the FAB to its default placement (drag is pointer-only). */
+internal const val RESET_FAB_ACTION_LABEL = "Reset position to default"
 
 /**
  * The Home "Log a meal" FAB, draggable so the user can move it off their data and back. Wraps the
@@ -151,7 +161,8 @@ private val FAB_EDGE_MARGIN = 16.dp
  * Positions are clamped to [containerSizePx] -- which the host has already inset for system bars --
  * so the FAB can never strand off-screen. A settled position is reported via [onOffsetSettled] for
  * persistence; [savedOffset] restores it, re-clamped to the current bounds so a stale value (from a
- * smaller past layout, or the FAB toggling hidden then shown) can't place it out of view.
+ * smaller past layout, or the FAB toggling hidden then shown) can't place it out of view. [onReset]
+ * clears the saved position so the accessibility action can return the FAB to its default spot.
  */
 @Composable
 fun BoxScope.DraggableMealFab(
@@ -159,6 +170,7 @@ fun BoxScope.DraggableMealFab(
     savedOffset: FabOffset?,
     onClick: () -> Unit,
     onOffsetSettled: (FabOffset) -> Unit,
+    onReset: () -> Unit,
 ) {
     val marginPx = with(LocalDensity.current) { FAB_EDGE_MARGIN.toPx() }
     var fabSizePx by remember { mutableStateOf(IntSize.Zero) }
@@ -174,9 +186,10 @@ fun BoxScope.DraggableMealFab(
     // is hidden then shown -- which also re-clamps it to the current bounds.
     var dragOffset by remember { mutableStateOf(savedOffset) }
 
-    // Resolve to a concrete, clamped, on-screen position from the latest sizes. Computed in the
-    // placement lambda below (not a LaunchedEffect) so it is correct on the first frame -- no flash
-    // from a transient top-left position before the offset settles.
+    // Resolve to a concrete, clamped, on-screen position from the latest measured sizes. Computed in
+    // the placement lambda below (not a LaunchedEffect) so it tracks the current sizes without a
+    // recomposition lag. Until the FAB and container are measured it resolves to the top-left; that
+    // is corrected within the same layout pass once onSizeChanged reports their real sizes.
     fun resolve(): FabOffset {
         val fabW = fabSizePx.width.toFloat()
         val fabH = fabSizePx.height.toFloat()
@@ -195,6 +208,17 @@ fun BoxScope.DraggableMealFab(
                 IntOffset(resolved.x.roundToInt(), resolved.y.roundToInt())
             }
             .onSizeChanged { fabSizePx = it }
+            .semantics {
+                // Drag is pointer-only; give screen-reader users a way to recover the FAB to its
+                // default spot if it ends up over content they need.
+                customActions = listOf(
+                    CustomAccessibilityAction(RESET_FAB_ACTION_LABEL) {
+                        dragOffset = null
+                        onReset()
+                        true
+                    },
+                )
+            }
             .pointerInput(Unit) {
                 detectDragGestures(
                     onDragEnd = { onOffsetSettled(resolve()) },
@@ -203,7 +227,9 @@ fun BoxScope.DraggableMealFab(
                     // Consuming only here (past touch slop) keeps a tap free to reach the FAB's
                     // onClick, while a drag repositions without triggering a click.
                     change.consume()
-                    val from = dragOffset ?: resolve()
+                    // Start from the current clamped on-screen position (not the raw stored value),
+                    // so a drag right after a container shrink can't jump from a now-stale base.
+                    val from = resolve()
                     dragOffset = clampFabOffset(
                         FabOffset(from.x + dragAmount.x, from.y + dragAmount.y),
                         fabSizePx.width.toFloat(),

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHomeComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHomeComponents.kt
@@ -1,13 +1,16 @@
 package com.glycemicgpt.mobile.presentation.meal
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -23,13 +26,24 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.glycemicgpt.mobile.data.meal.FoodRecord
+import kotlin.math.roundToInt
 
 /**
  * Home "Recent meal" glance: the most recent logged meal with its carb range, confidence, and the
@@ -123,5 +137,81 @@ fun MealFab(onClick: () -> Unit, modifier: Modifier = Modifier) {
         icon = { Icon(Icons.Default.PhotoCamera, contentDescription = null) },
         text = { Text("Log a meal") },
         modifier = modifier.testTag("home_meal_fab"),
+    )
+}
+
+/** Inset the FAB keeps from the container edges in its default bottom-end resting position. */
+private val FAB_EDGE_MARGIN = 16.dp
+
+/**
+ * The Home "Log a meal" FAB, draggable so the user can move it off their data and back. Wraps the
+ * tap-only [MealFab]: the FAB keeps its own onClick, while this owns the drag offset, so a tap still
+ * navigates and a drag (past touch slop) repositions instead of clicking.
+ *
+ * Positions are clamped to [containerSizePx] -- which the host has already inset for system bars --
+ * so the FAB can never strand off-screen. A settled position is reported via [onOffsetSettled] for
+ * persistence; [savedOffset] restores it, re-clamped to the current bounds so a stale value (from a
+ * smaller past layout, or the FAB toggling hidden then shown) can't place it out of view.
+ */
+@Composable
+fun BoxScope.DraggableMealFab(
+    containerSizePx: IntSize,
+    savedOffset: FabOffset?,
+    onClick: () -> Unit,
+    onOffsetSettled: (FabOffset) -> Unit,
+) {
+    val marginPx = with(LocalDensity.current) { FAB_EDGE_MARGIN.toPx() }
+    var fabSizePx by remember { mutableStateOf(IntSize.Zero) }
+    // The pointerInput(Unit) gesture closures below are created once and capture their scope, so a
+    // raw [containerSizePx] read there would freeze at the first-frame size (the parent only learns
+    // its size later, via onSizeChanged). Route it through a stable State so the drag always clamps
+    // against the *current* bounds -- including after a rotation/resize.
+    val container by rememberUpdatedState(containerSizePx)
+    // The user's chosen position, or null until they first drag (then use the default placement).
+    // Seeded once from [savedOffset]; the key is intentionally absent so this single MutableState
+    // stays stable for the gesture handler's lifetime (a re-key would strand the drag closures on a
+    // dead state). A new saved value is picked up when the FAB re-enters composition -- e.g. when it
+    // is hidden then shown -- which also re-clamps it to the current bounds.
+    var dragOffset by remember { mutableStateOf(savedOffset) }
+
+    // Resolve to a concrete, clamped, on-screen position from the latest sizes. Computed in the
+    // placement lambda below (not a LaunchedEffect) so it is correct on the first frame -- no flash
+    // from a transient top-left position before the offset settles.
+    fun resolve(): FabOffset {
+        val fabW = fabSizePx.width.toFloat()
+        val fabH = fabSizePx.height.toFloat()
+        val containerW = container.width.toFloat()
+        val containerH = container.height.toFloat()
+        val base = dragOffset ?: defaultFabOffset(fabW, fabH, containerW, containerH, marginPx)
+        return clampFabOffset(base, fabW, fabH, containerW, containerH)
+    }
+
+    MealFab(
+        onClick = onClick,
+        modifier = Modifier
+            .align(Alignment.TopStart)
+            .offset {
+                val resolved = resolve()
+                IntOffset(resolved.x.roundToInt(), resolved.y.roundToInt())
+            }
+            .onSizeChanged { fabSizePx = it }
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragEnd = { onOffsetSettled(resolve()) },
+                    onDragCancel = { onOffsetSettled(resolve()) },
+                ) { change, dragAmount ->
+                    // Consuming only here (past touch slop) keeps a tap free to reach the FAB's
+                    // onClick, while a drag repositions without triggering a click.
+                    change.consume()
+                    val from = dragOffset ?: resolve()
+                    dragOffset = clampFabOffset(
+                        FabOffset(from.x + dragAmount.x, from.y + dragAmount.y),
+                        fabSizePx.width.toFloat(),
+                        fabSizePx.height.toFloat(),
+                        container.width.toFloat(),
+                        container.height.toFloat(),
+                    )
+                }
+            },
     )
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModelTest.kt
@@ -182,4 +182,16 @@ class HomeMealViewModelTest {
 
             verify(exactly = 1) { appSettingsStore.setMealFabOffset(120, 341) }
         }
+
+    @Test
+    fun `resetFabOffset clears the stored position`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns Result.success(emptyList())
+        every { appSettingsStore.clearMealFabOffset() } just Runs
+        val vm = HomeMealViewModel(repository, appSettingsStore)
+        advanceUntilIdle()
+
+        vm.resetFabOffset()
+
+        verify(exactly = 1) { appSettingsStore.clearMealFabOffset() }
+    }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeMealViewModelTest.kt
@@ -1,16 +1,21 @@
 package com.glycemicgpt.mobile.presentation.home
 
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore.Companion.UNSET_FAB_OFFSET
 import com.glycemicgpt.mobile.data.meal.CarbConfidence
 import com.glycemicgpt.mobile.data.meal.CarbRange
 import com.glycemicgpt.mobile.data.meal.FoodRecord
 import com.glycemicgpt.mobile.data.meal.FoodRecordSource
 import com.glycemicgpt.mobile.data.meal.MealException
 import com.glycemicgpt.mobile.data.repository.MealRepository
+import com.glycemicgpt.mobile.presentation.meal.FabOffset
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -128,5 +133,53 @@ class HomeMealViewModelTest {
 
             assertNull(vm.uiState.value.recentMeal)
             assertTrue(vm.uiState.value.mealLoggingAvailable)
+        }
+
+    @Test
+    fun `savedFabOffset is null when the user has never moved the FAB`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns Result.success(emptyList())
+        every { appSettingsStore.mealFabOffsetXPx } returns UNSET_FAB_OFFSET
+        every { appSettingsStore.mealFabOffsetYPx } returns UNSET_FAB_OFFSET
+        val vm = HomeMealViewModel(repository, appSettingsStore)
+        advanceUntilIdle()
+
+        assertNull(vm.savedFabOffset())
+    }
+
+    @Test
+    fun `savedFabOffset returns the stored px position`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns Result.success(emptyList())
+        every { appSettingsStore.mealFabOffsetXPx } returns 120
+        every { appSettingsStore.mealFabOffsetYPx } returns 340
+        val vm = HomeMealViewModel(repository, appSettingsStore)
+        advanceUntilIdle()
+
+        val offset = vm.savedFabOffset()
+        assertEquals(FabOffset(120f, 340f), offset)
+    }
+
+    @Test
+    fun `savedFabOffset is null when only one axis is set`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns Result.success(emptyList())
+        every { appSettingsStore.mealFabOffsetXPx } returns 120
+        every { appSettingsStore.mealFabOffsetYPx } returns UNSET_FAB_OFFSET
+        val vm = HomeMealViewModel(repository, appSettingsStore)
+        advanceUntilIdle()
+
+        // Either axis unset means "never placed" -> default, never a half-resolved coordinate.
+        assertNull(vm.savedFabOffset())
+    }
+
+    @Test
+    fun `persistFabOffset writes the rounded px position in one atomic call`() =
+        runTest(testDispatcher) {
+            coEvery { repository.listFoodRecords(any(), any()) } returns Result.success(emptyList())
+            every { appSettingsStore.setMealFabOffset(any(), any()) } just Runs
+            val vm = HomeMealViewModel(repository, appSettingsStore)
+            advanceUntilIdle()
+
+            vm.persistFabOffset(FabOffset(120.4f, 340.6f))
+
+            verify(exactly = 1) { appSettingsStore.setMealFabOffset(120, 341) }
         }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealFabPlacementTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealFabPlacementTest.kt
@@ -1,0 +1,84 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Guards the draggable meal FAB's placement math: the FAB can never strand off-screen (clamped to
+ * the container) and its default resting spot is the bottom-end, inset by the edge margin.
+ */
+class MealFabPlacementTest {
+
+    // A representative container (px) and FAB size for the clamp cases.
+    private val containerW = 1080f
+    private val containerH = 1920f
+    private val fabW = 360f
+    private val fabH = 144f
+    private val maxX = containerW - fabW // 720
+    private val maxY = containerH - fabH // 1776
+
+    private fun clamp(x: Float, y: Float) =
+        clampFabOffset(FabOffset(x, y), fabW, fabH, containerW, containerH)
+
+    @Test
+    fun `an in-bounds offset is left unchanged`() {
+        val result = clamp(200f, 500f)
+        assertEquals(200f, result.x, EPS)
+        assertEquals(500f, result.y, EPS)
+    }
+
+    @Test
+    fun `dragging past the right edge clamps to the right bound`() {
+        val result = clamp(containerW + 500f, 500f)
+        assertEquals(maxX, result.x, EPS)
+    }
+
+    @Test
+    fun `dragging past the bottom edge clamps to the bottom bound`() {
+        val result = clamp(200f, containerH + 500f)
+        assertEquals(maxY, result.y, EPS)
+    }
+
+    @Test
+    fun `dragging past the left or top edge clamps to zero, never negative`() {
+        val result = clamp(-300f, -300f)
+        assertEquals(0f, result.x, EPS)
+        assertEquals(0f, result.y, EPS)
+    }
+
+    @Test
+    fun `a container smaller than the FAB pins it to the top-left, not off-screen`() {
+        val result = clampFabOffset(FabOffset(50f, 50f), fabW, fabH, 100f, 100f)
+        assertEquals(0f, result.x, EPS)
+        assertEquals(0f, result.y, EPS)
+    }
+
+    @Test
+    fun `an unmeasured zero container yields the top-left, not a negative offset`() {
+        val result = clampFabOffset(FabOffset(0f, 0f), fabW, fabH, 0f, 0f)
+        assertEquals(0f, result.x, EPS)
+        assertEquals(0f, result.y, EPS)
+    }
+
+    @Test
+    fun `the default position is the bottom-end, inset by the margin on both axes`() {
+        val margin = 48f
+        val result = defaultFabOffset(fabW, fabH, containerW, containerH, margin)
+        assertEquals(containerW - fabW - margin, result.x, EPS)
+        assertEquals(containerH - fabH - margin, result.y, EPS)
+    }
+
+    @Test
+    fun `the default position stays on-screen once clamped`() {
+        val margin = 48f
+        val default = defaultFabOffset(fabW, fabH, containerW, containerH, margin)
+        val clamped = clampFabOffset(default, fabW, fabH, containerW, containerH)
+        // The bottom-end default is already within bounds, so clamping is a no-op.
+        assertEquals(default.x, clamped.x, EPS)
+        assertEquals(default.y, clamped.y, EPS)
+    }
+
+    private companion object {
+        const val EPS = 0.001f
+    }
+}


### PR DESCRIPTION
## Summary

The Home "Log a meal" camera FAB was pinned to the bottom-end and could cover the pump/glucose data underneath, with no way to move it. This makes it a draggable floating button so the user can reposition it anywhere and uncover their data.

## What changed

- **Draggable:** wrap the existing tap-only FAB in a draggable overlay driven by a remembered px offset. The FAB keeps its own `onClick`; `detectDragGestures`' touch slop disambiguates tap from drag, so a tap still opens meal capture and a drag repositions without navigating.
- **Stays on-screen:** the offset is clamped to the container bounds, which the host `Scaffold` already insets for system bars (the app is edge-to-edge) — so the FAB can never strand off-screen or behind a system bar.
- **Persists per device:** the position is stored in `EncryptedSharedPreferences` and restored across navigation and app restarts, re-clamped to the current bounds (so a stale value from a different layout/rotation can't place it out of view). Local UI state only — not synced to the account.
- **Default + visibility unchanged:** the FAB still defaults to the bottom-end and still renders only when the per-account meal-intelligence setting is on.

## Design notes

- Placement math (clamp + default position) is pure and Compose-free, so it is unit-tested on the JVM; the position is resolved in the `Modifier.offset {}` placement lambda to avoid a first-frame flash.
- The drag clamp reads the container size through `rememberUpdatedState`, so it uses the live bounds rather than a stale first-frame size.

## Testing

- `:app:testDebugUnitTest` (pure placement math + view-model save/restore), `lintDebug`, `assembleDebug`.
- Instrumented (`connectedDebugAndroidTest`, runs on the CI emulator): tap navigates, default rests at the bottom-end, a drag follows the finger and repositions without navigating, the clamp holds at the edges, a saved position restores, and the encrypted offset round-trips across store instances.
- Emulator visual pass: dragging the FAB off a data card reveals the card underneath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a draggable “Log a meal” button on the Home screen with its position saved and restored across app restarts.
  * Added an accessibility reset action to return the button to its default placement.
* **Bug Fixes**
  * Improved button placement so it clamps correctly within the visible area, including during screen size changes and after restoring saved positions.
  * Enhanced tap vs. drag handling to keep taps reliably working.
* **Tests**
  * Added unit, ViewModel, and UI instrumentation coverage for persistence, clamping, and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->