### PR TITLE
feat(insulin): expand bolus insulin types with region-neutral brands

### DIFF
--- a/apps/api/src/schemas/insulin_config.py
+++ b/apps/api/src/schemas/insulin_config.py
@@ -5,16 +5,56 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
-# Allowed insulin type values
-VALID_INSULIN_TYPES = {"humalog", "novolog", "fiasp", "lyumjev", "apidra", "custom"}
+# Allowed insulin type values. Bolus/rapid insulins only -- this list drives the
+# DIA picker that feeds the IOB curve, so long-acting/basal insulins are
+# deliberately excluded (they are recognized separately on ingestion via
+# BASAL_INJECTION). Keep this allow-list closed: insulin_type is rendered into
+# the AI prompt, so it must never become free text. "custom" lets a user
+# hand-set DIA/onset and is the only valid type without a preset.
+VALID_INSULIN_TYPES = {
+    # Rapid-acting analogs
+    "humalog",
+    "novolog",
+    "fiasp",
+    "lyumjev",
+    "apidra",
+    "novorapid",
+    "liprolog",
+    "admelog",
+    "trurapi",
+    "kirsty",
+    # Regular (short-acting) human insulin
+    "humulin_r",
+    "novolin_r",
+    "insuman_rapid",
+    "custom",
+}
 
-# Preset insulin types with their default DIA and onset values
+# Preset DIA (hours) and onset (minutes) per insulin type. A brand that shares a
+# molecule with a shipped entry (aspart/lispro/glulisine) reuses that molecule's
+# PK verbatim, so its IOB curve is already correct. Regular human insulin uses a
+# longer DIA and later onset.
 INSULIN_PRESETS: dict[str, dict[str, float]] = {
+    # Rapid-acting analogs
     "humalog": {"dia_hours": 4.0, "onset_minutes": 15.0},
     "novolog": {"dia_hours": 4.0, "onset_minutes": 15.0},
     "fiasp": {"dia_hours": 3.5, "onset_minutes": 5.0},
     "lyumjev": {"dia_hours": 3.5, "onset_minutes": 5.0},
     "apidra": {"dia_hours": 4.0, "onset_minutes": 15.0},
+    "novorapid": {"dia_hours": 4.0, "onset_minutes": 15.0},
+    "liprolog": {"dia_hours": 4.0, "onset_minutes": 15.0},
+    "admelog": {"dia_hours": 4.0, "onset_minutes": 15.0},
+    "trurapi": {"dia_hours": 4.0, "onset_minutes": 15.0},
+    "kirsty": {"dia_hours": 4.0, "onset_minutes": 15.0},
+    # Regular (short-acting) human insulin. DIA 6.0h reflects the realistic
+    # total duration of action: the FDA Humulin R / Novolin R U-100 labels
+    # terminate ~8h (peak ~3h) and clinical references give 5-8h. The IOB curve
+    # zeroes at DIA, so a shorter value would truncate a still-active tail and
+    # under-count late IOB (the stacking direction). Duration is dose-dependent
+    # and large doses can act longer than this fixed model assumes.
+    "humulin_r": {"dia_hours": 6.0, "onset_minutes": 30.0},
+    "novolin_r": {"dia_hours": 6.0, "onset_minutes": 30.0},
+    "insuman_rapid": {"dia_hours": 6.0, "onset_minutes": 30.0},
 }
 
 
@@ -41,7 +81,10 @@ class InsulinConfigUpdate(BaseModel):
     insulin_type: str | None = Field(
         default=None,
         max_length=50,
-        description="Insulin type (e.g. humalog, novolog, fiasp, lyumjev, apidra, custom)",
+        description=(
+            "Bolus insulin type. Must be one of the supported values, "
+            "or 'custom' to hand-set DIA/onset."
+        ),
     )
     dia_hours: float | None = Field(
         default=None,

--- a/apps/api/tests/test_insulin_config.py
+++ b/apps/api/tests/test_insulin_config.py
@@ -11,6 +11,7 @@ from src.config import settings
 from src.main import app
 from src.schemas.insulin_config import (
     INSULIN_PRESETS,
+    VALID_INSULIN_TYPES,
     InsulinConfigDefaults,
     InsulinConfigUpdate,
 )
@@ -38,6 +39,13 @@ async def register_and_login(client) -> str:
     )
 
     return login_response.cookies.get(settings.jwt_cookie_name)
