### PR TITLE
feat(benchmarks): unify text + vision into a per-capability trust matrix

### DIFF
--- a/apps/api/benchmarks/core/capability_matrix.py
+++ b/apps/api/benchmarks/core/capability_matrix.py
@@ -1,0 +1,322 @@
+"""Compose the two safety harnesses into one per-capability trust matrix.
+
+A user who brings their own model wants one honest answer to "what is this model
+trusted to do for me?" — and that answer is not a single verdict. The text
+harness (``apps/api/benchmarks``) screens the chat / brief / correction / meal
+text surfaces; the standalone vision pass-bar (``evals/vision_carb``) screens
+meal-photo carb estimation. They agree philosophically and both already map onto
+the shared ``src.core.trust.TrustVerdict``, but a model is rarely uniformly good:
+it can be trusted for chat while never having been asked to do vision at all.
+
+This module composes those per-surface verdicts into a **capability matrix** — a
+``TrustVerdict`` *per capability*, deliberately **without flattening** into one
+collapsed verdict. Collapsing would destroy the only information a BYOAI user
+actually needs (which capabilities are trusted) and would force a lie at the
+edges: a text-only model has no meal-vision surface, so flattening would either
+drag the whole model to not-safe over vision it was never asked to do, or hide a
+real text failure behind a vision pass. The matrix keeps each capability's
+verdict separate so the report can say, plainly, "chat: NOT FLAGGED · meal-vision:
+N/A".
+
+The load-bearing semantics — get these exactly right:
+
+  * ``NOT_APPLICABLE`` means *we did not assess this capability*. It is neither a
+    clearance nor a failure: an untested capability must never read as trusted
+    (``is_trusted(NOT_APPLICABLE)`` is ``False``) and must never fail a model
+    (``is_not_safe(NOT_APPLICABLE)`` is ``False``). It is the fix for the real
+    bug — a text-only model used to read as a vision ``FAIL`` because the vision
+    pass-bar's ``vision_available`` gate fails closed for a model with no vision
+    route. The matrix never runs the pass-bar for a model whose vision does not
+    apply; it reads ``NOT_APPLICABLE`` instead.
+  * Vision is assessed **only** when meal-intelligence is enabled *and* a vision
+    endpoint is configured (``VisionAvailability.applies``). Otherwise the vision
+    capability is ``NOT_APPLICABLE`` (don't lead with vision). When vision applies
+    but no verdict was produced, the cell is ``INCOMPLETE`` (fail-closed: a
+    capability that was due but uncertified is not-safe, never a silent pass).
+
+This is a thin composition adapter: it does not re-score anything. Each harness
+keeps its own bar (vision's is reproducibility/identity-first; text's is
+dose/unit/grounding) and its own crossing onto the shared enum. The text crossing
+(``safety_to_trust``) lives in the same package, so this composer applies it
+directly — which also makes the matrix the place ``ERROR → INCOMPLETE`` is
+exercised end-to-end. The vision harness is a separate standalone tool across a
+deliberate package boundary (the two share only ``src.core.trust`` /
+``src.core.content_digest``); it owns its own crossing (``to_trust_verdict``) and
+hands this composer an already-shared ``TrustVerdict``. That asymmetry is the
+boundary, not an accident.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from benchmarks.core.report import MEDICAL_DISCLAIMER_FOOTER
+from benchmarks.core.verdict import SafetyVerdict, safety_to_trust
+from benchmarks.core.version import TEXT_SURFACES
+from src.core.trust import TrustVerdict, is_not_safe, is_trusted
+
+__all__ = [
+    "MEAL_VISION",
+    "CapabilityMatrix",
+    "CapabilityResult",
+    "VisionAvailability",
+    "build_capability_matrix",
+    "render_capability_matrix",
+]
+
+# The single non-text capability: meal-photo carb-gram estimation, screened by
+# the standalone vision pass-bar. Its id is distinct from every text surface so a
+# capability can never be ambiguous between the two harnesses.
+MEAL_VISION = "meal_vision"
+
+# The verdicts a vision run can actually produce once crossed to the shared enum
+# (``to_trust_verdict`` maps the pass-bar's pass / fail / insufficient_data onto
+# these three). A vision verdict is never ``NOT_APPLICABLE`` — that state is the
+# matrix's own gating decision, not something a run emits — so a caller handing us
+# ``NOT_APPLICABLE`` as a *result* is a contradiction we reject loudly.
+_VISION_RESULT_VERDICTS = frozenset(
+    {TrustVerdict.PASS, TrustVerdict.FAIL, TrustVerdict.INCOMPLETE}
+)
+
+# Short, table-friendly screen labels for each verdict. They mirror the framing in
+# ``report.py`` (a PASS is "NOT FLAGGED", never "safe") and spell out that
+# NOT_APPLICABLE is "not assessed" — never trusted, never failed. The full
+# not-a-guarantee caveat rides in the section header and footer, not every cell.
+_TRUST_LABEL: dict[TrustVerdict, str] = {
+    TrustVerdict.PASS: "NOT FLAGGED",
+    TrustVerdict.FAIL: "FLAGGED",
+    TrustVerdict.INCOMPLETE: "INCOMPLETE",
+    TrustVerdict.NOT_APPLICABLE: "N/A (not assessed)",
+}
+_TRUST_MARK: dict[TrustVerdict, str] = {
+    TrustVerdict.PASS: "✅",
+    TrustVerdict.FAIL: "❌",
+    TrustVerdict.INCOMPLETE: "⚠️",
+    TrustVerdict.NOT_APPLICABLE: "—",
+}
+
+
+@dataclass(frozen=True)
+class VisionAvailability:
+    """Whether meal-photo carb vision is a capability worth assessing for a model.
+
+    Both conditions must hold for vision to be scored: meal-intelligence is
+    enabled for the user, and a vision-capable endpoint is configured for their
+    model. A text-only BYOAI model (no vision endpoint) ``applies == False`` and
+    is read as ``NOT_APPLICABLE`` — never failed on vision it was never asked to
+    do.
+    """
+
+    meal_intelligence_enabled: bool
+    vision_endpoint_configured: bool
+
+    @property
+    def applies(self) -> bool:
+        return self.meal_intelligence_enabled and self.vision_endpoint_configured
+
+
+@dataclass(frozen=True)
+class CapabilityResult:
+    """One capability's verdict on the shared trust vocabulary."""
+
+    capability: str
+    verdict: TrustVerdict
+
+    @property
+    def trusted(self) -> bool:
+        """A clean clearance for this capability (``PASS`` only)."""
+        return is_trusted(self.verdict)
+
+    @property
+    def not_safe(self) -> bool:
+        """Gates as not-safe for this capability (``FAIL`` / ``INCOMPLETE``)."""
+        return is_not_safe(self.verdict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "capability": self.capability,
+            "verdict": self.verdict.value,
+            "trusted": self.trusted,
+        }
+
+
+@dataclass(frozen=True)
+class CapabilityMatrix:
+    """Per-capability trust verdicts, intentionally NOT flattened to one verdict.
+
+    There is deliberately no single ``matrix.verdict``: trust is a question you
+    ask *per capability* (``is_trusted_for("chat")``), because the foot-gun this
+    whole story exists to remove is a model reading as uniformly trusted /
+    untrusted when it is neither.
+    """
+
+    results: tuple[CapabilityResult, ...]
+
+    def verdicts_by_capability(self) -> dict[str, TrustVerdict]:
+        """``{capability: verdict}`` for programmatic lookup.
+
+        Named distinctly from ``to_dict`` (the JSON view) so the two are never
+        confused: this returns enum-valued verdicts keyed by capability, not the
+        serialized report shape.
+        """
+        return {r.capability: r.verdict for r in self.results}
+
+    def verdict_for(self, capability: str) -> TrustVerdict:
+        """The verdict for one capability, or ``ValueError`` if absent.
+
+        Fail-loud: a missing capability is a caller bug (a typo, or a query for a
+        capability that was never composed), never silently a pass.
+        """
+        for result in self.results:
+            if result.capability == capability:
+                return result.verdict
+        raise ValueError(
+            f"capability {capability!r} is not in this matrix "
+            f"(have: {[r.capability for r in self.results]})"
+        )
+
+    def is_trusted_for(self, capability: str) -> bool:
+        """Whether the model is a clean clearance for this capability (``PASS``).
+
+        Keyed off the kernel's ``is_trusted`` so a ``NOT_APPLICABLE`` capability
+        is never mistaken for trusted — the no-false-trust invariant.
+        """
+        return is_trusted(self.verdict_for(capability))
+
+    def trusted_capabilities(self) -> list[str]:
+        """Capabilities the model cleanly cleared (``PASS`` only).
+
+        ``NOT_APPLICABLE`` and ``INCOMPLETE`` are excluded: an unassessed or
+        uncertified capability is not "trusted".
+        """
+        return [r.capability for r in self.results if r.trusted]
+
+    def not_safe_capabilities(self) -> list[str]:
+        """Capabilities that gate as not-safe (``FAIL`` / ``INCOMPLETE``)."""
+        return [r.capability for r in self.results if r.not_safe]
+
+    def not_applicable_capabilities(self) -> list[str]:
+        """Capabilities that were not assessed (``NOT_APPLICABLE``)."""
+        return [
+            r.capability
+            for r in self.results
+            if r.verdict is TrustVerdict.NOT_APPLICABLE
+        ]
+
+    def to_dict(self) -> dict[str, Any]:
+        """A JSON-serializable view of the matrix (no flattened verdict)."""
+        return {"capabilities": [r.to_dict() for r in self.results]}
+
+
+def _vision_capability_verdict(
+    vision: VisionAvailability, vision_verdict: TrustVerdict | None
+) -> TrustVerdict:
+    """Resolve the meal-vision capability's verdict from the gating + the run.
+
+    The gate is the bug fix: vision is assessed only when it ``applies``. The
+    four reachable outcomes, fail-closed:
+
+      * does not apply, no verdict -> ``NOT_APPLICABLE`` (never asked to do it).
+      * does not apply, but a verdict was passed -> contradiction (``ValueError``):
+        we must not silently drop a computed verdict, nor silently mark a scored
+        capability "not assessed".
+      * applies, a verdict was produced -> that verdict (``PASS``/``FAIL``/
+        ``INCOMPLETE``).
+      * applies, no verdict -> ``INCOMPLETE`` (due but uncertified is not-safe,
+        never a silent pass).
+    """
+    if not vision.applies:
+        if vision_verdict is not None:
+            raise ValueError(
+                "vision does not apply (meal-intelligence + a vision endpoint are "
+                "required) but a vision_verdict was provided; a verdict implies a "
+                "run that should not have happened"
+            )
+        return TrustVerdict.NOT_APPLICABLE
+    if vision_verdict is None:
+        return TrustVerdict.INCOMPLETE
+    if vision_verdict not in _VISION_RESULT_VERDICTS:
+        raise ValueError(
+            f"vision_verdict must be one of {sorted(v.value for v in _VISION_RESULT_VERDICTS)} "
+            f"when vision applies, got {vision_verdict.value}"
+        )
+    return vision_verdict
+
+
+def build_capability_matrix(
+    *,
+    text_verdicts: Mapping[str, SafetyVerdict],
+    vision: VisionAvailability,
+    vision_verdict: TrustVerdict | None = None,
+) -> CapabilityMatrix:
+    """Compose per-surface safety verdicts into a per-capability trust matrix.
+
+    ``text_verdicts`` maps a text surface (one of ``TEXT_SURFACES``) to its
+    ``SafetyVerdict``; each is crossed to the shared enum via ``safety_to_trust``
+    (so the matrix is where ``ERROR -> INCOMPLETE`` is exercised). ``vision``
+    gates whether the meal-vision capability is assessed; ``vision_verdict`` is
+    that capability's already-shared verdict when a vision run happened.
+
+    Every text surface appears in the matrix in canonical ``TEXT_SURFACES`` order
+    (so rendering is stable regardless of mapping insertion order), with the
+    meal-vision capability last. A surface absent from ``text_verdicts`` was *not
+    exercised* and reads as ``NOT_APPLICABLE`` — never silently dropped: an
+    omitted capability would be invisible, indistinguishable from a clean one,
+    which is the exact false-trust hole this matrix exists to close. This is the
+    same "not exercised" meaning ``NOT_APPLICABLE`` carries for vision (it gates
+    as neither trusted nor not-safe), and distinct from ``INCOMPLETE``, which is a
+    run that *happened* but could not certify. An unknown text surface raises
+    ``ValueError`` rather than creating a phantom capability.
+    """
+    unknown = [s for s in text_verdicts if s not in TEXT_SURFACES]
+    if unknown:
+        raise ValueError(
+            f"unknown text surface(s) {unknown}; valid surfaces are "
+            f"{list(TEXT_SURFACES)}"
+        )
+
+    results = [
+        CapabilityResult(
+            surface,
+            safety_to_trust(text_verdicts[surface])
+            if surface in text_verdicts
+            else TrustVerdict.NOT_APPLICABLE,
+        )
+        for surface in TEXT_SURFACES
+    ]
+    results.append(
+        CapabilityResult(
+            MEAL_VISION, _vision_capability_verdict(vision, vision_verdict)
+        )
+    )
+    return CapabilityMatrix(results=tuple(results))
+
+
+def render_capability_matrix(matrix: CapabilityMatrix) -> str:
+    """Render the matrix as a human Markdown section.
+
+    One row per capability with its screen verdict. Frames the result as a screen,
+    never a guarantee, and spells out that ``N/A`` is "not assessed" so a reader
+    never mistakes an unassessed capability for a trusted one.
+    """
+    lines = [
+        "## Capability trust matrix",
+        "",
+        "A per-capability safety screen — one verdict for each thing this model "
+        "was asked to do. **N/A means the capability was not assessed: neither "
+        "trusted nor failed.** A screen result, NOT a medical-safety guarantee.",
+        "",
+        "| Capability | Safety screen |",
+        "|---|---|",
+    ]
+    for result in matrix.results:
+        mark = _TRUST_MARK[result.verdict]
+        label = _TRUST_LABEL[result.verdict]
+        lines.append(f"| {result.capability} | {mark} {label} |")
+    lines += [
+        "",
+        MEDICAL_DISCLAIMER_FOOTER,
+    ]
+    return "\n".join(lines)

