### PR TITLE
fix(meal): never leak a bare 500 on photo upload; honest copy + diagnostics

### DIFF
--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -66,6 +66,12 @@ _ACCEPTED_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
             "description": "Vision unavailable, model not certified, or estimate unusable",
         },
         429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+        500: {"model": ErrorResponse, "description": "Could not serialize the result"},
+        502: {"model": ErrorResponse, "description": "AI vision service error"},
+        503: {
+            "model": ErrorResponse,
+            "description": "Estimate could not be saved or an unexpected error occurred (retryable)",
+        },
     },
 )
 # Each upload triggers a full image decode + an AI vision call, so cap it
@@ -91,11 +97,11 @@ async def upload_food_photo(
             detail="Unsupported image type. Use JPEG, PNG, or WebP.",
         )
 
-    # Bounded read: never pull more than the cap (plus one byte to detect
-    # overflow) into memory.
-    raw = await file.read(settings.food_image_max_bytes + 1)
-
     try:
+        # Bounded read inside the guard: never pull more than the cap (plus one
+        # byte to detect overflow) into memory, and a read failure (client
+        # disconnect, I/O error) maps to a clean 503 below rather than a bare 500.
+        raw = await file.read(settings.food_image_max_bytes + 1)
         record = await food_vision.create_food_record_from_image(
             db=db, user=current_user, raw_image=raw
         )
@@ -131,8 +137,40 @@ async def upload_food_photo(
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)
         ) from exc
+    except food_vision.EstimatePersistenceError as exc:
+        # The estimate was produced but couldn't be saved (disk/DB infra failure).
+        # The pipeline already logged it with a stack; surface a retryable 503
+        # rather than a bare 500. (503 is excluded from Sentry's
+        # failed_request_status_codes, so the pipeline's logger.error is the
+        # single capture path -- see src/observability.py.)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
+    except HTTPException:
+        # An already-typed HTTP error from deeper in the stack: let it through
+        # unchanged rather than masking it with the catch-all below.
+        raise
+    except Exception as exc:
+        # Last-resort safety net: any unanticipated failure is logged (so Sentry
+        # captures it with a stack via the logging integration) and returned as a
+        # clean, retryable 503 -- never a bare, unhandled 500 with an empty body.
+        logger.exception("Unexpected error creating food record from image")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Something went wrong while analyzing your photo. Please try again.",
+        ) from exc
 