+
+
+# Bolus insulins added to the picker. Rapid analogs reuse a shipped molecule's
+# PK (aspart/lispro), so they inherit the existing 4.0h/15min curve; regular
+# (short-acting) human insulins use a longer DIA and later onset.
+ADDED_RAPID_ANALOG_TYPES = ("novorapid", "liprolog", "admelog", "trurapi", "kirsty")
+ADDED_REGULAR_HUMAN_TYPES = ("humulin_r", "novolin_r", "insuman_rapid")
 
 
 # -- Schema validation tests --
@@ -83,6 +91,20 @@ class TestInsulinConfigUpdate:
         assert update.dia_hours == 3.5
         assert update.onset_minutes == 5.0
 
+    @pytest.mark.parametrize("insulin_type", ADDED_RAPID_ANALOG_TYPES)
+    def test_added_rapid_analog_type_accepted(self, insulin_type):
+        update = InsulinConfigUpdate(insulin_type=insulin_type)
+        assert update.insulin_type == insulin_type
+
+    @pytest.mark.parametrize("insulin_type", ADDED_REGULAR_HUMAN_TYPES)
+    def test_added_regular_human_type_accepted(self, insulin_type):
+        update = InsulinConfigUpdate(insulin_type=insulin_type)
+        assert update.insulin_type == insulin_type
+
+    def test_unknown_insulin_type_rejected(self):
+        with pytest.raises(ValidationError):
+            InsulinConfigUpdate(insulin_type="not_an_insulin")
+
 
 class TestInsulinConfigDefaults:
     """Tests for InsulinConfigDefaults schema."""
@@ -102,6 +124,43 @@ class TestInsulinConfigDefaults:
     def test_fiasp_preset_values(self):
         assert INSULIN_PRESETS["fiasp"]["dia_hours"] == 3.5
         assert INSULIN_PRESETS["fiasp"]["onset_minutes"] == 5.0
+
+    @pytest.mark.parametrize(
+        "insulin_type", ADDED_RAPID_ANALOG_TYPES + ADDED_REGULAR_HUMAN_TYPES
+    )
+    def test_added_types_have_presets(self, insulin_type):
+        defaults = InsulinConfigDefaults()
+        assert insulin_type in defaults.presets
+
+    @pytest.mark.parametrize("insulin_type", ADDED_RAPID_ANALOG_TYPES)
+    def test_rapid_analog_presets_reuse_molecule_pk(self, insulin_type):
+        # A brand sharing a molecule with a shipped analog inherits its curve.
+        assert INSULIN_PRESETS[insulin_type]["dia_hours"] == 4.0
+        assert INSULIN_PRESETS[insulin_type]["onset_minutes"] == 15.0
+
+    @pytest.mark.parametrize("insulin_type", ADDED_REGULAR_HUMAN_TYPES)
+    def test_regular_human_preset_values(self, insulin_type):
+        assert INSULIN_PRESETS[insulin_type]["dia_hours"] == 6.0
+        assert INSULIN_PRESETS[insulin_type]["onset_minutes"] == 30.0
+
+    def test_presets_and_valid_types_stay_consistent(self):
+        # Drift guard: every preset key is a valid type, and "custom" is the
+        # only valid type without a preset.
+        assert set(INSULIN_PRESETS).issubset(VALID_INSULIN_TYPES)
+        assert VALID_INSULIN_TYPES - set(INSULIN_PRESETS) == {"custom"}
+
+    def test_every_preset_is_savable(self):
+        # Selecting a preset auto-fills the form, so every preset must produce a
+        # payload the InsulinConfigUpdate validator accepts -- otherwise the
+        # auto-filled value would 422 on save. Construct the schema instead of
+        # re-encoding its bounds so this tracks the validator (and the
+        # allow-list) automatically.
+        for insulin_type, values in INSULIN_PRESETS.items():
+            InsulinConfigUpdate(
+                insulin_type=insulin_type,
+                dia_hours=values["dia_hours"],
+                onset_minutes=values["onset_minutes"],
+            )
 
 
 # -- Service tests --
