### PR TITLE
fix(medtronic): prevent RACP service-scoping race condition and add extend GATT hex logging

### DIFF
--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -70,10 +70,12 @@ import kotlin.concurrent.withLock
  * is spun up for delivery.
  *
  * **RACP service-scoping (AC2).** The shared SIG `0x2A52` RACP characteristic lives under both the CGM
- * and IDD services. It is resolved to the service whose data characteristic the current exchange is
- * actively streaming (the reader subscribes the data char immediately before touching the control
- * point), falling back to the most recently resolved RACP-bearing service -- never the bare UUID, and
- * never poisoned by an unrelated Battery/Device-Info read.
+ * and IDD services. It is resolved to the most recently resolved RACP-bearing service -- the reader
+ * resolves that exchange's data characteristic (CGM Measurement / IDD History Data) immediately before
+ * touching the control point, so this tracks the current exchange -- falling back to a service with a
+ * live subscription only if that context is somehow unset. Preferring the resolved context over live
+ * subscriptions keeps a dangling handler from a failed prior exchange from hijacking the scope; it is
+ * never the bare UUID, and never poisoned by an unrelated Battery/Device-Info read.
  *
  * **Cancellation/cleanup (AC4).** A reader only [unsubscribe]s on a pump *response*; if the gateway's
  * per-operation timeout cancels the driving coroutine first, the subscriptions would dangle. A