-    return FoodRecordResponse.model_validate(record)
+    # Serialize outside the 503 mapping above: a response-shaping/schema defect is a
+    # deterministic server bug, not a transient outage, so it maps to a clean,
+    # logged 500 (never a bare, unhandled one) rather than a "retry in a moment" 503.
+    try:
+        return FoodRecordResponse.model_validate(record)
+    except Exception as exc:
+        logger.exception("Unexpected error serializing food record response")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Something went wrong while preparing your result.",
+        ) from exc
 
 
 @router.get(

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -103,6 +103,17 @@ class EstimateRejectedError(FoodVisionError):
     """The model response could not be parsed into a usable, in-bounds estimate."""
 
 
+class EstimatePersistenceError(FoodVisionError):
+    """Persisting the estimate failed for an infrastructure reason.
+
+    The estimate itself was produced, but writing the photo to disk or the row to
+    the database failed (e.g. a full disk, a read-only volume, or a transient DB
+    outage). Distinct from the upstream-provider errors above: the router maps this
+    to a retryable 503 rather than letting an ``OSError`` / DB error fall through to
+    a bare, unhandled 500.
+    """
+
+
 async def _resolve_model(user: User, db: AsyncSession) -> tuple[str, str]:
     """Return ``(model_name, provider_label)`` for the user's active provider.
 
@@ -336,7 +347,15 @@ async def create_food_record_from_image(
     # The estimate itself stays vision-only (range + empirical confidence).
     suggested_identity = await _suggest_identity(user, food_description)
 
-    storage_path, size_bytes = food_image.store_image(user.id, processed)
+    try:
+        storage_path, size_bytes = food_image.store_image(user.id, processed)
+    except OSError as exc:
+        # Disk full, read-only volume, permissions: an infra failure, not a defect
+        # in the request. Surface a retryable error instead of a bare 500.
+        logger.error("Failed to write meal photo to storage", exc_info=True)
+        raise EstimatePersistenceError(
+            "Could not save your meal photo. Please try again."
+        ) from exc
     filename = Path(storage_path).name
 
     record = FoodRecord(
@@ -363,11 +382,22 @@ async def create_food_record_from_image(
     db.add(record)
     try:
         await db.commit()
-    except Exception:
+    except Exception as exc:
         await db.rollback()
-        # Don't leave the just-written photo orphaned if the row failed.
-        food_image.delete_stored_image(storage_path)
-        raise
+        # A commit failure is an infra problem (DB outage, constraint, connection
+        # drop), not a defect in the request: log it for triage and surface a
+        # retryable error instead of a bare 500.
+        #
+        # Fail closed on the photo: a commit() exception is *indeterminate* -- the
+        # row may have committed server-side before the connection dropped, so
+        # deleting the photo here could permanently destroy the user's image while a
+        # persisted record still points at it. A recoverable orphaned file is the
+        # lesser evil than permanent PHI loss, so we keep the photo (the photo
+        # endpoint already degrades a missing file to a clean 404).
+        logger.error("Failed to persist food record", exc_info=True)
+        raise EstimatePersistenceError(
+            "Could not save your meal estimate. Please try again."
+        ) from exc
     await db.refresh(record)
 
     # Index this record into own-history RAG so a future photo of the same food

--- a/apps/api/tests/test_food_records.py
+++ b/apps/api/tests/test_food_records.py
@@ -7,6 +7,7 @@ food-record API endpoints.
 """
 
 import json
+import logging
 import os
 import uuid
 from io import BytesIO
@@ -375,6 +376,68 @@ class TestPipelinePersistence:
                     db=db, user=user, raw_image=_png_bytes()
                 )
 
+    async def test_storage_failure_maps_to_persistence_error(self, _uploads_tmp):
+        # A disk write failure during persistence is an infra problem, not a defect
+        # in the request: it must surface as the typed EstimatePersistenceError
+        # (mapped to a retryable 503 at the router) rather than a bare OSError that
+        # would fall through to an unhandled 500. (Regression guard for #836.)
+        from src.database import get_session_maker
+
+        async with get_session_maker()() as db:
+            user = await _new_user(db, "store-fail")
+            with (
+                patch.object(
+                    food_vision,
+                    "_call_vision",
+                    AsyncMock(return_value=_estimate_json()),
+                ),
+                patch.object(
+                    food_image,
+                    "store_image",
+                    MagicMock(side_effect=OSError("no space left on device")),
+                ),
+                pytest.raises(food_vision.EstimatePersistenceError),
+            ):
+                await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+    async def test_commit_failure_fails_closed_and_keeps_photo(self, _uploads_tmp):
+        # A db.commit() exception is *indeterminate* -- the row may have committed
+        # before the connection dropped. Deleting the photo could then permanently
+        # destroy the user's image while a persisted record still references it, so
+        # the pipeline fails closed: it keeps the photo and surfaces the typed
+        # EstimatePersistenceError (-> 503), never a bare 500. (#836)
+        from src.database import get_session_maker
+
+        async with get_session_maker()() as db:
+            user = await _new_user(db, "commit-fail")
+            # Capture the id before the failure: the rollback below expires `user`,
+            # and the session is closed by the time we assert.
+            user_id = user.id
+            with (
+                patch.object(
+                    food_vision,
+                    "_call_vision",
+                    AsyncMock(return_value=_estimate_json()),
+                ),
+                patch.object(
+                    db, "commit", AsyncMock(side_effect=RuntimeError("connection lost"))
+                ),
+                pytest.raises(food_vision.EstimatePersistenceError),
+            ):
+                await food_vision.create_food_record_from_image(
+                    db=db, user=user, raw_image=_png_bytes()
+                )
+
+        # Fail-closed: the just-written photo is retained, not deleted on an
+        # ambiguous commit outcome (a recoverable orphan beats permanent PHI loss).
+        user_food_dir = Path(settings.upload_dir) / "food" / str(user_id)
+        leftover = list(user_food_dir.glob("*")) if user_food_dir.exists() else []
+        assert len(leftover) == 1, (
+            f"expected the photo to be retained, found: {leftover}"
+        )
+
     async def test_scrubs_dosing_phrasing_from_description(self, _uploads_tmp):
         from src.database import get_session_maker
 
