### PR TITLE
feat(mobile): opt-in plaintext HTTP to private/LAN hosts on release builds

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -283,6 +283,35 @@ class AppSettingsStore @Inject constructor(
         get() = prefs.getBoolean(KEY_WATCHFACE_SHOW_MODES, true)
         set(value) { prefs.edit().putBoolean(KEY_WATCHFACE_SHOW_MODES, value).apply() }
 
+    /**
+     * Whether the app may connect to a self-hosted server over plaintext `http://` when the host is
+     * a private/LAN address (Story 57.1). Default OFF -- enabling it is an explicit, acknowledged
+     * choice. A *per-device* connection preference (the LAN box is the same across sign-ins), so it
+     * is intentionally NOT reset on logout. Public hosts are always refused over http regardless of
+     * this flag; enforcement lives in [com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy].
+     */
+    var allowInsecureLanHttp: Boolean
+        get() = prefs.getBoolean(KEY_ALLOW_INSECURE_LAN_HTTP, false)
+        set(value) {
+            prefs.edit().putBoolean(KEY_ALLOW_INSECURE_LAN_HTTP, value).apply()
+        }
+
+    /**
+     * Emits the current [allowInsecureLanHttp] and re-emits whenever it changes, so the app-wide
+     * insecure-HTTP indicator appears/disappears live when the user toggles the setting. Uses the
+     * same change-listener mechanism as [glucoseUnitFlow].
+     */
+    fun allowInsecureLanHttpFlow(): Flow<Boolean> = callbackFlow {
+        trySend(allowInsecureLanHttp)
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_ALLOW_INSECURE_LAN_HTTP || key == null) {
+                trySend(allowInsecureLanHttp)
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+
     /** Whether AI chat responses should be spoken aloud via TTS. */
     var aiTtsEnabled: Boolean
         get() = prefs.getBoolean(KEY_AI_TTS_ENABLED, false)
@@ -335,5 +364,6 @@ class AppSettingsStore @Inject constructor(
         private const val KEY_WATCHFACE_SHOW_MODES = "watchface_show_modes"
         private const val KEY_AI_TTS_ENABLED = "ai_tts_enabled"
         private const val KEY_AI_TTS_VOICE = "ai_tts_voice"
+        private const val KEY_ALLOW_INSECURE_LAN_HTTP = "allow_insecure_lan_http"
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
@@ -5,6 +5,9 @@ import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -52,6 +55,22 @@ class AuthTokenStore @Inject constructor(
     }
 
     fun getBaseUrl(): String? = prefs.getString(KEY_BASE_URL, null)
+
+    /**
+     * Emits the current base URL and re-emits whenever it changes, so surfaces that must track the
+     * live server address (e.g. the insecure-HTTP indicator) update the moment the URL is saved
+     * rather than only on the next recomposition.
+     */
+    fun baseUrlFlow(): Flow<String?> = callbackFlow {
+        trySend(getBaseUrl())
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_BASE_URL || key == null) {
+                trySend(getBaseUrl())
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
 
     fun getUserEmail(): String? = prefs.getString(KEY_USER_EMAIL, null)
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/BaseUrlInterceptor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/BaseUrlInterceptor.kt
@@ -1,5 +1,7 @@
 package com.glycemicgpt.mobile.data.remote
 
+import com.glycemicgpt.mobile.BuildConfig
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
@@ -15,10 +17,16 @@ import javax.inject.Singleton
  *
  * Throws [IOException] if no valid base URL is configured, preventing
  * requests from leaking to the Retrofit placeholder (localhost).
+ *
+ * Defense-in-depth: re-applies [UrlSecurityPolicy] here so a base URL that ever became
+ * inconsistent with the policy (e.g. the insecure-LAN-HTTP opt-in was turned back off after a
+ * cleartext URL was saved) can never actually issue a plaintext request to a public host. This is
+ * redundant with the save-time [AuthTokenStore] guard, by design.
  */
 @Singleton
 class BaseUrlInterceptor @Inject constructor(
     private val authTokenStore: AuthTokenStore,
+    private val appSettingsStore: AppSettingsStore,
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -31,6 +39,16 @@ class BaseUrlInterceptor @Inject constructor(
 
         val parsed = baseUrl.toHttpUrlOrNull()
             ?: throw IOException("Invalid server URL: $baseUrl")
+
+        if (!UrlSecurityPolicy.isAllowed(baseUrl, BuildConfig.DEBUG, appSettingsStore.allowInsecureLanHttp)) {
+            // Distinguish "private host but opt-in off" from "public host" so the error is accurate.
+            val message = if (UrlSecurityPolicy.isBlockedPendingLanOptIn(baseUrl, BuildConfig.DEBUG)) {
+                "Insecure LAN HTTP is off. Enable it in Settings, or use https://."
+            } else {
+                "Refusing cleartext HTTP to a non-private host. Use https:// or a private/LAN address."
+            }
+            throw IOException(message)
+        }
 
         val newUrl = original.url.newBuilder()
             .scheme(parsed.scheme)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/UrlSecurityPolicy.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/UrlSecurityPolicy.kt
@@ -56,6 +56,17 @@ object UrlSecurityPolicy {
     }
 
     /**
+     * True when [url] would actually be sent as cleartext -- the scheme is `http` AND [isAllowed]
+     * permits it. Drives the insecure-mode indicator so it reflects real cleartext traffic rather
+     * than a bare `http://` prefix (a public `http://` URL the request layer rejects must not light
+     * the banner).
+     */
+    fun isActiveInsecureHttp(url: String, isDebug: Boolean, allowInsecureLanHttp: Boolean): Boolean {
+        val parsed = url.toHttpUrlOrNull() ?: return false
+        return parsed.scheme == "http" && isAllowed(url, isDebug, allowInsecureLanHttp)
+    }
+
+    /**
      * Classify [host] (an OkHttp-canonicalized URL host: no brackets, no port, lowercased) as a
      * private/LAN destination. Accepts, by literal-IP inspection only:
      * - loopback `127.0.0.0/8`, `::1`

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/UrlSecurityPolicy.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/UrlSecurityPolicy.kt
@@ -1,0 +1,239 @@
+package com.glycemicgpt.mobile.data.remote
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+/**
+ * Single source of truth for whether a server base URL is allowed as a transport target.
+ *
+ * The release build permits cleartext at the platform layer (`network_security_config`
+ * `cleartextTrafficPermitted="true"`) so a self-hoster can reach a LAN box over `http://`.
+ * Because network-security-config matches exact hosts and cannot express CIDR ranges, the
+ * "private-only" rule lives here instead: this object is the *sole* guard that keeps a
+ * public host from being reached over plaintext.
+ *
+ * Policy:
+ * - `https` -> always allowed.
+ * - `http`  -> allowed only when [isDebug] (dev convenience, unchanged) OR the user has
+ *   opted in ([allowInsecureLanHttp]) AND the host is a private/LAN literal ([isPrivateHost]).
+ * - anything else -> rejected.
+ *
+ * [isPrivateHost] classifies the URL host as a **literal IP** (or the `.local` mDNS suffix) and
+ * **never performs a DNS lookup** -- resolving a name to decide "is it private" would invite
+ * DNS-rebinding (a public name pointing at a private IP, or vice-versa) and block the caller's
+ * thread. Everything here is pure and side-effect-free so it is exhaustively unit-testable on the
+ * JVM (including the `isDebug == false` release path, which `BuildConfig.DEBUG` cannot express in a
+ * `testDebug` run).
+ */
+object UrlSecurityPolicy {
+
+    /**
+     * Shared rejection message for a URL that fails [isAllowed]. Names the LAN exception so the
+     * three call sites (onboarding test, settings save, login) stay consistent.
+     */
+    const val INVALID_URL_MESSAGE =
+        "Invalid server URL. Use https://, or enable insecure LAN HTTP to reach a " +
+            "private/LAN address over http://."
+
+    /** True if [url] is an acceptable transport target under the policy described above. */
+    fun isAllowed(url: String, isDebug: Boolean, allowInsecureLanHttp: Boolean): Boolean {
+        val parsed = url.toHttpUrlOrNull() ?: return false
+        return when (parsed.scheme) {
+            "https" -> true
+            "http" -> isDebug || (allowInsecureLanHttp && isPrivateHost(parsed.host))
+            else -> false
+        }
+    }
+
+    /**
+     * True when [url] would be rejected today but *would* be accepted if insecure LAN HTTP were
+     * enabled -- i.e. it is `http://` to a private host. Lets the UI offer a one-tap opt-in instead
+     * of a dead end. In a debug build this is false (debug already permits the URL).
+     */
+    fun isBlockedPendingLanOptIn(url: String, isDebug: Boolean): Boolean {
+        if (isDebug) return false
+        val parsed = url.toHttpUrlOrNull() ?: return false
+        return parsed.scheme == "http" && isPrivateHost(parsed.host)
+    }
+
+    /**
+     * Classify [host] (an OkHttp-canonicalized URL host: no brackets, no port, lowercased) as a
+     * private/LAN destination. Accepts, by literal-IP inspection only:
+     * - loopback `127.0.0.0/8`, `::1`
+     * - RFC1918 `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+     * - CGNAT `100.64.0.0/10`
+     * - link-local `169.254.0.0/16`, `fe80::/10`
+     * - IPv6 ULA `fc00::/7`
+     * - hostnames ending in `.local` (mDNS)
+     *
+     * Rejects everything else. Non-canonical IPv4 encodings (octal `012.0.0.1`, hex `0x0a000001`,
+     * bare-decimal `2130706433`) do not parse as a literal IPv4 here and are rejected; a
+     * userinfo-spoofed authority like `10.0.0.1@evil.com` never reaches this function as a private
+     * host because OkHttp resolves its host to `evil.com`.
+     */
+    fun isPrivateHost(host: String): Boolean {
+        if (host.isEmpty()) return false
+        // Defensive: strip IPv6 brackets and a single trailing FQDN dot in case a raw host is
+        // passed (OkHttp already removes both, but callers/tests may not).
+        var h = host
+        if (h.startsWith("[") && h.endsWith("]")) h = h.substring(1, h.length - 1)
+        if (h.endsWith(".")) h = h.dropLast(1)
+        if (h.isEmpty()) return false
+
+        // mDNS names (RFC 6762). This is the ONE deliberate name-based exception to the
+        // literal-IP rule: a `.local` name is resolved at connect time, not by us, so unlike an IP
+        // literal we cannot prove the connect target is private. The residual risk is bounded and
+        // accepted: (a) `.local` resolution is multicast on the local link, so an attacker able to
+        // answer it is already on the LAN the user explicitly opted into (and could MITM a
+        // private-IP connection just the same); (b) Android does not fall back to unicast DNS for
+        // `.local` by default, and search-domain appending does not apply to a name already ending
+        // in `.local`. Require a label before `.local` so a bare `.local` is rejected.
+        if (h.length > LOCAL_SUFFIX.length && h.endsWith(LOCAL_SUFFIX, ignoreCase = true)) {
+            return true
+        }
+
+        parseStrictIpv4(h)?.let { return isPrivateIpv4(it[0], it[1]) }
+
+        if (h.contains(':')) {
+            parseIpv6ToBytes(h)?.let { return isPrivateIpv6(it) }
+        }
+        return false
+    }
+
+    private const val LOCAL_SUFFIX = ".local"
+
+    // ---- IPv4 -------------------------------------------------------------------------------
+
+    /**
+     * Parse a strict canonical dotted-decimal IPv4 (four base-10 octets, no leading zeros, each
+     * 0..255) into its octets, or null if [host] is not exactly that form. The strictness is
+     * deliberate: it rejects octal/hex/short/overflow encodings so only an unambiguous literal
+     * counts as an IP -- matching the address OkHttp will actually connect to.
+     */
+    private fun parseStrictIpv4(host: String): IntArray? {
+        val parts = host.split('.')
+        if (parts.size != 4) return null
+        val octets = IntArray(4)
+        for (i in 0 until 4) {
+            val part = parts[i]
+            if (part.isEmpty() || part.length > 3) return null
+            if (!part.all { it in '0'..'9' }) return null
+            if (part.length > 1 && part[0] == '0') return null // reject octal-looking leading zero
+            val value = part.toInt()
+            if (value > 255) return null
+            octets[i] = value
+        }
+        return octets
+    }
+
+    /** Classify an IPv4 by its first two octets against the accepted private/LAN ranges. */
+    private fun isPrivateIpv4(a: Int, b: Int): Boolean = when {
+        a == 127 -> true // loopback 127.0.0.0/8
+        a == 10 -> true // RFC1918 10.0.0.0/8
+        a == 172 && b in 16..31 -> true // RFC1918 172.16.0.0/12
+        a == 192 && b == 168 -> true // RFC1918 192.168.0.0/16
+        a == 100 && b in 64..127 -> true // CGNAT 100.64.0.0/10
+        a == 169 && b == 254 -> true // link-local 169.254.0.0/16
+        else -> false
+    }
+
+    // ---- IPv6 -------------------------------------------------------------------------------
+
+    private fun isPrivateIpv6(bytes: ByteArray): Boolean {
+        // IPv4-mapped (::ffff:a.b.c.d) -> classify the embedded IPv4 so a public v4 tunnelled
+        // through a v6 literal is still rejected.
+        if (isIpv4Mapped(bytes)) {
+            return isPrivateIpv4(bytes[12].u(), bytes[13].u())
+        }
+        if (isLoopbackV6(bytes)) return true // ::1
+        val b0 = bytes[0].u()
+        val b1 = bytes[1].u()
+        if (b0 == 0xFE && (b1 and 0xC0) == 0x80) return true // link-local fe80::/10
+        if ((b0 and 0xFE) == 0xFC) return true // unique-local fc00::/7
+        return false
+    }
+
+    private fun isIpv4Mapped(b: ByteArray): Boolean {
+        for (i in 0 until 10) if (b[i].u() != 0) return false
+        return b[10].u() == 0xFF && b[11].u() == 0xFF
+    }
+
+    private fun isLoopbackV6(b: ByteArray): Boolean {
+        for (i in 0 until 15) if (b[i].u() != 0) return false
+        return b[15].u() == 1
+    }
+
+    /**
+     * Parse a bracket-less IPv6 literal (optionally with an embedded IPv4 tail or a `%zone`
+     * suffix) into 16 bytes, or null if it is not a valid IPv6 literal. Pure string parsing --
+     * never resolves, so it cannot block or be tricked into a DNS lookup.
+     */
+    private fun parseIpv6ToBytes(input: String): ByteArray? {
+        val s = input.substringBefore('%') // drop a zone id (fe80::1%eth0)
+        if (s.length < 2) return null
+
+        // Split off a trailing embedded IPv4 (::ffff:1.2.3.4) if present.
+        var head = s
+        var tail: IntArray? = null
+        if (s.contains('.')) {
+            val lastColon = s.lastIndexOf(':')
+            if (lastColon < 0) return null
+            tail = parseStrictIpv4(s.substring(lastColon + 1)) ?: return null
+            head = s.substring(0, lastColon)
+        }
+
+        val leftGroups = ArrayList<Int>()
+        val rightGroups = ArrayList<Int>()
+        val doubleColon = head.indexOf("::")
+        if (doubleColon >= 0) {
+            if (head.indexOf("::", doubleColon + 1) >= 0) return null // more than one "::"
+            val left = head.substring(0, doubleColon)
+            val right = head.substring(doubleColon + 2)
+            if (left.startsWith(":") || right.endsWith(":")) return null
+            if (!parseHextets(left, leftGroups)) return null
+            if (!parseHextets(right, rightGroups)) return null
+        } else {
+            if (!parseHextets(head, leftGroups)) return null
+        }
+
+        val tailGroups = if (tail != null) 2 else 0
+        val present = leftGroups.size + rightGroups.size + tailGroups
+        if (doubleColon >= 0) {
+            if (present > 7) return null // "::" must stand for at least one zero group
+        } else {
+            if (present != 8) return null
+        }
+
+        val groups = IntArray(8)
+        var i = 0
+        for (g in leftGroups) groups[i++] = g
+        if (doubleColon >= 0) repeat(8 - present) { groups[i++] = 0 }
+        for (g in rightGroups) groups[i++] = g
+        if (tail != null) {
+            groups[6] = (tail[0] shl 8) or tail[1]
+            groups[7] = (tail[2] shl 8) or tail[3]
+        }
+
+        val out = ByteArray(16)
+        for (j in 0 until 8) {
+            out[j * 2] = ((groups[j] ushr 8) and 0xFF).toByte()
+            out[j * 2 + 1] = (groups[j] and 0xFF).toByte()
+        }
+        return out
+    }
+
+    /** Parse a colon-separated run of 1-4 hex digit hextets into [out]; empty run is a no-op. */
+    private fun parseHextets(part: String, out: MutableList<Int>): Boolean {
+        if (part.isEmpty()) return true
+        for (group in part.split(':')) {
+            if (group.isEmpty() || group.length > 4) return false
+            // Reject non-hex (e.g. a leading '+'/'-'), which toIntOrNull(16) would otherwise accept.
+            if (!group.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }) return false
+            val value = group.toIntOrNull(16) ?: return false
+            out.add(value)
+        }
+        return true
+    }
+
+    /** Unsigned byte value (0..255). */
+    private fun Byte.u(): Int = this.toInt() and 0xFF
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -10,6 +10,7 @@ import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpProfileStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy
 import com.glycemicgpt.mobile.data.remote.dto.GlucoseUnitUpdateRequest
 import com.glycemicgpt.mobile.data.remote.dto.LoginRequest
 import com.glycemicgpt.mobile.data.remote.dto.MealIntelligenceUpdateRequest
@@ -20,7 +21,6 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -79,7 +79,7 @@ class AuthRepository @Inject constructor(
             return LoginResult(success = false, error = "Configure server URL first")
         }
         if (!isValidUrl(baseUrl)) {
-            return LoginResult(success = false, error = "Invalid server URL. HTTPS required.")
+            return LoginResult(success = false, error = UrlSecurityPolicy.INVALID_URL_MESSAGE)
         }
         if (email.isBlank() || password.isBlank()) {
             return LoginResult(success = false, error = "Email and password are required")
@@ -146,11 +146,25 @@ class AuthRepository @Inject constructor(
         }
     }
 
-    fun isValidUrl(url: String): Boolean {
-        val parsed = url.toHttpUrlOrNull() ?: return false
-        if (BuildConfig.DEBUG && parsed.scheme == "http") return true
-        return parsed.scheme == "https"
-    }
+    /**
+     * The single chokepoint for server-URL transport policy: `https` always, `http` only in a
+     * debug build or when the user has opted into insecure LAN HTTP AND the host is a private/LAN
+     * literal. All three entry points (onboarding test, settings save, login) route through here.
+     */
+    fun isValidUrl(url: String): Boolean =
+        UrlSecurityPolicy.isAllowed(
+            url = url,
+            isDebug = BuildConfig.DEBUG,
+            allowInsecureLanHttp = appSettingsStore.allowInsecureLanHttp,
+        )
+
+    /**
+     * True when [url] is rejected today only because insecure LAN HTTP is off -- i.e. `http://` to
+     * a private host on a non-debug build. The UI uses this to offer a one-tap opt-in rather than a
+     * dead-end error.
+     */
+    fun isBlockedPendingLanHttpOptIn(url: String): Boolean =
+        !isValidUrl(url) && UrlSecurityPolicy.isBlockedPendingLanOptIn(url, BuildConfig.DEBUG)
 
     fun saveBaseUrl(url: String) {
         authTokenStore.saveBaseUrl(url)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
@@ -147,6 +147,12 @@ class AppUpdateChecker @Inject constructor(
     suspend fun downloadApk(url: String, fileName: String, expectedSize: Long): DownloadResult =
         withContext(Dispatchers.IO) {
             try {
+                // An APK download is a code-execution path: enforce https:// in code rather than
+                // relying solely on the network_security_config pin (the base config now permits
+                // cleartext globally for the LAN opt-in).
+                if (!isHttpsUrl(url)) {
+                    return@withContext DownloadResult.Error("Download blocked: insecure URL")
+                }
                 if (!isAllowedDownloadHost(url)) {
                     return@withContext DownloadResult.Error("Download blocked: untrusted host")
                 }
@@ -227,6 +233,16 @@ class AppUpdateChecker @Inject constructor(
             return ALLOWED_DOWNLOAD_HOSTS.any { allowed ->
                 host == allowed || host.endsWith(".$allowed")
             }
+        }
+
+        /** True only for an https:// URL; fail-closed on a malformed URL or any other scheme. */
+        fun isHttpsUrl(url: String): Boolean {
+            val scheme = try {
+                java.net.URI(url).scheme?.lowercase()
+            } catch (_: Exception) {
+                null
+            }
+            return scheme == "https"
         }
 
         fun sanitizeFileName(name: String): String {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
@@ -235,14 +235,18 @@ class AppUpdateChecker @Inject constructor(
             }
         }
 
-        /** True only for an https:// URL; fail-closed on a malformed URL or any other scheme. */
+        /**
+         * True only for a hierarchical `https://` URL with a host; fail-closed on a malformed URL,
+         * any other scheme, or an opaque `https:` URI (e.g. `https:payload`, which has scheme
+         * `https` but no host).
+         */
         fun isHttpsUrl(url: String): Boolean {
-            val scheme = try {
-                java.net.URI(url).scheme?.lowercase()
+            return try {
+                val uri = java.net.URI(url)
+                uri.scheme?.lowercase() == "https" && !uri.host.isNullOrEmpty()
             } catch (_: Exception) {
-                null
+                false
             }
-            return scheme == "https"
         }
 
         fun sanitizeFileName(name: String): String {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/WearAppUpdateChecker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/WearAppUpdateChecker.kt
@@ -125,6 +125,12 @@ class WearAppUpdateChecker @Inject constructor(
         expectedSize: Long,
     ): DownloadResult = withContext(Dispatchers.IO) {
         try {
+            // An APK download is a code-execution path: enforce https:// in code rather than
+            // relying solely on the network_security_config pin (the base config now permits
+            // cleartext globally for the LAN opt-in).
+            if (!AppUpdateChecker.isHttpsUrl(url)) {
+                return@withContext DownloadResult.Error("Download blocked: insecure URL")
+            }
             if (!AppUpdateChecker.isAllowedDownloadHost(url)) {
                 return@withContext DownloadResult.Error("Download blocked: untrusted host")
             }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/common/InsecureHttpUi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/common/InsecureHttpUi.kt
@@ -1,0 +1,98 @@
+package com.glycemicgpt.mobile.presentation.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.NoEncryption
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared UI for the Story 57.1 insecure-LAN-HTTP opt-in. Both entry points (onboarding server
+ * setup and Settings) reuse the same acknowledgement dialog and the same active-mode indicator so
+ * the risk framing is identical wherever it appears.
+ */
+
+/** Risk copy shown in the acknowledgement dialog; mirrors the onboarding DisclaimerCard tone. */
+const val INSECURE_HTTP_RISK_TEXT: String =
+    "This lets the app talk to your server over plain http://, which is unencrypted -- anyone on " +
+        "the same network could read your data and sign-in token. It is allowed only for " +
+        "private/LAN addresses (for example 10.x, 192.168.x, or a .local name); public addresses " +
+        "always require https://. Only enable this on a network you trust."
+
+/**
+ * "I understand the risk" acknowledgement, modeled on the onboarding DisclaimerCard (warning icon,
+ * error tint). Enabling insecure LAN HTTP only happens on [onConfirm].
+ */
+@Composable
+fun InsecureHttpConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+        },
+        title = { Text("Allow insecure LAN HTTP?") },
+        text = { Text(INSECURE_HTTP_RISK_TEXT) },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                modifier = Modifier.testTag("insecure_http_confirm"),
+            ) {
+                Text("Enable", color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+/**
+ * Persistent indicator shown while insecure-HTTP mode is active (the opt-in is on and the server
+ * base URL is `http://`). Mirrors the session-expired banner style with an error tint.
+ */
+@Composable
+fun InsecureHttpBanner(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.errorContainer)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag("insecure_http_banner"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.NoEncryption,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onErrorContainer,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "Insecure LAN HTTP is on -- traffic to your server is unencrypted.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+        )
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -53,6 +53,7 @@ import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.presentation.alerts.AlertsScreen
 import com.glycemicgpt.mobile.presentation.chat.AiChatScreen
+import com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy
 import com.glycemicgpt.mobile.presentation.common.InsecureHttpBanner
 import com.glycemicgpt.mobile.presentation.home.HomeScreen
 import com.glycemicgpt.mobile.presentation.meal.CommonFoodsScreen
@@ -139,8 +140,11 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
     )
     val baseUrlFlow = remember { authTokenStore.baseUrlFlow() }
     val baseUrl by baseUrlFlow.collectAsState(initial = authTokenStore.getBaseUrl())
-    val showInsecureHttpBanner = insecureHttpEnabled &&
-        baseUrl?.startsWith("http://", ignoreCase = true) == true
+    // Derive from the policy (single source of truth) so the banner shows only when the app would
+    // actually send cleartext -- never for a public http:// URL the request layer rejects.
+    val showInsecureHttpBanner = baseUrl?.let {
+        UrlSecurityPolicy.isActiveInsecureHttp(it, BuildConfig.DEBUG, insecureHttpEnabled)
+    } == true
 
     // Observe logout -> onboarding navigation event
     LaunchedEffect(Unit) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -53,6 +53,7 @@ import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.presentation.alerts.AlertsScreen
 import com.glycemicgpt.mobile.presentation.chat.AiChatScreen
+import com.glycemicgpt.mobile.presentation.common.InsecureHttpBanner
 import com.glycemicgpt.mobile.presentation.home.HomeScreen
 import com.glycemicgpt.mobile.presentation.meal.CommonFoodsScreen
 import com.glycemicgpt.mobile.presentation.meal.MealHistoryScreen
@@ -128,6 +129,19 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
     val isOnboarding = currentDestination?.route == Screen.Onboarding.route
     val showBottomNav = !isOnboarding && currentDestination?.route !in spokeRoutes
 
+    // Persistent insecure-HTTP indicator: shown whenever the opt-in is on and the server base URL
+    // is cleartext http://. Both halves are observed reactively (settings flow + base-URL flow) so
+    // the banner tracks a toggle flip OR a server-URL change immediately, not only on the next
+    // navigation.
+    val insecureHttpFlow = remember { appSettingsStore.allowInsecureLanHttpFlow() }
+    val insecureHttpEnabled by insecureHttpFlow.collectAsState(
+        initial = appSettingsStore.allowInsecureLanHttp,
+    )
+    val baseUrlFlow = remember { authTokenStore.baseUrlFlow() }
+    val baseUrl by baseUrlFlow.collectAsState(initial = authTokenStore.getBaseUrl())
+    val showInsecureHttpBanner = insecureHttpEnabled &&
+        baseUrl?.startsWith("http://", ignoreCase = true) == true
+
     // Observe logout -> onboarding navigation event
     LaunchedEffect(Unit) {
         settingsViewModel.navigateToOnboarding.collect {
@@ -173,6 +187,11 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
         },
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
+            // Insecure-HTTP indicator: visible everywhere (including onboarding) while active.
+            if (showInsecureHttpBanner) {
+                InsecureHttpBanner()
+            }
+
             // Session expired banner (not shown during onboarding)
             if (!isOnboarding) {
                 (authState as? AuthState.Expired)?.let { expired ->

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.glycemicgpt.mobile.presentation.common.InsecureHttpConfirmDialog
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -133,6 +134,8 @@ fun OnboardingScreen(
                     connectionTestResult = state.connectionTestResult,
                     connectionTestSuccess = state.connectionTestSuccess,
                     onTestConnection = viewModel::testConnection,
+                    showInsecureHttpOptIn = state.showInsecureHttpOptIn,
+                    onEnableInsecureHttp = viewModel::requestEnableInsecureHttp,
                 )
                 PAGE_LOGIN -> LoginPage(
                     email = state.email,
@@ -160,6 +163,13 @@ fun OnboardingScreen(
             onNext = {
                 coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
             },
+        )
+    }
+
+    if (state.showInsecureHttpConfirm) {
+        InsecureHttpConfirmDialog(
+            onConfirm = viewModel::confirmEnableInsecureHttp,
+            onDismiss = viewModel::dismissInsecureHttpConfirm,
         )
     }
 }
@@ -521,6 +531,8 @@ private fun ServerSetupPage(
     connectionTestResult: String?,
     connectionTestSuccess: Boolean,
     onTestConnection: () -> Unit,
+    showInsecureHttpOptIn: Boolean,
+    onEnableInsecureHttp: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -602,6 +614,20 @@ private fun ServerSetupPage(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.testTag("onboarding_connection_result"),
             )
+        }
+
+        // A fresh install can't reach Settings before signing in, so offer the insecure-LAN-HTTP
+        // opt-in inline when the entered URL is http:// to a private/LAN host.
+        if (showInsecureHttpOptIn) {
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = onEnableInsecureHttp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("onboarding_enable_insecure_http"),
+            ) {
+                Text("Allow insecure LAN HTTP")
+            }
         }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModel.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.mobile.presentation.onboarding
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +24,12 @@ data class OnboardingUiState(
     val loginError: String? = null,
     val onboardingComplete: Boolean = false,
     val requestNotificationPermission: Boolean = false,
+    // Shown when the entered URL is http:// to a private/LAN host but insecure LAN HTTP is off,
+    // so onboarding can offer a one-tap opt-in instead of a dead end (a fresh install cannot reach
+    // Settings before signing in).
+    val showInsecureHttpOptIn: Boolean = false,
+    // Gates the "I understand the risk" acknowledgement dialog for enabling insecure LAN HTTP.
+    val showInsecureHttpConfirm: Boolean = false,
 )
 
 @HiltViewModel
@@ -51,11 +58,12 @@ class OnboardingViewModel @Inject constructor(
                 baseUrl = url,
                 connectionTestResult = null,
                 connectionTestSuccess = false,
+                showInsecureHttpOptIn = false,
             )
         }
     }
 
-    fun testConnection() {
+    fun testConnection(force: Boolean = false) {
         if (_uiState.value.isTestingConnection) return
 
         val url = _uiState.value.baseUrl.trim()
@@ -71,16 +79,19 @@ class OnboardingViewModel @Inject constructor(
         if (!authRepository.isValidUrl(url)) {
             _uiState.update {
                 it.copy(
-                    connectionTestResult = "Invalid URL. HTTPS required.",
+                    connectionTestResult = UrlSecurityPolicy.INVALID_URL_MESSAGE,
                     connectionTestSuccess = false,
+                    showInsecureHttpOptIn = authRepository.isBlockedPendingLanHttpOptIn(url),
                 )
             }
             return
         }
 
-        // Debounce: minimum 1 second between connection tests (after validation)
+        // Debounce: minimum 1 second between connection tests (after validation). The opt-in
+        // confirm retry passes force=true so enabling insecure LAN HTTP always re-tests, even if a
+        // prior test ran within the window.
         val now = System.currentTimeMillis()
-        if (now - lastConnectionTestMs < 1_000L) return
+        if (!force && now - lastConnectionTestMs < 1_000L) return
         lastConnectionTestMs = now
 
         viewModelScope.launch {
@@ -119,6 +130,28 @@ class OnboardingViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    /** User tapped the opt-in affordance: show the risk acknowledgement before enabling. */
+    fun requestEnableInsecureHttp() {
+        _uiState.update { it.copy(showInsecureHttpConfirm = true) }
+    }
+
+    /** Cancel the acknowledgement without enabling insecure LAN HTTP. */
+    fun dismissInsecureHttpConfirm() {
+        _uiState.update { it.copy(showInsecureHttpConfirm = false) }
+    }
+
+    /**
+     * The user acknowledged the risk: enable insecure LAN HTTP (per-device) and immediately re-run
+     * the connection test so the flow proceeds without a second tap.
+     */
+    fun confirmEnableInsecureHttp() {
+        appSettingsStore.allowInsecureLanHttp = true
+        _uiState.update {
+            it.copy(showInsecureHttpConfirm = false, showInsecureHttpOptIn = false)
+        }
+        testConnection(force = true)
     }
 
     fun updateEmail(email: String) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.BluetoothDisabled
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.NoEncryption
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.Person
@@ -83,6 +84,7 @@ import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
+import com.glycemicgpt.mobile.presentation.common.InsecureHttpConfirmDialog
 import com.glycemicgpt.mobile.presentation.plugin.PluginSettingsRenderer
 import com.glycemicgpt.mobile.presentation.theme.ThemeMode
 import com.glycemicgpt.mobile.wear.WatchFaceVariant
@@ -128,6 +130,15 @@ fun SettingsScreen(
             onShowLogout = settingsViewModel::showLogoutConfirm,
             onClearConnectionResult = settingsViewModel::clearConnectionTestResult,
             onClearLoginError = settingsViewModel::clearLoginError,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // -- Network Section (Story 57.1: opt-in cleartext HTTP to private/LAN hosts) --
+        SectionHeader(title = "Network")
+        NetworkSection(
+            state = state,
+            onInsecureLanHttpToggle = settingsViewModel::onInsecureLanHttpToggle,
         )
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -394,6 +405,13 @@ fun SettingsScreen(
                     Text("Cancel")
                 }
             },
+        )
+    }
+
+    if (state.showInsecureHttpConfirm) {
+        InsecureHttpConfirmDialog(
+            onConfirm = settingsViewModel::confirmEnableInsecureLanHttp,
+            onDismiss = settingsViewModel::dismissInsecureHttpConfirm,
         )
     }
 }
@@ -1144,6 +1162,58 @@ private fun MealIntelligenceSection(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(top = 4.dp),
         )
+    }
+}
+
+@Composable
+private fun NetworkSection(
+    state: SettingsUiState,
+    onInsecureLanHttpToggle: (Boolean) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.NoEncryption,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = "Allow insecure LAN HTTP",
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Text(
+                            text = "Reach a self-hosted server on a private/LAN address over " +
+                                "unencrypted http://. Public addresses always require https://.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Switch(
+                    checked = state.allowInsecureLanHttp,
+                    onCheckedChange = onInsecureLanHttpToggle,
+                    modifier = Modifier.testTag("insecure_lan_http_toggle"),
+                )
+            }
+            // When active, the app-wide InsecureHttpBanner (NavHost) is the persistent
+            // "traffic is unencrypted" indicator, so no inline warning is repeated here.
+        }
     }
 }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -22,6 +22,7 @@ import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpCredentialStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
+import com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import com.glycemicgpt.mobile.data.update.AppUpdateChecker
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
@@ -141,6 +142,10 @@ data class SettingsUiState(
     val baseUrl: String = "",
     val isLoggedIn: Boolean = false,
     val userEmail: String? = null,
+    // Network: opt-in to plaintext http:// for private/LAN hosts (Story 57.1). Default off.
+    val allowInsecureLanHttp: Boolean = false,
+    // Gates the "I understand the risk" acknowledgement dialog for enabling insecure LAN HTTP.
+    val showInsecureHttpConfirm: Boolean = false,
     // Pump
     val isPumpPaired: Boolean = false,
     val pairedPumpAddress: String? = null,
@@ -315,6 +320,7 @@ class SettingsViewModel @Inject constructor(
             isPumpPaired = pumpCredentialStore.isPaired(),
             pairedPumpAddress = pumpCredentialStore.getPairedAddress(),
             backendSyncEnabled = appSettingsStore.backendSyncEnabled,
+            allowInsecureLanHttp = appSettingsStore.allowInsecureLanHttp,
             dataRetentionDays = appSettingsStore.dataRetentionDays,
             appVersion = BuildConfig.VERSION_NAME,
             buildType = BuildConfig.BUILD_TYPE,
@@ -381,7 +387,7 @@ class SettingsViewModel @Inject constructor(
         }
         if (!authRepository.isValidUrl(trimmed)) {
             _uiState.value = _uiState.value.copy(
-                connectionTestResult = "Invalid URL. HTTPS required.",
+                connectionTestResult = UrlSecurityPolicy.INVALID_URL_MESSAGE,
             )
             return
         }
@@ -592,6 +598,33 @@ class SettingsViewModel @Inject constructor(
     fun setBackendSyncEnabled(enabled: Boolean) {
         appSettingsStore.backendSyncEnabled = enabled
         _uiState.value = _uiState.value.copy(backendSyncEnabled = enabled)
+    }
+
+    /**
+     * Handle the insecure-LAN-HTTP switch. Enabling requires an explicit acknowledgement (the
+     * switch defers to a confirmation dialog and only flips on confirm); disabling is immediate.
+     */
+    fun onInsecureLanHttpToggle(enabled: Boolean) {
+        if (enabled) {
+            _uiState.value = _uiState.value.copy(showInsecureHttpConfirm = true)
+        } else {
+            appSettingsStore.allowInsecureLanHttp = false
+            _uiState.value = _uiState.value.copy(allowInsecureLanHttp = false)
+        }
+    }
+
+    /** Cancel the acknowledgement without enabling insecure LAN HTTP. */
+    fun dismissInsecureHttpConfirm() {
+        _uiState.value = _uiState.value.copy(showInsecureHttpConfirm = false)
+    }
+
+    /** The user acknowledged the risk: enable insecure LAN HTTP (per-device) and close the dialog. */
+    fun confirmEnableInsecureLanHttp() {
+        appSettingsStore.allowInsecureLanHttp = true
+        _uiState.value = _uiState.value.copy(
+            allowInsecureLanHttp = true,
+            showInsecureHttpConfirm = false,
+        )
     }
 
     fun setDataRetentionDays(days: Int) {

--- a/apps/mobile/app/src/main/res/xml/network_security_config.xml
+++ b/apps/mobile/app/src/main/res/xml/network_security_config.xml
@@ -1,11 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Block all cleartext (HTTP) traffic - HTTPS only -->
-    <base-config cleartextTrafficPermitted="false">
+    <!-- Cleartext (HTTP) is permitted at the platform layer so a self-hoster can reach a server on
+         a private/LAN address over http:// after an explicit, default-off opt-in (Story 57.1).
+         The platform cannot express the private-vs-public rule (network-security-config matches
+         exact hosts, not CIDR ranges), so that decision lives in app code
+         (UrlSecurityPolicy / AuthRepository.isValidUrl): http:// is accepted ONLY to a
+         private/loopback/link-local/.local host, and a public host over http:// is always rejected. -->
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
+
+    <!-- App-originated external traffic must never downgrade to cleartext, regardless of the LAN
+         opt-in. Pin the GitHub self-update hosts (api.github.com is covered by github.com via
+         includeSubdomains; release assets download from objects.githubusercontent.com) and the
+         Sentry ingest host (*.ingest.*.sentry.io) to HTTPS-only. -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">github.com</domain>
+        <domain includeSubdomains="true">githubusercontent.com</domain>
+        <domain includeSubdomains="true">sentry.io</domain>
+    </domain-config>
 
     <!-- Trust user-installed CAs in debug builds (for proxy debugging) -->
     <debug-overrides>

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/UrlSecurityPolicyTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/UrlSecurityPolicyTest.kt
@@ -1,0 +1,220 @@
+package com.glycemicgpt.mobile.data.remote
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Exhaustive coverage for the Story 57.1 transport policy. These are pure functions, so the
+ * release path (`isDebug == false`) is testable directly here even though a `testDebug` run
+ * compiles `BuildConfig.DEBUG == true`.
+ */
+class UrlSecurityPolicyTest {
+
+    // ---- isPrivateHost: accepted ranges -----------------------------------------------------
+
+    @Test
+    fun `isPrivateHost accepts loopback IPv4`() {
+        assertTrue(UrlSecurityPolicy.isPrivateHost("127.0.0.1"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("127.1.2.3"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("127.255.255.255"))
+    }
+
+    @Test
+    fun `isPrivateHost accepts RFC1918 ranges`() {
+        assertTrue(UrlSecurityPolicy.isPrivateHost("10.0.0.1"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("10.255.255.255"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("192.168.0.1"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("192.168.255.255"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("10.20.66.40"))
+    }
+
+    @Test
+    fun `isPrivateHost accepts 172_16 through 172_31 and rejects the boundaries`() {
+        assertTrue(UrlSecurityPolicy.isPrivateHost("172.16.0.1"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("172.31.255.255"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("172.20.1.1"))
+        // Just outside 172.16.0.0/12.
+        assertFalse(UrlSecurityPolicy.isPrivateHost("172.15.255.255"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("172.32.0.0"))
+    }
+
+    @Test
+    fun `isPrivateHost accepts CGNAT 100_64_0_0 slash 10 and rejects the boundaries`() {
+        assertTrue(UrlSecurityPolicy.isPrivateHost("100.64.0.1"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("100.127.255.255"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("100.63.255.255"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("100.128.0.0"))
+    }
+
+    @Test
+    fun `isPrivateHost accepts link-local 169_254 and rejects the boundaries`() {
+        assertTrue(UrlSecurityPolicy.isPrivateHost("169.254.0.1"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("169.254.255.255"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("169.253.0.1"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("169.255.0.1"))
+    }
+
+    @Test
+    fun `isPrivateHost accepts private IPv6`() {
+        assertTrue(UrlSecurityPolicy.isPrivateHost("::1")) // loopback
+        assertTrue(UrlSecurityPolicy.isPrivateHost("fe80::1")) // link-local
+        assertTrue(UrlSecurityPolicy.isPrivateHost("fe80::a00:27ff:fe12:3456"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("fc00::1")) // ULA
+        assertTrue(UrlSecurityPolicy.isPrivateHost("fd12:3456:789a:1::1")) // ULA (fd = fc00::/7)
+    }
+
+    @Test
+    fun `isPrivateHost classifies IPv4-mapped IPv6 by the embedded address`() {
+        assertTrue(UrlSecurityPolicy.isPrivateHost("::ffff:10.0.0.1"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("::ffff:192.168.1.1"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("::ffff:8.8.8.8"))
+    }
+
+    @Test
+    fun `isPrivateHost accepts dotlocal hostnames case-insensitively`() {
+        assertTrue(UrlSecurityPolicy.isPrivateHost("nas.local"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("My-Server.LOCAL"))
+        assertTrue(UrlSecurityPolicy.isPrivateHost("glycemicgpt.local"))
+        // Trailing FQDN dot is tolerated.
+        assertTrue(UrlSecurityPolicy.isPrivateHost("nas.local."))
+    }
+
+    // ---- isPrivateHost: rejected ------------------------------------------------------------
+
+    @Test
+    fun `isPrivateHost rejects public IPv4`() {
+        assertFalse(UrlSecurityPolicy.isPrivateHost("8.8.8.8"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("1.1.1.1"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("11.0.0.1"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("192.169.0.1"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("0.0.0.0"))
+    }
+
+    @Test
+    fun `isPrivateHost rejects public and reserved IPv6`() {
+        assertFalse(UrlSecurityPolicy.isPrivateHost("2001:db8::1"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("2606:4700:4700::1111"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("fe00::1")) // not fe80::/10
+        assertFalse(UrlSecurityPolicy.isPrivateHost("fec0::1")) // deprecated site-local, not fc00::/7
+    }
+
+    @Test
+    fun `isPrivateHost rejects malformed IPv6 literals`() {
+        assertFalse(UrlSecurityPolicy.isPrivateHost("fe80:::1")) // triple colon
+        assertFalse(UrlSecurityPolicy.isPrivateHost("fc00::1::2")) // two "::"
+        assertFalse(UrlSecurityPolicy.isPrivateHost("gggg::1")) // non-hex hextet
+        assertFalse(UrlSecurityPolicy.isPrivateHost("-100::")) // sign-prefixed hextet
+        assertFalse(UrlSecurityPolicy.isPrivateHost("fc00::+1")) // sign-prefixed hextet
+        assertFalse(UrlSecurityPolicy.isPrivateHost("12345::1")) // hextet too long
+    }
+
+    @Test
+    fun `isPrivateHost rejects hostnames that are not dotlocal`() {
+        assertFalse(UrlSecurityPolicy.isPrivateHost("example.com"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("localhost")) // a name, not a literal IP
+        assertFalse(UrlSecurityPolicy.isPrivateHost("local")) // no label before .local
+        assertFalse(UrlSecurityPolicy.isPrivateHost(".local"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("notlocal"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost("evil.local.attacker.com"))
+        assertFalse(UrlSecurityPolicy.isPrivateHost(""))
+    }
+
+    @Test
+    fun `isPrivateHost rejects non-canonical IPv4 encodings (spoofing)`() {
+        assertFalse(UrlSecurityPolicy.isPrivateHost("0x0a000001")) // hex 10.0.0.1
+        assertFalse(UrlSecurityPolicy.isPrivateHost("012.0.0.1")) // octal-looking leading zero
+        assertFalse(UrlSecurityPolicy.isPrivateHost("2130706433")) // decimal 127.0.0.1
+        assertFalse(UrlSecurityPolicy.isPrivateHost("10.0.0.256")) // octet overflow
+        assertFalse(UrlSecurityPolicy.isPrivateHost("10.0.0")) // too few octets
+        assertFalse(UrlSecurityPolicy.isPrivateHost("10.0.0.1.5")) // too many octets
+        assertFalse(UrlSecurityPolicy.isPrivateHost("10.0.0.-1")) // signs are not digits
+        assertFalse(UrlSecurityPolicy.isPrivateHost("10.0.0.1@evil.com")) // authority, not a host
+    }
+
+    // ---- isAllowed: https always allowed ----------------------------------------------------
+
+    @Test
+    fun `isAllowed always accepts https regardless of debug or toggle or host`() {
+        for (debug in listOf(true, false)) {
+            for (allow in listOf(true, false)) {
+                assertTrue(UrlSecurityPolicy.isAllowed("https://example.com", debug, allow))
+                assertTrue(UrlSecurityPolicy.isAllowed("https://8.8.8.8", debug, allow))
+                assertTrue(UrlSecurityPolicy.isAllowed("https://10.0.0.1", debug, allow))
+            }
+        }
+    }
+
+    // ---- isAllowed: http public is always rejected in release -------------------------------
+
+    @Test
+    fun `isAllowed rejects http to a public host in release even with the toggle on`() {
+        assertFalse(UrlSecurityPolicy.isAllowed("http://example.com", isDebug = false, allowInsecureLanHttp = true))
+        assertFalse(UrlSecurityPolicy.isAllowed("http://8.8.8.8", isDebug = false, allowInsecureLanHttp = true))
+        assertFalse(UrlSecurityPolicy.isAllowed("http://1.1.1.1:8080", isDebug = false, allowInsecureLanHttp = true))
+    }
+
+    // ---- isAllowed: http private gated by the toggle in release -----------------------------
+
+    @Test
+    fun `isAllowed accepts http to a private host in release only when the toggle is on`() {
+        assertFalse(UrlSecurityPolicy.isAllowed("http://10.20.66.40:3000", isDebug = false, allowInsecureLanHttp = false))
+        assertTrue(UrlSecurityPolicy.isAllowed("http://10.20.66.40:3000", isDebug = false, allowInsecureLanHttp = true))
+        assertTrue(UrlSecurityPolicy.isAllowed("http://192.168.1.5", isDebug = false, allowInsecureLanHttp = true))
+        assertTrue(UrlSecurityPolicy.isAllowed("http://127.0.0.1:8000", isDebug = false, allowInsecureLanHttp = true))
+        assertTrue(UrlSecurityPolicy.isAllowed("http://nas.local", isDebug = false, allowInsecureLanHttp = true))
+    }
+
+    // ---- isAllowed: debug permits any http (unchanged) --------------------------------------
+
+    @Test
+    fun `isAllowed permits any http in a debug build regardless of the toggle`() {
+        assertTrue(UrlSecurityPolicy.isAllowed("http://example.com", isDebug = true, allowInsecureLanHttp = false))
+        assertTrue(UrlSecurityPolicy.isAllowed("http://8.8.8.8", isDebug = true, allowInsecureLanHttp = false))
+        assertTrue(UrlSecurityPolicy.isAllowed("http://10.0.0.1", isDebug = true, allowInsecureLanHttp = false))
+    }
+
+    // ---- isAllowed: OkHttp-level spoofing / parsing -----------------------------------------
+
+    @Test
+    fun `isAllowed rejects a userinfo-spoofed authority (host resolves to the public part)`() {
+        // OkHttp parses "10.0.0.1" as userinfo and "evil.com" as the host.
+        assertFalse(
+            UrlSecurityPolicy.isAllowed("http://10.0.0.1@evil.com", isDebug = false, allowInsecureLanHttp = true),
+        )
+    }
+
+    @Test
+    fun `isAllowed accepts a bracketed private IPv6 and rejects a bracketed public IPv6`() {
+        assertTrue(UrlSecurityPolicy.isAllowed("http://[::1]:3000", isDebug = false, allowInsecureLanHttp = true))
+        assertTrue(UrlSecurityPolicy.isAllowed("http://[fe80::1]", isDebug = false, allowInsecureLanHttp = true))
+        assertFalse(UrlSecurityPolicy.isAllowed("http://[2001:db8::1]", isDebug = false, allowInsecureLanHttp = true))
+    }
+
+    @Test
+    fun `isAllowed rejects malformed URLs and non-http schemes`() {
+        assertFalse(UrlSecurityPolicy.isAllowed("not-a-url", isDebug = true, allowInsecureLanHttp = true))
+        assertFalse(UrlSecurityPolicy.isAllowed("", isDebug = true, allowInsecureLanHttp = true))
+        assertFalse(UrlSecurityPolicy.isAllowed("ftp://10.0.0.1", isDebug = true, allowInsecureLanHttp = true))
+    }
+
+    // ---- isBlockedPendingLanOptIn -----------------------------------------------------------
+
+    @Test
+    fun `isBlockedPendingLanOptIn is true only for release http to a private host`() {
+        assertTrue(UrlSecurityPolicy.isBlockedPendingLanOptIn("http://10.20.66.40:3000", isDebug = false))
+        assertTrue(UrlSecurityPolicy.isBlockedPendingLanOptIn("http://nas.local", isDebug = false))
+        // Public http -> enabling the toggle would not help.
+        assertFalse(UrlSecurityPolicy.isBlockedPendingLanOptIn("http://example.com", isDebug = false))
+        // https already works.
+        assertFalse(UrlSecurityPolicy.isBlockedPendingLanOptIn("https://10.0.0.1", isDebug = false))
+        // Debug already permits it, so no opt-in prompt.
+        assertFalse(UrlSecurityPolicy.isBlockedPendingLanOptIn("http://10.0.0.1", isDebug = true))
+    }
+
+    @Test
+    fun `INVALID_URL_MESSAGE names the LAN exception`() {
+        assertTrue(UrlSecurityPolicy.INVALID_URL_MESSAGE.contains("https://"))
+        assertTrue(UrlSecurityPolicy.INVALID_URL_MESSAGE.contains("http://"))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/UrlSecurityPolicyTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/UrlSecurityPolicyTest.kt
@@ -212,6 +212,22 @@ class UrlSecurityPolicyTest {
         assertFalse(UrlSecurityPolicy.isBlockedPendingLanOptIn("http://10.0.0.1", isDebug = true))
     }
 
+    // ---- isActiveInsecureHttp (drives the insecure-mode indicator) --------------------------
+
+    @Test
+    fun `isActiveInsecureHttp is true only for cleartext the policy actually permits`() {
+        // Private http + toggle on (release) -> cleartext is really sent.
+        assertTrue(UrlSecurityPolicy.isActiveInsecureHttp("http://192.168.1.5", isDebug = false, allowInsecureLanHttp = true))
+        // Public http + toggle on -> request layer rejects it, so it is NOT active cleartext.
+        assertFalse(UrlSecurityPolicy.isActiveInsecureHttp("http://example.com", isDebug = false, allowInsecureLanHttp = true))
+        // Private http + toggle off -> rejected, no cleartext.
+        assertFalse(UrlSecurityPolicy.isActiveInsecureHttp("http://192.168.1.5", isDebug = false, allowInsecureLanHttp = false))
+        // https is never cleartext.
+        assertFalse(UrlSecurityPolicy.isActiveInsecureHttp("https://192.168.1.5", isDebug = false, allowInsecureLanHttp = true))
+        // Malformed.
+        assertFalse(UrlSecurityPolicy.isActiveInsecureHttp("not-a-url", isDebug = false, allowInsecureLanHttp = true))
+    }
+
     @Test
     fun `INVALID_URL_MESSAGE names the LAN exception`() {
         assertTrue(UrlSecurityPolicy.INVALID_URL_MESSAGE.contains("https://"))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -227,6 +227,9 @@ class AuthRepositoryTest {
     fun `isValidUrl rejects malformed URL`() {
         assertFalse(repository.isValidUrl("not-a-url"))
     }
+    // isValidUrl/isBlockedPendingLanHttpOptIn delegate to UrlSecurityPolicy; the full
+    // scheme x debug x toggle x host matrix (including the release BuildConfig.DEBUG == false
+    // path, which a testDebug run cannot express) is covered in UrlSecurityPolicyTest.
 
     @Test
     fun `updateGlucoseUnit PATCHes the account and caches the server value`() = runTest {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
@@ -1,10 +1,15 @@
 package com.glycemicgpt.mobile.data.update
 
+import com.squareup.moshi.Moshi
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AppUpdateCheckerTest {
 
     @Test
@@ -76,6 +81,39 @@ class AppUpdateCheckerTest {
     @Test
     fun `isAllowedDownloadHost rejects malformed URL`() {
         assertFalse(AppUpdateChecker.isAllowedDownloadHost("not-a-url"))
+    }
+
+    // isHttpsUrl tests (APK downloads must be https:// -- a code-execution path)
+
+    @Test
+    fun `isHttpsUrl accepts https`() {
+        assertTrue(AppUpdateChecker.isHttpsUrl("https://github.com/releases/download/v1.0/app.apk"))
+    }
+
+    @Test
+    fun `isHttpsUrl rejects http`() {
+        assertFalse(AppUpdateChecker.isHttpsUrl("http://github.com/releases/download/v1.0/app.apk"))
+    }
+
+    @Test
+    fun `isHttpsUrl rejects malformed URL`() {
+        assertFalse(AppUpdateChecker.isHttpsUrl("not-a-url"))
+    }
+
+    @Test
+    fun `an https URL to an allowed host passes both download guards`() {
+        val url = "https://github.com/GlycemicGPT/GlycemicGPT/releases/download/v1.0/app.apk"
+        assertTrue(AppUpdateChecker.isHttpsUrl(url))
+        assertTrue(AppUpdateChecker.isAllowedDownloadHost(url))
+    }
+
+    @Test
+    fun `downloadApk rejects an insecure http URL even to an allowed host`() = runTest {
+        val checker = AppUpdateChecker(mockk(relaxed = true), Moshi.Builder().build())
+        // http:// fails the scheme guard before any host check or network access.
+        val result = checker.downloadApk("http://github.com/x/app.apk", "app.apk", 0L)
+        assertTrue(result is DownloadResult.Error)
+        assertEquals("Download blocked: insecure URL", (result as DownloadResult.Error).message)
     }
 
     // sanitizeFileName tests

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
@@ -101,6 +101,13 @@ class AppUpdateCheckerTest {
     }
 
     @Test
+    fun `isHttpsUrl rejects an opaque https URI without a host`() {
+        // "https:payload" is an opaque URI: scheme is https but there is no host.
+        assertFalse(AppUpdateChecker.isHttpsUrl("https:payload"))
+        assertFalse(AppUpdateChecker.isHttpsUrl("https:///no-host"))
+    }
+
+    @Test
     fun `an https URL to an allowed host passes both download guards`() {
         val url = "https://github.com/GlycemicGPT/GlycemicGPT/releases/download/v1.0/app.apk"
         assertTrue(AppUpdateChecker.isHttpsUrl(url))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/WearAppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/WearAppUpdateCheckerTest.kt
@@ -1,9 +1,14 @@
 package com.glycemicgpt.mobile.data.update
 
+import com.squareup.moshi.Moshi
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class WearAppUpdateCheckerTest {
 
     @Test
@@ -44,6 +49,21 @@ class WearAppUpdateCheckerTest {
         assertTrue(
             !AppUpdateChecker.isAllowedDownloadHost("https://evil.com/malware.apk"),
         )
+    }
+
+    @Test
+    fun `an https URL to an allowed host passes both wear download guards`() {
+        val url = "https://github.com/GlycemicGPT/GlycemicGPT/releases/download/v1.0/wear.apk"
+        assertTrue(AppUpdateChecker.isHttpsUrl(url))
+        assertTrue(AppUpdateChecker.isAllowedDownloadHost(url))
+    }
+
+    @Test
+    fun `downloadWearApk rejects an insecure http URL even to an allowed host`() = runTest {
+        val checker = WearAppUpdateChecker(mockk(relaxed = true), Moshi.Builder().build())
+        val result = checker.downloadWearApk("http://github.com/x/wear.apk", "wear.apk", 0L)
+        assertTrue(result is DownloadResult.Error)
+        assertEquals("Download blocked: insecure URL", (result as DownloadResult.Error).message)
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.glycemicgpt.mobile.presentation.onboarding
 
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import com.glycemicgpt.mobile.data.repository.LoginResult
 import io.mockk.coEvery
@@ -143,13 +144,65 @@ class OnboardingViewModelTest {
     @Test
     fun `testConnection rejects invalid URL`() {
         every { authRepository.isValidUrl("not-a-url") } returns false
+        every { authRepository.isBlockedPendingLanHttpOptIn("not-a-url") } returns false
         val vm = createViewModel()
         vm.updateBaseUrl("not-a-url")
 
         vm.testConnection()
 
-        assertEquals("Invalid URL. HTTPS required.", vm.uiState.value.connectionTestResult)
+        assertEquals(UrlSecurityPolicy.INVALID_URL_MESSAGE, vm.uiState.value.connectionTestResult)
         assertFalse(vm.uiState.value.connectionTestSuccess)
+        assertFalse(vm.uiState.value.showInsecureHttpOptIn)
+    }
+
+    @Test
+    fun `testConnection offers the insecure-HTTP opt-in for a blocked private http URL`() {
+        every { authRepository.isValidUrl("http://10.20.66.40:3000") } returns false
+        every { authRepository.isBlockedPendingLanHttpOptIn("http://10.20.66.40:3000") } returns true
+        val vm = createViewModel()
+        vm.updateBaseUrl("http://10.20.66.40:3000")
+
+        vm.testConnection()
+
+        assertEquals(UrlSecurityPolicy.INVALID_URL_MESSAGE, vm.uiState.value.connectionTestResult)
+        assertTrue(vm.uiState.value.showInsecureHttpOptIn)
+    }
+
+    @Test
+    fun `requestEnableInsecureHttp shows the acknowledgement without enabling`() {
+        val vm = createViewModel()
+
+        vm.requestEnableInsecureHttp()
+
+        assertTrue(vm.uiState.value.showInsecureHttpConfirm)
+        verify(exactly = 0) { appSettingsStore.allowInsecureLanHttp = any() }
+    }
+
+    @Test
+    fun `confirmEnableInsecureHttp enables the setting and re-runs the connection test`() = runTest {
+        every { authRepository.isValidUrl("http://10.20.66.40:3000") } returns true
+        coEvery { authRepository.testConnection() } returns Result.success("Connected successfully")
+        val vm = createViewModel()
+        vm.updateBaseUrl("http://10.20.66.40:3000")
+        vm.requestEnableInsecureHttp()
+
+        vm.confirmEnableInsecureHttp()
+
+        verify { appSettingsStore.allowInsecureLanHttp = true }
+        assertFalse(vm.uiState.value.showInsecureHttpConfirm)
+        assertFalse(vm.uiState.value.showInsecureHttpOptIn)
+        assertTrue(vm.uiState.value.connectionTestSuccess)
+    }
+
+    @Test
+    fun `dismissInsecureHttpConfirm hides the dialog and leaves the setting off`() {
+        val vm = createViewModel()
+        vm.requestEnableInsecureHttp()
+
+        vm.dismissInsecureHttpConfirm()
+
+        assertFalse(vm.uiState.value.showInsecureHttpConfirm)
+        verify(exactly = 0) { appSettingsStore.allowInsecureLanHttp = any() }
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -11,6 +11,7 @@ import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpCredentialStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.service.AlertNotificationManager
+import com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import com.glycemicgpt.mobile.data.repository.LoginResult
 import com.glycemicgpt.mobile.data.update.AppUpdateChecker
@@ -348,8 +349,53 @@ class SettingsViewModelTest {
         every { authRepository.isValidUrl("not-a-url") } returns false
         val vm = createViewModel()
         vm.saveBaseUrl("not-a-url")
-        assertEquals("Invalid URL. HTTPS required.", vm.uiState.value.connectionTestResult)
+        assertEquals(UrlSecurityPolicy.INVALID_URL_MESSAGE, vm.uiState.value.connectionTestResult)
         verify(exactly = 0) { authRepository.saveBaseUrl(any()) }
+    }
+
+    @Test
+    fun `onInsecureLanHttpToggle enable shows the acknowledgement without persisting`() {
+        val vm = createViewModel()
+
+        vm.onInsecureLanHttpToggle(true)
+
+        assertTrue(vm.uiState.value.showInsecureHttpConfirm)
+        assertFalse(vm.uiState.value.allowInsecureLanHttp)
+        verify(exactly = 0) { appSettingsStore.allowInsecureLanHttp = any() }
+    }
+
+    @Test
+    fun `onInsecureLanHttpToggle disable persists immediately`() {
+        val vm = createViewModel()
+
+        vm.onInsecureLanHttpToggle(false)
+
+        verify { appSettingsStore.allowInsecureLanHttp = false }
+        assertFalse(vm.uiState.value.allowInsecureLanHttp)
+        assertFalse(vm.uiState.value.showInsecureHttpConfirm)
+    }
+
+    @Test
+    fun `confirmEnableInsecureLanHttp persists and closes the dialog`() {
+        val vm = createViewModel()
+        vm.onInsecureLanHttpToggle(true)
+
+        vm.confirmEnableInsecureLanHttp()
+
+        verify { appSettingsStore.allowInsecureLanHttp = true }
+        assertTrue(vm.uiState.value.allowInsecureLanHttp)
+        assertFalse(vm.uiState.value.showInsecureHttpConfirm)
+    }
+
+    @Test
+    fun `dismissInsecureHttpConfirm cancels without persisting`() {
+        val vm = createViewModel()
+        vm.onInsecureLanHttpToggle(true)
+
+        vm.dismissInsecureHttpConfirm()
+
+        assertFalse(vm.uiState.value.showInsecureHttpConfirm)
+        verify(exactly = 0) { appSettingsStore.allowInsecureLanHttp = any() }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Release builds previously double-blocked cleartext HTTP — the platform `network_security_config` (`cleartextTrafficPermitted="false"`) **and** `AuthRepository.isValidUrl` (http only when `BuildConfig.DEBUG`). Self-hosters on a stable build could not point at `http://192.168.x.x`.

This adds a **default-off, explicitly-acknowledged** opt-in that lets a release build reach an `http://` server on a **private/LAN** address, while `http://` to any **public** host stays rejected — preserving the original "don't expose your platform unencrypted on the internet" protection where it matters. `https://` is always allowed; debug behavior is unchanged.

## How it works (two layers)

- **App logic** — new pure `UrlSecurityPolicy` is the single chokepoint: `https` always; `http` iff `BuildConfig.DEBUG` **or** (`allowInsecureLanHttp` **and** `isPrivateHost(host)`). `isPrivateHost` classifies **literal IPs only, never via DNS** (avoids rebinding/TOCTOU/UI-thread blocking): loopback, RFC1918, CGNAT `100.64/10`, link-local, IPv6 `fe80::/10` + `fc00::/7` + IPv4-mapped, plus the `.local` mDNS suffix. `AuthRepository.isValidUrl` delegates to it; `BaseUrlInterceptor` re-checks it as defense-in-depth.
- **Platform NSC** — `base-config` flipped to cleartext-permitted, with `domain-config` blocks re-pinning `github.com` (covers `api.github.com`), `githubusercontent.com`, and `sentry.io` to **https-only**, so the self-update and Sentry paths can never downgrade. The debug NSC is untouched.

## UX

- Settings → Network toggle with an "I understand the risk" confirmation modeled on the onboarding disclaimer card.
- Onboarding inline opt-in on the server-setup page (a fresh install cannot reach Settings before sign-in).
- A persistent, reactive in-app banner while insecure-HTTP mode is active.

## Testing

- New `UrlSecurityPolicyTest` covers the full accept/reject range matrix (incl. `172.16/12`, `100.64/10`, `169.254/16` boundaries), IPv4/IPv6, IPv4-mapped, and spoofing inputs (`0x0a000001`, `012.0.0.1`, `2130706433`, `10.0.0.1@evil.com`, bracketed IPv6, sign-prefixed hextets), plus the `scheme × debug × toggle × host` matrix on the release (`isDebug == false`) path. ViewModel tests cover the opt-in offer, confirm-gating, and debounce.
- `testDebugUnitTest`, `lintDebug`, `assembleDebug`, and a **release-variant** build all pass.
- Verified on a **release** emulator build against a private-IP http server: toggle off → rejected with the new message + inline opt-in; enable via the ack dialog → connects + indicator shown; `http://<public>` → rejected either way; `https://` → works.

Closes #840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Allow insecure LAN HTTP” toggle with onboarding and settings confirmation dialogs.
  * Added a persistent in-app warning banner when insecure LAN HTTP is actively in use.
* **Bug Fixes**
  * Improved base URL validation and clarified user-facing error messaging.
* **Security/Hardening**
  * Blocked app update downloads over non-HTTPS URLs.
  * Updated URL transport rules so HTTP is restricted to approved scenarios only.
  * Tightened cleartext network settings for specific external services.
* **Tests**
  * Added coverage for URL permissioning and the insecure-LAN-HTTP opt-in flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->