### PR TITLE
fix(medtronic): correct BLE vendor UUID base and SAKE/DIS GATT identities (#844)

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -103,7 +103,10 @@ class PumpPollingOrchestrator @Inject constructor(
                             startPollingLoops(scope)
                         }
                     } else {
-                        Timber.d("Pump disconnected (state=%s), pausing polling", state)
+                        // Any non-CONNECTED state (e.g. SCANNING/CONNECTING/AUTHENTICATING/DISCONNECTED)
+                        // pauses polling; log the actual state instead of always saying "disconnected",
+                        // which misleads debugging during a pairing attempt (issue #844).
+                        Timber.d("Pump not connected (state=%s), pausing polling", state)
                         previousAlertType = null
                         cancelPollingLoops()
                     }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicPeripheral.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicPeripheral.kt
@@ -291,9 +291,11 @@ class AndroidMedtronicPeripheral(context: Context) : MedtronicPeripheral {
             BluetoothGattService.SERVICE_TYPE_PRIMARY,
         )
         // SAKE characteristic: NOTIFY (phone -> pump) + WRITE (pump -> phone). Read-only data path;
-        // no control/calibration characteristic is ever exposed. TODO(48.A2): confirm the pump
-        // accepts MedtronicProtocol.SAKE_CHARACTERISTIC_UUID (JavaPumpConnector used a vendor-base
-        // variant of the same 16-bit code) against real hardware.
+        // no control/calibration characteristic is ever exposed. The UUID is on the Medtronic vendor
+        // base (same 0xFE82 short code as the SIG-based service) to match JavaPumpConnector, which
+        // paired on real hardware; the SIG-based form shipped before left the pump unable to find the
+        // characteristic, so the handshake never began (issue #844). Live re-confirmation on a real
+        // 780G is still pending (DESK).
         val sake = BluetoothGattCharacteristic(
             MedtronicProtocol.SAKE_CHARACTERISTIC_UUID,
             BluetoothGattCharacteristic.PROPERTY_NOTIFY or BluetoothGattCharacteristic.PROPERTY_WRITE,
@@ -323,16 +325,20 @@ class AndroidMedtronicPeripheral(context: Context) : MedtronicPeripheral {
             ).apply { @Suppress("DEPRECATION") setValue(value) }
 
         // Placeholder DIS values: the read-only handshake authenticates at the app layer (SAKE), not
-        // off these fields. JavaPumpConnector spoofs a realistic app-version string; TODO(48.A2):
-        // confirm a real pump does not validate any DIS field before falling back to these.
+        // off these fields. The characteristic *set* mirrors JavaPumpConnector (including Hardware
+        // Revision and the empty Regulatory Certification list) so a pump that enumerates DIS
+        // membership during discovery sees the same table. JavaPumpConnector spoofs a realistic
+        // app-version string; TODO(48.A2): confirm a real pump does not validate any DIS field value.
         val ascii = Charsets.US_ASCII
         service.addCharacteristic(readChar(MedtronicProtocol.MANUFACTURER_NAME_UUID, "GlycemicGPT".toByteArray(ascii)))
         service.addCharacteristic(readChar(MedtronicProtocol.MODEL_NUMBER_UUID, "Mobile".toByteArray(ascii)))
         service.addCharacteristic(readChar(MedtronicProtocol.SERIAL_NUMBER_UUID, currentName.toByteArray(ascii)))
+        service.addCharacteristic(readChar(MedtronicProtocol.HARDWARE_REVISION_UUID, "0".toByteArray(ascii)))
         service.addCharacteristic(readChar(MedtronicProtocol.FIRMWARE_REVISION_UUID, "0".toByteArray(ascii)))
         service.addCharacteristic(readChar(MedtronicProtocol.SOFTWARE_REVISION_UUID, "0".toByteArray(ascii)))
         service.addCharacteristic(readChar(MedtronicProtocol.SYSTEM_ID_UUID, ByteArray(8)))
         service.addCharacteristic(readChar(MedtronicProtocol.PNP_ID_UUID, ByteArray(7)))
+        service.addCharacteristic(readChar(MedtronicProtocol.REGULATORY_CERT_UUID, ByteArray(0)))
         return service
     }
 