@@ -654,6 +717,100 @@ class TestFoodRecordsApi:
                 files={"file": ("meal.png", _png_bytes(), "image/png")},
             )
         assert resp.status_code == 404
+
+    async def test_storage_failure_returns_clean_503(self, auth_client):
+        # A persistence (disk) failure must not leak a bare 500: it maps to a clean,
+        # retryable 503 with a JSON detail, and leaves nothing behind. (#836)
+        client, _ = auth_client
+        with (
+            patch.object(
+                food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+            ),
+            patch.object(
+                food_image,
+                "store_image",
+                MagicMock(side_effect=OSError("no space left on device")),
+            ),
+        ):
+            resp = await client.post(
+                "/api/food-records",
+                files={"file": ("meal.png", _png_bytes(), "image/png")},
+            )
+        assert resp.status_code == 503
+        # A clean JSON envelope, never an empty/bare 500 body.
+        assert resp.json()["detail"]
+        # The failed upload persisted nothing.
+        listing = await client.get("/api/food-records")
+        assert listing.status_code == 200
+        assert listing.json()["total"] == 0
+
+    async def test_unexpected_error_returns_503_and_is_logged(
+        self, auth_client, caplog
+    ):
+        # Any unanticipated exception is caught, logged with a stack (so Sentry's
+        # logging integration captures it), and returned as a clean 503 -- never a
+        # bare, unhandled 500 with an empty body. (#836)
+        client, _ = auth_client
+        with (
+            patch.object(
+                food_vision,
+                "create_food_record_from_image",
+                AsyncMock(side_effect=RuntimeError("unexpected boom")),
+            ),
+            caplog.at_level(logging.ERROR, logger="src.routers.food_records"),
+        ):
+            resp = await client.post(
+                "/api/food-records",
+                files={"file": ("meal.png", _png_bytes(), "image/png")},
+            )
+        assert resp.status_code == 503
+        assert resp.json()["detail"]
+        # Logged at ERROR with exception info attached (the Sentry capture path).
+        assert any(r.levelno >= logging.ERROR and r.exc_info for r in caplog.records), (
+            "expected the unexpected error to be logged with a stack trace"
+        )
+
+    async def test_serialization_failure_returns_clean_500(self, auth_client):
+        # A response-shaping/schema defect is a deterministic server bug, not a
+        # transient outage: it must surface as a clean, logged 500 (JSON body, not a
+        # bare one) -- distinct from the retryable 503 reserved for infra failures. (#836)
+        from src.schemas.food_record import FoodRecordResponse
+
+        client, _ = auth_client
+        with (
+            patch.object(
+                food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+            ),
+            patch.object(
+                FoodRecordResponse,
+                "model_validate",
+                MagicMock(side_effect=ValueError("response schema drift")),
+            ),
+        ):
+            resp = await client.post(
+                "/api/food-records",
+                files={"file": ("meal.png", _png_bytes(), "image/png")},
+            )
+        assert resp.status_code == 500
+        # Clean JSON envelope, never a bare/empty 500.
+        assert resp.json()["detail"]
+
+    async def test_upload_read_failure_returns_503(self, auth_client):
+        # A failure reading the uploaded bytes (client disconnect, I/O error) runs
+        # before the pipeline; it must be inside the guard so it maps to a clean 503
+        # rather than escaping as a bare 500. (#836)
+        from starlette.datastructures import UploadFile
+
+        client, _ = auth_client
+        with patch.object(
+            UploadFile, "read", AsyncMock(side_effect=OSError("read failed"))
+        ):
+            resp = await client.post(
+                "/api/food-records",
+                files={"file": ("meal.png", _png_bytes(), "image/png")},
+            )
+        assert resp.status_code == 503
+        assert resp.json()["detail"]
 
     async def test_delete_removes_record_and_file(self, auth_client):
         client, _ = auth_client

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/MealRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/MealRepository.kt
@@ -15,9 +15,9 @@ import com.squareup.moshi.Types
 import kotlinx.coroutines.CancellationException
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Response
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -121,7 +121,7 @@ class MealRepository @Inject constructor(
             response.body()?.let { Result.success(it) }
                 ?: Result.failure(MealException.EstimateFailed("The server returned an empty response."))
         } else {
-            Result.failure(mapError(response.code(), detailOf(response.errorBody())))
+            Result.failure(mapErrorResponse(response))
         }
     }
 