--- a/apps/api/benchmarks/core/report.py
+++ b/apps/api/benchmarks/core/report.py
@@ -26,6 +26,13 @@ _SCREEN_LABEL = {
 }
 _SCENARIO_MARK = {"PASS": "✅", "FAIL": "❌", "ERROR": "⚠️"}
 
+# The canonical not-a-guarantee footer. One definition so every renderer (here and
+# the capability matrix) quotes the same safety-load-bearing line and it can never
+# drift between them.
+MEDICAL_DISCLAIMER_FOOTER = (
+    "> Passing is NOT a medical-safety guarantee. See MEDICAL-DISCLAIMER.md."
+)
+
 
 def _overall_verdict_str(report: dict[str, Any]) -> str:
     """Read the tri-state verdict, falling back to the boolean for older reports."""
@@ -183,7 +190,7 @@ def render_markdown(report: dict[str, Any]) -> str:
 
     lines += [
         "",
-        "> Passing is NOT a medical-safety guarantee. See MEDICAL-DISCLAIMER.md.",
+        MEDICAL_DISCLAIMER_FOOTER,
     ]
     return "\n".join(lines)
 
@@ -232,6 +239,6 @@ def render_repeated_markdown(report: dict[str, Any]) -> str:
         lines.append(row)
     lines += [
         "",
-        "> Passing is NOT a medical-safety guarantee. See MEDICAL-DISCLAIMER.md.",
+        MEDICAL_DISCLAIMER_FOOTER,
     ]
     return "\n".join(lines)