@@ -368,13 +374,7 @@ class AndroidMedtronicPeripheral(context: Context) : MedtronicPeripheral {
             characteristic: BluetoothGattCharacteristic,
         ) {
             @Suppress("DEPRECATION")
-            val stored = characteristic.value ?: ByteArray(0)
-            if (offset > stored.size) {
-                sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, ByteArray(0))
-                return
-            }
-            val value = stored.copyOfRange(offset, stored.size)
-            sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
+            respondWithStoredBlob(device, requestId, offset, characteristic.value ?: ByteArray(0))
         }
 
         override fun onCharacteristicWriteRequest(
@@ -392,6 +392,21 @@ class AndroidMedtronicPeripheral(context: Context) : MedtronicPeripheral {
             if (responseNeeded) {
                 sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, value)
             }
+        }
+
+        override fun onDescriptorReadRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            offset: Int,
+            descriptor: BluetoothGattDescriptor,
+        ) {
+            // Android peripherals get no auto-response, so any descriptor read the pump issues (the
+            // SAKE CCCD around subscribe is the only descriptor this GATT table exposes) stalls unless
+            // we answer it. The descriptor's stored value (default 0x0000 = notifications off) is the
+            // correct reply for any descriptor, so this stays intentionally ungated -- unlike the CCCD
+            // write handler below (issue #844; JavaPumpConnector's BlePeripheralDevice answers the same).
+            @Suppress("DEPRECATION")
+            respondWithStoredBlob(device, requestId, offset, descriptor.value ?: byteArrayOf(0x00, 0x00))
         }
 
         override fun onDescriptorWriteRequest(
@@ -438,6 +453,17 @@ class AndroidMedtronicPeripheral(context: Context) : MedtronicPeripheral {
         } catch (e: SecurityException) {
             Timber.w(e, "sendResponse failed")
         }
+    }
+
+    /** Reply to a characteristic or descriptor read with [stored], honoring the central's [offset]. */
+    private fun respondWithStoredBlob(device: BluetoothDevice, requestId: Int, offset: Int, stored: ByteArray) {
+        // The ATT offset is an unsigned 16-bit field, so a negative value can't arrive from the wire;
+        // the `offset < 0` guard is defensive so copyOfRange() below can never throw.
+        if (offset < 0 || offset > stored.size) {
+            sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, ByteArray(0))
+            return
+        }
+        sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, stored.copyOfRange(offset, stored.size))
     }
 
     private companion object {

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/protocol/MedtronicProtocol.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/protocol/MedtronicProtocol.kt
@@ -31,9 +31,11 @@ object MedtronicProtocol {
     // Bluetooth SIG base: a 16-bit code XXXX expands to 0000XXXX-0000-1000-8000-00805f9b34fb.
     private const val SIG_BASE_SUFFIX = "-0000-1000-8000-00805f9b34fb"
 
-    // Medtronic vendor-specific 128-bit base (node ...-009132591325, per OpenMinimed uuids.py):
-    // a 16-bit code XXXX expands to 0000XXXX-0000-1000-8000-009132591325.
-    private const val MEDTRONIC_BASE_SUFFIX = "-0000-1000-8000-009132591325"
+    // Medtronic vendor-specific 128-bit base (node ...-009132591325, per OpenMinimed uuids.py and
+    // JavaPumpConnector): a 16-bit code XXXX expands to 0000XXXX-0000-1000-0000-009132591325. The
+    // variant field is 0000, NOT the SIG 8000 -- the real pump never finds vendor services advertised
+    // on the 8000 form, which silently broke pairing and every IDD/HAT/CM read (issue #844).
+    private const val MEDTRONIC_BASE_SUFFIX = "-0000-1000-0000-009132591325"
 
     private fun uuidFor(short16: Int, baseSuffix: String): UUID {
         val hex = (short16 and 0xFFFF).toString(16).padStart(4, '0')
@@ -105,11 +107,26 @@ object MedtronicProtocol {
     // medtronic-ble-reverse-engineering.md Sec. 8. All read-only for our purposes (subscribe/read);
     // no write/control characteristics are exposed by design.
 
-    /** SAKE authentication service: 0xFE82 first-pair / 0xFE81 reconnect. Char NOTIFY + WRITE. */
-    val SAKE_CHARACTERISTIC_UUID: UUID = sigUuid(SAKE_SERVICE_FIRST_PAIR_16)
+    /**
+     * SAKE authentication characteristic (NOTIFY + WRITE). It shares the 0xFE82 short code with the
+     * SAKE service but lives on the Medtronic vendor base, not the SIG base: the service is advertised
+     * and registered as SIG 0xFE82 while the characteristic the pump subscribes to is
+     * 0000fe82-...-009132591325. With the SIG base here the pump found the service but not the
+     * characteristic, so it never wrote the CCCD and the handshake never began (issue #844, confirmed
+     * against JavaPumpConnector BlePeripheralDevice).
+     */
+    val SAKE_CHARACTERISTIC_UUID: UUID = vendorUuid(SAKE_SERVICE_FIRST_PAIR_16)
 
-    /** Device Information service (0x180A): manufacturer/model/serial/hw/fw/sw, system + PnP id. */
-    val DEVICE_INFO_SERVICE_UUID: UUID = sigUuid(0x180A)
+    /**
+     * Device Information service container the phone exposes to the pump. Medtronic uses a proprietary
+     * vendor service (0x0900 on the vendor base), NOT the standard SIG 0x180A, even though the
+     * characteristics inside it are the standard SIG DIS strings below. The pump looks for the 0x0900
+     * service during GATT discovery (0x0900 is not advertised) and will not pair when only 0x180A is
+     * present (issue #844, per JavaPumpConnector
+     * BlePeripheralDevice; OpenMinimed uuids.py's 0x180A describes the pump's own DIS on the read side,
+     * which our read layer addresses by characteristic UUID, not by this service UUID).
+     */
+    val DEVICE_INFO_SERVICE_UUID: UUID = vendorUuid(0x0900)
     val MANUFACTURER_NAME_UUID: UUID = sigUuid(0x2A29)
     val MODEL_NUMBER_UUID: UUID = sigUuid(0x2A24)
     val SERIAL_NUMBER_UUID: UUID = sigUuid(0x2A25)
@@ -118,6 +135,9 @@ object MedtronicProtocol {
     val SOFTWARE_REVISION_UUID: UUID = sigUuid(0x2A28)
     val SYSTEM_ID_UUID: UUID = sigUuid(0x2A23)
     val PNP_ID_UUID: UUID = sigUuid(0x2A50)
+
+    /** IEEE 11073-20601 Regulatory Certification Data List (0x2A2A); exposed empty, like the reference. */
+    val REGULATORY_CERT_UUID: UUID = sigUuid(0x2A2A)
 
     /** Battery service (0x180F): Battery Level 0x2A19. */
     val BATTERY_SERVICE_UUID: UUID = sigUuid(0x180F)

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/protocol/MedtronicProtocolTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/protocol/MedtronicProtocolTest.kt
@@ -52,20 +52,46 @@ class MedtronicProtocolTest {
             "0000180a-0000-1000-8000-00805f9b34fb",
             MedtronicProtocol.sigUuid(0x180A).toString(),
         )
+        // Vendor base carries the Medtronic node id (...-009132591325) with variant field 0000, not
+        // the SIG 8000 (issue #844, per OpenMinimed uuids.py / JavaPumpConnector).
         assertEquals(
-            "0000fe82-0000-1000-8000-00805f9b34fb",
-            MedtronicProtocol.SAKE_CHARACTERISTIC_UUID.toString(),
-        )
-        // Vendor base carries the Medtronic node id (...-009132591325).
-        assertEquals(
-            "00000100-0000-1000-8000-009132591325",
+            "00000100-0000-1000-0000-009132591325",
             MedtronicProtocol.IDD_SERVICE_UUID.toString(),
         )
         assertEquals(
-            "00000300-0000-1000-8000-009132591325",
+            "00000300-0000-1000-0000-009132591325",
             MedtronicProtocol.HAT_SERVICE_UUID.toString(),
         )
         // The two bases must not collapse: the same short code maps to distinct UUIDs.
         assertNotEquals(MedtronicProtocol.sigUuid(0x100), MedtronicProtocol.vendorUuid(0x100))
+    }
+
+    @Test
+    fun `issue 844 - GATT identities the phone exposes match the validated JavaPumpConnector`() {
+        // The phone is the BLE peripheral; a real 780G only pairs when the GATT table it discovers
+        // matches what the official app exposes. These values are pinned against OpenMinimed's
+        // JavaPumpConnector BlePeripheralDevice, which paired on the reporter's hardware. Three
+        // identities are subtle and previously shipped wrong (issue #844), so assert them directly.
+
+        // 1. The Device Information service container is the proprietary vendor 0x0900, NOT SIG 0x180A.
+        assertEquals(
+            "00000900-0000-1000-0000-009132591325",
+            MedtronicProtocol.DEVICE_INFO_SERVICE_UUID.toString(),
+        )
+        // 2. The SAKE *service* is advertised and registered on the SIG base (0xFE82)...
+        assertEquals(
+            "0000fe82-0000-1000-8000-00805f9b34fb",
+            MedtronicProtocol.SAKE_SERVICE_FIRST_PAIR_UUID.toString(),
+        )
+        // 3. ...but the SAKE *characteristic* inside it lives on the vendor base (same 0xFE82 code).
+        assertEquals(
+            "0000fe82-0000-1000-0000-009132591325",
+            MedtronicProtocol.SAKE_CHARACTERISTIC_UUID.toString(),
+        )
+        // The service/characteristic split is the crux: same short code, different base.
+        assertNotEquals(
+            MedtronicProtocol.SAKE_SERVICE_FIRST_PAIR_UUID,
+            MedtronicProtocol.SAKE_CHARACTERISTIC_UUID,
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fixes #844. A Medtronic 780G could not complete the SAKE pairing handshake because the phone's GATT table (the phone is the BLE peripheral) exposed the wrong UUID identities. Corrected against the validated OpenMinimed JavaPumpConnector reference, which pairs on the same hardware.

## Root cause

Three UUID identities in `MedtronicProtocol.kt` were wrong:

1. **Vendor 128-bit base** used variant field `8000` (`-0000-1000-8000-009132591325`) instead of `0000` (`-0000-1000-0000-009132591325`). This corrupted every IDD/HAT/CM service and characteristic UUID. It is latent for pairing (the GATT server only builds SIG-based services) but silently breaks the post-pairing CGM/IOB/basal/history read layer.
2. **Device Information service** was exposed as the standard SIG `0x180A` instead of the proprietary vendor `0x0900` the pump looks for during GATT discovery.
3. **SAKE characteristic** used the SIG base instead of the vendor base. The SAKE *service* (SIG `0xFE82`) is advertised and correct, but the characteristic inside it must be on the vendor base (`0000fe82-…-009132591325`). With the SIG base the pump found the service but not the characteristic, never wrote the CCCD, and the handshake never began — the guaranteed blocker.

## Changes

- `MedtronicProtocol.kt`: fix the vendor base; `DEVICE_INFO_SERVICE_UUID` → `vendorUuid(0x0900)`; `SAKE_CHARACTERISTIC_UUID` → `vendorUuid(0xFE82)`; add `REGULATORY_CERT_UUID` (`0x2A2A`).
- `AndroidMedtronicPeripheral.kt`: add the missing `onDescriptorReadRequest` handler (Android peripherals do not auto-respond, so a CCCD read around subscribe would stall the connection); expose Hardware Revision (`0x2A27`) and the empty Regulatory Certification (`0x2A2A`) characteristics so the DIS membership mirrors the reference; factor the shared offset-aware read reply into `respondWithStoredBlob`.
- `PumpPollingOrchestrator.kt`: stop logging "Pump disconnected" for non-CONNECTED states (e.g. SCANNING/CONNECTING/AUTHENTICATING) during a pairing attempt — log the actual state instead.
- `MedtronicProtocolTest.kt`: correct the assertions that pinned the wrong base; add a regression test pinning the three GATT identities against the validated reference.

## Verification

- `:medtronic-pump-driver:testDebugUnitTest`, `:medtronic-pump-driver:lintDebug`, and `:app` `PumpPollingOrchestratorTest` all pass.
- Live pump pairing is hardware-gated and cannot be validated in CI or the emulator. The UUIDs are verified byte-for-byte against the JavaPumpConnector reference that pairs on the reporter's 780G; a final confirmation on real hardware is still needed before this is considered fully resolved.

## Out of scope (follow-ups)

- Spoofing a realistic DIS app-version string (the reference does; we expose placeholders). It is unverified whether the pump validates any DIS field value.
- The `RECONNECT` advertising path (`0xFE81`) has no reference counterpart and remains unvalidated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pump connection status messaging so polling pauses are reported more accurately during non-connected states.
  * Fixed BLE identity and service discovery behavior to better match expected device responses, including read handling for partial values and descriptor reads.
  * Added missing device information details and corrected UUID mappings so connected-device information is more consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->