### PR TITLE
fix(medtronic): decrypt per-PDU, guard deferred unsubscribe race, page history at gateway with per-batch timeout

### DIFF
--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -214,7 +214,8 @@ class AndroidMedtronicGattLink(
                 // Register the handler before enabling notifications so a PDU delivered the instant the
                 // CCCD takes effect is not lost. Re-subscribing replaces the handler (seam contract).
                 // Record the owning client so a deferred unsubscribe can't disable a later connection.
-                handlers[characteristic] = ActiveSubscription(resolved, onPdu, link)
+                val sub = ActiveSubscription(resolved, onPdu, link)
+                handlers[characteristic] = sub
                 val isIndication = isIndication(char)
                 val enable = if (isIndication) CCCD_ENABLE_INDICATION else CCCD_ENABLE_NOTIFICATION
                 Timber.v("GATT subscribe %s (%s)", characteristic, if (isIndication) "indication" else "notification")
@@ -223,11 +224,16 @@ class AndroidMedtronicGattLink(
                 val outcome = awaitGatt("subscribe", characteristic) { writeDescriptor(link, cccd, enable) }
                 if (outcome.status != BluetoothGatt.GATT_SUCCESS) {
                     logGattWarning("subscribe", characteristic, outcome.status)
-                    // The CCCD never took effect; drop the handler so it isn't a phantom subscription.
-                    handlers.remove(characteristic)
+                    // The CCCD never took effect; drop the handler so it isn't a phantom subscription
+                    // (identity-checked -- a cancel + re-subscribe may already own the slot).
+                    handlers.remove(characteristic, sub)
                     return
                 }
-                armWatchdog()
+                // [cancelAllSubscriptions] runs lock-free from the cancellation handler, so it can
+                // clear this registration while the CCCD ack above is still in flight. Arming the
+                // watchdog then would leave a stale timer that later fires against an unrelated live
+                // exchange and drops its handlers. Arm only if this registration is still current.
+                if (handlers[characteristic] === sub) armWatchdog()
             }
         } catch (e: MedtronicReadException) {
             // On a timeout [awaitGatt] already tore the connection down, clearing handlers; nothing to undo.

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -12,9 +12,11 @@
  *
  * READ-ONLY: only static reads and report/control-point writes (RACP / CGM SOCP / IDD SRCP, plus the
  * CCCD descriptor) are issued; [write] refuses any characteristic outside that allow-list, so no
- * therapeutic write opcode can be sent. MTU stays at 23 -- we never call `requestMtu()`; outbound
- * payloads arrive pre-fragmented to <= 20-byte PDUs via
- * [com.glycemicgpt.mobile.ble.protocol.PduFramer] and inbound reassembly stays above the seam.
+ * therapeutic write opcode can be sent. We never call `requestMtu()`; outbound payloads arrive
+ * pre-fragmented to <= 20-byte PDUs via [com.glycemicgpt.mobile.ble.protocol.PduFramer]. Inbound
+ * notification size is the pump's choice (the ATT MTU is per-bearer and the pump raises it from its
+ * side -- live multi-PDU history reads prove notifications above 20 bytes; see [PduFramer]); inbound
+ * reassembly stays above the seam.
  *
  * Over-the-air validation against a real pump rides with 48.A2 / Milestone F -- in particular that a
  * second (client) GATT connection attaches to the existing link rather than opening a new one. Nothing
@@ -244,11 +246,16 @@ class AndroidMedtronicGattLink(
     }
 
     override fun cancelAllSubscriptions() {
+        // Drop the handlers first, lock-free: no notification reaches the cancelled exchange. The CCCD
+        // disables are blocking GATT round trips (opLock + a completion wait each), and this is called
+        // from a coroutine's cancellation handler -- which on a timeout runs on kotlinx's process-global
+        // scheduler thread, where blocking would stall every delay/withTimeout in the app. Defer them to
+        // the cleanup thread, the same discipline as [unsubscribe].
         if (handlers.isEmpty()) return
         val orphaned = handlers.values.toList()
         handlers.clear()
         cancelWatchdog()
-        for (sub in orphaned) disableNotifications("cancel", sub)
+        watchdog.execute { for (sub in orphaned) disableNotifications("cancel", sub) }
     }
 
     // -- Connection / discovery ---------------------------------------------