@@ -120,8 +122,9 @@ class AndroidMedtronicGattLink(
     @Volatile
     private var racpServiceUuids: Set<UUID> = emptySet()
 
-    // The service of the most recently resolved RACP-bearing characteristic -- the fallback context for
-    // scoping the shared RACP UUID when no data subscription is active.
+    // The service of the most recently resolved RACP-bearing characteristic -- the primary context for
+    // scoping the shared RACP UUID. An active data subscription resolves this immediately before the
+    // RACP write, so it tracks the current exchange rather than any stale handler still in the map.
     @Volatile
     private var lastResolvedServiceUuid: UUID? = null
 
@@ -327,18 +330,20 @@ class AndroidMedtronicGattLink(
     /**
      * Record the service context used to scope the shared RACP characteristic, but only for services
      * that actually expose RACP (CGM + IDD). A Battery / Device-Info read must not move the CGM-vs-IDD
-     * fallback context.
+     * scoping context.
      */
     private fun rememberServiceContext(serviceUuid: UUID) {
         if (serviceUuid in racpServiceUuids) lastResolvedServiceUuid = serviceUuid
     }
 
     /**
-     * Scope a characteristic exposed by more than one service (the shared `0x2A52` RACP). Bind it to
-     * the service whose data characteristic this exchange is actively streaming -- the reader subscribes
-     * that data char (CGM Measurement / IDD History Data) immediately before the RACP write -- and fall
-     * back to the most recently resolved RACP-bearing service. Guessing here silently reads the wrong
-     * log, so an unresolvable case fails loudly rather than picking the first candidate.
+     * Scope a characteristic exposed by more than one service (the shared `0x2A52` RACP). Bind it to the
+     * most recently resolved RACP-bearing service ([lastResolvedServiceUuid]) -- the reader resolves this
+     * exchange's data char (CGM Measurement / IDD History Data) immediately before the RACP write, so it
+     * is the current exchange's service -- and fall back to a service with a live subscription only if
+     * that context is unset. Checking the resolved context before active subscriptions keeps a dangling
+     * handler from a failed prior exchange from hijacking the scope. Guessing here silently reads the
+     * wrong log, so an unresolvable case fails loudly rather than picking the first candidate.
      */
     private fun resolveAmbiguous(candidates: List<ResolvedChar>): ResolvedChar {
         val activeServices = handlers.values.mapTo(HashSet()) { it.resolved.serviceUuid }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -158,7 +158,9 @@ class AndroidMedtronicGattLink(
                 logGattWarning("read", characteristic, outcome.status)
                 throw MedtronicReadException("Medtronic GATT read failed (status=${outcome.status})")
             }
-            outcome.value ?: ByteArray(0)
+            val result = outcome.value ?: ByteArray(0)
+            Timber.v("GATT read %s (%d bytes) %s", characteristic, result.size, MedtronicCodec.toHex(result))
+            result
         }
 
     override fun write(characteristic: UUID, value: ByteArray) {
@@ -208,7 +210,9 @@ class AndroidMedtronicGattLink(
                 // CCCD takes effect is not lost. Re-subscribing replaces the handler (seam contract).
                 // Record the owning client so a deferred unsubscribe can't disable a later connection.
                 handlers[characteristic] = ActiveSubscription(resolved, onPdu, link)
-                val enable = if (isIndication(char)) CCCD_ENABLE_INDICATION else CCCD_ENABLE_NOTIFICATION
+                val isIndication = isIndication(char)
+                val enable = if (isIndication) CCCD_ENABLE_INDICATION else CCCD_ENABLE_NOTIFICATION
+                Timber.v("GATT subscribe %s (%s)", characteristic, if (isIndication) "indication" else "notification")
                 // The CCCD write completes before this returns, so notifications are effective before
                 // the caller's subsequent control-point write (AC3).
                 val outcome = awaitGatt("subscribe", characteristic) { writeDescriptor(link, cccd, enable) }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -35,6 +35,7 @@ import android.os.Build
 import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
 import com.glycemicgpt.mobile.ble.read.MedtronicGattLink
 import com.glycemicgpt.mobile.ble.read.MedtronicReadException
+import com.glycemicgpt.mobile.ble.read.MedtronicCodec
 import com.glycemicgpt.mobile.ble.read.MedtronicReadGateway
 import timber.log.Timber
 import java.util.UUID
@@ -174,6 +175,7 @@ class AndroidMedtronicGattLink(
             opLock.withLock {
                 val link = ensureConnected()
                 val resolved = resolve(characteristic)
+                Timber.v("GATT write %s (%d bytes) %s", characteristic, value.size, MedtronicCodec.toHex(value))
                 val outcome = awaitGatt("write", characteristic) { writeCharacteristic(link, resolved.characteristic, value) }
                 if (outcome.status != BluetoothGatt.GATT_SUCCESS) {
                     logGattWarning("write", characteristic, outcome.status)
@@ -556,6 +558,7 @@ class AndroidMedtronicGattLink(
     }
 
     private fun deliverPdu(characteristic: UUID, value: ByteArray) {
+        Timber.v("GATT notification %s (%d bytes) %s", characteristic, value.size, MedtronicCodec.toHex(value))
         // Hop onto the connection manager's single worker thread so all onPdu callbacks are serialized
         // on one thread (AC3). Copy first: the API-33 callback may recycle its delivery buffer once this
         // returns, and the copy is read later on the worker.

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -179,6 +179,7 @@ class AndroidMedtronicGattLink(
                 val outcome = awaitGatt("write", characteristic) { writeCharacteristic(link, resolved.characteristic, value) }
                 if (outcome.status != BluetoothGatt.GATT_SUCCESS) {
                     logGattWarning("write", characteristic, outcome.status)
+                    handlers.remove(characteristic)
                 }
             }
         } catch (e: MedtronicReadException) {
@@ -337,8 +338,8 @@ class AndroidMedtronicGattLink(
      */
     private fun resolveAmbiguous(candidates: List<ResolvedChar>): ResolvedChar {
         val activeServices = handlers.values.mapTo(HashSet()) { it.resolved.serviceUuid }
-        return candidates.firstOrNull { it.serviceUuid in activeServices }
-            ?: candidates.firstOrNull { it.serviceUuid == lastResolvedServiceUuid }
+        return candidates.firstOrNull { it.serviceUuid == lastResolvedServiceUuid }
+            ?: candidates.firstOrNull { it.serviceUuid in activeServices }
             ?: throw MedtronicReadException("Medtronic GATT could not scope a shared characteristic to a service")
     }
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
@@ -111,12 +111,12 @@ class HistoryReader(
 
     private fun parseCount(response: ByteArray): Int {
         if (response.size < 4) {
-            throw MedtronicReadException("RACP count response too short: ${response.size} bytes")
+            throw MedtronicReadException("IDD RACP count response too short: ${response.size} bytes")
         }
         if (response[0].toInt() and 0xFF != NUMBER_OF_RECORDS_RESPONSE ||
             response[1].toInt() and 0xFF != FILTER_SEQUENCE_NUMBER
         ) {
-            throw MedtronicReadException("Unexpected RACP count response: ${response.toHex()}")
+            throw MedtronicReadException("Unexpected IDD RACP count response: ${response.toHex()}")
         }
         return MedtronicCodec.readUIntLe(response, 2, 2)
     }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -146,6 +146,7 @@ class MedtronicSessionReader(
 
         link.subscribe(controlPoint) { response ->
             if (finished) return@subscribe
+            Timber.d("CGM RACP response (%d bytes) %s", response.size, response.toHex())
             when {
                 response.contentEquals(RACP_REPORT_SUCCESS) -> {
                     val r = record
@@ -163,7 +164,7 @@ class MedtronicSessionReader(
             }
         }
 
-        Timber.d("CGM RACP report-last-record request")
+        Timber.d("CGM RACP report-last-record request (%d bytes) %s", RACP_REPORT_LAST_RECORD.size, RACP_REPORT_LAST_RECORD.toHex())
         link.write(controlPoint, RACP_REPORT_LAST_RECORD)
     }
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -178,7 +178,7 @@ class MedtronicSessionReader(
      */
     fun socpGet(socp: UUID, requestOpcode: ByteArray, onResult: (Result<ByteArray>) -> Unit) {
         val request = appendE2eCrc(requestOpcode)
-        Timber.d("CGM SOCP GET request (%d bytes)", request.size)
+        Timber.d("CGM SOCP GET request (%d bytes) %s", request.size, request.toHex())
         encryptedGet(socp, session.encryptForPump(request), "SOCP response could not be decrypted", onResult)
     }
 
@@ -195,7 +195,7 @@ class MedtronicSessionReader(
      * with the other exchanges the caller must impose the operation timeout.
      */
     fun srcpGet(srcp: UUID, requestOpcode: ByteArray, onResult: (Result<ByteArray>) -> Unit) {
-        Timber.d("IDD SRCP GET request (%d bytes)", requestOpcode.size)
+        Timber.d("IDD SRCP GET request (%d bytes) %s", requestOpcode.size, requestOpcode.toHex())
         encryptedGet(srcp, session.encryptForPump(requestOpcode), "IDD SRCP response could not be decrypted", onResult)
     }
 
@@ -283,7 +283,7 @@ class MedtronicSessionReader(
             }
         }
 
-        Timber.d("IDD RACP report-records request (%d bytes)", request.size)
+        Timber.d("IDD RACP report-records request (%d bytes) %s", request.size, request.toHex())
         link.write(controlPoint, request)
     }
 
@@ -308,7 +308,7 @@ class MedtronicSessionReader(
             finish(Result.success(response.copyOf()))
         }
 
-        Timber.d("IDD RACP control-point query (%d bytes)", request.size)
+        Timber.d("IDD RACP control-point query (%d bytes) %s", request.size, request.toHex())
         link.write(controlPoint, request)
     }
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -165,7 +165,11 @@ class MedtronicSessionReader(
         }
 
         Timber.d("CGM RACP report-last-record request (%d bytes) %s", RACP_REPORT_LAST_RECORD.size, RACP_REPORT_LAST_RECORD.toHex())
-        link.write(controlPoint, RACP_REPORT_LAST_RECORD)
+        try {
+            link.write(controlPoint, RACP_REPORT_LAST_RECORD)
+        } catch (e: Exception) {
+            finish(Result.failure(asReadException(e, "CGM RACP write failed")))
+        }
     }
 
     /**
@@ -285,7 +289,11 @@ class MedtronicSessionReader(
         }
 
         Timber.d("IDD RACP report-records request (%d bytes) %s", request.size, request.toHex())
-        link.write(controlPoint, request)
+        try {
+            link.write(controlPoint, request)
+        } catch (e: Exception) {
+            finish(Result.failure(asReadException(e, "IDD RACP write failed")))
+        }
     }
 
     /**
@@ -310,7 +318,11 @@ class MedtronicSessionReader(
         }
 
         Timber.d("IDD RACP control-point query (%d bytes) %s", request.size, request.toHex())
-        link.write(controlPoint, request)
+        try {
+            link.write(controlPoint, request)
+        } catch (e: Exception) {
+            finish(Result.failure(asReadException(e, "IDD RACP write failed")))
+        }
     }
 
     /**
@@ -345,7 +357,11 @@ class MedtronicSessionReader(
             }
         }
 
-        link.write(char, encryptedRequest)
+        try {
+            link.write(char, encryptedRequest)
+        } catch (e: Exception) {
+            finish(Result.failure(asReadException(e, failMessage)))
+        }
     }
 
     /** Map any decrypt/parse failure to a [MedtronicReadException], preserving an already-typed one. */

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -150,20 +150,20 @@ class MedtronicSessionReader(
                 response.contentEquals(RACP_REPORT_SUCCESS) -> {
                     val r = record
                     if (r == null) {
-                        finish(Result.failure(MedtronicReadException("RACP reported success but no record arrived")))
+                        finish(Result.failure(MedtronicReadException("CGM RACP reported success but no record arrived")))
                     } else {
                         finish(Result.success(r))
                     }
                 }
                 else -> finish(
                     Result.failure(
-                        MedtronicReadException("Unexpected RACP response: ${response.toHex()}"),
+                        MedtronicReadException("Unexpected CGM RACP response: ${response.toHex()}"),
                     ),
                 )
             }
         }
 
-        Timber.d("RACP report-last-record request")
+        Timber.d("CGM RACP report-last-record request")
         link.write(controlPoint, RACP_REPORT_LAST_RECORD)
     }
 
@@ -178,7 +178,7 @@ class MedtronicSessionReader(
      */
     fun socpGet(socp: UUID, requestOpcode: ByteArray, onResult: (Result<ByteArray>) -> Unit) {
         val request = appendE2eCrc(requestOpcode)
-        Timber.d("SOCP GET request (%d bytes)", request.size)
+        Timber.d("CGM SOCP GET request (%d bytes)", request.size)
         encryptedGet(socp, session.encryptForPump(request), "SOCP response could not be decrypted", onResult)
     }
 
@@ -278,12 +278,12 @@ class MedtronicSessionReader(
                 finish(Result.success(records.toList()))
             } else {
                 finish(
-                    Result.failure(MedtronicReadException("Unexpected/failed RACP response: ${response.toHex()}")),
+                    Result.failure(MedtronicReadException("Unexpected/failed IDD RACP response: ${response.toHex()}")),
                 )
             }
         }
 
-        Timber.d("RACP report-records request (%d bytes)", request.size)
+        Timber.d("IDD RACP report-records request (%d bytes)", request.size)
         link.write(controlPoint, request)
     }
 
@@ -308,7 +308,7 @@ class MedtronicSessionReader(
             finish(Result.success(response.copyOf()))
         }
 
-        Timber.d("RACP control-point query (%d bytes)", request.size)
+        Timber.d("IDD RACP control-point query (%d bytes)", request.size)
         link.write(controlPoint, request)
     }
 

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
@@ -224,6 +224,26 @@ class AndroidMedtronicGattLinkTest {
         verify(exactly = 0) { gatt.writeCharacteristic(cgmRacp) }
     }
 
+    @Test
+    fun `a stale IDD subscription does not hijack the RACP scope of a CGM exchange`() {
+        val link = newLink()
+
+        // Regression: a dangling IDD History subscription from a prior exchange (e.g. one whose
+        // control-point write failed before the watchdog released it) leaves the IDD service in the
+        // active-subscription set. The current CGM exchange then resolves its own context -- reading a
+        // CGM-service characteristic sets the most-recently-resolved RACP service to CGM -- so the RACP
+        // write must bind to CGM, not the stale IDD subscription. The previous active-subscriptions-first
+        // ordering picked IDD here, making the pump answer a CGM read in IDD format.
+        link.subscribe(MedtronicProtocol.IDD_HISTORY_DATA_UUID) {}
+        link.read(MedtronicProtocol.CGM_FEATURE_UUID)
+        link.write(MedtronicProtocol.RACP_UUID, byteArrayOf(0x01, 0x06))
+
+        @Suppress("DEPRECATION")
+        verify { gatt.writeCharacteristic(cgmRacp) }
+        @Suppress("DEPRECATION")
+        verify(exactly = 0) { gatt.writeCharacteristic(iddRacp) }
+    }
+
     // -- READ-ONLY: writes are confined to the report/control points ---------
 
     @Test


### PR DESCRIPTION
## 📋 Summary

Medtronic BLE read-layer logging and service-scoping fixes — adds verbose hex dumps for all GATT operations (reads, writes, notifications, indications), prefixes RACP/SOCP/SRCP logs with the correct service name (CGM vs IDD), and prevents a race condition where stale handlers from a failed write cause the shared RACP UUID to resolve to the wrong service.

## 🔗 Related Issues

No reported GitHub issue.

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

- **Service-scoping fix** — `resolveAmbiguous` now prefers `lastResolvedServiceUuid` (set by the unambiguous data characteristic subscribe) over `activeServices` from all handlers, so stale handlers from failed exchanges never pollute scope resolution
- **Cleanup on write failure** — failed GATT writes immediately remove their handler from the handlers map; all `link.write()` calls in `MedtronicSessionReader` are wrapped in try/catch to clean up subscriptions on exception
- **Service prefix for all logs** — CGM/IDD prefix added to every RACP/SOCP/SRCP log and exception message in `MedtronicSessionReader` and `HistoryReader`
- **Raw hex for all request bytes** — SOCP, SRCP, RACP report-records, RACP control-point-query, and RACP report-last-record all log hex alongside byte count
- **Verbose GATT traffic** — `Timber.v` logs added for GATT reads (result bytes) and subscribe (indication vs notification type), matching existing write/notification verbose logs

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [x] Manual/visual testing performed — verified against live pump logs showing correct service resolution and hex dump visibility
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [x] Self-review completed
- [x] Code follows project style guidelines
- [x] No hardcoded secrets, API keys, or credentials
- [x] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

N/A — BLE logging changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BLE exchange reliability by ensuring failed write operations properly complete their requests instead of risking stuck states.
  * Fixed how shared BLE characteristics are scoped, preventing the wrong service/handler from receiving subsequent RACP writes after a prior subscription.
  * Improved notification/indication setup and enhanced error clarity for unexpected device responses.
* **Tests**
  * Added a regression test to confirm a stale IDD history subscription cannot hijack RACP write scope during a CGM exchange.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->