### PR TITLE
feat(api): make CGM primary-source serve-side filter universal (GLY-123)

### DIFF
--- a/apps/api/src/routers/caregivers.py
+++ b/apps/api/src/routers/caregivers.py
@@ -472,6 +472,8 @@ async def get_caregiver_patient_status(
     if permissions.can_view_glucose:
         from src.services.dexcom_sync import get_latest_glucose_reading
 
+        # The patient's primary CGM source only (GLY-123) -- the caregiver sees
+        # what the patient sees, never a lagging non-primary source.
         reading = await get_latest_glucose_reading(db, patient_id)
         if reading is not None:
             from src.services.glucose_unit import resolve_glucose_unit
@@ -545,6 +547,7 @@ async def get_caregiver_glucose_history(
 
     from src.services.dexcom_sync import get_glucose_readings
 
+    # The patient's primary CGM source only (GLY-123).
     readings = await get_glucose_readings(db, patient_id, minutes=minutes, limit=limit)
 
     return CaregiverGlucoseHistoryResponse(

--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -901,7 +901,7 @@ async def get_sync_status(
     )
     readings_count = count_result.scalar() or 0
 
-    # Get latest reading
+    # Get latest reading (primary CGM source only by default -- GLY-123)
     latest = await get_latest_glucose_reading(db, current_user.id)
     latest_response = None
     if latest:

--- a/apps/api/src/services/cgm_source.py
+++ b/apps/api/src/services/cgm_source.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 
-from sqlalchemy import select
+from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.glucose import GlucoseReading
@@ -175,6 +175,49 @@ async def get_excluded_cgm_sources(
         ):
             excluded.append(src.source)
     return excluded
+
+
+async def glucose_readings_query(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    entities: tuple | None = None,
+    include_secondary: bool = False,
+    excluded_sources: list[str] | None = None,
+) -> Select:
+    """Base ``SELECT`` over a user's glucose readings with the primary-source
+    precedence filter ALWAYS applied.
+
+    This is the single funnel every glucose-read consumer should build on, so
+    a non-primary source can never leak into alerting, AI, exports, or widgets
+    (GLY-123). The exclusion set is resolved here -- callers cannot forget it --
+    and the fail-safe still holds: with no primary source ``get_excluded_cgm_sources``
+    returns an empty list, so nothing is filtered (see that function's docstring).
+
+    Callers refine the returned statement with time bounds / ordering / limit,
+    e.g. ``(await glucose_readings_query(db, uid)).order_by(...).limit(...)``.
+
+    Args:
+        entities: Columns to project (``select(*entities)``); defaults to the
+            whole ``GlucoseReading`` ORM entity. Pass a tuple of columns when a
+            consumer only needs a subset (e.g. ``(GlucoseReading.value,)``).
+        include_secondary: When resolving the exclusion here, keep ``secondary``
+            sources (``off`` sources are always excluded). Ignored when
+            ``excluded_sources`` is provided.
+        excluded_sources: Pre-resolved exclusion set to use verbatim, for a
+            caller that already computed it (e.g. to honor an
+            ``include_secondary`` request from a query param). Leave ``None`` to
+            resolve it here.
+    """
+    if excluded_sources is None:
+        excluded_sources = await get_excluded_cgm_sources(
+            db, user_id, include_secondary=include_secondary
+        )
+    columns = entities if entities is not None else (GlucoseReading,)
+    return select(*columns).where(
+        GlucoseReading.user_id == user_id,
+        *glucose_source_exclusion_clause(excluded_sources),
+    )
 
 
 async def has_primary_cgm(db: AsyncSession, user_id: uuid.UUID) -> bool:

--- a/apps/api/src/services/correction_analysis.py
+++ b/apps/api/src/services/correction_analysis.py
@@ -26,6 +26,7 @@ from src.models.user import User
 from src.schemas.ai_response import AIMessage
 from src.schemas.correction_analysis import TimePeriodData
 from src.services.ai_client import get_ai_client
+from src.services.cgm_source import glucose_readings_query
 from src.services.diabetes_context import (
     PumpProfileSummary,
     build_allowed_glucose,
@@ -226,17 +227,25 @@ async def analyze_correction_outcomes(
     )
     corrections = list(bolus_result.scalars().all())
 
-    # Fetch all glucose readings for the full period plus correction window
+    # Fetch all glucose readings for the full period plus correction window.
+    # Primary CGM source only (GLY-123) so observed-ISF isn't computed against a
+    # non-primary source reposting the same sensor.
     extended_end = period_end + timedelta(hours=POST_CORRECTION_WINDOW_HOURS)
-    all_readings_result = await db.execute(
-        select(GlucoseReading.reading_timestamp, GlucoseReading.value)
+    readings_stmt = (
+        (
+            await glucose_readings_query(
+                db,
+                user_id,
+                entities=(GlucoseReading.reading_timestamp, GlucoseReading.value),
+            )
+        )
         .where(
-            GlucoseReading.user_id == user_id,
             GlucoseReading.reading_timestamp >= period_start,
             GlucoseReading.reading_timestamp <= extended_end,
         )
         .order_by(GlucoseReading.reading_timestamp)
     )
+    all_readings_result = await db.execute(readings_stmt)
     all_readings = [(row[0], row[1]) for row in all_readings_result.all()]
 
     # Group corrections by time period and analyze outcomes

--- a/apps/api/src/services/dexcom_sync.py
+++ b/apps/api/src/services/dexcom_sync.py
@@ -21,7 +21,7 @@ from src.models.integration import (
     IntegrationStatus,
     IntegrationType,
 )
-from src.services.cgm_source import glucose_source_exclusion_clause
+from src.services.cgm_source import glucose_readings_query
 
 logger = get_logger(__name__)
 
@@ -268,23 +268,22 @@ async def get_latest_glucose_reading(
     Args:
         db: Database session
         user_id: User ID
-        excluded_sources: CGM ``source`` strings to exclude (Story 43.10
-            secondary/off sources). When non-empty the latest reading is
-            drawn from the primary source only.
+        excluded_sources: CGM ``source`` strings to exclude. Leave ``None``
+            (default) to resolve the user's primary-source exclusion
+            automatically (Story 43.10 / GLY-123) so the latest reading is
+            drawn from the primary source only, with the fail-safe
+            "no primary => exclude nothing". Pass an explicit list (e.g. an
+            ``include_secondary``-aware set) to override the auto-resolution.
 
     Returns:
         Most recent GlucoseReading or None
     """
-    conditions = [
-        GlucoseReading.user_id == user_id,
-        *glucose_source_exclusion_clause(excluded_sources),
-    ]
-    result = await db.execute(
-        select(GlucoseReading)
-        .where(*conditions)
+    stmt = (
+        (await glucose_readings_query(db, user_id, excluded_sources=excluded_sources))
         .order_by(GlucoseReading.reading_timestamp.desc())
         .limit(1)
     )
+    result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
 
@@ -307,9 +306,12 @@ async def get_glucose_readings(
         limit: Maximum readings to return (applied regardless of date range)
         start: Optional absolute start of date range (overrides minutes)
         end: Optional absolute end of date range (overrides minutes)
-        excluded_sources: CGM ``source`` strings to exclude (Story 43.10
-            secondary/off sources) so the history reflects the primary CGM
-            only.
+        excluded_sources: CGM ``source`` strings to exclude. Leave ``None``
+            (default) to resolve the user's primary-source exclusion
+            automatically (Story 43.10 / GLY-123) so the history reflects the
+            primary CGM only, with the fail-safe "no primary => exclude
+            nothing". Pass an explicit list (e.g. an ``include_secondary``-aware
+            set) to override the auto-resolution.
 
     Returns:
         List of GlucoseReading objects, ordered by timestamp descending
@@ -329,18 +331,11 @@ async def get_glucose_readings(
         cutoff = datetime.now(UTC) - timedelta(minutes=minutes)
         upper = None
 
-    conditions = [
-        GlucoseReading.user_id == user_id,
-        GlucoseReading.reading_timestamp >= cutoff,
-    ]
+    stmt = await glucose_readings_query(db, user_id, excluded_sources=excluded_sources)
+    stmt = stmt.where(GlucoseReading.reading_timestamp >= cutoff)
     if upper is not None:
-        conditions.append(GlucoseReading.reading_timestamp < upper)
-    conditions.extend(glucose_source_exclusion_clause(excluded_sources))
+        stmt = stmt.where(GlucoseReading.reading_timestamp < upper)
+    stmt = stmt.order_by(GlucoseReading.reading_timestamp.desc()).limit(limit)
 
-    result = await db.execute(
-        select(GlucoseReading)
-        .where(*conditions)
-        .order_by(GlucoseReading.reading_timestamp.desc())
-        .limit(limit)
-    )
+    result = await db.execute(stmt)
     return list(result.scalars().all())

--- a/apps/api/src/services/meal_analysis.py
+++ b/apps/api/src/services/meal_analysis.py
@@ -24,6 +24,7 @@ from src.models.user import User
 from src.schemas.ai_response import AIMessage
 from src.schemas.meal_analysis import MealPeriodData
 from src.services.ai_client import get_ai_client
+from src.services.cgm_source import glucose_readings_query
 from src.services.diabetes_context import (
     PumpProfileSummary,
     build_allowed_glucose,
@@ -202,17 +203,24 @@ async def analyze_post_meal_patterns(
     boluses = list(bolus_result.scalars().all())
 
     # Fetch all glucose readings for the full period plus 2hr buffer in one query
-    # to avoid N+1 queries (one per bolus)
+    # to avoid N+1 queries (one per bolus). Primary CGM source only (GLY-123) so
+    # post-meal peaks aren't skewed by a non-primary source reposting the sensor.
     extended_end = period_end + timedelta(hours=POST_MEAL_WINDOW_HOURS)
-    all_readings_result = await db.execute(
-        select(GlucoseReading.reading_timestamp, GlucoseReading.value)
+    readings_stmt = (
+        (
+            await glucose_readings_query(
+                db,
+                user_id,
+                entities=(GlucoseReading.reading_timestamp, GlucoseReading.value),
+            )
+        )
         .where(
-            GlucoseReading.user_id == user_id,
             GlucoseReading.reading_timestamp >= period_start,
             GlucoseReading.reading_timestamp <= extended_end,
         )
         .order_by(GlucoseReading.reading_timestamp)
     )
+    all_readings_result = await db.execute(readings_stmt)
     all_readings = [(row[0], row[1]) for row in all_readings_result.all()]
 
     # Group boluses by meal period and analyze post-meal glucose

--- a/apps/api/src/services/predictive_alerts.py
+++ b/apps/api/src/services/predictive_alerts.py
@@ -16,9 +16,9 @@ from src.core.units import GlucoseUnit, format_glucose, format_glucose_value
 from src.logging_config import get_logger
 from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.alert_threshold import AlertThreshold
-from src.models.glucose import GlucoseReading
 from src.services.alert_notifier import notify_user_of_alerts
 from src.services.alert_threshold import get_or_create_thresholds
+from src.services.dexcom_sync import get_latest_glucose_reading
 from src.services.glucose_unit import resolve_glucose_unit
 from src.services.iob_projection import get_iob_projection, get_user_dia
 
@@ -564,14 +564,11 @@ async def evaluate_alerts_for_user(
     Returns:
         List of newly created Alert records.
     """
-    # Get latest glucose reading
-    result = await db.execute(
-        select(GlucoseReading)
-        .where(GlucoseReading.user_id == user_id)
-        .order_by(desc(GlucoseReading.reading_timestamp))
-        .limit(1)
-    )
-    latest_reading = result.scalar_one_or_none()
+    # Latest glucose reading from the PRIMARY CGM source only (GLY-123): a
+    # non-primary (e.g. lagging secondary) reading must never drive or suppress
+    # a safety alert. get_latest_glucose_reading resolves the primary-source
+    # exclusion itself, with the fail-safe "no primary => reading unfiltered".
+    latest_reading = await get_latest_glucose_reading(db, user_id)
 
     if latest_reading is None:
         logger.debug("No glucose readings for user", user_id=str(user_id))

--- a/apps/api/src/services/settings_export.py
+++ b/apps/api/src/services/settings_export.py
@@ -212,7 +212,11 @@ async def _export_all_data(
     data: dict = {}
     limit = MAX_EXPORT_RECORDS_PER_CATEGORY
 
-    # Glucose readings
+    # Glucose readings -- this is the portability/backup "all data" export, so
+    # it intentionally includes EVERY source's readings (NOT primary-source
+    # filtered like the live views/alerts/AI in GLY-123): an export must be
+    # complete. Each row carries its own ``source``, so a consumer can still
+    # apply primary-source precedence itself.
     result = await db.execute(
         select(GlucoseReading)
         .where(GlucoseReading.user_id == user_id)

--- a/apps/api/src/services/telegram_caregiver.py
+++ b/apps/api/src/services/telegram_caregiver.py
@@ -109,6 +109,7 @@ async def _handle_caregiver_status(
             )
             continue
 
+        # The patient's primary CGM source only (GLY-123).
         reading = await get_latest_glucose_reading(db, link.patient_id)
 
         if reading is None:

--- a/apps/api/src/services/telegram_commands.py
+++ b/apps/api/src/services/telegram_commands.py
@@ -24,12 +24,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.units import format_glucose
 from src.logging_config import get_logger
-from src.models.glucose import GlucoseReading
 from src.models.telegram_link import TelegramLink
 from src.models.user import User, UserRole
 from src.services.alert_notifier import trend_description
 from src.services.brief_notifier import format_brief_message
 from src.services.daily_brief import list_briefs
+from src.services.dexcom_sync import get_latest_glucose_reading
 from src.services.glucose_unit import resolve_glucose_unit
 from src.services.iob_projection import get_iob_projection, get_user_dia
 from src.services.predictive_alerts import acknowledge_alert, get_active_alerts
@@ -101,14 +101,8 @@ async def _handle_status(db: AsyncSession, user_id: uuid.UUID) -> str:
 
     Includes current glucose, trend, IoB, and reading age.
     """
-    # Latest glucose reading
-    result = await db.execute(
-        select(GlucoseReading)
-        .where(GlucoseReading.user_id == user_id)
-        .order_by(GlucoseReading.reading_timestamp.desc())
-        .limit(1)
-    )
-    reading = result.scalar_one_or_none()
+    # Latest glucose reading from the PRIMARY CGM source only (GLY-123).
+    reading = await get_latest_glucose_reading(db, user_id)
 
     if reading is None:
         return "\u2139\ufe0f No glucose data available yet."

--- a/apps/api/tests/test_cgm_source.py
+++ b/apps/api/tests/test_cgm_source.py
@@ -27,12 +27,14 @@ from src.models.nightscout_connection import (
     NightscoutConnection,
     NightscoutSyncStatus,
 )
+from src.models.pump_data import PumpEvent, PumpEventType
 from src.services.cgm_source import (
     CGM_ROLE_OFF,
     CGM_ROLE_PRIMARY,
     CGM_ROLE_SECONDARY,
     default_cgm_role_for_new_source,
     get_excluded_cgm_sources,
+    glucose_readings_query,
     list_cgm_sources,
     set_primary_cgm_source,
 )
@@ -469,3 +471,424 @@ class TestGlucoseFilteringByPrimary:
                 cookies={settings.jwt_cookie_name: cookie},
             )
             assert agp.status_code == 200
+
+
+async def _seed_one(
+    db: AsyncSession,
+    uid: uuid.UUID,
+    source: str,
+    value: int,
+    ts: datetime,
+) -> None:
+    """Seed a single glucose reading with an explicit value + timestamp."""
+    db.add(
+        GlucoseReading(
+            user_id=uid,
+            value=value,
+            reading_timestamp=ts,
+            trend=TrendDirection.FLAT,
+            trend_rate=0.0,
+            received_at=ts,
+            source=source,
+        )
+    )
+    await db.commit()
+
+
+async def _add_bolus(
+    db: AsyncSession,
+    uid: uuid.UUID,
+    ts: datetime,
+    units: float,
+    *,
+    bg_at_event: int | None = None,
+) -> None:
+    """Seed a manual (non-automated) bolus event."""
+    db.add(
+        PumpEvent(
+            user_id=uid,
+            event_type=PumpEventType.BOLUS,
+            event_timestamp=ts,
+            units=units,
+            is_automated=False,
+            bg_at_event=bg_at_event,
+            received_at=ts,
+            source="tandem",
+        )
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+class TestGlucoseReadingsQueryFunnel:
+    """The shared ``glucose_readings_query`` funnel (GLY-123) -- the single
+    place every glucose-read consumer builds on so the primary-source filter
+    can't be forgotten."""
+
+    async def test_funnel_returns_primary_only(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _seed_glucose(db, uid, "dexcom", 8)
+                await _seed_glucose(db, uid, f"nightscout:{ns_id}", 8)
+
+                rows = (
+                    (await db.execute(await glucose_readings_query(db, uid)))
+                    .scalars()
+                    .all()
+                )
+                assert len(rows) == 8
+                assert {r.source for r in rows} == {"dexcom"}
+                break
+
+    async def test_funnel_entities_projection(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _seed_glucose(db, uid, "dexcom", 5)
+                await _seed_glucose(db, uid, f"nightscout:{ns_id}", 5)
+
+                stmt = await glucose_readings_query(
+                    db,
+                    uid,
+                    entities=(GlucoseReading.value, GlucoseReading.source),
+                )
+                rows = (await db.execute(stmt)).all()
+                assert len(rows) == 5
+                assert all(source == "dexcom" for _value, source in rows)
+                break
+
+    async def test_funnel_include_secondary(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _seed_glucose(db, uid, "dexcom", 6)
+                await _seed_glucose(db, uid, f"nightscout:{ns_id}", 6)
+
+                stmt = await glucose_readings_query(db, uid, include_secondary=True)
+                rows = (await db.execute(stmt)).scalars().all()
+                assert len(rows) == 12
+                assert {r.source for r in rows} == {"dexcom", f"nightscout:{ns_id}"}
+                break
+
+    async def test_funnel_no_primary_failsafe(self):
+        # No primary source -> exclude nothing, so a lone secondary still shows.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Survivor NS")
+                await _seed_glucose(db, uid, f"nightscout:{ns_id}", 7)
+
+                rows = (
+                    (await db.execute(await glucose_readings_query(db, uid)))
+                    .scalars()
+                    .all()
+                )
+                assert len(rows) == 7
+                break
+
+    async def test_funnel_excluded_override_wins(self):
+        # An explicit excluded_sources list is used verbatim -- here [] forces
+        # "all sources" even though a primary exists.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _seed_glucose(db, uid, "dexcom", 4)
+                await _seed_glucose(db, uid, f"nightscout:{ns_id}", 4)
+
+                stmt = await glucose_readings_query(db, uid, excluded_sources=[])
+                rows = (await db.execute(stmt)).scalars().all()
+                assert len(rows) == 8
+                break
+
+
+@pytest.mark.asyncio
+class TestDexcomSyncHelpersAutoFilter:
+    """``get_latest_glucose_reading`` / ``get_glucose_readings`` auto-resolve the
+    primary-source exclusion when no explicit list is passed (GLY-123) -- this is
+    what closes the caregiver + sync-status call sites that never passed one."""
+
+    async def test_get_latest_auto_filters_primary(self):
+        from src.services.dexcom_sync import get_latest_glucose_reading
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            now = datetime.now(UTC)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                # Secondary posts the NEWEST row; primary is older.
+                await _seed_one(db, uid, "dexcom", 99, now - timedelta(minutes=5))
+                await _seed_one(db, uid, f"nightscout:{ns_id}", 222, now)
+
+                latest = await get_latest_glucose_reading(db, uid)
+                assert latest is not None
+                assert latest.value == 99  # primary, not the newer secondary 222
+                break
+
+    async def test_get_readings_auto_filters_primary(self):
+        from src.services.dexcom_sync import get_glucose_readings
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _seed_glucose(db, uid, "dexcom", 10)
+                await _seed_glucose(db, uid, f"nightscout:{ns_id}", 10)
+
+                readings = await get_glucose_readings(db, uid, minutes=1440, limit=100)
+                assert len(readings) == 10
+                assert {r.source for r in readings} == {"dexcom"}
+                break
+
+    async def test_get_latest_no_primary_failsafe(self):
+        from src.services.dexcom_sync import get_latest_glucose_reading
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            now = datetime.now(UTC)
+            async for db in get_db():
+                # Lone secondary, no primary -> nothing excluded, the row shows.
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Survivor NS")
+                await _seed_one(db, uid, f"nightscout:{ns_id}", 140, now)
+
+                latest = await get_latest_glucose_reading(db, uid)
+                assert latest is not None
+                assert latest.value == 140
+                break
+
+
+@pytest.mark.asyncio
+class TestConsumersHonorPrimary:
+    """The five previously-unfiltered consumers now act on primary readings
+    only (GLY-123 acceptance)."""
+
+    async def test_predictive_alerts_evaluate_uses_primary_reading(self):
+        # A NEWER in-range secondary would suppress the low alert if it leaked;
+        # the OLDER primary is an urgent low and must drive the alert.
+        from src.models.alert import AlertType
+        from src.services.predictive_alerts import evaluate_alerts_for_user
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            now = datetime.now(UTC)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _seed_one(db, uid, "dexcom", 45, now - timedelta(minutes=2))
+                await _seed_one(db, uid, f"nightscout:{ns_id}", 120, now)
+
+                alerts = await evaluate_alerts_for_user(db, uid)
+                assert alerts, "expected the primary urgent-low to raise an alert"
+                assert all(a.current_value == 45 for a in alerts)
+                assert any(a.alert_type == AlertType.LOW_URGENT for a in alerts)
+                break
+
+    async def test_predictive_alerts_no_primary_not_suppressed(self):
+        # Fail-safe: with no primary, a lone secondary low must STILL alert --
+        # the filter must never silently suppress a safety alert.
+        from src.services.predictive_alerts import evaluate_alerts_for_user
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            now = datetime.now(UTC)
+            async for db in get_db():
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Survivor NS")
+                await _seed_one(db, uid, f"nightscout:{ns_id}", 45, now)
+
+                alerts = await evaluate_alerts_for_user(db, uid)
+                assert alerts, "no-primary low must not be suppressed"
+                assert all(a.current_value == 45 for a in alerts)
+                break
+
+    async def test_predictive_alerts_stale_primary_ignores_fresh_secondary(self):
+        # Intended GLY-123 posture (documented, not a regression): alerting is
+        # driven by the designated PRIMARY only. If the connected primary is
+        # stale, the existing staleness gate suppresses alerts even when a
+        # non-primary secondary is fresh -- a demoted source must not drive a
+        # safety alert. (The no-primary fail-safe path is covered above.)
+        from src.services.predictive_alerts import (
+            GLUCOSE_STALE_MINUTES,
+            evaluate_alerts_for_user,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            now = datetime.now(UTC)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                # Primary is stale; secondary is fresh and low.
+                await _seed_one(
+                    db,
+                    uid,
+                    "dexcom",
+                    120,
+                    now - timedelta(minutes=GLUCOSE_STALE_MINUTES + 10),
+                )
+                await _seed_one(db, uid, f"nightscout:{ns_id}", 45, now)
+
+                alerts = await evaluate_alerts_for_user(db, uid)
+                assert alerts == []  # stale primary -> no alert; secondary ignored
+                break
+
+    async def test_meal_analysis_primary_only(self):
+        from src.services.meal_analysis import analyze_post_meal_patterns
+
+        base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _add_bolus(db, uid, base, 5.0)
+                # Both in the 2hr post-bolus window; the secondary peaks higher.
+                await _seed_one(db, uid, "dexcom", 250, base + timedelta(minutes=30))
+                await _seed_one(
+                    db, uid, f"nightscout:{ns_id}", 400, base + timedelta(minutes=60)
+                )
+
+                periods = await analyze_post_meal_patterns(
+                    uid, db, base, base + timedelta(minutes=1)
+                )
+                active = [p for p in periods if p.bolus_count > 0]
+                assert len(active) == 1
+                assert active[0].avg_peak_glucose == 250.0  # primary, not 400
+                assert all(p.avg_peak_glucose != 400.0 for p in periods)
+                break
+
+    async def test_meal_analysis_no_primary_failsafe(self):
+        from src.services.meal_analysis import analyze_post_meal_patterns
+
+        base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                # Lone secondary, no primary -> readings unfiltered.
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Survivor NS")
+                await _add_bolus(db, uid, base, 5.0)
+                await _seed_one(
+                    db, uid, f"nightscout:{ns_id}", 400, base + timedelta(minutes=30)
+                )
+
+                periods = await analyze_post_meal_patterns(
+                    uid, db, base, base + timedelta(minutes=1)
+                )
+                active = [p for p in periods if p.bolus_count > 0]
+                assert len(active) == 1
+                assert active[0].avg_peak_glucose == 400.0  # unfiltered fail-safe
+                break
+
+    async def test_correction_analysis_primary_only(self):
+        from src.services.correction_analysis import analyze_correction_outcomes
+
+        base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _add_bolus(db, uid, base, 2.0, bg_at_event=250)
+                # Post-correction window (3h). final_glucose = last reading.
+                # Primary settles at 150; a later secondary at 100 would change
+                # the computed drop if it leaked in.
+                await _seed_one(db, uid, "dexcom", 150, base + timedelta(hours=2))
+                await _seed_one(
+                    db,
+                    uid,
+                    f"nightscout:{ns_id}",
+                    100,
+                    base + timedelta(hours=2, minutes=30),
+                )
+
+                periods = await analyze_correction_outcomes(
+                    uid, db, base, base + timedelta(minutes=1)
+                )
+                active = [p for p in periods if p.correction_count > 0]
+                assert len(active) == 1
+                # drop = 250 (bg_at_event) - 150 (primary final) = 100
+                assert active[0].avg_glucose_drop == 100.0
+                assert all(p.avg_glucose_drop != 150.0 for p in periods)
+                break
+
+    async def test_telegram_status_primary_only(self):
+        from src.services.telegram_commands import _handle_status
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            now = datetime.now(UTC)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _seed_one(db, uid, "dexcom", 99, now - timedelta(minutes=2))
+                await _seed_one(db, uid, f"nightscout:{ns_id}", 222, now)
+
+                status = await _handle_status(db, uid)
+                assert "99" in status  # primary reading
+                assert "222" not in status  # newer secondary excluded
+                break
+
+    async def test_settings_export_includes_all_sources(self):
+        # The portability/backup "all data" export is intentionally NOT
+        # primary-filtered (GLY-123): a multi-source user's export must be
+        # complete and include the secondary source's readings too. Each row
+        # still carries its own ``source`` for consumer-side dedupe.
+        from src.services.settings_export import _export_all_data
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            _, uid = await _register(client)
+            async for db in get_db():
+                await _add_dexcom(db, uid, CGM_ROLE_PRIMARY)
+                ns_id = await _add_ns(db, uid, CGM_ROLE_SECONDARY, "Loop NS")
+                await _seed_glucose(db, uid, "dexcom", 6)
+                await _seed_glucose(db, uid, f"nightscout:{ns_id}", 6)
+
+                data = await _export_all_data(uid, db)
+                exported = data["glucose_readings"]
+                assert len(exported) == 12
+                assert {r["source"] for r in exported} == {
+                    "dexcom",
+                    f"nightscout:{ns_id}",
+                }
+                break

--- a/apps/api/tests/test_correction_analysis.py
+++ b/apps/api/tests/test_correction_analysis.py
@@ -230,6 +230,18 @@ class TestBuildCorrectionPrompt:
 class TestAnalyzeCorrectionOutcomes:
     """Tests for analyze_correction_outcomes."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_empty_cgm_exclusion(self):
+        # These unit tests mock the DB and configure no CGM sources, so the
+        # user's primary-source exclusion is empty. Stub it (GLY-123) so the
+        # shared glucose-read funnel doesn't issue its list_cgm_sources queries
+        # against the rigid execute mocks.
+        with patch(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            new=AsyncMock(return_value=[]),
+        ):
+            yield
+
     async def test_no_corrections_returns_empty_periods(self):
         """Test that no corrections returns zeroed time periods."""
         mock_db = AsyncMock()

--- a/apps/api/tests/test_meal_analysis.py
+++ b/apps/api/tests/test_meal_analysis.py
@@ -189,6 +189,18 @@ class TestBuildMealPrompt:
 class TestAnalyzePostMealPatterns:
     """Tests for analyze_post_meal_patterns."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_empty_cgm_exclusion(self):
+        # These unit tests mock the DB and configure no CGM sources, so the
+        # user's primary-source exclusion is empty. Stub it (GLY-123) so the
+        # shared glucose-read funnel doesn't issue its list_cgm_sources queries
+        # against the rigid execute mocks.
+        with patch(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            new=AsyncMock(return_value=[]),
+        ):
+            yield
+
     async def test_no_boluses_returns_empty_periods(self):
         """Test that no boluses returns zeroed meal periods."""
         mock_db = AsyncMock()

--- a/apps/api/tests/test_predictive_alerts.py
+++ b/apps/api/tests/test_predictive_alerts.py
@@ -299,6 +299,18 @@ class TestCheckIoBThreshold:
 class TestEvaluateAlertsForUser:
     """Tests for the full alert evaluation pipeline."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_empty_cgm_exclusion(self):
+        # These unit tests mock the DB and configure no CGM sources, so the
+        # user's primary-source exclusion is empty. Stub it (GLY-123) so the
+        # shared glucose-read funnel doesn't issue its list_cgm_sources queries
+        # against the rigid execute mocks.
+        with patch(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            new=AsyncMock(return_value=[]),
+        ):
+            yield
+
     @pytest.mark.asyncio
     async def test_no_readings_returns_empty(self):
         """Should return empty list when no glucose readings exist."""

--- a/apps/api/tests/test_telegram_commands.py
+++ b/apps/api/tests/test_telegram_commands.py
@@ -178,6 +178,18 @@ class TestHandleStatus:
     """Tests for _handle_status."""
 
     @pytest.fixture(autouse=True)
+    def _stub_empty_cgm_exclusion(self):
+        # _handle_status now reads the latest reading through the shared
+        # primary-source funnel (GLY-123). These tests mock the DB and set no
+        # CGM sources, so stub the exclusion to empty to avoid the funnel's
+        # list_cgm_sources queries against the single-result execute mock.
+        with patch(
+            "src.services.cgm_source.get_excluded_cgm_sources",
+            new=AsyncMock(return_value=[]),
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
     def _mgdl_unit(self):
         # _handle_status resolves the patient's unit before rendering; default it
         # to mg/dL so the existing assertions check a real resolved unit rather


### PR DESCRIPTION
## Summary

Story 43.10 introduced a single-primary CGM-source model (each CGM feed carries a `cgm_role` of primary/secondary/off) with serve-time precedence via `get_excluded_cgm_sources()` and the fail-safe **"no primary ⇒ exclude nothing."** But the filter was applied **inconsistently** — several glucose-read consumers bypassed it, so for a multi-source user with a designated primary (e.g. Dexcom-primary + Nightscout-secondary) a non-primary source's reading could leak into alerting, AI, and widgets.

This makes the primary-source filter **universal** by funneling every serve-time glucose read through one helper, so the filter can never be forgotten again.

## Changes

- **New `cgm_source.glucose_readings_query()`** — the single funnel. It always applies `user_id` scoping + the primary-source exclusion, resolving the exclusion itself (fail-safe preserved). Supports column projection (`entities`), `include_secondary`, and an explicit `excluded_sources` override for callers that already resolved it (e.g. the `include_secondary` query-param path).
- **`dexcom_sync.get_latest_glucose_reading` / `get_glucose_readings`** now build on the funnel. A `None` `excluded_sources` (the default) **auto-resolves** the primary-only exclusion. Explicit callers are unchanged. This also closes bypasses the issue didn't enumerate but are the same class: **caregiver** patient-status + history, **telegram_caregiver**, and the **sync-status** endpoint (all previously called these with no exclusion).
- **The 5 enumerated consumers** now route through the funnel: `predictive_alerts.evaluate_alerts_for_user` (the reading that drives alerting — done first), `meal_analysis.analyze_post_meal_patterns`, `correction_analysis.analyze_correction_outcomes`, `telegram_commands._handle_status`.
- **Data export left complete (intentional exception):** `settings_export._export_all_data` is a portability/backup "download all my data" export, so it deliberately stays **unfiltered** — an export must be complete, and each row already carries its own `source` for consumer-side dedupe. (Reviewer-flagged; confirmed with maintainer.)
- Preserved intentionally source-scoped reads (`nightscout.py` audit) and maintenance counts (data-retention).

## Behavioral notes for reviewers

- **Fail-safe intact:** single-source and no-primary users are never filtered (the dashboard/alerts never go dark).
- **Stale-primary posture (intended):** alerting is driven by the designated primary only. If a *connected* primary is stale, the existing staleness gate suppresses alerts even when a non-primary secondary is fresh — a demoted source must not drive a safety alert. This is locked by a test.
- **Deferred, tracked separately (GLY-124):** the bolus CGM-freshness dosing gate (`treatment_safety.validator._check_cgm_freshness`) is the one remaining any-source read; whether it should honor primary precedence changes clinical dosing-gate strictness, so it's left for a deliberate decision.

## Tests

New tests in `tests/test_cgm_source.py`: the funnel (primary-only, projection, `include_secondary`, no-primary fail-safe, explicit override), `dexcom_sync` auto-filter, each fixed consumer (primary-only + fail-safe), the export-includes-all-sources behavior, and the stale-primary/fresh-secondary alert posture. Mock-DB unit-test classes get a scoped fixture stubbing the (now-shared) exclusion resolver so their rigid `execute` sequences stay valid.

## Gates

- `pytest` full suite green (pre-existing Python-3.14 nightscout-scheduler timing flake unaffected); `ruff check` + `ruff format --check` clean.
- Adversarial + senior-engineer + security + completeness multi-lens review with adversarial verification of each finding; all confirmed findings addressed.
- CodeRabbit CLI: no findings. Dedicated security review: PASS.
- Sentry validation gate: PASS — stack brought up Sentry-enabled, every changed glucose-read path exercised for a multi-source user with a designated primary (in-container consumer drive + HTTP read endpoints); no new unresolved issue attributable to the change (the only flood is the pre-existing `nightscout/sync.py` fernet-decrypt `ValueError`, first seen 2026-05-29). Synthetic validation marker resolved; stack restored to Sentry-off.

Closes GLY-123. Related: GLY-124 (deferred freshness-gate decision).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Caregiver, status, and alert-related views now consistently use the patient’s primary glucose source for displayed readings.

* **Bug Fixes**
  * Improved glucose-reading selection across sync, analysis, and messaging flows so recent values and trends match the intended primary-source view.
  * Exported glucose data continues to include all sources, preserving full history for import and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->