### PR TITLE
feat(mobile): connectivity + staleness substrate

### DIFF
--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseHeroStalenessUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/home/GlucoseHeroStalenessUiTest.kt
@@ -1,0 +1,71 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.Instant
+
+/**
+ * On-device rendering of the glucose hero staleness treatment. Uses the real
+ * FreshnessPolicy.CGM bounds (STALE at 6 min, TOO_STALE at 15 min) with timestamps aged past those
+ * bounds so classification is deterministic regardless of wall-clock jitter.
+ */
+@RunWith(AndroidJUnit4::class)
+class GlucoseHeroStalenessUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun reading(ageSeconds: Long) = CgmReading(
+        glucoseMgDl = 120,
+        trendArrow = CgmTrend.FLAT,
+        timestamp = Instant.now().minusSeconds(ageSeconds),
+    )
+
+    private fun setHero(cgm: CgmReading) {
+        compose.setContent {
+            GlycemicGptTheme {
+                GlucoseHero(cgm = cgm, iob = null, basalRate = null, battery = null, reservoir = null)
+            }
+        }
+    }
+
+    @Test
+    fun freshReading_showsValue_withNoStalenessBadge() {
+        setHero(reading(ageSeconds = 30))
+
+        compose.onNodeWithTag("glucose_hero_value").assertTextEquals("120")
+        compose.onAllNodesWithTag("staleness_badge").assertCountEquals(0)
+    }
+
+    @Test
+    fun staleReading_showsStalenessBadge_andStillShowsValue() {
+        // 7 minutes: past the 6-min STALE bound, below the 15-min TOO_STALE bound.
+        setHero(reading(ageSeconds = 7 * 60))
+
+        compose.onNodeWithTag("glucose_hero_value").assertTextEquals("120")
+        compose.onNodeWithTag("staleness_badge").assertExists()
+        compose.onNodeWithText("Stale").assertIsDisplayed()
+    }
+
+    @Test
+    fun tooStaleReading_isLabelledTooOld_butValueStillRenders() {
+        // 20 minutes: past the 15-min TOO_STALE bound → de-emphasised, never hidden.
+        setHero(reading(ageSeconds = 20 * 60))
+
+        compose.onNodeWithTag("glucose_hero_value").assertTextEquals("120")
+        compose.onNodeWithTag("staleness_badge").assertExists()
+        compose.onNodeWithText("Too old").assertIsDisplayed()
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
@@ -8,6 +8,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.glycemicgpt.mobile.data.auth.AuthManager
 import com.glycemicgpt.mobile.data.local.PumpCredentialStore
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import com.glycemicgpt.mobile.logging.ReleaseTree
 import com.glycemicgpt.mobile.logging.SentryInitializer
 import com.glycemicgpt.mobile.plugin.PluginRegistry
@@ -36,6 +37,9 @@ class GlycemicGptApp : Application(), Configuration.Provider {
     @Inject
     lateinit var pluginRegistry: PluginRegistry
 
+    @Inject
+    lateinit var networkMonitor: NetworkMonitor
+
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     override val workManagerConfiguration: Configuration
@@ -56,6 +60,10 @@ class GlycemicGptApp : Application(), Configuration.Provider {
         }
         SentryInitializer.init(this)
         scheduleDataRetention()
+
+        // Start observing device connectivity so the home screen can tell "offline" apart from
+        // "backend unreachable". Backend reachability itself is fed by the OkHttp path.
+        networkMonitor.start()
 
         // Initialize the plugin system (discovers and creates all registered plugins)
         pluginRegistry.initialize()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.glycemicgpt.mobile.BuildConfig
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.presentation.theme.ThemeMode
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -312,6 +313,45 @@ class AppSettingsStore @Inject constructor(
         awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
     }
 
+    /**
+     * Debug-only fault injection (reusable debug harness): when on, [ReachabilityInterceptor]
+     * fails every backend request so the "backend unreachable" state is reproducible on an emulator.
+     * Hard-gated to debug builds — the getter is always false and the setter is a no-op in release,
+     * so the fault can never be triggered by an end user.
+     */
+    var simulateBackendUnreachable: Boolean
+        get() = BuildConfig.DEBUG && prefs.getBoolean(KEY_SIMULATE_BACKEND_UNREACHABLE, false)
+        set(value) {
+            if (!BuildConfig.DEBUG) return
+            prefs.edit().putBoolean(KEY_SIMULATE_BACKEND_UNREACHABLE, value).apply()
+        }
+
+    /**
+     * Debug-only fault injection (reusable debug harness): when on, the home screen uses the
+     * compressed [FreshnessPolicy.CGM_DEBUG_FAST] thresholds so the FRESH → STALE → TOO_STALE hero
+     * transitions can be watched in seconds instead of the real 15-minute CGM bound. Debug-only,
+     * same hard gate as [simulateBackendUnreachable].
+     */
+    var debugFastStaleness: Boolean
+        get() = BuildConfig.DEBUG && prefs.getBoolean(KEY_DEBUG_FAST_STALENESS, false)
+        set(value) {
+            if (!BuildConfig.DEBUG) return
+            prefs.edit().putBoolean(KEY_DEBUG_FAST_STALENESS, value).apply()
+        }
+
+    /** Emits [debugFastStaleness] and re-emits on change, so the home screen re-derives freshness
+     *  live when the debug toggle flips. Uses the same change-listener mechanism as [glucoseUnitFlow]. */
+    fun debugFastStalenessFlow(): Flow<Boolean> = callbackFlow {
+        trySend(debugFastStaleness)
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_DEBUG_FAST_STALENESS || key == null) {
+                trySend(debugFastStaleness)
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+
     /** Whether AI chat responses should be spoken aloud via TTS. */
     var aiTtsEnabled: Boolean
         get() = prefs.getBoolean(KEY_AI_TTS_ENABLED, false)
@@ -365,5 +405,7 @@ class AppSettingsStore @Inject constructor(
         private const val KEY_AI_TTS_ENABLED = "ai_tts_enabled"
         private const val KEY_AI_TTS_VOICE = "ai_tts_voice"
         private const val KEY_ALLOW_INSECURE_LAN_HTTP = "allow_insecure_lan_http"
+        private const val KEY_SIMULATE_BACKEND_UNREACHABLE = "debug_simulate_backend_unreachable"
+        private const val KEY_DEBUG_FAST_STALENESS = "debug_fast_staleness"
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/network/NetworkMonitor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/network/NetworkMonitor.kt
@@ -1,0 +1,144 @@
+package com.glycemicgpt.mobile.data.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import timber.log.Timber
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Coarse network status the home screen surfaces so a cached reading is never mistaken for a live
+ * one. Three states, deliberately kept distinct:
+ *
+ * - [REACHABLE] — device online and our backend answered recently.
+ * - [BACKEND_UNREACHABLE] — device is online but our server/self-hosted box isn't responding.
+ * - [OFFLINE] — the device has no network at all (airplane mode / no Wi-Fi).
+ *
+ * Device-offline takes precedence: when there's no network we can't distinguish a backend outage
+ * from the missing radio, so we report [OFFLINE] rather than misattributing it to the backend.
+ */
+enum class NetworkStatus { REACHABLE, BACKEND_UNREACHABLE, OFFLINE }
+
+/**
+ * The app's single source of truth for connectivity. Combines two independent signals:
+ *
+ * 1. **Device connectivity** from [ConnectivityManager]'s default-network callback (online/offline).
+ * 2. **Backend reachability** derived entirely client-side from the traffic the app already makes —
+ *    [recordBackendSuccess] / [recordBackendFailure] are called by [ReachabilityInterceptor] on the
+ *    existing OkHttp path. Any HTTP response (even 4xx/5xx) proves the server is reachable; only
+ *    transport-level failures (connect refused, timeout, unknown host) count against it, and only
+ *    after [FAILURE_THRESHOLD] consecutive failures do we flip to unreachable to avoid flapping on a
+ *    single transient blip. There is intentionally **no backend health endpoint** — this stays
+ *    mobile-only and split-neutral.
+ *
+ * Registration is deferred to [start] (called once from the Application) so construction is cheap
+ * and the reachability logic is unit-testable without the Android framework.
+ */
+@Singleton
+class NetworkMonitor @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val _deviceOnline = MutableStateFlow(true)
+    /** Whether the device currently has any active network. Optimistic until the first callback. */
+    val deviceOnline: StateFlow<Boolean> = _deviceOnline.asStateFlow()
+
+    private val _backendReachable = MutableStateFlow(true)
+    /** Whether our backend has responded more recently than [FAILURE_THRESHOLD] consecutive
+     *  transport failures. Optimistic until the first failures accumulate. */
+    val backendReachable: StateFlow<Boolean> = _backendReachable.asStateFlow()
+
+    private val _lastSuccessfulResponseAtMs = MutableStateFlow<Long?>(null)
+    /** Wall-clock ms of the last HTTP response from the backend, or null if none yet this process. */
+    val lastSuccessfulResponseAtMs: StateFlow<Long?> = _lastSuccessfulResponseAtMs.asStateFlow()
+
+    private val _status = MutableStateFlow(NetworkStatus.REACHABLE)
+    /** The combined, UI-facing status. Derived synchronously from the two signals above. */
+    val status: StateFlow<NetworkStatus> = _status.asStateFlow()
+
+    // Mutated from ReachabilityInterceptor, which runs on OkHttp's (multi-threaded) dispatcher, so
+    // the read-modify-write must be atomic — concurrent request completions would otherwise lose an
+    // increment and miss the flip to unreachable.
+    private val consecutiveFailures = AtomicInteger(0)
+
+    private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) = setDeviceOnline(true)
+        override fun onLost(network: Network) = setDeviceOnline(false)
+    }
+
+    /**
+     * Begin observing device connectivity. Idempotent-safe to call once from the Application's
+     * onCreate. Never unregistered — this is an app-lifetime singleton.
+     */
+    fun start() {
+        val cm = context.getSystemService(ConnectivityManager::class.java)
+        if (cm == null) {
+            Timber.w("ConnectivityManager unavailable; device-connectivity signal disabled")
+            return
+        }
+        // Seed the current state before the first callback so a cold start on an offline device
+        // reports OFFLINE immediately rather than the optimistic default.
+        setDeviceOnline(hasActiveNetwork(cm))
+        try {
+            cm.registerDefaultNetworkCallback(callback)
+        } catch (e: RuntimeException) {
+            // registerDefaultNetworkCallback can throw if too many callbacks are registered.
+            Timber.w(e, "Failed to register network callback; device-connectivity signal disabled")
+        }
+    }
+
+    private fun hasActiveNetwork(cm: ConnectivityManager): Boolean {
+        val active = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(active) ?: return false
+        // A LAN-only network (self-hosted backend, no internet) still counts as "online" — we only
+        // need a route to reach the configured server, so INTERNET (a default route) is enough and
+        // we deliberately do not require NET_CAPABILITY_VALIDATED.
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    /** Record that the backend returned an HTTP response — it is reachable regardless of status code. */
+    fun recordBackendSuccess() {
+        consecutiveFailures.set(0)
+        _lastSuccessfulResponseAtMs.value = System.currentTimeMillis()
+        if (!_backendReachable.value) {
+            _backendReachable.value = true
+            recompute()
+        }
+    }
+
+    /** Record a transport-level failure (connect/timeout/unknown-host). Flips to unreachable only
+     *  once [FAILURE_THRESHOLD] consecutive failures accrue with no intervening success. */
+    fun recordBackendFailure() {
+        if (consecutiveFailures.incrementAndGet() >= FAILURE_THRESHOLD && _backendReachable.value) {
+            _backendReachable.value = false
+            recompute()
+        }
+    }
+
+    /** Update device-connectivity. Internal so the [callback] and unit tests can drive it. */
+    internal fun setDeviceOnline(online: Boolean) {
+        if (_deviceOnline.value != online) {
+            _deviceOnline.value = online
+            recompute()
+        }
+    }
+
+    private fun recompute() {
+        _status.value = when {
+            !_deviceOnline.value -> NetworkStatus.OFFLINE
+            !_backendReachable.value -> NetworkStatus.BACKEND_UNREACHABLE
+            else -> NetworkStatus.REACHABLE
+        }
+    }
+
+    companion object {
+        /** Consecutive transport failures before the backend is declared unreachable. */
+        const val FAILURE_THRESHOLD = 2
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/ReachabilityInterceptor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/ReachabilityInterceptor.kt
@@ -1,0 +1,53 @@
+package com.glycemicgpt.mobile.data.remote
+
+import com.glycemicgpt.mobile.BuildConfig
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Feeds the client-side backend-reachability signal. Sits below the URL/auth/token
+ * interceptors in the OkHttp chain so it wraps the actual network call: a config-time throw from
+ * [BaseUrlInterceptor] (no server configured) happens above it and is never counted as a backend
+ * outage, while a real connect/timeout failure propagates up through it and is.
+ *
+ * Any [Response] — including 4xx/5xx — means the server answered, so it counts as reachable; only an
+ * [IOException] (transport failure) counts against reachability. See [NetworkMonitor] for how the
+ * consecutive-failure threshold turns that into the "backend unreachable" state.
+ *
+ * In debug builds it also honours the "simulate backend unreachable" fault-injection toggle so the
+ * unreachable state is reproducible on an emulator without real network chaos (the seed for the
+ * reusable debug harness). The toggle is compiled to a no-op in release
+ * ([AppSettingsStore.simulateBackendUnreachable] is always false there).
+ */
+@Singleton
+class ReachabilityInterceptor @Inject constructor(
+    private val networkMonitor: NetworkMonitor,
+    private val appSettingsStore: AppSettingsStore,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        if (BuildConfig.DEBUG && appSettingsStore.simulateBackendUnreachable) {
+            networkMonitor.recordBackendFailure()
+            throw IOException("Simulated backend unreachable (debug fault injection)")
+        }
+
+        return try {
+            val response = chain.proceed(chain.request())
+            networkMonitor.recordBackendSuccess()
+            response
+        } catch (e: IOException) {
+            // A canceled call (ViewModel scope teardown, navigation, a superseded request) also
+            // surfaces as an IOException but is NOT a reachability signal — only genuine transport
+            // failures count, so don't let cancellation pollute the consecutive-failure counter.
+            if (!chain.call().isCanceled()) {
+                networkMonitor.recordBackendFailure()
+            }
+            throw e
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/NetworkModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.mobile.di
 import com.glycemicgpt.mobile.data.remote.AuthInterceptor
 import com.glycemicgpt.mobile.data.remote.BaseUrlInterceptor
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.ReachabilityInterceptor
 import com.glycemicgpt.mobile.data.remote.TokenRefreshInterceptor
 import com.glycemicgpt.mobile.data.remote.InstantAdapter
 import com.squareup.moshi.Moshi
@@ -38,6 +39,7 @@ object NetworkModule {
         authInterceptor: AuthInterceptor,
         baseUrlInterceptor: BaseUrlInterceptor,
         tokenRefreshInterceptor: TokenRefreshInterceptor,
+        reachabilityInterceptor: ReachabilityInterceptor,
     ): OkHttpClient {
         val logging = HttpLoggingInterceptor().apply {
             level = if (BuildConfig.DEBUG) {
@@ -50,6 +52,9 @@ object NetworkModule {
             .addInterceptor(baseUrlInterceptor)
             .addInterceptor(authInterceptor)
             .addInterceptor(tokenRefreshInterceptor)
+            // Below auth/token so a config-time throw from BaseUrlInterceptor is not counted as a
+            // backend outage; wraps the real network call so connect/timeout failures are.
+            .addInterceptor(reachabilityInterceptor)
             .addInterceptor(logging)
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(15, TimeUnit.SECONDS)
@@ -79,7 +84,9 @@ object NetworkModule {
     @Named("chat")
     fun provideChatApi(client: OkHttpClient, moshi: Moshi): GlycemicGptApi {
         val chatClient = client.newBuilder()
-            .apply { interceptors().removeAll { it is HttpLoggingInterceptor } }
+            // Drop reachability tracking too: a 90s LLM inference that times out is not a signal the
+            // backend is unreachable, so it must not count toward NetworkMonitor's failure threshold.
+            .apply { interceptors().removeAll { it is HttpLoggingInterceptor || it is ReachabilityInterceptor } }
             .readTimeout(90, TimeUnit.SECONDS)
             .dispatcher(Dispatcher())
             .connectionPool(ConnectionPool(2, 90, TimeUnit.SECONDS))

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt
@@ -1,0 +1,97 @@
+package com.glycemicgpt.mobile.domain.freshness
+
+/**
+ * How trustworthy a timestamped data point is, given its age.
+ *
+ * One classifier shared across every dashboard source so staleness is judged the same
+ * way everywhere instead of each surface re-deriving it. The three tiers map to a display policy:
+ *
+ * - [FRESH] — recent; render normally, "just now" / "Xm ago" is advisory only.
+ * - [STALE] — older than the source's expected cadence; show a "last updated Xm ago" badge so the
+ *   user knows it is cached, but the value is still shown.
+ * - [TOO_STALE] — old enough that the value must NOT be presented as a current reading. For glucose
+ *   this is a safety-grade de-emphasis (grey + "stale") rather than a confident live number
+ *   ([FreshnessThresholds.tooStaleAfterMs]).
+ *
+ * The local freshness-gated alerting layer reuses this exact policy — do not fork a second
+ * staleness definition.
+ */
+enum class Freshness { FRESH, STALE, TOO_STALE }
+
+/**
+ * Per-source staleness bounds, in milliseconds, mirroring the `STALE_THRESHOLD_MS` idiom used by the
+ * cached-settings stores (`SafetyLimitsStore`, `GlucoseRangeStore`, ...).
+ *
+ * @property staleAfterMs age at which [FRESH] flips to [STALE] (the "last updated Xm ago" advisory).
+ * @property tooStaleAfterMs age at which [STALE] flips to [TOO_STALE] (the value is no longer shown
+ *   as a live reading; for glucose this is the de-emphasis threshold — a safety call).
+ *
+ * Boundaries are half-open: `age < staleAfterMs` is FRESH, `staleAfterMs <= age < tooStaleAfterMs`
+ * is STALE, and `age >= tooStaleAfterMs` is TOO_STALE. So a point exactly at [staleAfterMs] is STALE
+ * and one exactly at [tooStaleAfterMs] is TOO_STALE.
+ */
+data class FreshnessThresholds(
+    val staleAfterMs: Long,
+    val tooStaleAfterMs: Long,
+) {
+    init {
+        require(staleAfterMs in 1 until tooStaleAfterMs) {
+            "staleAfterMs ($staleAfterMs) must be positive and < tooStaleAfterMs ($tooStaleAfterMs)"
+        }
+    }
+
+    /** Classify a point of the given [ageMs] (now - timestamp). Negative ages (clock skew, a
+     *  future timestamp) are treated as [Freshness.FRESH]. */
+    fun classify(ageMs: Long): Freshness = when {
+        ageMs < staleAfterMs -> Freshness.FRESH
+        ageMs < tooStaleAfterMs -> Freshness.STALE
+        else -> Freshness.TOO_STALE
+    }
+}
+
+/** Human "how long ago" for an age in ms. Pure (no Android/Compose) so it is unit-testable and can
+ *  be reused by the watch/complication surfaces. Negative ages read as "just now". */
+fun relativeAgeLabel(ageMs: Long): String {
+    val seconds = ageMs / 1000
+    return when {
+        seconds < 60 -> "just now"
+        seconds < 3600 -> "${seconds / 60}m ago"
+        seconds < 86_400 -> "${seconds / 3600}h ago"
+        else -> "${seconds / 86_400}d ago"
+    }
+}
+
+/**
+ * The documented staleness policy per data source. These thresholds are a **display safety
+ * decision**: they decide when a cached number stops being presented as
+ * current. They are deliberately conservative and are surfaced for PM/clinical sign-off at review.
+ */
+object FreshnessPolicy {
+    private const val MINUTE_MS = 60_000L
+
+    /**
+     * CGM glucose. Sensors (Dexcom G6/G7, Libre) publish a new value roughly every 5 minutes, so a
+     * single missed reading (~6 min) is [Freshness.STALE] — worth a badge but still plausibly
+     * current. By ~15 min (three missed readings) the trend and value can no longer be trusted as a
+     * live glucose, so it is [Freshness.TOO_STALE] and de-emphasised. The freshness-gated alerting layer reuses
+     * TOO_STALE as the "don't fire a glucose alert off this" floor.
+     */
+    val CGM = FreshnessThresholds(staleAfterMs = 6 * MINUTE_MS, tooStaleAfterMs = 15 * MINUTE_MS)
+
+    /**
+     * Pump-state values shown as secondary metrics — IOB, basal, battery, reservoir. These are
+     * polled far less aggressively than glucose (battery/reservoir every ~5 min) and are not a
+     * safety-critical live vital, so the policy is looser: a ~15-minute gap (several missed polls)
+     * means the pump link has dropped ([Freshness.STALE]); an hour old is clearly not current
+     * ([Freshness.TOO_STALE]).
+     */
+    val PUMP = FreshnessThresholds(staleAfterMs = 15 * MINUTE_MS, tooStaleAfterMs = 60 * MINUTE_MS)
+
+    /**
+     * Debug-only compressed thresholds so the FRESH → STALE → TOO_STALE transitions can be observed
+     * in seconds on an emulator instead of waiting out the real 15-min
+     * CGM bound. Never used in release paths — the compressed policy is only substituted when the
+     * debug "Fast staleness" fault-injection toggle is on. Seeds the reusable debug harness.
+     */
+    val CGM_DEBUG_FAST = FreshnessThresholds(staleAfterMs = 20_000L, tooStaleAfterMs = 45_000L)
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugScreen.kt
@@ -64,8 +64,19 @@ fun BleDebugScreen(
                 text = "BLE Debug",
                 style = MaterialTheme.typography.headlineMedium,
             )
-            OutlinedButton(onClick = viewModel::clearEntries) {
-                Text("Clear")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                // Debug harness: seed a fresh CGM reading so the emulator (no live
+                // pump feed) can render the glucose hero and exercise the staleness/de-emphasis path.
+                OutlinedButton(
+                    onClick = viewModel::injectTestCgm,
+                    modifier = Modifier.testTag("inject_test_cgm_button"),
+                ) {
+                    Text("Inject CGM")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                OutlinedButton(onClick = viewModel::clearEntries) {
+                    Text("Clear")
+                }
             }
         }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugViewModel.kt
@@ -1,17 +1,25 @@
 package com.glycemicgpt.mobile.presentation.debug
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.BuildConfig
 import com.glycemicgpt.mobile.data.local.BleDebugStore
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
 class BleDebugViewModel @Inject constructor(
     private val debugStore: BleDebugStore,
     private val connectionManager: PumpConnectionManager,
+    private val pumpDataRepository: PumpDataRepository,
 ) : ViewModel() {
 
     val entries: StateFlow<List<BleDebugStore.Entry>> = debugStore.entries
@@ -19,5 +27,30 @@ class BleDebugViewModel @Inject constructor(
 
     fun clearEntries() {
         debugStore.clear()
+    }
+
+    /**
+     * Debug-only (reusable debug harness): write a fresh synthetic CGM reading to the Room
+     * cache so the emulator — which has no live pump feed — can render the glucose hero and, combined
+     * with the "Fast staleness" toggle, exercise the FRESH → STALE → TOO_STALE de-emphasis path.
+     */
+    fun injectTestCgm() {
+        // Defense-in-depth: this writes to the same Room cache that drives the real glucose hero, so
+        // hard-gate it to debug the same way the sibling fault-injection settings are, not just via
+        // the debug-only navigation to this screen.
+        if (!BuildConfig.DEBUG) return
+        viewModelScope.launch {
+            pumpDataRepository.saveCgm(
+                CgmReading(
+                    glucoseMgDl = TEST_CGM_MG_DL,
+                    trendArrow = CgmTrend.FLAT,
+                    timestamp = Instant.now(),
+                ),
+            )
+        }
+    }
+
+    private companion object {
+        const val TEST_CGM_MG_DL = 120
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/FreshnessUi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/FreshnessUi.kt
@@ -1,0 +1,92 @@
+package com.glycemicgpt.mobile.presentation.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.glycemicgpt.mobile.domain.freshness.Freshness
+import com.glycemicgpt.mobile.domain.freshness.FreshnessThresholds
+import com.glycemicgpt.mobile.domain.freshness.relativeAgeLabel
+import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
+import kotlinx.coroutines.delay
+import java.time.Instant
+
+/**
+ * Reusable staleness UI for the home dashboard. One source of truth over the shared
+ * [Freshness] classifier so every timestamped source (glucose + pump metrics) is aged and labelled
+ * the same way — this replaces the old ad-hoc per-value colour thresholds in `GlucoseHero`.
+ */
+
+/** The current, ticking freshness of a single data point. */
+data class FreshnessState(
+    val freshness: Freshness,
+    val ageMs: Long,
+    val label: String,
+)
+
+/** Default re-evaluation cadence for the relative-age label; matches the previous FreshnessLabel. */
+private const val FRESHNESS_TICK_MS = 30_000L
+
+/** Never tick faster than this, to keep recompositions cheap. */
+private const val MIN_FRESHNESS_TICK_MS = 2_000L
+
+/**
+ * Observe the live freshness of [timestamp] against [thresholds]. Recomputes on a cadence derived
+ * from the thresholds so a badge appears / the age grows without needing a new reading — fast
+ * enough that even the compressed debug policy crosses STALE/TOO_STALE near its documented marks,
+ * but never below [MIN_FRESHNESS_TICK_MS].
+ */
+@Composable
+fun rememberFreshness(timestamp: Instant, thresholds: FreshnessThresholds): FreshnessState {
+    val tickMs = (thresholds.staleAfterMs / 4).coerceIn(MIN_FRESHNESS_TICK_MS, FRESHNESS_TICK_MS)
+    var now by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(timestamp, thresholds) {
+        while (true) {
+            delay(tickMs)
+            now = System.currentTimeMillis()
+        }
+    }
+    val ageMs = now - timestamp.toEpochMilli()
+    return FreshnessState(thresholds.classify(ageMs), ageMs, relativeAgeLabel(ageMs))
+}
+
+/** Colour for the relative-age caption: fresh green, stale amber, too-stale de-emphasised grey. */
+@Composable
+fun freshnessColor(freshness: Freshness): Color = when (freshness) {
+    Freshness.FRESH -> GlucoseColors.InRange
+    Freshness.STALE -> GlucoseColors.High
+    Freshness.TOO_STALE -> MaterialTheme.colorScheme.onSurfaceVariant
+}
+
+/**
+ * A compact "Stale" / "Too old" pill shown only when [freshness] is not [Freshness.FRESH]. Absent on
+ * fresh data, so a fresh golden-path screen renders zero `staleness_badge` nodes.
+ */
+@Composable
+fun StalenessBadge(freshness: Freshness, modifier: Modifier = Modifier) {
+    val (text, color) = when (freshness) {
+        Freshness.FRESH -> return
+        Freshness.STALE -> "Stale" to GlucoseColors.High
+        Freshness.TOO_STALE -> "Too old" to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = color,
+        modifier = modifier
+            .testTag("staleness_badge")
+            .background(color.copy(alpha = 0.15f), RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    )
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseHero.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/GlucoseHero.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.domain.freshness.Freshness
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.domain.freshness.FreshnessThresholds
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.CgmReading
@@ -32,6 +35,7 @@ import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.model.ReservoirReading
 import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
+import java.time.Instant
 
 /**
  * Glucose threshold container. Defaults match the backend's default settings.
@@ -82,8 +86,21 @@ fun GlucoseHero(
     reservoir: ReservoirReading?,
     thresholds: GlucoseThresholds = GlucoseThresholds(),
     glucoseUnit: GlucoseUnit = GlucoseUnit.MGDL,
+    // Staleness policy for the primary glucose value. Overridable so the debug "fast staleness"
+    // affordance (and tests) can drive the FRESH → STALE → TOO_STALE transitions deterministically.
+    cgmThresholds: FreshnessThresholds = FreshnessPolicy.CGM,
     modifier: Modifier = Modifier,
 ) {
+    // Always computed (a safe EPOCH stand-in when there's no reading) so the ticking effect keeps a
+    // stable composition slot; only consumed when the corresponding value is present. Kept
+    // unconditional (never called inside the per-metric `if` blocks below) so the composition
+    // structure is stable regardless of which metrics are present.
+    val cgmFreshness = rememberFreshness(cgm?.timestamp ?: Instant.EPOCH, cgmThresholds)
+    val iobFreshness = rememberFreshness(iob?.timestamp ?: Instant.EPOCH, FreshnessPolicy.PUMP).freshness
+    val basalFreshness = rememberFreshness(basalRate?.timestamp ?: Instant.EPOCH, FreshnessPolicy.PUMP).freshness
+    val batteryFreshness = rememberFreshness(battery?.timestamp ?: Instant.EPOCH, FreshnessPolicy.PUMP).freshness
+    val reservoirFreshness = rememberFreshness(reservoir?.timestamp ?: Instant.EPOCH, FreshnessPolicy.PUMP).freshness
+
     val a11yDescription = if (cgm != null) {
         buildString {
             append(
@@ -91,6 +108,11 @@ fun GlucoseHero(
                     "${GlucoseFormat.spokenUnit(glucoseUnit)}, ",
             )
             append(cgm.trendArrow.name.lowercase().replace('_', ' '))
+            // Safety: when the value is too old to be trusted as current, say so up front so a
+            // TalkBack user is never read a stale number as if it were live.
+            if (cgmFreshness.freshness == Freshness.TOO_STALE) {
+                append(", reading is stale, last updated ${cgmFreshness.label}")
+            }
             if (iob != null) append(", insulin on board %.2f units".format(iob.iob))
             if (basalRate != null) append(", basal rate %.2f units per hour".format(basalRate.rate))
             if (battery != null) append(", battery ${battery.percentage} percent")
@@ -115,7 +137,14 @@ fun GlucoseHero(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (cgm != null) {
-                val color = glucoseColor(cgm.glucoseMgDl, thresholds)
+                val tooStale = cgmFreshness.freshness == Freshness.TOO_STALE
+                // Past TOO_STALE the value is no longer a confident live reading: drop the glucose
+                // color and render it de-emphasised so it can't be mistaken for current.
+                val color = if (tooStale) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    glucoseColor(cgm.glucoseMgDl, thresholds)
+                }
 
                 // Primary: large glucose value + trend arrow
                 Row(
@@ -147,7 +176,19 @@ fun GlucoseHero(
                 )
 
                 Spacer(modifier = Modifier.height(4.dp))
-                FreshnessLabel(cgm.timestamp)
+                // "Xm ago" caption + a Stale/Too-old badge that only appears once the reading is
+                // past FRESH. On the golden path this is a fresh green caption with no badge.
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = cgmFreshness.label,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = freshnessColor(cgmFreshness.freshness),
+                    )
+                    if (cgmFreshness.freshness != Freshness.FRESH) {
+                        Spacer(modifier = Modifier.width(6.dp))
+                        StalenessBadge(cgmFreshness.freshness)
+                    }
+                }
 
                 // Secondary metrics: IoB + Basal + Battery + Reservoir
                 if (iob != null || basalRate != null || battery != null || reservoir != null) {
@@ -160,6 +201,7 @@ fun GlucoseHero(
                             SecondaryMetric(
                                 label = "IoB",
                                 value = "%.2fu".format(iob.iob),
+                                freshness = iobFreshness,
                                 modifier = Modifier.testTag("hero_iob"),
                             )
                         }
@@ -173,6 +215,7 @@ fun GlucoseHero(
                             SecondaryMetric(
                                 label = "Basal",
                                 value = basalText + modeLabel,
+                                freshness = basalFreshness,
                                 modifier = Modifier.testTag("hero_basal"),
                             )
                         }
@@ -180,6 +223,7 @@ fun GlucoseHero(
                             SecondaryMetric(
                                 label = "Battery",
                                 value = "${battery.percentage}%",
+                                freshness = batteryFreshness,
                                 modifier = Modifier.testTag("hero_battery"),
                             )
                         }
@@ -187,6 +231,7 @@ fun GlucoseHero(
                             SecondaryMetric(
                                 label = "Reservoir",
                                 value = "%.0fu".format(reservoir.unitsRemaining),
+                                freshness = reservoirFreshness,
                                 modifier = Modifier.testTag("hero_reservoir"),
                             )
                         }
@@ -214,6 +259,7 @@ private fun SecondaryMetric(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
+    freshness: Freshness = Freshness.FRESH,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -228,7 +274,16 @@ private fun SecondaryMetric(
             text = value,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface,
+            // A stale pump metric is de-emphasised so it doesn't read as a live value.
+            color = if (freshness == Freshness.FRESH) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
         )
+        if (freshness != Freshness.FRESH) {
+            Spacer(modifier = Modifier.height(2.dp))
+            StalenessBadge(freshness)
+        }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -27,10 +27,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -45,12 +43,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import com.glycemicgpt.mobile.presentation.meal.DraggableMealFab
 import com.glycemicgpt.mobile.presentation.meal.RecentMealCard
+import com.glycemicgpt.mobile.data.network.NetworkStatus
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.presentation.plugin.PluginDashboardCardRenderer
-import com.glycemicgpt.mobile.presentation.theme.GlucoseColors
 import com.glycemicgpt.mobile.service.SyncStatus
-import kotlinx.coroutines.delay
-import java.time.Instant
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -85,6 +81,8 @@ fun HomeScreen(
     val battery by viewModel.battery.collectAsState()
     val reservoir by viewModel.reservoir.collectAsState()
     val syncStatus by viewModel.syncStatus.collectAsState()
+    val networkStatus by viewModel.networkStatus.collectAsState()
+    val cgmFreshnessThresholds by viewModel.cgmFreshnessThresholds.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
     val selectedPeriod by viewModel.selectedPeriod.collectAsState()
     val cgmHistory by viewModel.cgmHistory.collectAsState()
@@ -125,8 +123,8 @@ fun HomeScreen(
                 .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 88.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Compact connection + sync status row
-            ConnectionSyncRow(connectionState, syncStatus)
+            // Compact connection + sync status row (BLE pump + outbound sync + backend reachability)
+            ConnectionSyncRow(connectionState, syncStatus, networkStatus)
 
             Spacer(modifier = Modifier.height(12.dp))
 
@@ -139,6 +137,7 @@ fun HomeScreen(
                 reservoir = reservoir,
                 thresholds = thresholds,
                 glucoseUnit = glucoseUnit,
+                cgmThresholds = cgmFreshnessThresholds,
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -265,7 +264,11 @@ fun HomeScreen(
 }
 
 @Composable
-private fun ConnectionSyncRow(state: ConnectionState, syncStatus: SyncStatus) {
+private fun ConnectionSyncRow(
+    state: ConnectionState,
+    syncStatus: SyncStatus,
+    networkStatus: NetworkStatus,
+) {
     val (bleIcon, bleA11y, bleColor, bleText) = when (state) {
         ConnectionState.CONNECTED -> Quad(
             Icons.Default.BluetoothConnected,
@@ -356,38 +359,57 @@ private fun ConnectionSyncRow(state: ConnectionState, syncStatus: SyncStatus) {
             tint = syncColor,
             modifier = Modifier.size(16.dp),
         )
+        Spacer(modifier = Modifier.width(12.dp))
+        BackendStatusIndicator(networkStatus)
+    }
+}
+
+/**
+ * Backend/device reachability chip, distinct from the BLE and sync indicators. Always
+ * present so it can be asserted in tests via the `backend_status` tag; only shows text when there's
+ * something to warn about, keeping the reachable golden path visually quiet.
+ */
+@Composable
+private fun BackendStatusIndicator(networkStatus: NetworkStatus) {
+    val (icon, a11y, color, text) = when (networkStatus) {
+        NetworkStatus.REACHABLE -> Quad(
+            Icons.Default.CloudDone,
+            "Backend reachable",
+            MaterialTheme.colorScheme.primary,
+            null,
+        )
+        NetworkStatus.BACKEND_UNREACHABLE -> Quad(
+            Icons.Default.CloudOff,
+            "Backend unreachable",
+            MaterialTheme.colorScheme.error,
+            "Backend unreachable",
+        )
+        NetworkStatus.OFFLINE -> Quad(
+            Icons.Default.CloudOff,
+            "Device offline",
+            MaterialTheme.colorScheme.error,
+            "Offline",
+        )
+    }
+    Row(
+        modifier = Modifier.testTag("backend_status"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = a11y,
+            tint = color,
+            modifier = Modifier.size(16.dp),
+        )
+        if (text != null) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = text,
+                style = MaterialTheme.typography.labelSmall,
+                color = color,
+            )
+        }
     }
 }
 
 private data class Quad<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
-
-@Composable
-internal fun FreshnessLabel(timestamp: Instant) {
-    var now by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(30_000)
-            now = System.currentTimeMillis()
-        }
-    }
-
-    val ageSeconds = (now - timestamp.toEpochMilli()) / 1000
-    val label = when {
-        ageSeconds < 60 -> "just now"
-        ageSeconds < 3600 -> "${ageSeconds / 60}m ago"
-        ageSeconds < 86400 -> "${ageSeconds / 3600}h ago"
-        else -> "stale"
-    }
-
-    val color = when {
-        ageSeconds < 120 -> GlucoseColors.InRange
-        ageSeconds < 600 -> GlucoseColors.High
-        else -> GlucoseColors.UrgentHigh
-    }
-
-    Text(
-        text = label,
-        style = MaterialTheme.typography.labelSmall,
-        color = color,
-    )
-}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -7,11 +7,15 @@ import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpProfileStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.network.NetworkStatus
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.PluginDeclarationRequest
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import com.glycemicgpt.mobile.data.repository.PumpDataRepository
 import com.glycemicgpt.mobile.domain.compute.DashboardComputations
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.domain.freshness.FreshnessThresholds
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.BolusCategory
@@ -69,10 +73,27 @@ class HomeViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val api: GlycemicGptApi,
     private val pluginRegistry: PluginRegistry,
+    private val networkMonitor: NetworkMonitor,
 ) : ViewModel() {
 
     val connectionState: StateFlow<ConnectionState> = pumpDriver.observeConnectionState()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ConnectionState.DISCONNECTED)
+
+    /**
+     * Backend/device reachability. Distinct from [connectionState] (the BLE pump link)
+     * and [syncStatus] (the outbound push queue): this answers "can we reach our server right now?"
+     */
+    val networkStatus: StateFlow<NetworkStatus> = networkMonitor.status
+
+    /**
+     * Staleness policy applied to the primary glucose value. Normally [FreshnessPolicy.CGM];
+     * swapped to the compressed debug policy when the "fast staleness" fault-injection toggle is on
+     * so the FRESH → STALE → TOO_STALE transitions are observable in seconds during E2E testing.
+     */
+    val cgmFreshnessThresholds: StateFlow<FreshnessThresholds> =
+        appSettingsStore.debugFastStalenessFlow()
+            .map { fast -> if (fast) FreshnessPolicy.CGM_DEBUG_FAST else FreshnessPolicy.CGM }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), FreshnessPolicy.CGM)
 
     val cgm: StateFlow<CgmReading?> = repository.observeLatestCgm()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -330,6 +330,56 @@ fun SettingsScreen(
                     onCheckedChange = { settingsViewModel.setShowPumpLabels(it) },
                 )
             }
+            Spacer(modifier = Modifier.height(8.dp))
+            // Debug harness: reproduce the offline/staleness
+            // states on an emulator (which has no live pump feed) without real network chaos.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("simulate_backend_unreachable_toggle"),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Simulate Backend Unreachable",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = "Fail all backend requests so the app shows \"backend unreachable\" while cached data stays on screen",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = state.simulateBackendUnreachable,
+                    onCheckedChange = { settingsViewModel.setSimulateBackendUnreachable(it) },
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("fast_staleness_toggle"),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Fast Staleness",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = "Compress CGM staleness to seconds so the fresh/stale/too-old transitions are observable",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = state.debugFastStaleness,
+                    onCheckedChange = { settingsViewModel.setDebugFastStaleness(it) },
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -204,6 +204,9 @@ data class SettingsUiState(
     val overrideSilentForLow: Boolean = true,
     // Debug-only
     val showPumpLabels: Boolean = false,
+    // Debug-only fault injection (reusable debug harness)
+    val simulateBackendUnreachable: Boolean = false,
+    val debugFastStaleness: Boolean = false,
     // Appearance
     val themeMode: com.glycemicgpt.mobile.presentation.theme.ThemeMode =
         com.glycemicgpt.mobile.presentation.theme.ThemeMode.System,
@@ -335,6 +338,8 @@ class SettingsViewModel @Inject constructor(
             activePluginIds = pluginRegistry.allActivePlugins.value.map { it.metadata.id }.toSet(),
             runtimePlugins = pluginRegistry.runtimePlugins.value,
             showPumpLabels = appSettingsStore.showPumpLabels,
+            simulateBackendUnreachable = appSettingsStore.simulateBackendUnreachable,
+            debugFastStaleness = appSettingsStore.debugFastStaleness,
             themeMode = appSettingsStore.themeMode,
             glucoseUnit = appSettingsStore.glucoseUnit,
             seedNeedsConfirm = appSettingsStore.glucoseUnitSeedPending,
@@ -1234,6 +1239,25 @@ class SettingsViewModel @Inject constructor(
     fun setShowPumpLabels(enabled: Boolean) {
         appSettingsStore.showPumpLabels = enabled
         _uiState.value = _uiState.value.copy(showPumpLabels = enabled)
+    }
+
+    /**
+     * Debug-only (reusable debug harness): black-hole every backend request
+     * so the "backend unreachable" state can be exercised on an emulator. No-op in release
+     * ([AppSettingsStore.simulateBackendUnreachable] ignores writes there).
+     */
+    fun setSimulateBackendUnreachable(enabled: Boolean) {
+        appSettingsStore.simulateBackendUnreachable = enabled
+        _uiState.value = _uiState.value.copy(simulateBackendUnreachable = enabled)
+    }
+
+    /**
+     * Debug-only (reusable debug harness): compress the CGM staleness thresholds so the
+     * FRESH → STALE → TOO_STALE hero transitions can be watched in seconds instead of ~15 minutes.
+     */
+    fun setDebugFastStaleness(enabled: Boolean) {
+        appSettingsStore.debugFastStaleness = enabled
+        _uiState.value = _uiState.value.copy(debugFastStaleness = enabled)
     }
 
     fun setThemeMode(mode: com.glycemicgpt.mobile.presentation.theme.ThemeMode) {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/network/NetworkMonitorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/network/NetworkMonitorTest.kt
@@ -1,0 +1,103 @@
+package com.glycemicgpt.mobile.data.network
+
+import android.content.Context
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure reachability logic. [NetworkMonitor.start] (which touches
+ * ConnectivityManager) is never called, so a relaxed Context mock is enough — construction does no
+ * framework work, by design.
+ */
+class NetworkMonitorTest {
+
+    private fun monitor() = NetworkMonitor(mockk<Context>(relaxed = true))
+
+    @Test
+    fun `starts optimistic - online, reachable, no timestamp`() {
+        val m = monitor()
+        assertTrue(m.deviceOnline.value)
+        assertTrue(m.backendReachable.value)
+        assertNull(m.lastSuccessfulResponseAtMs.value)
+        assertEquals(NetworkStatus.REACHABLE, m.status.value)
+    }
+
+    @Test
+    fun `a single failure does not flip to unreachable`() {
+        val m = monitor()
+        m.recordBackendFailure()
+        assertTrue(m.backendReachable.value)
+        assertEquals(NetworkStatus.REACHABLE, m.status.value)
+    }
+
+    @Test
+    fun `reaching the failure threshold flips to backend unreachable`() {
+        val m = monitor()
+        repeat(NetworkMonitor.FAILURE_THRESHOLD) { m.recordBackendFailure() }
+        assertFalse(m.backendReachable.value)
+        assertEquals(NetworkStatus.BACKEND_UNREACHABLE, m.status.value)
+    }
+
+    @Test
+    fun `a success resets reachability and records a timestamp`() {
+        val m = monitor()
+        repeat(NetworkMonitor.FAILURE_THRESHOLD) { m.recordBackendFailure() }
+        assertEquals(NetworkStatus.BACKEND_UNREACHABLE, m.status.value)
+
+        m.recordBackendSuccess()
+        assertTrue(m.backendReachable.value)
+        assertEquals(NetworkStatus.REACHABLE, m.status.value)
+        assertNotNull(m.lastSuccessfulResponseAtMs.value)
+    }
+
+    @Test
+    fun `a success resets the consecutive-failure counter`() {
+        val m = monitor()
+        // One below the threshold, then a success, then one more failure: must NOT be unreachable
+        // because the counter reset — otherwise a slow drip of unrelated failures would trip it.
+        repeat(NetworkMonitor.FAILURE_THRESHOLD - 1) { m.recordBackendFailure() }
+        m.recordBackendSuccess()
+        m.recordBackendFailure()
+        assertTrue(m.backendReachable.value)
+        assertEquals(NetworkStatus.REACHABLE, m.status.value)
+    }
+
+    @Test
+    fun `going offline reports OFFLINE and takes precedence over backend reachability`() {
+        val m = monitor()
+        m.setDeviceOnline(false)
+        assertEquals(NetworkStatus.OFFLINE, m.status.value)
+    }
+
+    @Test
+    fun `offline takes precedence even when the backend is also unreachable`() {
+        val m = monitor()
+        repeat(NetworkMonitor.FAILURE_THRESHOLD) { m.recordBackendFailure() }
+        m.setDeviceOnline(false)
+        assertEquals(NetworkStatus.OFFLINE, m.status.value)
+    }
+
+    @Test
+    fun `coming back online with a reachable backend returns to REACHABLE`() {
+        val m = monitor()
+        m.setDeviceOnline(false)
+        assertEquals(NetworkStatus.OFFLINE, m.status.value)
+        m.setDeviceOnline(true)
+        assertEquals(NetworkStatus.REACHABLE, m.status.value)
+    }
+
+    @Test
+    fun `coming back online while the backend is still unreachable reports BACKEND_UNREACHABLE`() {
+        val m = monitor()
+        repeat(NetworkMonitor.FAILURE_THRESHOLD) { m.recordBackendFailure() }
+        m.setDeviceOnline(false)
+        assertEquals(NetworkStatus.OFFLINE, m.status.value)
+        m.setDeviceOnline(true)
+        assertEquals(NetworkStatus.BACKEND_UNREACHABLE, m.status.value)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/ReachabilityInterceptorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/ReachabilityInterceptorTest.kt
@@ -1,0 +1,111 @@
+package com.glycemicgpt.mobile.data.remote
+
+import com.glycemicgpt.mobile.BuildConfig
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+class ReachabilityInterceptorTest {
+
+    private val networkMonitor = mockk<NetworkMonitor>(relaxed = true)
+    private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true)
+    private val interceptor = ReachabilityInterceptor(networkMonitor, appSettingsStore)
+
+    private val request = Request.Builder().url("http://localhost/api/health").build()
+
+    private fun chainReturning(response: Response): Interceptor.Chain = mockk {
+        every { request() } returns request
+        every { proceed(any()) } returns response
+    }
+
+    private fun chainThrowing(error: IOException, canceled: Boolean = false): Interceptor.Chain = mockk {
+        every { request() } returns request
+        every { proceed(any()) } throws error
+        every { call() } returns mockk { every { isCanceled() } returns canceled }
+    }
+
+    private fun okResponse(code: Int = 200): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .message("OK")
+        .body("".toResponseBody(null))
+        .build()
+
+    @Test
+    fun `a successful response records backend reachable and passes it through`() {
+        every { appSettingsStore.simulateBackendUnreachable } returns false
+        val response = okResponse()
+
+        val result = interceptor.intercept(chainReturning(response))
+
+        assertEquals(response, result)
+        verify(exactly = 1) { networkMonitor.recordBackendSuccess() }
+        verify(exactly = 0) { networkMonitor.recordBackendFailure() }
+    }
+
+    @Test
+    fun `a server error still counts as reachable - the server answered`() {
+        every { appSettingsStore.simulateBackendUnreachable } returns false
+
+        interceptor.intercept(chainReturning(okResponse(code = 503)))
+
+        verify(exactly = 1) { networkMonitor.recordBackendSuccess() }
+        verify(exactly = 0) { networkMonitor.recordBackendFailure() }
+    }
+
+    @Test
+    fun `a transport failure records a backend failure and rethrows`() {
+        every { appSettingsStore.simulateBackendUnreachable } returns false
+        val boom = IOException("connect timed out")
+
+        val thrown = assertThrows(IOException::class.java) {
+            interceptor.intercept(chainThrowing(boom))
+        }
+
+        assertEquals(boom, thrown)
+        verify(exactly = 1) { networkMonitor.recordBackendFailure() }
+        verify(exactly = 0) { networkMonitor.recordBackendSuccess() }
+    }
+
+    @Test
+    fun `a canceled call is not counted as a backend failure`() {
+        every { appSettingsStore.simulateBackendUnreachable } returns false
+        val canceled = IOException("Canceled")
+
+        assertThrows(IOException::class.java) {
+            interceptor.intercept(chainThrowing(canceled, canceled = true))
+        }
+
+        verify(exactly = 0) { networkMonitor.recordBackendFailure() }
+        verify(exactly = 0) { networkMonitor.recordBackendSuccess() }
+    }
+
+    @Test
+    fun `debug fault injection short-circuits before the network and records a failure`() {
+        // Guarded by BuildConfig.DEBUG, which is true for the debug unit-test variant.
+        assertTrue("expected the debug variant for this test", BuildConfig.DEBUG)
+        every { appSettingsStore.simulateBackendUnreachable } returns true
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+        }
+
+        assertThrows(IOException::class.java) { interceptor.intercept(chain) }
+
+        verify(exactly = 1) { networkMonitor.recordBackendFailure() }
+        // proceed() must never be reached when the fault is injected.
+        verify(exactly = 0) { chain.proceed(any()) }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/freshness/FreshnessTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/freshness/FreshnessTest.kt
@@ -1,0 +1,90 @@
+package com.glycemicgpt.mobile.domain.freshness
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class FreshnessTest {
+
+    // -- classify() boundaries -------------------------------------------------
+
+    @Test
+    fun `classify is FRESH below the stale threshold`() {
+        val t = FreshnessThresholds(staleAfterMs = 1000, tooStaleAfterMs = 2000)
+        assertEquals(Freshness.FRESH, t.classify(0))
+        assertEquals(Freshness.FRESH, t.classify(999))
+    }
+
+    @Test
+    fun `classify is STALE exactly at and above the stale threshold`() {
+        val t = FreshnessThresholds(staleAfterMs = 1000, tooStaleAfterMs = 2000)
+        assertEquals(Freshness.STALE, t.classify(1000))
+        assertEquals(Freshness.STALE, t.classify(1999))
+    }
+
+    @Test
+    fun `classify is TOO_STALE exactly at and above the too-stale threshold`() {
+        val t = FreshnessThresholds(staleAfterMs = 1000, tooStaleAfterMs = 2000)
+        assertEquals(Freshness.TOO_STALE, t.classify(2000))
+        assertEquals(Freshness.TOO_STALE, t.classify(10_000))
+    }
+
+    @Test
+    fun `classify treats a negative age (clock skew) as FRESH`() {
+        val t = FreshnessThresholds(staleAfterMs = 1000, tooStaleAfterMs = 2000)
+        assertEquals(Freshness.FRESH, t.classify(-5000))
+    }
+
+    @Test
+    fun `invalid thresholds are rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FreshnessThresholds(staleAfterMs = 2000, tooStaleAfterMs = 1000)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            FreshnessThresholds(staleAfterMs = 0, tooStaleAfterMs = 1000)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            FreshnessThresholds(staleAfterMs = 1000, tooStaleAfterMs = 1000)
+        }
+    }
+
+    // -- Per-source policy -----------------------------------------------------
+
+    @Test
+    fun `CGM policy flips stale at 6 minutes and too-stale at 15 minutes`() {
+        val cgm = FreshnessPolicy.CGM
+        assertEquals(Freshness.FRESH, cgm.classify(5 * 60_000L))
+        assertEquals(Freshness.STALE, cgm.classify(6 * 60_000L))
+        assertEquals(Freshness.STALE, cgm.classify(14 * 60_000L))
+        assertEquals(Freshness.TOO_STALE, cgm.classify(15 * 60_000L))
+    }
+
+    @Test
+    fun `PUMP policy is looser than CGM`() {
+        val pump = FreshnessPolicy.PUMP
+        assertEquals(Freshness.FRESH, pump.classify(14 * 60_000L))
+        assertEquals(Freshness.STALE, pump.classify(15 * 60_000L))
+        assertEquals(Freshness.TOO_STALE, pump.classify(60 * 60_000L))
+    }
+
+    @Test
+    fun `debug fast policy compresses transitions into seconds`() {
+        val fast = FreshnessPolicy.CGM_DEBUG_FAST
+        assertEquals(Freshness.FRESH, fast.classify(10_000L))
+        assertEquals(Freshness.STALE, fast.classify(20_000L))
+        assertEquals(Freshness.TOO_STALE, fast.classify(45_000L))
+    }
+
+    // -- relativeAgeLabel ------------------------------------------------------
+
+    @Test
+    fun `relativeAgeLabel formats seconds, minutes, hours and days`() {
+        assertEquals("just now", relativeAgeLabel(0))
+        assertEquals("just now", relativeAgeLabel(59_000))
+        assertEquals("1m ago", relativeAgeLabel(60_000))
+        assertEquals("59m ago", relativeAgeLabel(59 * 60_000L))
+        assertEquals("1h ago", relativeAgeLabel(60 * 60_000L))
+        assertEquals("23h ago", relativeAgeLabel(23 * 60 * 60_000L))
+        assertEquals("1d ago", relativeAgeLabel(24 * 60 * 60_000L))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -5,11 +5,15 @@ import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpProfileStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.network.NetworkStatus
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.PluginDeclarationRequest
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import com.glycemicgpt.mobile.data.remote.dto.GlucoseRangeResponse
 import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.domain.freshness.FreshnessThresholds
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.CgmReading
@@ -132,6 +136,7 @@ class HomeViewModelTest {
         every { dataRetentionDays } returns 7
         every { glucoseUnit } returns GlucoseUnit.MGDL
         every { glucoseUnitFlow() } returns flowOf(GlucoseUnit.MGDL)
+        every { debugFastStalenessFlow() } returns flowOf(false)
     }
 
     private val authRepository = mockk<AuthRepository>(relaxed = true)
@@ -140,6 +145,11 @@ class HomeViewModelTest {
     private val pluginRegistry = mockk<PluginRegistry>(relaxed = true) {
         every { allActivePlugins } returns MutableStateFlow<List<Plugin>>(emptyList())
         every { activePumpPlugin } returns MutableStateFlow(null)
+    }
+
+    private val networkStatusFlow = MutableStateFlow(NetworkStatus.REACHABLE)
+    private val networkMonitor = mockk<NetworkMonitor>(relaxed = true) {
+        every { status } returns networkStatusFlow
     }
 
     @Before
@@ -152,7 +162,7 @@ class HomeViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, api, pluginRegistry)
+    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, api, pluginRegistry, networkMonitor)
 
     @Test
     fun `initial state has null readings and not refreshing`() = runTest {
@@ -165,6 +175,49 @@ class HomeViewModelTest {
         assertNull(vm.cgm.value)
         assertFalse(vm.isRefreshing.value)
         assertEquals(ConnectionState.DISCONNECTED, vm.connectionState.value)
+    }
+
+    @Test
+    fun `networkStatus reflects the network monitor`() = runTest {
+        val vm = createViewModel()
+        assertEquals(NetworkStatus.REACHABLE, vm.networkStatus.value)
+
+        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+        assertEquals(NetworkStatus.BACKEND_UNREACHABLE, vm.networkStatus.value)
+    }
+
+    @Test
+    fun `cgmFreshnessThresholds defaults to the CGM policy`() = runTest {
+        val vm = createViewModel()
+
+        // Subscribe so the WhileSubscribed mapping actually runs (debugFastStalenessFlow = false),
+        // rather than asserting the pre-collection seed value.
+        val collected = mutableListOf<FreshnessThresholds>()
+        val job = backgroundScope.launch(testDispatcher) {
+            vm.cgmFreshnessThresholds.collect { collected.add(it) }
+        }
+        runCurrent()
+
+        assertEquals(FreshnessPolicy.CGM, collected.last())
+        assertEquals(FreshnessPolicy.CGM, vm.cgmFreshnessThresholds.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `cgmFreshnessThresholds switches to the fast debug policy when enabled`() = runTest {
+        every { appSettingsStore.debugFastStalenessFlow() } returns flowOf(true)
+        val vm = createViewModel()
+
+        // Collecting activates the WhileSubscribed stateIn so the mapping actually runs.
+        val collected = mutableListOf<FreshnessThresholds>()
+        val job = backgroundScope.launch(testDispatcher) {
+            vm.cgmFreshnessThresholds.collect { collected.add(it) }
+        }
+        runCurrent()
+
+        assertEquals(FreshnessPolicy.CGM_DEBUG_FAST, collected.last())
+        assertEquals(FreshnessPolicy.CGM_DEBUG_FAST, vm.cgmFreshnessThresholds.value)
+        job.cancel()
     }
 
     @Test


### PR DESCRIPTION
## Connectivity + staleness substrate

Detect when the backend is unreachable and clearly tell the user whether on-screen data is live or cached (and how old) — and **never present a stale glucose value as current**. **Mobile-only; no backend/web/sidecar change.**

### What changed
- **One reusable staleness model** — `domain/freshness/Freshness.kt`: `Freshness{FRESH, STALE, TOO_STALE}` + `FreshnessThresholds.classify` + a documented per-source `FreshnessPolicy` (CGM 6/15 min, pump 15/60 min). The home hero's ad-hoc `FreshnessLabel` was refactored onto this — no second implementation. The local freshness-gated alerting layer will reuse this policy.
- **Central reachability monitor** — `data/network/NetworkMonitor.kt` (Hilt singleton): device connectivity via `ConnectivityManager`'s default-network callback, and **backend reachability derived client-side** from the existing API traffic (`ReachabilityInterceptor`: any HTTP response = reachable; two consecutive transport failures = unreachable; success resets; canceled calls excluded). No backend health endpoint — stays mobile-only. Three distinct states — device offline / backend unreachable / BLE pump disconnected — are never conflated; **device-offline takes precedence**.
- **Staleness + reachability UX** — `ConnectionSyncRow` gains a `backend_status` indicator (reachable / "Backend unreachable" / "Offline"); per-source `staleness_badge`s; and past `TOO_STALE` the hero glucose is **de-emphasised** (greyed + "Too old") so it can never be read as a confident live number. The connected/fresh golden path is unchanged.
- **Debug fault-injection affordance** — DEBUG-gated `simulateBackendUnreachable` + `debugFastStaleness` toggles (Settings → Developer) and an "Inject CGM" affordance (BLE Debug Console), all hard-gated to `BuildConfig.DEBUG` (false getter + no-op setter in release).

### Safety call for sign-off
The `TOO_STALE` bounds decide when a cached glucose stops being shown as current — a display safety decision. Conservative defaults, documented in `FreshnessPolicy`:
- **CGM:** STALE at **6 min** (~1 missed reading), TOO_STALE at **15 min** (~3 missed → de-emphasise).
- **Pump (IOB/basal/battery/reservoir):** STALE **15 min**, TOO_STALE **60 min**.

Please confirm these before the local alerting layer keys off them.

### Testing
- `./gradlew testDebugUnitTest lintDebug assembleDebug` — green.
- New unit tests: `Freshness` boundaries per source, `NetworkMonitor` transitions (incl. offline-vs-unreachable precedence + failure-threshold reset), `ReachabilityInterceptor` success/failure recording + cancellation + fault injection.
- Instrumented Compose test (`GlucoseHeroStalenessUiTest`) — fresh shows no badge, stale shows the badge, too-old is labelled and still renders (3/3 on emulator).
- **Manual E2E on emulator:** all four states watched fail + recover — golden path (fresh, no badge, backend reachable); backend-unreachable + BLE (cached BG de-emphasised + "Too old" + "Backend unreachable", no blank/spin); airplane (distinct "Offline"); recovery (badges clear, back to reachable).

New testTags: `backend_status`, `staleness_badge`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a home “glucose freshness” experience with relative age labels and “Stale” / “Too old” staleness badges.
  * Introduced a home connectivity indicator that distinguishes offline vs backend unreachable.
  * Added developer debug controls to simulate backend unreachable, fast staleness transitions, and an “Inject CGM” option.
* **Bug Fixes**
  * Improved handling of outdated glucose data so values remain visible while staleness is clearly labeled and visually de-emphasized.
* **Tests**
  * Added unit and UI test coverage for freshness thresholds, reachability behavior, interceptor logic, and badge rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->