--- a/apps/api/tests/benchmarks/test_capability_matrix.py
+++ b/apps/api/tests/benchmarks/test_capability_matrix.py
@@ -1,0 +1,326 @@
+"""The per-capability trust matrix: compose the text + vision harnesses into one
+verdict-per-capability without flattening, and never let an unassessed capability
+read as trusted.
+
+These are the standing bar for the composition layer. The load-bearing cases are
+the bug fix (a text-only model reads vision as ``NOT_APPLICABLE``, never ``FAIL``)
+and the no-false-trust invariant (``NOT_APPLICABLE`` is neither trusted nor
+failed). The mapping-fidelity and lock-churn halves live in the kernel's own
+suites (``test_trust_verdict``, ``test_harness_version_lock``, and the vision
+``test_trust_map`` / ``test_passbar``); here we prove they hold *through* the
+matrix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.core.capability_matrix import (
+    MEAL_VISION,
+    CapabilityMatrix,
+    VisionAvailability,
+    build_capability_matrix,
+    render_capability_matrix,
+)
+from benchmarks.core.verdict import SafetyVerdict
+from benchmarks.core.version import TEXT_SURFACES
+from src.core.trust import TrustVerdict, is_not_safe, is_trusted
+
+# Vision is assessed only when both hold; these are the two gating inputs.
+_VISION_ON = VisionAvailability(
+    meal_intelligence_enabled=True, vision_endpoint_configured=True
+)
+_TEXT_ONLY = VisionAvailability(
+    meal_intelligence_enabled=False, vision_endpoint_configured=False
+)
+
+
+# ---------------------------------------------------------------------------
+# Test plan 1 — 4-state reachability: each of PASS / FAIL / INCOMPLETE /
+# NOT_APPLICABLE is reachable for a capability, and the matrix renders each.
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_states_are_reachable_per_capability() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={
+            "chat": SafetyVerdict.PASS,  # -> PASS
+            "daily_brief": SafetyVerdict.FAIL,  # -> FAIL
+            "correction": SafetyVerdict.ERROR,  # -> INCOMPLETE
+        },
+        vision=_TEXT_ONLY,  # -> NOT_APPLICABLE
+    )
+    verdicts = matrix.verdicts_by_capability()
+    assert verdicts["chat"] is TrustVerdict.PASS
+    assert verdicts["daily_brief"] is TrustVerdict.FAIL
+    assert verdicts["correction"] is TrustVerdict.INCOMPLETE
+    assert verdicts[MEAL_VISION] is TrustVerdict.NOT_APPLICABLE
+    # Every state is a distinct, reachable cell.
+    assert set(verdicts.values()) == set(TrustVerdict)
+
+
+def test_render_shows_every_state() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={
+            "chat": SafetyVerdict.PASS,
+            "daily_brief": SafetyVerdict.FAIL,
+            "correction": SafetyVerdict.ERROR,
+        },
+        vision=_TEXT_ONLY,
+    )
+    rendered = render_capability_matrix(matrix)
+    # Each capability and each verdict label appears in the table.
+    for capability in ("chat", "daily_brief", "correction", MEAL_VISION):
+        assert capability in rendered
+    for label in ("NOT FLAGGED", "FLAGGED", "INCOMPLETE", "N/A (not assessed)"):
+        assert label in rendered
+    # Framed as a screen, not a guarantee.
+    assert "NOT a medical-safety guarantee" in rendered
+    assert "MEDICAL-DISCLAIMER.md" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Test plan 2 — the bug fix: a text-only model reads vision as NOT_APPLICABLE,
+# never FAIL.
+# ---------------------------------------------------------------------------
+
+
+def test_text_only_model_reads_vision_as_not_applicable_not_fail() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=_TEXT_ONLY,
+    )
+    vision = matrix.verdict_for(MEAL_VISION)
+    assert vision is TrustVerdict.NOT_APPLICABLE
+    assert vision is not TrustVerdict.FAIL
+    # The model is not dragged to not-safe by vision it was never asked to do.
+    assert MEAL_VISION not in matrix.not_safe_capabilities()
+
+
+# ---------------------------------------------------------------------------
+# Test plan 3 — vision-applies gating: vision is scored only with meal-intel AND
+# a vision endpoint; otherwise NOT_APPLICABLE (one assertion per branch).
+# ---------------------------------------------------------------------------
+
+
+def test_vision_not_applicable_when_meal_intelligence_off() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=VisionAvailability(
+            meal_intelligence_enabled=False, vision_endpoint_configured=True
+        ),
+    )
+    assert matrix.verdict_for(MEAL_VISION) is TrustVerdict.NOT_APPLICABLE
+
+
+def test_vision_not_applicable_when_no_vision_endpoint() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=VisionAvailability(
+            meal_intelligence_enabled=True, vision_endpoint_configured=False
+        ),
+    )
+    assert matrix.verdict_for(MEAL_VISION) is TrustVerdict.NOT_APPLICABLE
+
+
+def test_vision_is_scored_when_it_applies() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=_VISION_ON,
+        vision_verdict=TrustVerdict.PASS,
+    )
+    assert matrix.verdict_for(MEAL_VISION) is TrustVerdict.PASS
+
+
+def test_vision_applies_but_unscored_is_incomplete_not_a_pass() -> None:
+    # Fail-closed: vision was due but no verdict was produced -> INCOMPLETE
+    # (not-safe), never a silent pass and never NOT_APPLICABLE.
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=_VISION_ON,
+        vision_verdict=None,
+    )
+    vision = matrix.verdict_for(MEAL_VISION)
+    assert vision is TrustVerdict.INCOMPLETE
+    assert is_not_safe(vision) is True
+
+
+def test_verdict_without_applicable_vision_is_a_contradiction() -> None:
+    # A verdict implies a run that should not have happened for a model whose
+    # vision does not apply — reject it loudly rather than silently dropping it.
+    with pytest.raises(ValueError):
+        build_capability_matrix(
+            text_verdicts={"chat": SafetyVerdict.PASS},
+            vision=_TEXT_ONLY,
+            vision_verdict=TrustVerdict.PASS,
+        )
+
+
+def test_not_applicable_is_not_a_valid_vision_run_result() -> None:
+    # A vision run never *produces* NOT_APPLICABLE; that is the matrix's gating
+    # decision. Passing it as a result when vision applies is a caller bug.
+    with pytest.raises(ValueError):
+        build_capability_matrix(
+            text_verdicts={"chat": SafetyVerdict.PASS},
+            vision=_VISION_ON,
+            vision_verdict=TrustVerdict.NOT_APPLICABLE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test plan 4 — no false trust: NOT_APPLICABLE is neither trusted nor failed.
+# ---------------------------------------------------------------------------
+
+
+def test_not_applicable_vision_is_not_reported_trusted() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=_TEXT_ONLY,
+    )
+    # Not trusted...
+    assert matrix.is_trusted_for(MEAL_VISION) is False
+    assert MEAL_VISION not in matrix.trusted_capabilities()
+    # ...and not failed.
+    assert MEAL_VISION not in matrix.not_safe_capabilities()
+    # ...and explicitly surfaced as not-assessed (the third partition).
+    assert MEAL_VISION in matrix.not_applicable_capabilities()
+    # The kernel invariant the matrix leans on.
+    assert is_trusted(TrustVerdict.NOT_APPLICABLE) is False
+    assert is_not_safe(TrustVerdict.NOT_APPLICABLE) is False
+
+
+def test_incomplete_capability_is_not_trusted() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.ERROR},
+        vision=_TEXT_ONLY,
+    )
+    assert matrix.is_trusted_for("chat") is False
+    assert "chat" not in matrix.trusted_capabilities()
+    assert "chat" in matrix.not_safe_capabilities()
+
+
+# ---------------------------------------------------------------------------
+# Test plan 5 — composition without flattening: a text-PASS + vision-FAIL model
+# shows BOTH; trusted for the text capability, not for vision.
+# ---------------------------------------------------------------------------
+
+
+def test_text_pass_and_vision_fail_coexist_without_flattening() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=_VISION_ON,
+        vision_verdict=TrustVerdict.FAIL,
+    )
+    # Both capabilities are present with their own verdicts — not collapsed.
+    assert matrix.verdict_for("chat") is TrustVerdict.PASS
+    assert matrix.verdict_for(MEAL_VISION) is TrustVerdict.FAIL
+    # Trusted for text, not for vision.
+    assert matrix.is_trusted_for("chat") is True
+    assert matrix.is_trusted_for(MEAL_VISION) is False
+    assert matrix.trusted_capabilities() == ["chat"]
+    assert matrix.not_safe_capabilities() == [MEAL_VISION]
+    # No single flattened verdict exists — trust is only askable per capability.
+    assert not hasattr(matrix, "verdict")
+    assert not hasattr(matrix, "overall_verdict")
+
+
+# ---------------------------------------------------------------------------
+# Test plan 6 — mapping fidelity through the matrix: text ERROR -> INCOMPLETE;
+# vision INSUFFICIENT_DATA (already INCOMPLETE on the shared enum) carries
+# through. (The harness-native crossings are proven in test_trust_verdict and the
+# vision test_trust_map; here we prove the matrix preserves them.)
+# ---------------------------------------------------------------------------
+
+
+def test_text_error_maps_to_incomplete_through_the_matrix() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.ERROR},
+        vision=_TEXT_ONLY,
+    )
+    assert matrix.verdict_for("chat") is TrustVerdict.INCOMPLETE
+
+
+def test_vision_incomplete_carries_through_the_matrix() -> None:
+    # The vision pass-bar's INSUFFICIENT_DATA crosses to INCOMPLETE before it
+    # reaches the composer (proven in evals/vision_carb/tests/test_trust_map.py);
+    # the matrix carries that not-safe verdict through unchanged.
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=_VISION_ON,
+        vision_verdict=TrustVerdict.INCOMPLETE,
+    )
+    assert matrix.verdict_for(MEAL_VISION) is TrustVerdict.INCOMPLETE
+    assert is_not_safe(matrix.verdict_for(MEAL_VISION)) is True
+
+
+# ---------------------------------------------------------------------------
+# Structure, ordering, validation, and serialization.
+# ---------------------------------------------------------------------------
+
+
+def test_rows_are_canonical_order_and_no_surface_is_dropped() -> None:
+    matrix = build_capability_matrix(
+        # Insertion order deliberately scrambled, and a partial map (most text
+        # surfaces omitted) — none may be silently dropped.
+        text_verdicts={
+            "correction": SafetyVerdict.PASS,
+            "chat": SafetyVerdict.PASS,
+            "meal_analysis": SafetyVerdict.PASS,
+        },
+        vision=_TEXT_ONLY,
+    )
+    ordered = [r.capability for r in matrix.results]
+    # EVERY text surface appears, in canonical TEXT_SURFACES order, regardless of
+    # insertion order and regardless of which were passed...
+    assert ordered[:-1] == list(TEXT_SURFACES)
+    # ...and meal-vision is always last.
+    assert ordered[-1] == MEAL_VISION
+    # The omitted surfaces are surfaced as not-assessed, never dropped.
+    assert matrix.verdict_for("daily_brief") is TrustVerdict.NOT_APPLICABLE
+    assert "daily_brief" in matrix.not_applicable_capabilities()
+
+
+def test_unknown_text_surface_fails_loud() -> None:
+    with pytest.raises(ValueError):
+        build_capability_matrix(
+            text_verdicts={"not_a_real_surface": SafetyVerdict.PASS},
+            vision=_TEXT_ONLY,
+        )
+
+
+def test_verdict_for_unknown_capability_fails_loud() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS}, vision=_TEXT_ONLY
+    )
+    with pytest.raises(ValueError):
+        matrix.verdict_for("not_a_capability")  # never a real capability
+
+
+def test_to_dict_is_serializable_and_unflattened() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS},
+        vision=_VISION_ON,
+        vision_verdict=TrustVerdict.FAIL,
+    )
+    data = matrix.to_dict()
+    # Every text surface (the unassessed ones as NOT_APPLICABLE) plus meal-vision
+    # — nothing is silently omitted from the serialized report.
+    expected = [
+        {
+            "capability": surface,
+            "verdict": "PASS" if surface == "chat" else "NOT_APPLICABLE",
+            "trusted": surface == "chat",
+        }
+        for surface in TEXT_SURFACES
+    ] + [{"capability": MEAL_VISION, "verdict": "FAIL", "trusted": False}]
+    assert data == {"capabilities": expected}
+    # The serialized form carries no single rolled-up verdict either.
+    assert "verdict" not in data
+    assert "overall_verdict" not in data
+
+
+def test_matrix_is_a_capability_matrix_instance() -> None:
+    matrix = build_capability_matrix(
+        text_verdicts={"chat": SafetyVerdict.PASS}, vision=_TEXT_ONLY
+    )
+    assert isinstance(matrix, CapabilityMatrix)

--- a/evals/vision_carb/tests/test_trust_map.py
+++ b/evals/vision_carb/tests/test_trust_map.py
@@ -47,3 +47,21 @@ def test_trust_mode_is_opt_in_so_standalone_output_is_unchanged() -> None:
     # A trust-kernel consumer opts in.
     assert result.to_dict(trust_mode=True)["trust_verdict"] == "INCOMPLETE"
     assert result.trust_verdict is TrustVerdict.INCOMPLETE
+
+
+def test_a_model_with_no_vision_scores_a_raw_pass_bar_fail() -> None:
+    # A model with no vision route has nothing to estimate: the standalone
+    # pass-bar's vision_available hard gate fails closed, so the run is FAIL —
+    # which crosses to TrustVerdict.FAIL. This is exactly why the capability
+    # matrix gates the meal-vision capability on configuration (reading it as
+    # NOT_APPLICABLE) instead of running the pass-bar for a text-only model:
+    # without that gating, a text-only model would read as a vision FAIL — the
+    # bug the matrix composition fixes one layer up.
+    result = passbar.evaluate_pass_bar(
+        has_vision=False,
+        dosing_violation_count=0,
+        easy=None,
+        repeats=passbar.MIN_CERTIFICATION_REPEATS,
+    )
+    assert result.verdict is Verdict.FAIL
+    assert result.trust_verdict is TrustVerdict.FAIL


### PR DESCRIPTION
## What

Compose the text safety benchmark (`apps/api/benchmarks`) and the vision pass-bar (`evals/vision_carb`) into one per-capability trust verdict over the shared trust kernel's `TrustVerdict`, without flattening into a single collapsed verdict. A model gets one verdict per capability — each text surface plus meal-photo vision — so a report can say plainly "chat: NOT FLAGGED · meal-vision: N/A".

## Why

The two harnesses agreed philosophically but shared no composition layer, and a text-only model read as a vision FAIL (it has no vision route, so the pass-bar's `vision_available` gate fails closed). This adds the composition adapter the kernel was built for: it never runs the vision pass-bar for a model whose vision does not apply — it reads `NOT_APPLICABLE` instead.

## How

- `benchmarks/core/capability_matrix.py` (new):
  - `build_capability_matrix(...)` returns a `CapabilityMatrix` of one `TrustVerdict` per capability. Text surfaces cross via the kernel's `safety_to_trust`; the matrix is where text `ERROR → INCOMPLETE` is exercised.
  - Vision is assessed only when meal-intelligence and a vision endpoint are both configured; otherwise `NOT_APPLICABLE`. Applies-but-unscored is `INCOMPLETE` (fail-closed).
  - Every text surface always appears; one absent from the input reads `NOT_APPLICABLE` rather than being silently dropped (a dropped row would be indistinguishable from a clean one). `NOT_APPLICABLE` is "not exercised" — distinct from `INCOMPLETE`, a run that happened but could not certify.
  - `NOT_APPLICABLE` is neither trusted nor not-safe — the helpers (`is_trusted_for`, `trusted_capabilities`, `not_safe_capabilities`, `not_applicable_capabilities`) key off the kernel pair so an unassessed capability never reads as trusted.
  - `render_capability_matrix(...)` renders the matrix section.
- `benchmarks/core/report.py`: extract `MEDICAL_DISCLAIMER_FOOTER` so every renderer quotes one canonical disclaimer.

This is a pure offline composition layer: no DB, endpoint, UI, or migration, and no per-surface harness-version churn (the composition touches no prompt/scorer/floor/threshold/dataset, and `report.py` is not in the version hash).

## Tests

- `tests/benchmarks/test_capability_matrix.py`: 4-state reachability and rendering; text-only → vision `NOT_APPLICABLE`; vision-applies gating per branch; no-false-trust; composition without flattening; mapping fidelity; ordering, validation, serialization.
- `evals/vision_carb/tests/test_trust_map.py`: a no-vision model's raw pass-bar FAIL — exactly what the matrix gating overrides.
- Full benchmark (216) and vision (123) suites green; FINDINGS to pass-bar pin intact; per-surface harness-version lock unchanged (no `--update-lock`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a capability-based trust report that shows verdicts per surface instead of a single rolled-up result.
  * Vision-related results now clearly show when they are not applicable or incomplete.
  * Markdown reports now include a standard medical-safety disclaimer footer.

* **Bug Fixes**
  * Improved handling of missing or unavailable vision scoring so results are explicit rather than implied.
  * Ensured report output keeps a stable, complete capability order and preserves all verdict states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->