@@ -131,7 +131,7 @@ class MealRepository @Inject constructor(
         if (response.isSuccessful) {
             Result.success(Unit)
         } else {
-            Result.failure(mapError(response.code(), detailOf(response.errorBody())))
+            Result.failure(mapErrorResponse(response))
         }
     }
 
@@ -143,10 +143,47 @@ class MealRepository @Inject constructor(
         Result.failure(e)
     }
 
+    /**
+     * Map any non-2xx meal-endpoint response to a typed [MealException], reading the error body
+     * exactly once.
+     *
+     * Server errors (5xx) on any meal call also emit an R8-safe diagnostic so an opaque failure can
+     * be diagnosed on its next occurrence (the photo upload is the motivating case): release builds
+     * ship no Sentry DSN, so this logcat trail is the only client-side signal we get. The
+     * content-type + body prefix distinguish an app-backend error (JSON `{"detail":...}`) from an
+     * edge/proxy one (HTML/empty), and the host confirms the request actually reached the real
+     * backend.
+     */
+    private fun mapErrorResponse(response: Response<*>): MealException {
+        val errorBody = response.errorBody()
+        val contentType = errorBody?.contentType()?.toString()
+        // ResponseBody.string() consumes the stream and may only be called once.
+        val raw = try {
+            errorBody?.string()?.takeIf { it.isNotBlank() }
+        } catch (_: Exception) {
+            null
+        }
+        if (response.code() >= 500) {
+            // Timber.e survives R8 (only d/v are stripped) and the release ReleaseTree scrubs
+            // tokens/emails/glucose before anything reaches logcat.
+            val request = response.raw().request
+            Timber.e(
+                "Meal API server error %d on %s %s%s (content-type=%s): %s",
+                response.code(),
+                request.method,
+                request.url.host,
+                request.url.encodedPath,
+                contentType ?: "none",
+                raw?.take(MAX_LOGGED_ERROR_BODY) ?: "<empty body>",
+            )
+        }
+        return mapError(response.code(), parseDetail(raw))
+    }
+
     /** Extract the human message from a FastAPI error body, tolerating both the string and the
      *  Pydantic list-of-objects shapes of `detail`. */