@@ -427,6 +434,10 @@ class AndroidMedtronicGattLink(
                 // have been replaced by a reconnect meanwhile. The old connection's subscriptions died
                 // with it, so skip rather than disable a characteristic on the new connection.
                 if (link !== sub.ownerGatt) return
+                // A new exchange may have re-subscribed this characteristic before the deferred disable
+                // ran (subscribe also serializes on [opLock], so this check cannot race it). The CCCD
+                // belongs to the new exchange now -- disabling it would silently starve that read.
+                if (handlers.containsKey(sub.resolved.characteristic.uuid)) return
                 val char = sub.resolved.characteristic
                 if (!link.setCharacteristicNotification(char, false)) {
                     Timber.w("Medtronic GATT %s: setCharacteristicNotification(false) was rejected", op)
@@ -487,8 +498,9 @@ class AndroidMedtronicGattLink(
                         connectPending?.offer(GattOutcome(status, null))
                         return
                     }
-                    // Never requestMtu(): the pump only honors 23-byte PDUs (AC5). Go straight to
-                    // discovery.
+                    // Never requestMtu(): our writes stay within the default MTU's 20-byte payloads
+                    // (AC5); the pump raises the MTU from its own side when it wants larger
+                    // notifications. Go straight to discovery.
                     val started =
                         try {
                             g.discoverServices()

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -442,8 +442,12 @@ class AndroidMedtronicGattLink(
                 if (link !== sub.ownerGatt) return
                 // A new exchange may have re-subscribed this characteristic before the deferred disable
                 // ran (subscribe also serializes on [opLock], so this check cannot race it). The CCCD
-                // belongs to the new exchange now -- disabling it would silently starve that read.
-                if (handlers.containsKey(sub.resolved.characteristic.uuid)) return
+                // belongs to the new exchange now -- disabling it would silently starve that read. The
+                // check must be the *resolved* characteristic, not the bare UUID: RACP is exposed by
+                // both the CGM and IDD services, and a new subscription on the other service's RACP
+                // must not shield this one's CCCD from being disabled.
+                val current = handlers[sub.resolved.characteristic.uuid]
+                if (current != null && current.resolved.characteristic === sub.resolved.characteristic) return
                 val char = sub.resolved.characteristic
                 if (!link.setCharacteristicNotification(char, false)) {
                     Timber.w("Medtronic GATT %s: setCharacteristicNotification(false) was rejected", op)

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLink.kt
@@ -243,6 +243,14 @@ class AndroidMedtronicGattLink(
         watchdog.execute { disableNotifications("unsubscribe", sub) }
     }
 
+    override fun cancelAllSubscriptions() {
+        if (handlers.isEmpty()) return
+        val orphaned = handlers.values.toList()
+        handlers.clear()
+        cancelWatchdog()
+        for (sub in orphaned) disableNotifications("cancel", sub)
+    }
+
     // -- Connection / discovery ---------------------------------------------
 
     private fun ensureConnected(): BluetoothGatt {

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/protocol/PduFramer.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/protocol/PduFramer.kt
@@ -2,11 +2,13 @@
  * Application-layer PDU fragmentation for the Medtronic MiniMed 700-series read-only driver.
  *
  * Honors the 23-byte ATT MTU / 20-byte PDU constraint documented in
- * `medtronic-ble-reverse-engineering.md` Sec. 6 (carried from OpenMinimed's Linux client, GPL-3.0):
- * the pump advertises MTU 184 but only honors 23-byte PDUs, and the official Android app never
- * negotiates the MTU up. We never call requestMtu(); every notification/write payload must stay
+ * `medtronic-ble-reverse-engineering.md` Sec. 6 (carried from OpenMinimed's Linux client, GPL-3.0)
+ * for the *outbound* direction: we never call requestMtu(), and every payload we write must stay
  * <= 20 bytes (23 - 3-byte ATT header). SAKE handshake messages are already exactly 20 bytes and
- * pass through unfragmented.
+ * pass through unfragmented. Inbound is looser: the ATT MTU is per-bearer and the pump raises it
+ * from its own side (it advertises MTU 184), so pump-to-phone notifications can exceed 20 bytes --
+ * live multi-PDU history reads (PR #852) arrive as per-PDU SAKE ciphertext whose 20-byte plaintext
+ * fragments imply 23-byte on-wire notifications.
  */
 package com.glycemicgpt.mobile.ble.protocol
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
@@ -17,8 +17,6 @@ import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
 import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
 import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
-import kotlin.math.max
-import kotlin.math.min
 
 /**
  * Reads the pump's IDD event-log (bolus / basal / sensor / alarm / cartridge-battery events) over the
@@ -65,52 +63,34 @@ class HistoryReader(
     /** All records with sequence number in [firstSeq]..[lastSeq] inclusive. */
     fun readRecordsInRange(firstSeq: Int, lastSeq: Int, onResult: (Result<List<HistoryLogRecord>>) -> Unit) {
         val e2e = e2eFlagOr(onResult) ?: return
-        fetchRecords(rangeRequest(firstSeq, lastSeq), e2e, onResult)
+        readRecordsInRange(firstSeq, lastSeq, e2e, onResult)
+    }
+
+    /** Same as [readRecordsInRange] but with an already-resolved [useE2e] flag (avoids re-reading IDD Features). */
+    fun readRecordsInRange(
+        firstSeq: Int,
+        lastSeq: Int,
+        useE2e: Boolean,
+        onResult: (Result<List<HistoryLogRecord>>) -> Unit,
+    ) {
+        fetchRecords(rangeRequest(firstSeq, lastSeq), useE2e, onResult)
     }
 
     /**
      * Incremental backfill: every record newer than [sinceSequence]. Reads the last record to learn
-     * the newest sequence, then ranges from `sinceSequence + 1` to it. Empty when the log is already
-     * caught up. Matches the `getHistoryLogs(sinceSequence)` contract the C3 PumpStatus capability uses.
+     * the newest sequence. The caller (the gateway) is responsible for paging the actual range
+     * with per-batch timeouts. Empty when the log is already caught up.
+     *
+     * Matches the `getHistoryLogs(sinceSequence)` contract the C3 PumpStatus capability uses.
      */
     fun readSinceSequence(sinceSequence: Int, onResult: (Result<List<HistoryLogRecord>>) -> Unit) {
-        val e2e = e2eFlagOr(onResult) ?: return
-        fetchRecords(REQUEST_REPORT_LAST_RECORD, e2e) { lastResult ->
-            val last = lastResult.getOrElse { onResult(Result.failure(it)); return@fetchRecords }.firstOrNull()
+        readLastRecord { lastResult ->
+            val last = lastResult.getOrElse { onResult(Result.failure(it)); return@readLastRecord }
             when {
                 last == null -> onResult(Result.success(emptyList()))
                 last.sequenceNumber <= sinceSequence -> onResult(Result.success(emptyList()))
-                else -> fetchRecordsPaged(last.sequenceNumber, sinceSequence, e2e, emptyList(), onResult)
+                else -> onResult(Result.success(listOf(last)))
             }
-        }
-    }
-
-    /**
-     * Fetch history records in [BATCH_SIZE]-sized pages, working **backwards** from [highSeq]
-     * (the newest record's sequence) down to [sinceSeq] (the last known sequence). Each page
-     * requests a narrow range anchored near the upper bound, so the pump always finds matching
-     * records. Accumulated pages are delivered newest-first; the caller receives the full list
-     * reversed into chronological order once [highSeq] passes [sinceSeq].
-     */
-    private fun fetchRecordsPaged(
-        highSeq: Int,
-        sinceSeq: Int,
-        useE2e: Boolean,
-        accumulated: List<HistoryLogRecord>,
-        onResult: (Result<List<HistoryLogRecord>>) -> Unit,
-    ) {
-        if (highSeq <= sinceSeq) {
-            onResult(Result.success(accumulated.reversed()))
-            return
-        }
-        val lowSeq = max(sinceSeq + 1, highSeq - BATCH_SIZE + 1)
-        fetchRecords(rangeRequest(lowSeq, highSeq), useE2e) { result ->
-            result.fold(
-                onSuccess = { records ->
-                    fetchRecordsPaged(lowSeq - 1, sinceSeq, useE2e, accumulated + records, onResult)
-                },
-                onFailure = { onResult(Result.failure(it)) },
-            )
         }
     }
 
@@ -174,9 +154,6 @@ class HistoryReader(
         private const val OPERATOR_LAST_RECORD = 105 // 0x69
         private const val FILTER_SEQUENCE_NUMBER = 15 // 0x0F
         private const val RESPONSE_SUCCESS = 240 // 0xF0
-
-        /** Maximum number of records fetched in a single RACP exchange. */
-        private const val BATCH_SIZE = 50
 
         /** RACP: report stored records, last record, by sequence number. */
         val REQUEST_REPORT_LAST_RECORD =

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
@@ -17,6 +17,7 @@ import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
 import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
 import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import kotlin.math.min
 
 /**
  * Reads the pump's IDD event-log (bolus / basal / sensor / alarm / cartridge-battery events) over the
@@ -78,8 +79,36 @@ class HistoryReader(
             when {
                 last == null -> onResult(Result.success(emptyList()))
                 last.sequenceNumber <= sinceSequence -> onResult(Result.success(emptyList()))
-                else -> fetchRecords(rangeRequest(sinceSequence + 1, last.sequenceNumber), e2e, onResult)
+                else -> fetchRecordsPaged(sinceSequence + 1, last.sequenceNumber, e2e, emptyList(), onResult)
             }
+        }
+    }
+
+    /**
+     * Fetch history records in [BATCH_SIZE]-sized pages so each individual RACP exchange completes
+     * well within the 30 s operation timeout. The [accumulated] list collects results across pages;
+     * when [nextSeq] passes [lastSeq] the combined result is delivered.
+     */
+    private fun fetchRecordsPaged(
+        nextSeq: Int,
+        lastSeq: Int,
+        useE2e: Boolean,
+        accumulated: List<HistoryLogRecord>,
+        onResult: (Result<List<HistoryLogRecord>>) -> Unit,
+    ) {
+        val pageEnd = min(nextSeq + BATCH_SIZE - 1, lastSeq)
+        fetchRecords(rangeRequest(nextSeq, pageEnd), useE2e) { result ->
+            result.fold(
+                onSuccess = { records ->
+                    val all = accumulated + records
+                    if (pageEnd >= lastSeq) {
+                        onResult(Result.success(all))
+                    } else {
+                        fetchRecordsPaged(pageEnd + 1, lastSeq, useE2e, all, onResult)
+                    }
+                },
+                onFailure = { onResult(Result.failure(it)) },
+            )
         }
     }
 
@@ -143,6 +172,9 @@ class HistoryReader(
         private const val OPERATOR_LAST_RECORD = 105 // 0x69
         private const val FILTER_SEQUENCE_NUMBER = 15 // 0x0F
         private const val RESPONSE_SUCCESS = 240 // 0xF0
+
+        /** Maximum number of records fetched in a single RACP exchange. */
+        private const val BATCH_SIZE = 200
 
         /** RACP: report stored records, last record, by sequence number. */
         val REQUEST_REPORT_LAST_RECORD =

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
@@ -17,6 +17,7 @@ import com.glycemicgpt.mobile.ble.messages.MedtronicHistoryParser
 import com.glycemicgpt.mobile.ble.protocol.MedtronicProtocol
 import com.glycemicgpt.mobile.ble.sake.MedtronicSakeSession
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
+import kotlin.math.max
 import kotlin.math.min
 
 /**
@@ -79,33 +80,34 @@ class HistoryReader(
             when {
                 last == null -> onResult(Result.success(emptyList()))
                 last.sequenceNumber <= sinceSequence -> onResult(Result.success(emptyList()))
-                else -> fetchRecordsPaged(sinceSequence + 1, last.sequenceNumber, e2e, emptyList(), onResult)
+                else -> fetchRecordsPaged(last.sequenceNumber, sinceSequence, e2e, emptyList(), onResult)
             }
         }
     }
 
     /**
-     * Fetch history records in [BATCH_SIZE]-sized pages so each individual RACP exchange completes
-     * well within the 30 s operation timeout. The [accumulated] list collects results across pages;
-     * when [nextSeq] passes [lastSeq] the combined result is delivered.
+     * Fetch history records in [BATCH_SIZE]-sized pages, working **backwards** from [highSeq]
+     * (the newest record's sequence) down to [sinceSeq] (the last known sequence). Each page
+     * requests a narrow range anchored near the upper bound, so the pump always finds matching
+     * records. Accumulated pages are delivered newest-first; the caller receives the full list
+     * reversed into chronological order once [highSeq] passes [sinceSeq].
      */
     private fun fetchRecordsPaged(
-        nextSeq: Int,
-        lastSeq: Int,
+        highSeq: Int,
+        sinceSeq: Int,
         useE2e: Boolean,
         accumulated: List<HistoryLogRecord>,
         onResult: (Result<List<HistoryLogRecord>>) -> Unit,
     ) {
-        val pageEnd = min(nextSeq + BATCH_SIZE - 1, lastSeq)
-        fetchRecords(rangeRequest(nextSeq, pageEnd), useE2e) { result ->
+        if (highSeq <= sinceSeq) {
+            onResult(Result.success(accumulated.reversed()))
+            return
+        }
+        val lowSeq = max(sinceSeq + 1, highSeq - BATCH_SIZE + 1)
+        fetchRecords(rangeRequest(lowSeq, highSeq), useE2e) { result ->
             result.fold(
                 onSuccess = { records ->
-                    val all = accumulated + records
-                    if (pageEnd >= lastSeq) {
-                        onResult(Result.success(all))
-                    } else {
-                        fetchRecordsPaged(pageEnd + 1, lastSeq, useE2e, all, onResult)
-                    }
+                    fetchRecordsPaged(lowSeq - 1, sinceSeq, useE2e, accumulated + records, onResult)
                 },
                 onFailure = { onResult(Result.failure(it)) },
             )
@@ -174,7 +176,7 @@ class HistoryReader(
         private const val RESPONSE_SUCCESS = 240 // 0xF0
 
         /** Maximum number of records fetched in a single RACP exchange. */
-        private const val BATCH_SIZE = 200
+        private const val BATCH_SIZE = 50
 
         /** RACP: report stored records, last record, by sequence number. */
         val REQUEST_REPORT_LAST_RECORD =

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
@@ -31,12 +31,14 @@ import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
  * wiring must address [MedtronicProtocol.RACP_UUID] under the IDD service for these reads
  * (`TODO(48.C3)` for the on-device service scoping).
  *
- * **Record framing caveat.** Records are delimited by the short-PDU rule of the C1 reassembler
- * (multi-byte records fragment at the 23-byte MTU and the trailing short PDU ends each one). Upstream's
- * Linux client negotiated a larger MTU and so received one record per notification; on Android we hold
- * MTU 23 (never `requestMtu()`) and must reassemble. A record whose encrypted length is an exact
- * multiple of the PDU size has no short terminator -- the documented [NotificationReassembler]
- * ambiguity. The exact on-wire delimiting is unconfirmed offline; `TODO(48.A2)` to verify against a
+ * **Record framing.** Each notification PDU is individually SAKE-encrypted (its own 3-byte trailer);
+ * the C1 reassembler delimits records on the decrypted *plaintext* fragments by its short-PDU rule (a
+ * fragment shorter than 20 bytes ends the record). Live 780G reads through this path MAC-pass on
+ * multi-PDU records (PR #852), which is cryptographic proof of the per-PDU model -- and implies the
+ * pump's notifications exceed the 20-byte payload of a default MTU-23 link (we never `requestMtu()`,
+ * but the ATT MTU is per-bearer and the pump raises it from its side; see [PduFramer]). A record whose
+ * plaintext is an exact multiple of the fragment size has no short terminator -- the documented
+ * [NotificationReassembler] ambiguity; `TODO(48.A2)` to pin the exact on-wire fragment sizes from a
  * live capture. As with the other readers the caller (C3) imposes the per-operation timeout.
  */
 class HistoryReader(
@@ -60,38 +62,14 @@ class HistoryReader(
         }
     }
 
-    /** All records with sequence number in [firstSeq]..[lastSeq] inclusive. */
+    /**
+     * All records with sequence number in [firstSeq]..[lastSeq] inclusive. A window the pump holds no
+     * records for (the RACP "no records found" indication) is a successful empty list, not a failure
+     * -- the gateway's paging walk relies on that to detect the oldest retained record.
+     */
     fun readRecordsInRange(firstSeq: Int, lastSeq: Int, onResult: (Result<List<HistoryLogRecord>>) -> Unit) {
         val e2e = e2eFlagOr(onResult) ?: return
-        readRecordsInRange(firstSeq, lastSeq, e2e, onResult)
-    }
-
-    /** Same as [readRecordsInRange] but with an already-resolved [useE2e] flag (avoids re-reading IDD Features). */
-    fun readRecordsInRange(
-        firstSeq: Int,
-        lastSeq: Int,
-        useE2e: Boolean,
-        onResult: (Result<List<HistoryLogRecord>>) -> Unit,
-    ) {
-        fetchRecords(rangeRequest(firstSeq, lastSeq), useE2e, onResult)
-    }
-
-    /**
-     * Incremental backfill: every record newer than [sinceSequence]. Reads the last record to learn
-     * the newest sequence. The caller (the gateway) is responsible for paging the actual range
-     * with per-batch timeouts. Empty when the log is already caught up.
-     *
-     * Matches the `getHistoryLogs(sinceSequence)` contract the C3 PumpStatus capability uses.
-     */
-    fun readSinceSequence(sinceSequence: Int, onResult: (Result<List<HistoryLogRecord>>) -> Unit) {
-        readLastRecord { lastResult ->
-            val last = lastResult.getOrElse { onResult(Result.failure(it)); return@readLastRecord }
-            when {
-                last == null -> onResult(Result.success(emptyList()))
-                last.sequenceNumber <= sinceSequence -> onResult(Result.success(emptyList()))
-                else -> onResult(Result.success(listOf(last)))
-            }
-        }
+        fetchRecords(rangeRequest(firstSeq, lastSeq), e2e, onResult)
     }
 
     /** Read the IDD Features E2E flag, routing a read/parse failure to [onResult]; null = abort. */
@@ -112,9 +90,18 @@ class HistoryReader(
         ) { result ->
             onResult(
                 result.mapCatching { frames ->
-                    MedtronicHistoryParser.dedupBySequence(
-                        frames.mapNotNull { MedtronicHistoryParser.toHistoryLogRecord(it, useE2e) },
-                    )
+                    val parsed = frames.mapNotNull { MedtronicHistoryParser.toHistoryLogRecord(it, useE2e) }
+                    // Any undecodable frame must fail the read, not silently shrink the page: the
+                    // gateway's walk advances past this window and the callers advance their cursor to
+                    // the max sequence seen, so a dropped record would be skipped for good (this is
+                    // bolus history feeding IOB). Failing leaves the cursor put and the read retried.
+                    // Checked before dedup -- duplicate frames legitimately shrink the list.
+                    if (parsed.size < frames.size) {
+                        throw MedtronicReadException(
+                            "${frames.size - parsed.size} of ${frames.size} history frames in the page were undecodable",
+                        )
+                    }
+                    MedtronicHistoryParser.dedupBySequence(parsed)
                 },
             )
         }
@@ -132,10 +119,17 @@ class HistoryReader(
         return MedtronicCodec.readUIntLe(response, 2, 2)
     }
 
-    /** True when the terminating RACP indication is the IDD "report records: success" response code. */
+    /**
+     * True when the terminating RACP indication completes the exchange successfully: the IDD "report
+     * records: success" response, or "no records found" -- a successful exchange over a window the
+     * pump simply holds nothing in (`history_reader.py` IddRacpResponseCode.NO_RECORDS_FOUND), which
+     * must yield an empty list rather than fail the read.
+     */
     private fun isReportSuccess(response: ByteArray): Boolean =
-        response.size >= EXPECTED_REPORT_SUCCESS.size &&
-            EXPECTED_REPORT_SUCCESS.indices.all { response[it] == EXPECTED_REPORT_SUCCESS[it] }
+        matchesResponse(response, EXPECTED_REPORT_SUCCESS) || matchesResponse(response, REPORT_NO_RECORDS_FOUND)
+
+    private fun matchesResponse(response: ByteArray, expected: ByteArray): Boolean =
+        response.size >= expected.size && expected.indices.all { response[it] == expected[it] }
 
     private fun rangeRequest(firstSeq: Int, lastSeq: Int): ByteArray =
         REQUEST_REPORT_WITHIN_RANGE_PREFIX + MedtronicCodec.u32Le(firstSeq) + MedtronicCodec.u32Le(lastSeq)
@@ -154,6 +148,7 @@ class HistoryReader(
         private const val OPERATOR_LAST_RECORD = 105 // 0x69
         private const val FILTER_SEQUENCE_NUMBER = 15 // 0x0F
         private const val RESPONSE_SUCCESS = 240 // 0xF0
+        private const val RESPONSE_NO_RECORDS_FOUND = 6 // 0x06
 
         /** RACP: report stored records, last record, by sequence number. */
         val REQUEST_REPORT_LAST_RECORD =
@@ -170,5 +165,9 @@ class HistoryReader(
         /** Terminating success indication: response-code / null / report-records / success. */
         val EXPECTED_REPORT_SUCCESS =
             byteArrayOf(RESPONSE_CODE.toByte(), OPERATOR_NULL.toByte(), OP_REPORT_RECORDS.toByte(), RESPONSE_SUCCESS.toByte())
+
+        /** Terminating "no records found" indication: a successful exchange over an empty window. */
+        val REPORT_NO_RECORDS_FOUND =
+            byteArrayOf(RESPONSE_CODE.toByte(), OPERATOR_NULL.toByte(), OP_REPORT_RECORDS.toByte(), RESPONSE_NO_RECORDS_FOUND.toByte())
     }
 }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
@@ -82,14 +82,34 @@ class HistoryReader(
         }
 
     private fun fetchRecords(request: ByteArray, useE2e: Boolean, onResult: (Result<List<HistoryLogRecord>>) -> Unit) {
+        // Which terminal ended the exchange; set on the link's single delivery thread before the
+        // completion callback below runs on that same thread (the C1 threading contract).
+        var noRecordsTerminal = false
         sessionReader.reportRecords(
             dataChar = MedtronicProtocol.IDD_HISTORY_DATA_UUID,
             controlPoint = MedtronicProtocol.RACP_UUID,
             request = request,
-            isSuccess = ::isReportSuccess,
+            isSuccess = { response ->
+                when {
+                    response.contentEquals(EXPECTED_REPORT_SUCCESS) -> true
+                    response.contentEquals(REPORT_NO_RECORDS_FOUND) -> {
+                        noRecordsTerminal = true
+                        true
+                    }
+                    else -> false
+                }
+            },
         ) { result ->
             onResult(
                 result.mapCatching { frames ->
+                    // A pump that says "no records found" after streaming frames is contradicting
+                    // itself; trusting either side risks returning stale/misordered data or silently
+                    // dropping records. Fail so the read is retried with the cursors unchanged.
+                    if (noRecordsTerminal && frames.isNotEmpty()) {
+                        throw MedtronicReadException(
+                            "IDD RACP reported no records but ${frames.size} frames arrived",
+                        )
+                    }
                     val parsed = frames.mapNotNull { MedtronicHistoryParser.toHistoryLogRecord(it, useE2e) }
                     // Any undecodable frame must fail the read, not silently shrink the page: the
                     // gateway's walk advances past this window and the callers advance their cursor to
@@ -118,18 +138,6 @@ class HistoryReader(
         }
         return MedtronicCodec.readUIntLe(response, 2, 2)
     }
-
-    /**
-     * True when the terminating RACP indication completes the exchange successfully: the IDD "report
-     * records: success" response, or "no records found" -- a successful exchange over a window the
-     * pump simply holds nothing in (`history_reader.py` IddRacpResponseCode.NO_RECORDS_FOUND), which
-     * must yield an empty list rather than fail the read.
-     */
-    private fun isReportSuccess(response: ByteArray): Boolean =
-        matchesResponse(response, EXPECTED_REPORT_SUCCESS) || matchesResponse(response, REPORT_NO_RECORDS_FOUND)
-
-    private fun matchesResponse(response: ByteArray, expected: ByteArray): Boolean =
-        response.size >= expected.size && expected.indices.all { response[it] == expected[it] }
 
     private fun rangeRequest(firstSeq: Int, lastSeq: Int): ByteArray =
         REQUEST_REPORT_WITHIN_RANGE_PREFIX + MedtronicCodec.u32Le(firstSeq) + MedtronicCodec.u32Le(lastSeq)

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicGattLink.kt
@@ -60,7 +60,10 @@ interface MedtronicGattLink {
     /**
      * Release every outstanding subscription on this link, clearing all handlers and disabling
      * CCCD notifications. Called when the driving coroutine is cancelled (e.g. operation timeout)
-     * and the readers' normal [unsubscribe] path was not reached.
+     * and the readers' normal [unsubscribe] path was not reached. Must not block the caller: on a
+     * timeout the cancellation handler runs on kotlinx's process-global scheduler thread, where a
+     * blocking GATT round trip would stall every `delay`/`withTimeout` in the app -- implementations
+     * drop the handlers immediately and defer any blocking CCCD teardown off the calling thread.
      */
     fun cancelAllSubscriptions()
 }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicGattLink.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicGattLink.kt
@@ -56,4 +56,11 @@ interface MedtronicGattLink {
 
     /** Disable notifications and drop the handler for [characteristic]. */
     fun unsubscribe(characteristic: UUID)
+
+    /**
+     * Release every outstanding subscription on this link, clearing all handlers and disabling
+     * CCCD notifications. Called when the driving coroutine is cancelled (e.g. operation timeout)
+     * and the readers' normal [unsubscribe] path was not reached.
+     */
+    fun cancelAllSubscriptions()
 }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -56,12 +56,17 @@ import timber.log.Timber
  *     is connected (see the class header).
  * @param ioDispatcher dispatcher for the blocking SIG reads (Device Info / Battery).
  * @param operationTimeoutMs hard upper bound on every read; expiry surfaces as a failed [Result].
+ * @param maxTotalHistoryRecords ceiling on one [getHistoryLogs] walk's total accumulation, across
+ *     all pages -- the cross-page analog of the per-exchange [MedtronicSessionReader.MAX_RECORDS_PER_REPORT]
+ *     bound, so a malfunctioning (but authenticated) pump reporting a bogus huge last-sequence and
+ *     answering every window cannot grow memory without limit.
  */
 class MedtronicReadGateway(
     private val sessionProvider: () -> MedtronicSakeSession?,
     private val linkProvider: () -> MedtronicGattLink?,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val operationTimeoutMs: Long = DEFAULT_OPERATION_TIMEOUT_MS,
+    private val maxTotalHistoryRecords: Int = MedtronicSessionReader.MAX_RECORDS_PER_REPORT,
 ) {
 
     /**
@@ -139,6 +144,13 @@ class MedtronicReadGateway(
             }
             val records = batchResult.getOrElse { return Result.failure(it) }
             all.addAll(records)
+            if (all.size > maxTotalHistoryRecords) {
+                // Defense-in-depth (see the constructor KDoc): fail loudly rather than accumulate
+                // without bound; the cursors stay put, so nothing is silently skipped.
+                return Result.failure(
+                    MedtronicReadException("Medtronic history fetch exceeded $maxTotalHistoryRecords records; aborting"),
+                )
+            }
             if (records.isEmpty()) break
             highSeq = lowSeq - 1
         }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -103,10 +103,28 @@ class MedtronicReadGateway(
             IddStatusReader(link, session).readReservoir(onResult)
         }
 
-    /** Incremental history fetch: every record newer than [sinceSequence] (raw, preserved for dedup). */
+    /**
+     * Incremental history fetch: every record newer than [sinceSequence] (raw, preserved for dedup).
+     *
+     * Paged newest-first in [HISTORY_BATCH_SIZE]-sequence windows, each page its own [sessionRead]
+     * with its own operation timeout (one unbounded range read overran the 30s budget and orphaned
+     * the session). [readMutex] is released between pages so a CGM/keep-alive read can interleave
+     * with a long backfill; each individual RACP exchange stays single-flight.
+     *
+     * The walk is driven by the *requested window* (`highSeq = lowSeq - 1`), never by page content:
+     * a page routinely parses smaller than its window (duplicate frames dedup away; the window can
+     * straddle the oldest retained record), and ending the walk on page content would let the
+     * cursor-advancing callers (the insulin source's bolus cursor, the orchestrator's persisted
+     * sequence cursor) advance to the max sequence seen and permanently skip the older records. A
+     * page with any undecodable frame fails outright in [HistoryReader] for the same reason. A page
+     * that comes back *empty* (the pump's "no records found") does end the walk: the
+     * pump purges oldest-first, so its retained sequences are contiguous and nothing older remains.
+     * A failed page fails the whole call -- returning the newer pages collected so far would advance
+     * the callers' cursors past the un-fetched older window (the same permanent skip).
+     */
     suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> {
         val lastResult = sessionRead("history-last") { link, session, onResult ->
-            HistoryReader(link, session).readLastRecord { onResult(it) }
+            HistoryReader(link, session).readLastRecord(onResult)
         }
         val lastRecord = lastResult.getOrElse { return Result.failure(it) }
         if (lastRecord == null || lastRecord.sequenceNumber <= sinceSequence) {
@@ -117,15 +135,14 @@ class MedtronicReadGateway(
         while (highSeq > sinceSequence) {
             val lowSeq = maxOf(sinceSequence + 1, highSeq - HISTORY_BATCH_SIZE + 1)
             val batchResult = sessionRead("history-page") { link, session, onResult ->
-                HistoryReader(link, session).readRecordsInRange(lowSeq, highSeq) { onResult(it) }
+                HistoryReader(link, session).readRecordsInRange(lowSeq, highSeq, onResult)
             }
             val records = batchResult.getOrElse { return Result.failure(it) }
             all.addAll(records)
-            val minInBatch = records.minOfOrNull { it.sequenceNumber } ?: break
-            highSeq = minInBatch - 1
-            if (records.size < HISTORY_BATCH_SIZE) break
+            if (records.isEmpty()) break
+            highSeq = lowSeq - 1
         }
-        return Result.success(all.reversed())
+        return Result.success(all.sortedBy { it.sequenceNumber })
     }
 
     /** Battery percentage (plain SIG Battery Level read; no session required). */
@@ -146,10 +163,11 @@ class MedtronicReadGateway(
      *
      * **Cancellation/cleanup contract.** On a timeout this coroutine is cancelled while the reader may
      * still hold notification subscriptions on the link (the reader only unsubscribes when the pump
-     * responds). The gateway cannot drop them here -- it does not know which characteristics the reader
-     * subscribed. The on-device `AndroidMedtronicGattLink` satisfies this: a subscription watchdog
-     * releases all outstanding subscriptions when an operation can no longer complete, so a timed-out
-     * read leaves no dangling notifications that would desync the next exchange.
+     * responds). The gateway does not know which characteristics the reader subscribed, so it releases
+     * them all: [MedtronicGattLink.cancelAllSubscriptions] drops every handler immediately (no PDU can
+     * reach the finished exchange) and defers the CCCD disables off this thread -- the cancellation
+     * callback may run on kotlinx's process-global timeout thread, which must never block on GATT. The
+     * on-device link's subscription watchdog remains the backstop for any path that misses this hook.
      */
     private suspend fun <T> sessionRead(
         op: String,
@@ -243,7 +261,7 @@ class MedtronicReadGateway(
          */
         const val DEFAULT_OPERATION_TIMEOUT_MS = 30_000L
 
-        /** Maximum number of history records fetched in a single RACP exchange (one page). */
+        /** Sequence-window width of a single history RACP exchange (one page). */
         private const val HISTORY_BATCH_SIZE = 200
     }
 }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -148,6 +148,9 @@ class MedtronicReadGateway(
                 // to [ioDispatcher] (as [blockingRead] does); the callback resume is dispatcher-agnostic.
                 withContext(ioDispatcher) {
                     suspendCancellableCoroutine { cont ->
+                        cont.invokeOnCancellation {
+                            link.cancelAllSubscriptions()
+                        }
                         start(link, session) { result -> if (cont.isActive) cont.resume(result) }
                     }
                 }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -104,10 +104,29 @@ class MedtronicReadGateway(
         }
 
     /** Incremental history fetch: every record newer than [sinceSequence] (raw, preserved for dedup). */
-    suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
-        sessionRead("history") { link, session, onResult ->
-            HistoryReader(link, session).readSinceSequence(sinceSequence, onResult)
+    suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> {
+        val lastResult = sessionRead("history-last") { link, session, onResult ->
+            HistoryReader(link, session).readLastRecord { onResult(it) }
         }
+        val lastRecord = lastResult.getOrElse { return Result.failure(it) }
+        if (lastRecord == null || lastRecord.sequenceNumber <= sinceSequence) {
+            return Result.success(emptyList())
+        }
+        var highSeq = lastRecord.sequenceNumber
+        val all = mutableListOf<HistoryLogRecord>()
+        while (highSeq > sinceSequence) {
+            val lowSeq = maxOf(sinceSequence + 1, highSeq - HISTORY_BATCH_SIZE + 1)
+            val batchResult = sessionRead("history-page") { link, session, onResult ->
+                HistoryReader(link, session).readRecordsInRange(lowSeq, highSeq) { onResult(it) }
+            }
+            val records = batchResult.getOrElse { return Result.failure(it) }
+            all.addAll(records)
+            val minInBatch = records.minOfOrNull { it.sequenceNumber } ?: break
+            highSeq = minInBatch - 1
+            if (records.size < HISTORY_BATCH_SIZE) break
+        }
+        return Result.success(all.reversed())
+    }
 
     /** Battery percentage (plain SIG Battery Level read; no session required). */
     suspend fun getBatteryStatus(): Result<BatteryStatus> =
@@ -223,5 +242,8 @@ class MedtronicReadGateway(
          * 30s connect timeout the [com.glycemicgpt.mobile.domain.plugin.DevicePlugin] contract documents.
          */
         const val DEFAULT_OPERATION_TIMEOUT_MS = 30_000L
+
+        /** Maximum number of history records fetched in a single RACP exchange (one page). */
+        private const val HISTORY_BATCH_SIZE = 200
     }
 }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -15,17 +15,18 @@ import java.util.UUID
 import timber.log.Timber
 
 /**
- * Accumulates inbound notification PDUs into a complete application frame.
+ * Accumulates inbound notification fragments into a complete application frame.
  *
- * Application frames are fragmented into <= 20-byte PDUs ([PduFramer.fragment]); the standard BLE
- * convention used here is "full PDUs until a short one ends the frame", so a frame is complete when
- * a PDU smaller than [maxPduSize] arrives (a single short PDU completes immediately). This is the
- * incremental inverse of [PduFramer.fragment] for any payload whose length is not an exact multiple
- * of [maxPduSize].
+ * Each notification PDU is individually SAKE-encrypted, so what is offered here is the decrypted
+ * *plaintext* fragment. Frames fragment at 20 bytes ([PduFramer.MAX_PDU_SIZE]); the standard BLE
+ * convention used here is "full fragments until a short one ends the frame", so a frame is complete
+ * when a fragment smaller than [maxPduSize] arrives (a single short fragment completes immediately).
+ * This is the incremental inverse of [PduFramer.fragment] for any payload whose length is not an
+ * exact multiple of [maxPduSize].
  *
- * The exact-multiple ambiguity (a frame that fragments into all-full PDUs has no short terminator)
- * does not arise for the small SAKE-encrypted CGM records this story handles; record-level,
- * length-prefixed paging for the larger history reads lands with the history reader in 48.C2.
+ * The exact-multiple ambiguity (a frame that fragments into all-full fragments has no short
+ * terminator) has not bitten on live multi-PDU history reads (PR #852); pinning the exact on-wire
+ * fragment sizes rides with the 48.A2 capture work.
  */
 internal class NotificationReassembler(
     private val maxPduSize: Int = PduFramer.MAX_PDU_SIZE,
@@ -176,8 +177,8 @@ class MedtronicSessionReader(
     /**
      * SOCP read-only GET (e.g. sensor details): take a [requestOpcode] (a GET-class opcode, optionally
      * followed by operands), append the E2E-CRC and SAKE-encrypt it for the pump exactly as
-     * `socp.py._trigger_opcode` does, write it to the [socp] characteristic, then reassemble + decrypt
-     * the SAKE-encrypted response and deliver the plaintext (its first byte is the response opcode; any
+     * `socp.py._trigger_opcode` does, write it to the [socp] characteristic, then decrypt each
+     * SAKE-encrypted response PDU and reassemble the plaintext, delivering it (its first byte is the response opcode; any
      * E2E-CRC trailer is validated by the response parser in 48.C2). Only GET-class opcodes belong here
      * -- no calibration or control opcode is ever issued. As with [reportLastRecord], the caller must
      * impose the operation timeout (see the class-level timeout contract).
@@ -190,8 +191,8 @@ class MedtronicSessionReader(
 
     /**
      * IDD Status Reader Control Point (SRCP) read-only GET: SAKE-encrypt the (little-endian)
-     * [requestOpcode], write it to the [srcp] characteristic, then reassemble + decrypt the
-     * SAKE-encrypted indication and deliver the plaintext, exactly as `idd/status/reader.py`'s
+     * [requestOpcode], write it to the [srcp] characteristic, then decrypt each SAKE-encrypted
+     * indication PDU and reassemble + deliver the plaintext, exactly as `idd/status/reader.py`'s
      * `_send_and_receive_opcode` does. Only GET-class opcodes (IOB, active basal, therapy state, ...)
      * belong here -- no reset or control opcode is ever issued.
      *
@@ -232,7 +233,7 @@ class MedtronicSessionReader(
      * Mirrors `history_reader.py` (`get_records_between` / `get_last_record`): the RACP itself is not
      * encrypted, only the IDD History Data records it triggers are, and the RACP indication follows
      * after all records. Records are delimited by the same short-PDU rule [NotificationReassembler]
-     * uses; see the record-framing caveat on [HistoryReader]. The caller imposes the operation
+     * uses; see the record-framing notes on [HistoryReader]. The caller imposes the operation
      * timeout (class-level contract).
      */
     fun reportRecords(
@@ -331,8 +332,8 @@ class MedtronicSessionReader(
 
     /**
      * Shared body for the encrypted request -> single encrypted response exchanges ([socpGet],
-     * [srcpGet]): subscribe to [char], reassemble + decrypt the first complete response frame, and
-     * finish. Decrypting only while the exchange is live keeps a late/duplicate notification after
+     * [srcpGet]): subscribe to [char], decrypt each PDU and reassemble the first complete response
+     * frame, and finish. Decrypting only while the exchange is live keeps a late/duplicate notification after
      * finish() from consuming the next operation's sequence slot and desyncing the session.
      */
     private fun encryptedGet(

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -61,6 +61,13 @@ internal class NotificationReassembler(
         return null
     }
 
+    /**
+     * True while fragments are accumulated but no short terminator has arrived. Lets an exchange's
+     * terminal indication distinguish "all records delivered" from "a record is still unterminated"
+     * (the exact-multiple ambiguity) and fail loudly instead of silently dropping the partial frame.
+     */
+    fun hasPartialFrame(): Boolean = fragments.isNotEmpty()
+
     /** Discard any partially-accumulated frame. */
     fun reset() {
         fragments.clear()
@@ -152,7 +159,11 @@ class MedtronicSessionReader(
             when {
                 response.contentEquals(RACP_REPORT_SUCCESS) -> {
                     val r = record
-                    if (r == null) {
+                    if (assembler.hasPartialFrame()) {
+                        // The record never got its short terminator (the exact-multiple ambiguity):
+                        // returning r (or null) would silently misreport what the pump sent.
+                        finish(Result.failure(MedtronicReadException("CGM RACP reported success with an unterminated record pending")))
+                    } else if (r == null) {
                         finish(Result.failure(MedtronicReadException("CGM RACP reported success but no record arrived")))
                     } else {
                         finish(Result.success(r))
@@ -285,7 +296,18 @@ class MedtronicSessionReader(
         link.subscribe(controlPoint) { response ->
             if (finished) return@subscribe
             if (isSuccess(response)) {
-                finish(Result.success(records.toList()))
+                if (assembler.hasPartialFrame()) {
+                    // A record is still unterminated at the terminal indication (the exact-multiple
+                    // ambiguity). Dropping it silently would let the history cursors advance past a
+                    // record the pump sent -- fail instead so the read is retried with nothing skipped.
+                    finish(
+                        Result.failure(
+                            MedtronicReadException("IDD RACP reported success with an unterminated record pending"),
+                        ),
+                    )
+                } else {
+                    finish(Result.success(records.toList()))
+                }
             } else {
                 finish(
                     Result.failure(MedtronicReadException("Unexpected/failed IDD RACP response: ${response.toHex()}")),

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -132,10 +132,11 @@ class MedtronicSessionReader(
         link.subscribe(dataChar) { pdu ->
             if (finished) return@subscribe
             try {
-                val frame = assembler.offer(pdu) ?: return@subscribe
-                // Decrypting advances the session's inbound sequence counter, so only do it while the
-                // exchange is live; a late notification after finish() would desync the next read.
-                record = session.decryptFromPump(frame)
+                // Each notification PDU is individually SAKE-encrypted with its own 3-byte trailer.
+                // Decrypt first, then reassemble plaintext fragments into the complete record.
+                val plaintext = session.decryptFromPump(pdu)
+                val frame = assembler.offer(plaintext) ?: return@subscribe
+                record = frame
             } catch (e: Exception) {
                 // Any decrypt/auth failure (MacFailureException) or session-state/length error
                 // (IllegalState/IllegalArgument from SeqCrypt) must fail the read cleanly rather than
@@ -256,8 +257,11 @@ class MedtronicSessionReader(
         link.subscribe(dataChar) { pdu ->
             if (finished) return@subscribe
             try {
-                val frame = assembler.offer(pdu) ?: return@subscribe
-                records.add(session.decryptFromPump(frame))
+                // Each notification PDU is individually SAKE-encrypted with its own 3-byte trailer.
+                // Decrypt first, then reassemble plaintext fragments into the complete record.
+                val plaintext = session.decryptFromPump(pdu)
+                val frame = assembler.offer(plaintext) ?: return@subscribe
+                records.add(frame)
                 // Defense-in-depth: a misbehaving (but authenticated) pump that streams records but
                 // never sends the terminating RACP indication must not grow memory without bound. The
                 // ceiling is far above any realistic single-fetch window; the operation timeout the C3
@@ -350,8 +354,11 @@ class MedtronicSessionReader(
         link.subscribe(char) { pdu ->
             if (finished) return@subscribe
             try {
-                val frame = assembler.offer(pdu) ?: return@subscribe
-                finish(Result.success(session.decryptFromPump(frame)))
+                // Each notification PDU is individually SAKE-encrypted with its own 3-byte trailer.
+                // Decrypt first, then reassemble plaintext fragments into the complete response.
+                val plaintext = session.decryptFromPump(pdu)
+                val frame = assembler.offer(plaintext) ?: return@subscribe
+                finish(Result.success(frame))
             } catch (e: Exception) {
                 finish(Result.failure(asReadException(e, failMessage)))
             }

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
@@ -346,6 +346,47 @@ class AndroidMedtronicGattLinkTest {
     }
 
     @Test
+    fun `cancelAllSubscriptions drops handlers immediately and defers the CCCD disables`() {
+        val deferring = DeferringWatchdog()
+        val link = AndroidMedtronicGattLink(context, deviceProvider = { device }, worker = DirectSerialWorker(), watchdog = deferring)
+        val received = mutableListOf<ByteArray>()
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) { received.add(it) } // CCCD enable #1
+        link.subscribe(MedtronicProtocol.RACP_UUID) { received.add(it) } // CCCD enable #2
+
+        link.cancelAllSubscriptions()
+
+        // The caller -- a coroutine cancellation handler, on a timeout kotlinx's process-global
+        // scheduler thread -- is released immediately: the handlers are gone but no blocking CCCD
+        // round trip has run on its thread.
+        assertEquals(0, link.activeSubscriptionCount())
+        assertEquals(2, events.count { it == "write-cccd" })
+        callback.onCharacteristicChanged(gatt, cgmMeasurement, byteArrayOf(0x0e))
+        assertTrue("a cancelled subscription must not deliver notifications", received.isEmpty())
+
+        deferring.runDeferred() // the disables run on the cleanup thread
+
+        assertEquals(4, events.count { it == "write-cccd" })
+    }
+
+    @Test
+    fun `a deferred cancel does not disable a characteristic that was re-subscribed meanwhile`() {
+        val deferring = DeferringWatchdog()
+        val link = AndroidMedtronicGattLink(context, deviceProvider = { device }, worker = DirectSerialWorker(), watchdog = deferring)
+        val received = mutableListOf<ByteArray>()
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {} // CCCD enable #1
+        link.cancelAllSubscriptions() // queues the disable, deferred
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) { received.add(it) } // CCCD enable #2: the next exchange
+
+        deferring.runDeferred()
+
+        // Two enables, zero disables: the deferred cleanup must not strip the CCCD the new exchange
+        // just enabled, and the new subscription must keep delivering.
+        assertEquals(2, events.count { it == "write-cccd" })
+        callback.onCharacteristicChanged(gatt, cgmMeasurement, byteArrayOf(0x0e))
+        assertEquals(1, received.size)
+    }
+
+    @Test
     fun `a deferred unsubscribe does not disable a characteristic on a reconnected client`() {
         val gattB = mockk<BluetoothGatt>(relaxed = true)
         stubGattClient(gattB)

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
@@ -346,6 +346,28 @@ class AndroidMedtronicGattLinkTest {
     }
 
     @Test
+    fun `subscribe does not arm the watchdog when cancelled while awaiting the CCCD ack`() {
+        // cancelAllSubscriptions runs lock-free from the coroutine cancellation handler, so it can
+        // clear the registration while subscribe() is still blocked on the CCCD enable ack. Arming
+        // the watchdog on that ack would leave a stale timer ticking against whatever exchange runs
+        // next -- when it fires, onWatchdogFire drops that live exchange's handlers.
+        val deferring = DeferringWatchdog()
+        val link = AndroidMedtronicGattLink(context, deviceProvider = { device }, worker = DirectSerialWorker(), watchdog = deferring)
+        @Suppress("DEPRECATION")
+        every { gatt.writeDescriptor(any<BluetoothGattDescriptor>()) } answers {
+            // The gateway timeout cancels the driving coroutine while this CCCD ack is in flight.
+            link.cancelAllSubscriptions()
+            callback.onDescriptorWrite(gatt, firstArg(), descriptorStatus)
+            true
+        }
+
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {}
+
+        assertEquals(0, link.activeSubscriptionCount())
+        assertFalse("a cancelled subscribe must not arm a stale watchdog", deferring.armed)
+    }
+
+    @Test
     fun `cancelAllSubscriptions drops handlers immediately and defers the CCCD disables`() {
         val deferring = DeferringWatchdog()
         val link = AndroidMedtronicGattLink(context, deviceProvider = { device }, worker = DirectSerialWorker(), watchdog = deferring)
@@ -510,6 +532,9 @@ class AndroidMedtronicGattLinkTest {
     private class DeferringWatchdog : SubscriptionWatchdog {
         private var timerTask: (() -> Unit)? = null
         private val deferred = ArrayDeque<() -> Unit>()
+
+        /** True while a scheduled (un-cancelled) watchdog timer is armed. */
+        val armed: Boolean get() = timerTask != null
 
         override fun schedule(delayMs: Long, task: () -> Unit): SubscriptionWatchdog.Handle {
             timerTask = task

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/connection/AndroidMedtronicGattLinkTest.kt
@@ -409,6 +409,26 @@ class AndroidMedtronicGattLinkTest {
     }
 
     @Test
+    fun `a deferred cancel still disables a shared-UUID characteristic re-subscribed on the other service`() {
+        // RACP is exposed by both the CGM and IDD services under one UUID. A cancelled CGM RACP
+        // cleanup must not be shielded by a newer IDD RACP subscription: the guard compares the
+        // resolved characteristic, not the bare UUID, so the old CGM CCCD is still disabled.
+        val deferring = DeferringWatchdog()
+        val link = AndroidMedtronicGattLink(context, deviceProvider = { device }, worker = DirectSerialWorker(), watchdog = deferring)
+        link.subscribe(MedtronicProtocol.CGM_MEASUREMENT_UUID) {} // CGM service context
+        link.subscribe(MedtronicProtocol.RACP_UUID) {} // resolves to the CGM RACP
+        link.cancelAllSubscriptions() // queues the CGM disables, deferred
+        link.subscribe(MedtronicProtocol.IDD_HISTORY_DATA_UUID) {} // IDD service context
+        link.subscribe(MedtronicProtocol.RACP_UUID) {} // resolves to the IDD RACP
+
+        deferring.runDeferred()
+
+        // The cancelled CGM RACP subscription is released even though the bare UUID is live again.
+        verify(exactly = 1) { gatt.setCharacteristicNotification(cgmRacp, false) }
+        verify(exactly = 0) { gatt.setCharacteristicNotification(iddRacp, false) }
+    }
+
+    @Test
     fun `a deferred unsubscribe does not disable a characteristic on a reconnected client`() {
         val gattB = mockk<BluetoothGatt>(relaxed = true)
         stubGattClient(gattB)

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
@@ -116,6 +116,50 @@ class HistoryReaderTest {
     }
 
     @Test
+    fun `readRecordsInRange fails when the pump reports no records after streaming frames`() {
+        // A contradictory pump: frames arrived but the terminal says the window was empty. Trusting
+        // either side risks returning stale data or silently dropping records -- the page must fail.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.size > 3 &&
+                value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
+            ) {
+                PduFramer.fragment(basalRecord).forEach { emit(data, two.pumpEncrypt(it)) }
+                emit(racp, HistoryReader.REPORT_NO_RECORDS_FOUND)
+            }
+        }
+
+        var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
+        HistoryReader(link, two.server).readRecordsInRange(100, 130) { result = it }
+
+        assertTrue(result!!.isFailure)
+    }
+
+    @Test
+    fun `readRecordsInRange rejects a terminal indication with trailing bytes`() {
+        // Terminals are matched exactly (as upstream does); a prefix match would accept a malformed
+        // or truncated-then-padded indication as a clean success.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.size > 3 &&
+                value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
+            ) {
+                PduFramer.fragment(basalRecord).forEach { emit(data, two.pumpEncrypt(it)) }
+                emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS + byteArrayOf(0x00))
+            }
+        }
+
+        var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
+        HistoryReader(link, two.server).readRecordsInRange(100, 130) { result = it }
+
+        assertTrue(result!!.isFailure)
+    }
+
+    @Test
     fun `readLastRecord returns null when the log is empty (no-records-found)`() {
         val two = TwoSidedSession()
         val link = FakeGattLink()

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
@@ -157,6 +157,31 @@ class HistoryReaderTest {
     }
 
     @Test
+    fun `readRecordsInRange fails when a record is still unterminated at the success indication`() {
+        // A record whose plaintext is an exact PDU multiple has no short terminator (the documented
+        // reassembler ambiguity). Dropping it silently would let the cursors advance past a record
+        // the pump sent; the page must fail so the read is retried with nothing skipped.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        // 20-byte record: header (8) + 12-byte body -- exactly one full fragment, never terminated.
+        val exactMultiple = le16(0x0099) + le32(121) + le16(0) + ByteArray(12) { it.toByte() }
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.size > 3 &&
+                value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
+            ) {
+                PduFramer.fragment(exactMultiple).forEach { emit(data, two.pumpEncrypt(it)) }
+                emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
+        HistoryReader(link, two.server).readRecordsInRange(100, 130) { result = it }
+
+        assertTrue(result!!.isFailure)
+    }
+
+    @Test
     fun `readRecordsInRange fails when every frame in the page is undecodable`() {
         // Frames arrived but none survived parsing: reporting an empty page here would end the
         // gateway's walk and let the callers' cursors skip these records permanently. It must fail.

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
@@ -1,8 +1,9 @@
 /*
  * AC2: the history reader drives the IDD RACP over the C1 framework -- the plaintext count query, and
  * the multi-record report that collects SAKE-encrypted records on the IDD History Data characteristic
- * and terminates on the RACP success indication. Records are encrypted by a genuine two-sided SAKE
- * session and fragmented through PduFramer (MTU 23 discipline), in decrypt order.
+ * and terminates on the RACP success indication. Records are fragmented through PduFramer and each
+ * fragment individually SAKE-encrypted by a genuine two-sided session (the per-PDU encryption
+ * model), in decrypt order.
  */
 package com.glycemicgpt.mobile.ble.read
 
@@ -93,22 +94,89 @@ class HistoryReaderTest {
     }
 
     @Test
-    fun `readSinceSequence returns empty when already caught up`() {
+    fun `readRecordsInRange treats a no-records-found window as a successful empty page`() {
+        // The gateway's paging walk crosses the oldest retained record on deep backfills; the pump
+        // answers the empty window with NO_RECORDS_FOUND, which must be an empty page -- not a failure
+        // that discards every newer page already collected.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.size > 3 &&
+                value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
+            ) {
+                emit(racp, HistoryReader.REPORT_NO_RECORDS_FOUND)
+            }
+        }
+
+        var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
+        HistoryReader(link, two.server).readRecordsInRange(1, 20) { result = it }
+
+        assertTrue(result!!.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `readLastRecord returns null when the log is empty (no-records-found)`() {
         val two = TwoSidedSession()
         val link = FakeGattLink()
         link.reads[features] = two.pumpEncrypt(featuresPlain)
         link.onWrite = { characteristic, value ->
             if (characteristic == racp && value.contentEquals(HistoryReader.REQUEST_REPORT_LAST_RECORD)) {
-                // Each plaintext fragment is individually SAKE-encrypted (per-PDU encryption model).
-                PduFramer.fragment(basalRecord).forEach { emit(data, two.pumpEncrypt(it)) } // seq 120
+                emit(racp, HistoryReader.REPORT_NO_RECORDS_FOUND)
+            }
+        }
+
+        var result: Result<com.glycemicgpt.mobile.domain.model.HistoryLogRecord?>? = null
+        HistoryReader(link, two.server).readLastRecord { result = it }
+
+        assertNull(result!!.getOrThrow())
+    }
+
+    @Test
+    fun `readRecordsInRange fails when any frame in the page is undecodable`() {
+        // A partially-undecodable page must not return just the survivors: the gateway's walk moves
+        // past the window and the callers' cursors advance to the max sequence seen, so the dropped
+        // record would be skipped permanently. The whole page fails so the cursor stays put.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.size > 3 &&
+                value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
+            ) {
+                PduFramer.fragment(basalRecord).forEach { emit(data, two.pumpEncrypt(it)) } // decodes fine
+                emit(data, two.pumpEncrypt(hex("01020304"))) // shorter than the 8-byte record header
                 emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
             }
         }
 
         var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
-        HistoryReader(link, two.server).readSinceSequence(sinceSequence = 200) { result = it }
+        HistoryReader(link, two.server).readRecordsInRange(100, 120) { result = it }
 
-        assertTrue(result!!.getOrThrow().isEmpty())
+        assertTrue(result!!.isFailure)
+    }
+
+    @Test
+    fun `readRecordsInRange fails when every frame in the page is undecodable`() {
+        // Frames arrived but none survived parsing: reporting an empty page here would end the
+        // gateway's walk and let the callers' cursors skip these records permanently. It must fail.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.size > 3 &&
+                value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
+            ) {
+                // A frame shorter than the 8-byte record header is dropped by the parser.
+                emit(data, two.pumpEncrypt(hex("01020304")))
+                emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
+        HistoryReader(link, two.server).readRecordsInRange(100, 120) { result = it }
+
+        assertTrue(result!!.isFailure)
     }
 
     @Test

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
@@ -47,7 +47,8 @@ class HistoryReaderTest {
         link.reads[features] = two.pumpEncrypt(featuresPlain)
         link.onWrite = { characteristic, value ->
             if (characteristic == racp && value.contentEquals(HistoryReader.REQUEST_REPORT_LAST_RECORD)) {
-                PduFramer.fragment(two.pumpEncrypt(basalRecord)).forEach { emit(data, it) }
+                // Each plaintext fragment is individually SAKE-encrypted (per-PDU encryption model).
+                PduFramer.fragment(basalRecord).forEach { emit(data, two.pumpEncrypt(it)) }
                 emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
             }
         }
@@ -74,10 +75,11 @@ class HistoryReaderTest {
             if (characteristic == racp && value.size > 3 &&
                 value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
             ) {
-                PduFramer.fragment(two.pumpEncrypt(rec1)).forEach { emit(data, it) }
+                // Each plaintext fragment is individually SAKE-encrypted (per-PDU encryption model).
+                PduFramer.fragment(rec1).forEach { emit(data, two.pumpEncrypt(it)) }
                 // Emit rec1 again (same sequence 118) so dedup is actually exercised end to end.
-                PduFramer.fragment(two.pumpEncrypt(rec1)).forEach { emit(data, it) }
-                PduFramer.fragment(two.pumpEncrypt(rec2)).forEach { emit(data, it) }
+                PduFramer.fragment(rec1).forEach { emit(data, two.pumpEncrypt(it)) }
+                PduFramer.fragment(rec2).forEach { emit(data, two.pumpEncrypt(it)) }
                 emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
             }
         }
@@ -97,7 +99,8 @@ class HistoryReaderTest {
         link.reads[features] = two.pumpEncrypt(featuresPlain)
         link.onWrite = { characteristic, value ->
             if (characteristic == racp && value.contentEquals(HistoryReader.REQUEST_REPORT_LAST_RECORD)) {
-                PduFramer.fragment(two.pumpEncrypt(basalRecord)).forEach { emit(data, it) } // seq 120
+                // Each plaintext fragment is individually SAKE-encrypted (per-PDU encryption model).
+                PduFramer.fragment(basalRecord).forEach { emit(data, two.pumpEncrypt(it)) } // seq 120
                 emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
             }
         }

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
@@ -178,6 +178,140 @@ class MedtronicReadGatewayTest {
         assertEquals(249, second.await().getOrThrow().glucoseMgDl)
     }
 
+    // -- History paging (getHistoryLogs) -------------------------------------
+
+    @Test
+    fun `getHistoryLogs pages by requested window so a sparse page cannot skip older records`() = runTest {
+        val two = TwoSidedSession()
+        val pump = ScriptedHistoryPump(two, retainedSequences = listOf(150, 400))
+
+        val records = gateway(link = pump.link, session = two.server).getHistoryLogs(sinceSequence = 0).getOrThrow()
+
+        assertEquals(listOf(150, 400), records.map { it.sequenceNumber })
+        // Window-driven walk: the first page parses sparse (1 record in a 200-sequence window) yet the
+        // walk continues into the next window. Content-driven paging would stop after the first page
+        // and -- because the callers advance their cursor to the max sequence seen -- skip record 150
+        // permanently.
+        assertEquals(listOf(201..400, 1..200), pump.rangeRequests)
+    }
+
+    @Test
+    fun `getHistoryLogs stops paging at the pump's oldest retained record`() = runTest {
+        val two = TwoSidedSession()
+        val pump = ScriptedHistoryPump(two, retainedSequences = (950..1000).toList())
+
+        val records = gateway(link = pump.link, session = two.server).getHistoryLogs(sinceSequence = 0).getOrThrow()
+
+        assertEquals((950..1000).toList(), records.map { it.sequenceNumber })
+        // The pump purges oldest-first, so the window below the retained tail answers "no records
+        // found" (an empty page) and the walk ends there -- no futile scan down to sequence 1.
+        assertEquals(listOf(801..1000, 601..800), pump.rangeRequests)
+    }
+
+    @Test
+    fun `getHistoryLogs returns multi-page results in ascending sequence order`() = runTest {
+        val two = TwoSidedSession()
+        val pump = ScriptedHistoryPump(two, retainedSequences = (1..450).toList())
+
+        val records = gateway(link = pump.link, session = two.server).getHistoryLogs(sinceSequence = 50).getOrThrow()
+
+        assertEquals((51..450).toList(), records.map { it.sequenceNumber })
+    }
+
+    @Test
+    fun `getHistoryLogs is empty when already caught up`() = runTest {
+        val two = TwoSidedSession()
+        val pump = ScriptedHistoryPump(two, retainedSequences = listOf(100))
+
+        val records = gateway(link = pump.link, session = two.server).getHistoryLogs(sinceSequence = 100).getOrThrow()
+
+        assertTrue(records.isEmpty())
+        assertTrue(pump.rangeRequests.isEmpty())
+    }
+
+    @Test
+    fun `getHistoryLogs fails the whole fetch when a page fails`() = runTest {
+        // Older pages are still un-fetched when a page fails; returning the newer pages collected so
+        // far would let the callers advance their cursor past the gap and skip those records for good.
+        val two = TwoSidedSession()
+        val pump = ScriptedHistoryPump(two, retainedSequences = (1..450).toList())
+        pump.failWindowsBelow = 251 // the first page succeeds, the second page errors
+
+        val result = gateway(link = pump.link, session = two.server).getHistoryLogs(sinceSequence = 50)
+
+        assertTrue(result.isFailure)
+    }
+
+    /**
+     * Scripts a pump's IDD history service on a [FakeGattLink]: answers the last-record request with
+     * the newest retained record and each within-range request with the retained records in that
+     * window -- or the "no records found" indication when the window is empty, as a real pump does
+     * once a walk crosses its oldest retained record. Every frame is freshly SAKE-encrypted at
+     * delivery time so the two-sided session's sequence counters stay aligned across pages.
+     */
+    private class ScriptedHistoryPump(
+        private val two: TwoSidedSession,
+        retainedSequences: List<Int>,
+    ) {
+        val link = FakeGattLink()
+        val rangeRequests = mutableListOf<IntRange>()
+
+        /** Windows whose first sequence is below this fail with an RACP error (for failure tests). */
+        var failWindowsBelow = Int.MIN_VALUE
+
+        private val retained = retainedSequences.toSortedSet()
+        private val racp = MedtronicProtocol.RACP_UUID
+        private val data = MedtronicProtocol.IDD_HISTORY_DATA_UUID
+
+        init {
+            link.onRead = { characteristic ->
+                if (characteristic == MedtronicProtocol.IDD_FEATURES_UUID) two.pumpEncrypt(hex(IDD_FEATURES_E2E_DISABLED_HEX)) else null
+            }
+            link.onWrite = { characteristic, value ->
+                if (characteristic == racp) respond(value)
+            }
+        }
+
+        private fun respond(request: ByteArray) {
+            when {
+                request.contentEquals(HistoryReader.REQUEST_REPORT_LAST_RECORD) -> {
+                    val newest = retained.last()
+                    emitRecord(newest)
+                    link.emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
+                }
+                request.size == 11 && request[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0] -> {
+                    val first = MedtronicCodec.readULongLe(request, 3, 4).toInt()
+                    val last = MedtronicCodec.readULongLe(request, 7, 4).toInt()
+                    rangeRequests.add(first..last)
+                    if (first < failWindowsBelow) {
+                        link.emit(racp, byteArrayOf(0x0F, 0x0F, 0x33, 0x02)) // op-code-not-supported
+                        return
+                    }
+                    val inWindow = retained.subSet(first, last + 1)
+                    if (inWindow.isEmpty()) {
+                        link.emit(racp, HistoryReader.REPORT_NO_RECORDS_FOUND)
+                    } else {
+                        inWindow.forEach { emitRecord(it) }
+                        link.emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
+                    }
+                }
+            }
+        }
+
+        private fun emitRecord(seq: Int) {
+            link.emit(data, two.pumpEncrypt(historyRecord(seq)))
+        }
+
+        /** An 18-byte basal-rate-changed record (single PDU): type 0x0099, [seq], offset 0. */
+        private fun historyRecord(seq: Int): ByteArray =
+            byteArrayOf(0x99.toByte(), 0x00) + MedtronicCodec.u32Le(seq) + byteArrayOf(0, 0) + hex("010a0000ff050000ff55")
+
+        companion object {
+            /** IDD Features characteristic value with E2E protection disabled. */
+            private const val IDD_FEATURES_E2E_DISABLED_HEX = "ffff006400fede801f"
+        }
+    }
+
     /**
      * A [MedtronicGattLink] that defers each RACP exchange's response until [releaseNext], so a read
      * stays in flight (holding the single-flight lock) until the test chooses to complete it. Counts

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
@@ -230,6 +230,26 @@ class MedtronicReadGatewayTest {
     }
 
     @Test
+    fun `getHistoryLogs fails once the walk accumulates past the total-record ceiling`() = runTest {
+        // The cross-page analog of MAX_RECORDS_PER_REPORT: a malfunctioning (but authenticated) pump
+        // reporting a bogus huge last-sequence and answering every window must not grow memory
+        // without bound. Failing leaves the cursors put, so nothing is silently skipped.
+        val two = TwoSidedSession()
+        val pump = ScriptedHistoryPump(two, retainedSequences = (1..450).toList())
+        val gw = MedtronicReadGateway(
+            sessionProvider = { two.server },
+            linkProvider = { pump.link },
+            ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+            maxTotalHistoryRecords = 300,
+        )
+
+        val result = gw.getHistoryLogs(sinceSequence = 0)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("exceeded 300 records"))
+    }
+
+    @Test
     fun `getHistoryLogs fails the whole fetch when a page fails`() = runTest {
         // Older pages are still un-fetched when a page fails; returning the newer pages collected so
         // far would let the callers advance their cursor past the gap and skip those records for good.

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
@@ -126,6 +126,7 @@ class MedtronicReadGatewayTest {
             override fun write(characteristic: UUID, value: ByteArray) = error("unused")
             override fun subscribe(characteristic: UUID, onPdu: (ByteArray) -> Unit) = error("unused")
             override fun unsubscribe(characteristic: UUID) = error("unused")
+            override fun cancelAllSubscriptions() = error("unused")
         }
         val gateway = MedtronicReadGateway(
             sessionProvider = { TwoSidedSession().server },
@@ -212,6 +213,11 @@ class MedtronicReadGatewayTest {
 
         override fun unsubscribe(characteristic: UUID) {
             handlers.remove(characteristic)
+        }
+
+        override fun cancelAllSubscriptions() {
+            handlers.clear()
+            pendingResponses.clear()
         }
 
         /** Deliver the next deferred pump response, completing the oldest in-flight exchange. */

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
@@ -67,6 +67,29 @@ class MedtronicSessionReaderTest {
     }
 
     @Test
+    fun `reportLastRecord fails when the record is still unterminated at the RACP success response`() {
+        // The exact-multiple ambiguity: a record whose plaintext is an exact multiple of the PDU size
+        // has no short terminator, so the reassembler is still holding fragments when the terminal
+        // indication arrives. Reporting "no record" here would silently misreport what the pump sent.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        val record = ByteArray(PduFramer.MAX_PDU_SIZE * 2) { it.toByte() } // 40 bytes: two full fragments
+        val pdus = PduFramer.fragment(record).map { two.pumpEncrypt(it) }
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                pdus.forEach { emit(dataChar, it) }
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<ByteArray>? = null
+        MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { result = it }
+
+        assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull()!!.message!!.contains("unterminated"))
+    }
+
+    @Test
     fun `reportLastRecord fails on an unsuccessful RACP response`() {
         val two = TwoSidedSession()
         val link = FakeGattLink()

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
@@ -48,10 +48,10 @@ class MedtronicSessionReaderTest {
     fun `reportLastRecord reassembles a fragmented measurement before decrypting`() {
         val two = TwoSidedSession()
         val link = FakeGattLink()
-        // A record large enough that its encrypted form exceeds one 20-byte PDU and must reassemble.
+        // A record large enough that its plaintext exceeds one 20-byte PDU and must reassemble.
         val record = ByteArray(25) { it.toByte() }
-        val encrypted = two.pumpEncrypt(record)
-        val pdus = PduFramer.fragment(encrypted)
+        // Each plaintext fragment is individually SAKE-encrypted (per-PDU encryption model).
+        val pdus = PduFramer.fragment(record).map { two.pumpEncrypt(it) }
         assertTrue("expected fragmentation", pdus.size > 1)
         link.onWrite = { characteristic, _ ->
             if (characteristic == racp) {

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
@@ -33,8 +33,17 @@ internal class FakeGattLink : MedtronicGattLink {
     /** Invoked on every [write]; the receiver scripts notifications via [emit]. */
     var onWrite: (FakeGattLink.(characteristic: UUID, value: ByteArray) -> Unit)? = null
 
+    /**
+     * Optional dynamic read stub, tried before [reads]. Needed when a test's session decrypts the
+     * same characteristic more than once (e.g. the per-page IDD Features read): SAKE sequence
+     * counters step per frame, so each read must be freshly encrypted at delivery time.
+     */
+    var onRead: ((UUID) -> ByteArray?)? = null
+
     override fun read(characteristic: UUID): ByteArray =
-        reads[characteristic] ?: throw MedtronicReadException("no read stub for $characteristic")
+        onRead?.invoke(characteristic)
+            ?: reads[characteristic]
+            ?: throw MedtronicReadException("no read stub for $characteristic")
 
     override fun write(characteristic: UUID, value: ByteArray) {
         writes.add(characteristic to value)

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/ReadTestSupport.kt
@@ -50,6 +50,11 @@ internal class FakeGattLink : MedtronicGattLink {
         handlers.remove(characteristic)
     }
 
+    override fun cancelAllSubscriptions() {
+        handlers.clear()
+        retained.clear()
+    }
+
     /** Deliver one inbound PDU to whatever handler is currently subscribed on [characteristic]. */
     fun emit(characteristic: UUID, pdu: ByteArray) {
         handlers[characteristic]?.invoke(pdu)


### PR DESCRIPTION
## 📋 Summary
Three fixes for the Medtronic BLE history-read path: decrypt each SAKE-encrypted notification PDU individually (fixes MacFailureException on multi-PDU records), guard deferred unsubscribe against re-subscription (fixes GATT write failures from killed indication path), and page history reads at the gateway with per-batch timeouts (fixes cascading timeout/SAKE-desync failures on large backfills).
## 🔗 Related Issues
Fixes `MacFailureException` on multi-PDU history records. Fixes `GATT write failed (status=0xfd)` on sequential IDD RACP reads. Fixes `Unexpected/failed IDD RACP response` and `Medtronic history read timed out` after large backfills.
## 🏷️ Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies


## 🔨 Changes Made
- **MedtronicSessionReader** — decrypt each notification PDU individually before reassembly, not the concatenated ciphertext blob. Applies to reportRecords, reportLastRecord, and encryptedGet (SOCP/SRCP). Each PDU is independently SAKE-encrypted with its own 3-byte trailer; reassembling and decrypting once included intermediate trailers as ciphertext data, corrupting the MAC.
- **AndroidMedtronicGattLink** — guard disableNotifications with a handlers.containsKey() check. A deferred unsubscribe could race with a new session that already re-subscribed the same characteristic, calling setCharacteristicNotification(false) between the new session's subscribe and write, killing the indication path.
- **MedtronicReadGateway + HistoryReader** — move paging from HistoryReader (single coroutine under one 30s timeout) to MedtronicReadGateway (each 200-record page is an independent sessionRead with its own 30s timeout). Added cancelAllSubscriptions() to MedtronicGattLink interface + implementations, called via invokeOnCancellation in sessionRead to clean up on timeout.

## Maintainer follow-up (review fixes, pushed with the author's go-ahead)
Driven to mergeable per the author's request; all review findings addressed on top of the original commits:

- **Paging is window-driven, never content-driven.** The walk advances by the requested window (`highSeq = lowSeq - 1`); the previous content-driven exit (`minOfOrNull`/`size < batch`) could end the walk on a sparse page while both history consumers advance their cursor to the max sequence seen, permanently skipping older bolus records that feed IOB. The pump's `NO_RECORDS_FOUND` indication is now a successful empty page (per upstream `IddRacpResponseCode`), which ends deep backfills at the oldest retained record and lets an empty log resolve the last-record read to null. Results are returned in ascending sequence order. A failed page fails the whole call so cursors stay put.
- **Any undecodable frame fails its page**, and a record left unterminated at the terminal RACP indication (the documented exact-multiple reassembly ambiguity) fails the exchange — nothing the pump sent can be silently skipped; the read is retried with cursors unchanged.
- **Cancellation cleanup no longer blocks the coroutine timeout thread.** `cancelAllSubscriptions()` drops handlers immediately and defers the blocking CCCD disables to the cleanup executor (kotlinx's cancellation handler runs on the process-global scheduler thread on a timeout, where a blocking GATT round trip would stall every `delay`/`withTimeout` in the app). The `disableNotifications` re-subscribe guard described above is included, and `subscribe()` no longer arms a stale watchdog when cancelled while awaiting the CCCD ack.
- **Total-accumulation ceiling** on a history walk (cross-page analog of `MAX_RECORDS_PER_REPORT`) so a malfunctioning but authenticated pump cannot grow memory without bound.
- **MTU docs reconciled with the per-PDU model:** outbound writes stay at 20-byte payloads (we never call `requestMtu()`), while the pump raises the per-bearer ATT MTU from its own side — which is how the >20-byte notifications proven by the hardware MAC-pass reach us. Removed the production-dead `readSinceSequence` and the unused `readRecordsInRange(useE2e)` overload.
- **Tests:** 14 new unit tests covering window-driven paging (sparse page, oldest-retained stop, ascending order, page failure, accumulation ceiling), no-records-found and undecodable/unterminated-record handling, and the cancel-path threading/races on the link.

Known follow-ups (out of scope here): the orchestrator's batch comments/stuck-guard now describe the old per-call paging model; proactive SAKE re-handshake on repeated MAC failures (today a desynced session heals on the next disconnect/reconnect); initial-sync resumability across pages. Hardware sanity-check of the updated paging on a real 780G is welcome when the author has time — unit suites and reviews are green, but only the pump can confirm on-wire behavior.

## 🧪 Test Plan

- [x] Unit tests pass
- [x] New tests added for new functionality
- [x] Manual/visual testing performed (original commits hardware-validated on a real 780G by the author; maintainer fixes unit-tested, hardware re-check requested above)
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [x] Self-review completed
- [x] Code follows project style guidelines
- [x] No hardcoded secrets, API keys, or credentials
- [x] Changes generate no new warnings
- [x] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added windowed, incremental paging for more reliable Medtronic history retrieval, including safeguards for very large results.
* **Bug Fixes**
  * Improved behavior when reads are cancelled by ensuring active BLE notification subscriptions are cleaned up safely.
  * Fixed history termination handling for “no records found” and unterminated multi-part responses to prevent incorrect success.
  * Updated notification parsing to decrypt and reassemble per-part content for more consistent reads.
* **Tests**
  * Expanded coverage for paging behavior, cancellation cleanup, and fragmentation/decryption edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->