@@ -320,3 +379,46 @@ class TestInsulinConfigEndpoints:
                 cookies={settings.jwt_cookie_name: cookie},
             )
         assert response.status_code == 422
+
+    async def test_patch_unknown_insulin_type_returns_422(self):
+        """PATCH with a type outside the allow-list is rejected at the body."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+            response = await client.patch(
+                "/api/settings/insulin-config",
+                json={"insulin_type": "not_an_insulin"},
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize("insulin_type", ("novorapid", "humulin_r"))
+    async def test_patch_new_insulin_type_persists(self, insulin_type):
+        """A newly added bolus insulin saves and reads back unchanged."""
+        preset = INSULIN_PRESETS[insulin_type]
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            cookie = await register_and_login(client)
+            patch_response = await client.patch(
+                "/api/settings/insulin-config",
+                json={
+                    "insulin_type": insulin_type,
+                    "dia_hours": preset["dia_hours"],
+                    "onset_minutes": preset["onset_minutes"],
+                },
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+            assert patch_response.status_code == 200
+            get_response = await client.get(
+                "/api/settings/insulin-config",
+                cookies={settings.jwt_cookie_name: cookie},
+            )
+        assert patch_response.json()["insulin_type"] == insulin_type
+        data = get_response.json()
+        assert data["insulin_type"] == insulin_type
+        assert data["dia_hours"] == preset["dia_hours"]
+        assert data["onset_minutes"] == preset["onset_minutes"]

--- a/apps/web/__tests__/lib/insulin.test.ts
+++ b/apps/web/__tests__/lib/insulin.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Guards the web insulin catalog (apps/web/src/lib/insulin.ts) against the kind
+ * of drift the backend already guards in test_insulin_config.py: every dropdown
+ * label except "custom" must have a fallback preset, every preset must have a
+ * label, and every preset must be savable (within the PATCH validator's DIA/onset
+ * bounds, so the auto-filled value never 422s offline). "custom" must stay last
+ * so it renders at the bottom of the dropdown.
+ */
+
+import { FALLBACK_PRESETS, INSULIN_LABELS, INSULIN_LIMITS } from "@/lib/insulin";
+
+describe("insulin catalog parity", () => {
+  it("gives every preset a dropdown label", () => {
+    for (const key of Object.keys(FALLBACK_PRESETS)) {
+      expect(INSULIN_LABELS).toHaveProperty(key);
+    }
+  });
+
+  it("gives every non-custom label a preset, and only custom has none", () => {
+    const labelsWithoutPreset = Object.keys(INSULIN_LABELS).filter(
+      (key) => !(key in FALLBACK_PRESETS)
+    );
+    expect(labelsWithoutPreset).toEqual(["custom"]);
+  });
+
+  it("keeps every preset within the savable DIA/onset bounds", () => {
+    for (const [key, preset] of Object.entries(FALLBACK_PRESETS)) {
+      expect(preset.dia_hours).toBeGreaterThanOrEqual(INSULIN_LIMITS.diaMinHours);
+      expect(preset.dia_hours).toBeLessThanOrEqual(INSULIN_LIMITS.diaMaxHours);
+      expect(preset.onset_minutes).toBeGreaterThanOrEqual(INSULIN_LIMITS.onsetMinMinutes);
+      expect(preset.onset_minutes).toBeLessThanOrEqual(INSULIN_LIMITS.onsetMaxMinutes);
+      // Touch `key` so a failure names the offending insulin.
+      expect(key).toBeTruthy();
+    }
+  });
+
+  it("renders custom last in the dropdown", () => {
+    const keys = Object.keys(INSULIN_LABELS);
+    expect(keys[keys.length - 1]).toBe("custom");
+  });
+});

--- a/apps/web/src/app/dashboard/settings/insulin/page.tsx
+++ b/apps/web/src/app/dashboard/settings/insulin/page.tsx
@@ -25,6 +25,7 @@ import {
   type InsulinConfigResponse,
   type InsulinPresets,
 } from "@/lib/api";
+import { FALLBACK_PRESETS, INSULIN_LABELS, INSULIN_LIMITS } from "@/lib/insulin";
 import { OfflineBanner } from "@/components/ui/offline-banner";
 
 type SavedConfig = Pick<InsulinConfigResponse, "insulin_type" | "dia_hours" | "onset_minutes">;
@@ -33,24 +34,6 @@ const DEFAULTS = {
   insulin_type: "humalog",
   dia_hours: 4.0,
   onset_minutes: 15.0,
-};
-
-// Hardcoded fallback so the page works when the API is unreachable
-const FALLBACK_PRESETS: InsulinPresets = {
-  humalog: { dia_hours: 4.0, onset_minutes: 15.0 },
-  novolog: { dia_hours: 4.0, onset_minutes: 15.0 },
-  fiasp: { dia_hours: 3.5, onset_minutes: 5.0 },
-  lyumjev: { dia_hours: 3.5, onset_minutes: 5.0 },
-  apidra: { dia_hours: 4.0, onset_minutes: 15.0 },
-};
-
-const INSULIN_LABELS: Record<string, string> = {
-  humalog: "Humalog (Lispro)",
-  novolog: "NovoLog (Aspart)",
-  fiasp: "Fiasp (Faster Aspart)",
-  lyumjev: "Lyumjev (Faster Lispro)",
-  apidra: "Apidra (Glulisine)",
-  custom: "Custom",
 };
 
 export default function InsulinConfigPage() {
@@ -183,10 +166,10 @@ export default function InsulinConfigPage() {
   const isValid =
     !isNaN(diaNum) &&
     !isNaN(onsetNum) &&
-    diaNum >= 2.0 &&
-    diaNum <= 8.0 &&
-    onsetNum >= 1.0 &&
-    onsetNum <= 60.0;
+    diaNum >= INSULIN_LIMITS.diaMinHours &&
+    diaNum <= INSULIN_LIMITS.diaMaxHours &&
+    onsetNum >= INSULIN_LIMITS.onsetMinMinutes &&
+    onsetNum <= INSULIN_LIMITS.onsetMaxMinutes;
   const isCustom = insulinType === "custom" || !(insulinType in (presets || {}));
 
   return (
@@ -293,7 +276,7 @@ export default function InsulinConfigPage() {
                 ))}
               </select>
               <p className="text-xs text-slate-500 mt-1">
-                Select the rapid-acting insulin in your pump
+                Select your bolus (mealtime) insulin
               </p>
             </div>
 
@@ -309,8 +292,8 @@ export default function InsulinConfigPage() {
                 <input
                   id="dia-hours"
                   type="number"
-                  min={2}
-                  max={8}
+                  min={INSULIN_LIMITS.diaMinHours}
+                  max={INSULIN_LIMITS.diaMaxHours}
                   step={0.5}
                   value={diaHours}
                   onChange={(e) => setDiaHours(e.target.value)}
@@ -342,8 +325,8 @@ export default function InsulinConfigPage() {
                 <input
                   id="onset-minutes"
                   type="number"
-                  min={1}
-                  max={60}
+                  min={INSULIN_LIMITS.onsetMinMinutes}
+                  max={INSULIN_LIMITS.onsetMaxMinutes}
                   step={1}
                   value={onsetMinutes}
                   onChange={(e) => setOnsetMinutes(e.target.value)}

--- a/apps/web/src/lib/insulin.ts
+++ b/apps/web/src/lib/insulin.ts
@@ -1,0 +1,62 @@
+/**
+ * Bolus insulin catalog for the Settings -> Insulin picker.
+ *
+ * Both tables mirror the backend in apps/api/src/schemas/insulin_config.py:
+ * FALLBACK_PRESETS mirrors INSULIN_PRESETS and is used only when the API is
+ * unreachable (the online path uses the API-fetched presets); INSULIN_LABELS
+ * supplies the dropdown's display names and its keys mirror VALID_INSULIN_TYPES.
+ * Keep all three in sync when adding a type -- the insulin.test.ts parity test
+ * guards the relationship between these two tables.
+ */
+
+import type { InsulinPresets } from "@/lib/api";
+
+export const FALLBACK_PRESETS: InsulinPresets = {
+  humalog: { dia_hours: 4.0, onset_minutes: 15.0 },
+  novolog: { dia_hours: 4.0, onset_minutes: 15.0 },
+  fiasp: { dia_hours: 3.5, onset_minutes: 5.0 },
+  lyumjev: { dia_hours: 3.5, onset_minutes: 5.0 },
+  apidra: { dia_hours: 4.0, onset_minutes: 15.0 },
+  // Rapid analogs -- same molecule/PK as an entry above
+  novorapid: { dia_hours: 4.0, onset_minutes: 15.0 },
+  liprolog: { dia_hours: 4.0, onset_minutes: 15.0 },
+  admelog: { dia_hours: 4.0, onset_minutes: 15.0 },
+  trurapi: { dia_hours: 4.0, onset_minutes: 15.0 },
+  kirsty: { dia_hours: 4.0, onset_minutes: 15.0 },
+  // Regular (short-acting) human insulin -- longer DIA, later onset
+  humulin_r: { dia_hours: 6.0, onset_minutes: 30.0 },
+  novolin_r: { dia_hours: 6.0, onset_minutes: 30.0 },
+  insuman_rapid: { dia_hours: 6.0, onset_minutes: 30.0 },
+};
+
+/**
+ * DIA/onset input bounds. These mirror the InsulinConfigUpdate Field
+ * constraints in apps/api/src/schemas/insulin_config.py -- the backend is the
+ * source of truth, this is the single frontend copy so the form's validation
+ * and its tests check the same numbers (and an offline preset auto-fill never
+ * produces a value the backend would 422 on save).
+ */
+export const INSULIN_LIMITS = {
+  diaMinHours: 2.0,
+  diaMaxHours: 8.0,
+  onsetMinMinutes: 1.0,
+  onsetMaxMinutes: 60.0,
+} as const;
+
+// Dropdown labels. "custom" stays last so it renders at the bottom of the list.
+export const INSULIN_LABELS: Record<string, string> = {
+  humalog: "Humalog (Lispro)",
+  novolog: "NovoLog (Aspart)",
+  fiasp: "Fiasp (Faster Aspart)",
+  lyumjev: "Lyumjev (Faster Lispro)",
+  apidra: "Apidra (Glulisine)",
+  novorapid: "NovoRapid (Aspart)",
+  liprolog: "Liprolog (Lispro)",
+  admelog: "Admelog / Insulin lispro Sanofi (Lispro)",
+  trurapi: "Trurapi (Aspart)",
+  kirsty: "Kirsty (Aspart)",
+  humulin_r: "Humulin R (Regular human)",
+  novolin_r: "Novolin R / Actrapid (Regular human)",
+  insuman_rapid: "Insuman Rapid (Regular human)",
+  custom: "Custom",
+};

--- a/docs/daily-use/integrations.md
+++ b/docs/daily-use/integrations.md
@@ -79,7 +79,7 @@ Schedule rows have a **Preview** button that expands a table showing every segme
 
 Below the table, **Import history for** picks how far back to pull entries on the first sync: 1 day, 7 days, 30 days, 90 days, or all available.
 
-> **Insulin type is not auto-imported.** GlycemicGPT needs to know what insulin you're on (Humalog, Novolog, Fiasp, Lyumjev, etc.) to compute IoB curves correctly. The wizard intentionally doesn't guess -- pick yours under **Settings → Insulin** once after the wizard finishes.
+> **Insulin type is not auto-imported.** GlycemicGPT needs to know what insulin you're on (Humalog, NovoLog/NovoRapid, Fiasp, Lyumjev, etc.) to compute IoB curves correctly. The wizard intentionally doesn't guess -- pick yours under **Settings → Insulin** once after the wizard finishes.
 
 > **mmol/L users.** If your Nightscout reports `units: mmol`, the wizard automatically converts target ranges and ISF to mg/dL before they land in GlycemicGPT and surfaces a banner so you can see the conversion happened. GlycemicGPT stores glucose values in mg/dL internally regardless of how you view them.
 


### PR DESCRIPTION
## Summary

Expands the **Settings → Insulin** bolus picker with eight region-neutral insulin brands so non-US users can select their insulin (the #841 reporter is an EU user asking for NovoRapid). This is an additive expansion of the existing insulin-config feature — no migration, no IOB-engine change, no new endpoints.

## What's added

**Rapid-acting analogs** — reuse the shipped molecule's PK (4.0h DIA / 15min onset):
NovoRapid (aspart), Liprolog, Admelog / Insulin lispro Sanofi, Trurapi, Kirsty.

**Regular (short-acting) human insulin** (6.0h DIA / 30min onset):
Humulin R, Novolin R / Actrapid, Insuman Rapid.

## Regular-human DIA = 6.0h (clinical basis)

DIA is set to **6.0h** based on the FDA prescribing information: Humulin R and Novolin R U-100 both list action terminating ~8h (peak ~3h); clinical references give 5–8h. The IOB-remaining curve `1-(t/DIA)²` zeroes at DIA, so DIA must equal the realistic *total* duration — a shorter value would truncate a still-active tail and under-count late insulin on board (the stacking direction). 6.0h sits at the conservative low end of the documented range while staying below the 8h label, so it does not over-estimate. Onset 30min matches the labeled ~30min.

> Sources: DailyMed / FDA labels for Humulin R (NDA 018780) and Novolin R (NDA 019938); Endotext insulin pharmacology. Note: regular human insulin is dose-dependent and large doses can act longer than this fixed model assumes.

## Scope guardrails (intentional exclusions)

- **No long-acting/basal** (Toujeo, Lantus, Tresiba, Levemir), **premix**, or **inhaled** (Afrezza) in this picker. Basal is semantically wrong for a bolus DIA picker — its real duration exceeds the 2–8h validator — and is already recognised separately on ingestion (`BASAL_INJECTION`). Toujeo/basal remains ingestion-tracked but is intentionally not bolus-selectable.
- Validation stays allow-list-driven: `insulin_type` is rendered into the AI prompt, so it must never become free text. The new keys are constant `[a-z_]` identifiers.
- No migration (free-text VARCHAR); no IOB-engine change (only `dia_hours` feeds the curve, and the rapid analogs reuse an existing DIA).

## Tests & quality

- **Backend:** acceptance tests for all new types, preset-value assertions, two drift-guards (every preset key is a valid type; every preset is provably savable through the real validator), and an unknown-type → **HTTP 422** check.
- **Web:** catalog extracted to `src/lib/insulin.ts` — a single source for the dropdown labels, the offline fallback presets, and the DIA/onset bounds (previously duplicated in the page) — with a parity test.
- Verified end-to-end in the browser: all 14 options render with Custom last, new types auto-fill the correct DIA/onset, and a save persists across reload.

Closes #841


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the list of selectable insulin types, including more rapid-acting and regular human options.
  * Added shared insulin presets and labels so the settings screen can show consistent choices and default values.

* **Bug Fixes**
  * Improved insulin settings validation to keep DIA and onset values within supported ranges.
  * Updated insulin settings to use shared limits, reducing mismatches between the app and backend.

* **Documentation**
  * Clarified insulin type naming and updated the setup guidance for insulin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->