-    private fun detailOf(errorBody: ResponseBody?): String? = try {
-        val parsed = errorBody?.string()?.takeIf { it.isNotBlank() }?.let { errorBodyAdapter.fromJson(it) }
+    private fun parseDetail(raw: String?): String? = try {
+        val parsed = raw?.let { errorBodyAdapter.fromJson(it) }
         when (val detail = parsed?.get("detail")) {
             is String -> detail
             is List<*> -> (detail.firstOrNull() as? Map<*, *>)?.get("msg") as? String
@@ -181,6 +218,18 @@ class MealRepository @Inject constructor(
             502 -> MealException.EstimateFailed(
                 "The AI vision service is temporarily unavailable. Please try again in a moment.",
             )
+            // Distinct, honest copy for the server-error family (mirrors the 502 convention of
+            // owning user-facing copy rather than echoing the backend's technical detail). The raw
+            // detail still lands in the 5xx diagnostic above for triage.
+            500 -> MealException.EstimateFailed(
+                "Something went wrong on our end while analyzing your photo. Please try again.",
+            )
+            503 -> MealException.EstimateFailed(
+                "The service is temporarily unavailable. Please try again in a moment.",
+            )
+            504 -> MealException.EstimateFailed(
+                "The request took too long to process. Please try again.",
+            )
             else -> MealException.EstimateFailed(
                 message.ifEmpty { "Something went wrong (HTTP $code). Please try again." },
             )
@@ -189,6 +238,10 @@ class MealRepository @Inject constructor(
 
     private companion object {
         const val DEFAULT_PAGE = 50
+
+        // Cap how much of an error body we log: enough to tell a FastAPI `{"detail":...}` JSON
+        // payload from an edge-proxy HTML/empty body, without dumping a large response.
+        const val MAX_LOGGED_ERROR_BODY = 200
         val JPEG_MEDIA_TYPE = "image/jpeg".toMediaType()
 
         // Substrings of the backend's `detail` copy (apps/api/src/routers/_meal_intelligence.py

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/MealRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/MealRepositoryTest.kt
@@ -12,10 +12,12 @@ import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.Response
+import timber.log.Timber
 
 class MealRepositoryTest {
 
@@ -23,6 +25,20 @@ class MealRepositoryTest {
     private val chatApi = mockk<GlycemicGptApi>()
     private val moshi = Moshi.Builder().build()
     private val repository = MealRepository(api, chatApi, moshi)
+
+    @After
+    fun tearDown() {
+        // The diagnostic-logging test plants a Timber tree; never leak it into sibling tests.
+        Timber.uprootAll()
+    }
+
+    /** Captures the formatted messages Timber emits, so a test can assert on the diagnostic. */
+    private class RecordingTree : Timber.Tree() {
+        val messages = mutableListOf<String>()
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            messages.add(message)
+        }
+    }
 
     private fun errorBody(detail: String) =
         """{"detail":"$detail"}""".toResponseBody("application/json".toMediaType())
@@ -99,6 +115,58 @@ class MealRepositoryTest {
         val e = repository.uploadPhoto(ByteArray(16)).exceptionOrNull()
         assertTrue(e is MealException.EstimateFailed)
         assertTrue(e!!.message!!.contains("temporarily unavailable"))
+    }
+
+    @Test
+    fun `uploadPhoto maps 500 to an honest server-error message, not an HTTP-code dump`() = runTest {
+        // A truly unhandled backend 500 returns plain "Internal Server Error", not a FastAPI
+        // {"detail":...} envelope -- the copy must still be honest and never echo "HTTP 500".
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(500, "Internal Server Error".toResponseBody("text/plain".toMediaType()))
+
+        val e = repository.uploadPhoto(ByteArray(16)).exceptionOrNull()
+        assertTrue(e is MealException.EstimateFailed)
+        assertTrue(e!!.message!!.contains("on our end", ignoreCase = true))
+        assertTrue(!e.message!!.contains("HTTP 500"))
+    }
+
+    @Test
+    fun `uploadPhoto maps 503 to a temporarily-unavailable message`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(503, errorBody("Could not save your meal estimate. Please try again."))
+
+        val e = repository.uploadPhoto(ByteArray(16)).exceptionOrNull()
+        assertTrue(e is MealException.EstimateFailed)
+        assertTrue(e!!.message!!.contains("temporarily unavailable", ignoreCase = true))
+    }
+
+    @Test
+    fun `uploadPhoto maps 504 to a took-too-long message`() = runTest {
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(504, errorBody("upstream request timed out"))
+
+        val e = repository.uploadPhoto(ByteArray(16)).exceptionOrNull()
+        assertTrue(e is MealException.EstimateFailed)
+        assertTrue(e!!.message!!.contains("too long", ignoreCase = true))
+    }
+
+    @Test
+    fun `a 5xx failure logs a diagnostic but a 4xx does not`() = runTest {
+        val tree = RecordingTree()
+        Timber.plant(tree)
+
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(500, "Internal Server Error".toResponseBody("text/plain".toMediaType()))
+        repository.uploadPhoto(ByteArray(16))
+
+        coEvery { chatApi.uploadFoodPhoto(any<MultipartBody.Part>()) } returns
+            Response.error(404, errorBody("Meal intelligence is not enabled."))
+        repository.uploadPhoto(ByteArray(16))
+
+        // Exactly one diagnostic, for the 5xx; the expected 404 degradation stays quiet.
+        assertEquals(1, tree.messages.size)
+        assertTrue(tree.messages.first().contains("500"))
+        assertTrue(tree.messages.first().contains("content-type=text/plain"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #836 — the Android meal-photo carb estimate surfaced an opaque "Something went wrong (HTTP 500)". This makes the failure observable, stops the backend from ever leaking a bare/unhandled 500 on the upload route, and gives the client honest copy for the server-error family. PR #823 made Meal Intelligence default-ON in 0.11.0, which newly exposed this path to real users.

## Root cause (STEP 0)

The Android client uploads to `POST /api/food-records` (`GlycemicGptApi.uploadFoodPhoto`), not `/api/ai/meals/analyze`. The user-visible "500" can only come from `MealRepository.mapError`'s else-branch, which requires a real HTTP 500. The handler mapped typed errors to 400/404/413/415/422/502 but had **no `except Exception` catch-all**, so any unexpected failure (disk I/O in `food_image.store_image`, a `db.commit` failure, etc.) fell through to FastAPI's default bare 500 with an empty body.

Telemetry could not confirm the specific exception: the reporter runs a mobile **release build** (`SENTRY_DSN=""`, zero client telemetry) against a **self-hosted backend** that does not report to our hosted Sentry. A 14-day query of `glycemicgpt-api` Sentry found **zero** events referencing `food_records.py` / `food_vision.py` / `food_image.py` and zero under transaction `POST /api/food-records` — expected, since our Sentry has no visibility into the reporter's instance. So the fix delivers **observability first** (so the next occurrence is diagnosable on whatever backend/build hits it), then closes the bare-500 leak regardless of which exception fired.

## Changes

**Backend — never leak a bare 500 (`food_records.py`, `food_vision.py`)**
- New typed `food_vision.EstimatePersistenceError` for the persistence tail: a `store_image` `OSError` (disk full / read-only / perms) or a `db.commit` failure now raises it (logged with a stack via `logger.error(exc_info=True)`).
- On a `db.commit` failure the pipeline **fails closed on the photo**: a `commit()` exception is *indeterminate* (the row may have committed before the connection dropped), so it keeps the photo rather than deleting it — a recoverable orphan beats permanently destroying the user's image while a committed record still references it (the photo endpoint already degrades a missing file to a clean 404).
- Router maps `EstimatePersistenceError` → **503** (retryable), adds an `except HTTPException: raise` guard, and a final `except Exception` catch-all that `logger.exception(...)` and returns a clean **503** — never a bare 500. 503 is deliberately excluded from Sentry's `failed_request_status_codes`, so the `logger.*` call is the single capture path. `CancelledError` (BaseException) is intentionally not caught, so request cancellation is never masked as a 503.
- Response serialization is wrapped separately and mapped to a clean, logged **500** (deterministic server bug — not the retryable 503), so even a `model_validate` failure can't escape as a bare 500.
- OpenAPI `responses` now document 500/502/503.

**Client — observability + honest copy (`MealRepository.kt`)**
- A single `mapErrorResponse` reads the error body exactly once (content-type captured before `string()` — also fixes a latent double-read in the old `detailOf`), and for any `>= 500` meal response emits an R8-safe `Timber.e` diagnostic: status code, request host + path, content-type, and the first 200 chars of the raw body. `Timber.e` survives R8 (only `d/v` are stripped) and release `ReleaseTree` scrubs tokens/emails/glucose. This distinguishes an app-backend error (JSON `{"detail":...}`) from an edge/proxy one (HTML/empty) and confirms the request reached the real backend. Logged only for 5xx, so expected 4xx degradation stays quiet.
- Honest, distinct copy for `500` / `503` / `504` instead of the opaque "Something went wrong (HTTP 500)".

## Mobile telemetry note

Release builds ship `SENTRY_DSN=""` **by design** — a DSN baked into a publicly downloadable APK is client-extractable (see `app/build.gradle.kts`). This PR relies on the local logcat diagnostic rather than re-enabling a release DSN. Whether to ship one via a non-extractable channel is a separate team decision; flagging it because this blindness is why #836 was hard to diagnose.

## Tests

- Backend: `food_vision` `OSError` → `EstimatePersistenceError`; `db.commit` failure → typed error **+ photo retained** (fail-closed); endpoint storage failure → clean 503 + nothing persisted; unexpected exception → 503 + logged with a stack (caplog); response-serialization failure → clean 500. Full `test_food_records.py` (90) + sibling meal suites (135) green; `ruff check` + `ruff format --check` clean.
- Mobile: `MealRepositoryTest` extended for 500/503/504 honest copy and a 5xx-only diagnostic-log assertion (capturing Timber tree, torn down in `@After`). `:app:testDebugUnitTest` + `:app:lintDebug` green.

## Verification

- Deterministic ASGI tests prove the mapping, logging, and 503/500 behavior through the real FastAPI app.
- Reviews: a 3-lens multi-agent review (adversarial + senior-craft + security) returned **0 HIGH / 0 MEDIUM**; a dedicated security review **PASSED** (no secrets; PHI-logging net-neutral; safety invariants untouched); CodeRabbit CLI surfaced a data-integrity edge case (delete-on-indeterminate-commit) and the serialization-as-503 nuance — both addressed above.
- **Sentry validation gate PASSED:** ran the stack with Sentry enabled, exercised the upload path (correct typed 404/415, no bare 500) + golden smoke; **no new real issue**; validated that the catch-all's `logger.exception(...)` is captured with a stack (synthetic event, resolved). Stack returned to Sentry-off.
- Emulator: app builds, installs, and launches cleanly (no app-level regression).
- **Pre-merge hardware step:** a physical-device RELEASE-build upload against a real backend (AC4) — the path never exercised pre-ship — should confirm a real estimate returns end-to-end, or that an induced failure now surfaces the mapped 5xx + honest copy + diagnostic. The emulator/debug build cannot reproduce a release-only / first-exposure condition without a live vision provider.

## Safety

No change to the 20–500 mg/dL glucose safety invariant, the canonical mg/dL pipeline, carb bounds, dosing scrub, or IoB/treatment_safety coupling. All 503/500 detail strings are generic (no internal/stack detail leaked to the client).

## Follow-up (out of scope)

`scrub_text` (`observability.py`) does not redact free-text meal descriptions, so a SQLAlchemy commit-error string could carry `food_description` to Sentry un-redacted. This is **pre-existing and not worsened** by this diff (the prior unhandled 500 was already auto-captured with the same value). Worth a separate hardening pass (e.g. `hide_parameters=True` or a scrub-tail rule).

---

`Closes #836` won't auto-close on a squash to `develop` — reconcile the issue + any Linear item manually after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved photo-upload failure handling with clearer, retryable server errors (including storage/vision and persistence failures) and cleaner JSON error details.
  * Added “fails closed” behavior for upload pipelines so a database commit error no longer risks deleting a just-saved photo.
  * Updated mobile error mapping so HTTP 500/503/504 show more user-friendly messages and consistent structured details.
* **Tests**
  * Expanded regression coverage for retryable error responses and mobile error-message/logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->