### PR TITLE
feat(mobile): T0 read-only resilience hardening (GLY-109)

### DIFF
--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/AppSettingsStoreMealFabTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/AppSettingsStoreMealFabTest.kt
@@ -23,13 +23,13 @@ class AppSettingsStoreMealFabTest {
 
     @Before
     fun setUp() {
-        clearEncryptedPrefs()
         store = AppSettingsStore(context)
+        clearFabState()
     }
 
     @After
     fun tearDown() {
-        clearEncryptedPrefs()
+        clearFabState()
     }
 
     @Test
@@ -72,8 +72,14 @@ class AppSettingsStoreMealFabTest {
         assertEquals(AppSettingsStore.UNSET_FAB_OFFSET, reread.mealFabOffsetYPx)
     }
 
-    /** Resets the encrypted settings file so default/round-trip assertions are deterministic. */
-    private fun clearEncryptedPrefs() {
-        context.deleteSharedPreferences(AppSettingsStore.ENCRYPTED_PREFS_NAME)
+    /**
+     * Resets the FAB keys THROUGH the store so the reset reaches the process-cached
+     * SharedPreferences instance. Deleting the prefs file (the previous approach) is not enough
+     * once any earlier test in the instrumentation run has warmed that cache — e.g. an activity
+     * test creating the Hilt singleton — because the cached instance keeps its in-memory values
+     * after the file is gone and re-persists them, leaking state across tests.
+     */
+    private fun clearFabState() {
+        store.clearMealFabOffset()
     }
 }

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/alerts/AlertsDegradedUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/alerts/AlertsDegradedUiTest.kt
@@ -1,9 +1,6 @@
 package com.glycemicgpt.mobile.presentation.alerts
 
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -14,6 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import com.glycemicgpt.mobile.testutil.indeterminateSpinner
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,11 +26,6 @@ class AlertsDegradedUiTest {
 
     @get:Rule
     val compose = createComposeRule()
-
-    private val indeterminateSpinner = SemanticsMatcher.expectValue(
-        SemanticsProperties.ProgressBarRangeInfo,
-        ProgressBarRangeInfo.Indeterminate,
-    )
 
     private fun cachedAlert(id: String = "alert-1") = AlertEntity(
         serverId = id,

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/alerts/AlertsDegradedUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/alerts/AlertsDegradedUiTest.kt
@@ -1,0 +1,103 @@
+package com.glycemicgpt.mobile.presentation.alerts
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device rendering of the alerts surface in the degraded (backend unreachable / SSE down)
+ * state: the honest banner shows, cached alerts stay visible, and no indeterminate spinner
+ * remains (the AC1 no-hang assertion at the composable level).
+ */
+@RunWith(AndroidJUnit4::class)
+class AlertsDegradedUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val indeterminateSpinner = SemanticsMatcher.expectValue(
+        SemanticsProperties.ProgressBarRangeInfo,
+        ProgressBarRangeInfo.Indeterminate,
+    )
+
+    private fun cachedAlert(id: String = "alert-1") = AlertEntity(
+        serverId = id,
+        alertType = "high_warning",
+        severity = "warning",
+        message = "High glucose warning",
+        currentValue = 250.0,
+        timestampMs = System.currentTimeMillis(),
+        acknowledged = false,
+    )
+
+    private fun setContent(
+        degraded: Boolean,
+        alerts: List<AlertEntity>,
+        isLoading: Boolean = false,
+    ) {
+        compose.setContent {
+            GlycemicGptTheme {
+                AlertsContent(
+                    uiState = AlertsUiState(isLoading = isLoading),
+                    alerts = alerts,
+                    glucoseUnit = GlucoseUnit.MGDL,
+                    alertingDegraded = degraded,
+                    snackbarHostState = SnackbarHostState(),
+                    onRefresh = {},
+                    onAcknowledge = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun degraded_showsBanner_andKeepsCachedAlerts_withNoSpinner() {
+        setContent(degraded = true, alerts = listOf(cachedAlert()))
+
+        compose.onNodeWithTag(TAG_ALERTING_DEGRADED_BANNER).assertIsDisplayed()
+        compose.onNodeWithText("High glucose warning").assertIsDisplayed()
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
+    }
+
+    @Test
+    fun degraded_bannerIsHonest_serverAlertsPaused_noDeviceFloorClaim() {
+        setContent(degraded = true, alerts = emptyList())
+
+        // Says plainly that server-pushed alerts are paused...
+        compose.onNodeWithText("Server alerts paused", substring = true).assertIsDisplayed()
+        // ...and never implies a device/local alert floor is protecting the user (that's 57.9).
+        compose.onNodeWithText("device", substring = true, ignoreCase = true).assertDoesNotExist()
+        compose.onNodeWithText("threshold", substring = true, ignoreCase = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun goldenPath_rendersNoBanner() {
+        setContent(degraded = false, alerts = listOf(cachedAlert()))
+
+        compose.onAllNodesWithTag(TAG_ALERTING_DEGRADED_BANNER).assertCountEquals(0)
+        compose.onNodeWithText("High glucose warning").assertIsDisplayed()
+    }
+
+    @Test
+    fun degraded_withNoCachedAlerts_showsEmptyState_notBlank() {
+        setContent(degraded = true, alerts = emptyList())
+
+        compose.onNodeWithTag(TAG_ALERTING_DEGRADED_BANNER).assertIsDisplayed()
+        compose.onNodeWithText("No alerts").assertIsDisplayed()
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
+    }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/chat/AiChatOfflineUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/chat/AiChatOfflineUiTest.kt
@@ -1,0 +1,61 @@
+package com.glycemicgpt.mobile.presentation.chat
+
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device rendering of the chat offline state (AC3): a clear "can't connect" message with a
+ * Retry — never an indeterminate spinner.
+ */
+@RunWith(AndroidJUnit4::class)
+class AiChatOfflineUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val indeterminateSpinner = SemanticsMatcher.expectValue(
+        SemanticsProperties.ProgressBarRangeInfo,
+        ProgressBarRangeInfo.Indeterminate,
+    )
+
+    @Test
+    fun offlineState_showsClearMessageWithRetry_andNoSpinner() {
+        compose.setContent {
+            GlycemicGptTheme {
+                OfflineContent(onRetry = {})
+            }
+        }
+
+        compose.onNodeWithTag("ai_chat_offline").assertIsDisplayed()
+        compose.onNodeWithText("Unable to Connect").assertIsDisplayed()
+        compose.onNodeWithText("Retry").assertIsDisplayed()
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
+    }
+
+    @Test
+    fun offlineState_retryInvokesCallback() {
+        var retried = false
+        compose.setContent {
+            GlycemicGptTheme {
+                OfflineContent(onRetry = { retried = true })
+            }
+        }
+
+        compose.onNodeWithText("Retry").performClick()
+
+        assertTrue(retried)
+    }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/chat/AiChatOfflineUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/chat/AiChatOfflineUiTest.kt
@@ -1,8 +1,5 @@
 package com.glycemicgpt.mobile.presentation.chat
 
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -11,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import com.glycemicgpt.mobile.testutil.indeterminateSpinner
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -26,11 +24,6 @@ class AiChatOfflineUiTest {
     @get:Rule
     val compose = createComposeRule()
 
-    private val indeterminateSpinner = SemanticsMatcher.expectValue(
-        SemanticsProperties.ProgressBarRangeInfo,
-        ProgressBarRangeInfo.Indeterminate,
-    )
-
     @Test
     fun offlineState_showsClearMessageWithRetry_andNoSpinner() {
         compose.setContent {
@@ -43,6 +36,19 @@ class AiChatOfflineUiTest {
         compose.onNodeWithText("Unable to Connect").assertIsDisplayed()
         compose.onNodeWithText("Retry").assertIsDisplayed()
         compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
+    }
+
+    @Test
+    fun loadingState_isTheOnlyStateWithASpinner() {
+        // Positive control: proves the spinner matcher matches this surface's spinner, so the
+        // zero-spinner assertion above cannot pass vacuously.
+        compose.setContent {
+            GlycemicGptTheme {
+                LoadingContent()
+            }
+        }
+
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(1)
     }
 
     @Test

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealScreensOfflineUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealScreensOfflineUiTest.kt
@@ -1,8 +1,5 @@
 package com.glycemicgpt.mobile.presentation.meal
 
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -12,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import com.glycemicgpt.mobile.testutil.indeterminateSpinner
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -27,11 +25,6 @@ class MealScreensOfflineUiTest {
 
     @get:Rule
     val compose = createComposeRule()
-
-    private val indeterminateSpinner = SemanticsMatcher.expectValue(
-        SemanticsProperties.ProgressBarRangeInfo,
-        ProgressBarRangeInfo.Indeterminate,
-    )
 
     // -- Meal history -----------------------------------------------------------
 

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealScreensOfflineUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealScreensOfflineUiTest.kt
@@ -1,0 +1,168 @@
+package com.glycemicgpt.mobile.presentation.meal
+
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device rendering of the backend-only meal screens in the offline/failed state (AC3): a clear
+ * message + Retry — never an indeterminate spinner, never a misleading "nothing logged yet" empty
+ * state while the backend is unreachable.
+ */
+@RunWith(AndroidJUnit4::class)
+class MealScreensOfflineUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val indeterminateSpinner = SemanticsMatcher.expectValue(
+        SemanticsProperties.ProgressBarRangeInfo,
+        ProgressBarRangeInfo.Indeterminate,
+    )
+
+    // -- Meal history -----------------------------------------------------------
+
+    @Test
+    fun mealHistory_offline_showsErrorWithRetry_noSpinner_noMisleadingEmptyState() {
+        val offline = MealHistoryUiState(
+            isLoading = false,
+            errorMessage = "Can't reach your server — your meal history isn't available right now.",
+        )
+        compose.setContent {
+            GlycemicGptTheme {
+                MealHistoryBody(uiState = offline, onRetry = {}, onDelete = {})
+            }
+        }
+
+        compose.onNodeWithTag("meal_history_error").assertIsDisplayed()
+        compose.onNodeWithTag("meal_error_retry").assertIsDisplayed()
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
+        compose.onAllNodesWithTag("meal_history_empty").assertCountEquals(0)
+    }
+
+    @Test
+    fun mealHistory_retryInvokesCallback() {
+        var retried = false
+        val offline = MealHistoryUiState(isLoading = false, errorMessage = "Can't reach your server.")
+        compose.setContent {
+            GlycemicGptTheme {
+                MealHistoryBody(uiState = offline, onRetry = { retried = true }, onDelete = {})
+            }
+        }
+
+        compose.onNodeWithTag("meal_error_retry").performClick()
+
+        assertTrue(retried)
+    }
+
+    @Test
+    fun mealHistory_goldenPath_rendersListWithoutErrorState() {
+        val loaded = MealHistoryUiState(isLoading = false, records = emptyList())
+        compose.setContent {
+            GlycemicGptTheme {
+                MealHistoryBody(uiState = loaded, onRetry = {}, onDelete = {})
+            }
+        }
+
+        compose.onNodeWithTag("meal_history_empty").assertIsDisplayed()
+        compose.onAllNodesWithTag("meal_history_error").assertCountEquals(0)
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
+    }
+
+    // -- Common foods -----------------------------------------------------------
+
+    @Test
+    fun commonFoods_offline_showsErrorWithRetry_noSpinner_noMisleadingEmptyState() {
+        val offline = CommonFoodsUiState(
+            isLoading = false,
+            errorMessage = "Can't reach your server — your common foods aren't available right now.",
+        )
+        compose.setContent {
+            GlycemicGptTheme {
+                CommonFoodsBody(
+                    uiState = offline,
+                    onRetry = {},
+                    onReLog = {},
+                    onEdit = {},
+                    onDelete = {},
+                )
+            }
+        }
+
+        compose.onNodeWithTag("common_foods_error").assertIsDisplayed()
+        compose.onNodeWithTag("meal_error_retry").assertIsDisplayed()
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
+        compose.onAllNodesWithTag("common_foods_empty").assertCountEquals(0)
+    }
+
+    @Test
+    fun commonFoods_retryInvokesCallback() {
+        var retried = false
+        val offline = CommonFoodsUiState(isLoading = false, errorMessage = "Can't reach your server.")
+        compose.setContent {
+            GlycemicGptTheme {
+                CommonFoodsBody(
+                    uiState = offline,
+                    onRetry = { retried = true },
+                    onReLog = {},
+                    onEdit = {},
+                    onDelete = {},
+                )
+            }
+        }
+
+        compose.onNodeWithTag("meal_error_retry").performClick()
+
+        assertTrue(retried)
+    }
+
+    @Test
+    fun commonFoods_loadingState_isTheOnlyStateWithASpinner() {
+        compose.setContent {
+            GlycemicGptTheme {
+                CommonFoodsBody(
+                    uiState = CommonFoodsUiState(isLoading = true),
+                    onRetry = {},
+                    onReLog = {},
+                    onEdit = {},
+                    onDelete = {},
+                )
+            }
+        }
+
+        // Sanity check that the spinner matcher actually matches our spinner, so the
+        // zero-spinner assertions above cannot pass vacuously.
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(1)
+    }
+
+    @Test
+    fun commonFoods_goldenPath_rendersEmptyStateWithoutErrorState() {
+        compose.setContent {
+            GlycemicGptTheme {
+                CommonFoodsBody(
+                    uiState = CommonFoodsUiState(isLoading = false),
+                    onRetry = {},
+                    onReLog = {},
+                    onEdit = {},
+                    onDelete = {},
+                )
+            }
+        }
+
+        compose.onNodeWithText("No common foods yet", substring = true).assertIsDisplayed()
+        compose.onAllNodesWithTag("common_foods_error").assertCountEquals(0)
+    }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/testutil/ComposeTestMatchers.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/testutil/ComposeTestMatchers.kt
@@ -1,0 +1,15 @@
+package com.glycemicgpt.mobile.testutil
+
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+
+/**
+ * Matches any indeterminate progress indicator (e.g. [androidx.compose.material3.CircularProgressIndicator]).
+ * The resilience suites assert zero of these remain once a screen reaches a terminal state — no
+ * screen may hang on a spinner while the backend is unreachable.
+ */
+val indeterminateSpinner: SemanticsMatcher = SemanticsMatcher.expectValue(
+    SemanticsProperties.ProgressBarRangeInfo,
+    ProgressBarRangeInfo.Indeterminate,
+)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/ReachabilityInterceptor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/ReachabilityInterceptor.kt
@@ -1,7 +1,5 @@
 package com.glycemicgpt.mobile.data.remote
 
-import com.glycemicgpt.mobile.BuildConfig
-import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -19,23 +17,15 @@ import javax.inject.Singleton
  * [IOException] (transport failure) counts against reachability. See [NetworkMonitor] for how the
  * consecutive-failure threshold turns that into the "backend unreachable" state.
  *
- * In debug builds it also honours the "simulate backend unreachable" fault-injection toggle so the
- * unreachable state is reproducible on an emulator without real network chaos (the seed for the
- * reusable debug harness). The toggle is compiled to a no-op in release
- * ([AppSettingsStore.simulateBackendUnreachable] is always false there).
+ * The debug "simulate backend unreachable" fault lives in [SimulateUnreachableInterceptor], which
+ * sits below this one so an injected fault is recorded exactly like a real transport failure.
  */
 @Singleton
 class ReachabilityInterceptor @Inject constructor(
     private val networkMonitor: NetworkMonitor,
-    private val appSettingsStore: AppSettingsStore,
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        if (BuildConfig.DEBUG && appSettingsStore.simulateBackendUnreachable) {
-            networkMonitor.recordBackendFailure()
-            throw IOException("Simulated backend unreachable (debug fault injection)")
-        }
-
         return try {
             val response = chain.proceed(chain.request())
             networkMonitor.recordBackendSuccess()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/SimulateUnreachableInterceptor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/SimulateUnreachableInterceptor.kt
@@ -1,0 +1,36 @@
+package com.glycemicgpt.mobile.data.remote
+
+import com.glycemicgpt.mobile.BuildConfig
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Debug-only fault injection: when the "simulate backend unreachable" toggle is on, every request
+ * through this interceptor fails with an [IOException] before reaching the network, so the
+ * unreachable state is reproducible on an emulator without real network chaos.
+ *
+ * Split from [ReachabilityInterceptor] so the fault covers ALL backend clients — including the
+ * long-timeout chat/LLM client, which deliberately drops [ReachabilityInterceptor] (an LLM
+ * inference timeout must not count toward the reachability failure threshold) but must still be
+ * fault-injectable. On the main client this sits below [ReachabilityInterceptor], so the injected
+ * failure propagates up through it and is recorded exactly like a real transport failure.
+ *
+ * Compiled to a no-op in release ([AppSettingsStore.simulateBackendUnreachable] is always false
+ * there).
+ */
+@Singleton
+class SimulateUnreachableInterceptor @Inject constructor(
+    private val appSettingsStore: AppSettingsStore,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        if (BuildConfig.DEBUG && appSettingsStore.simulateBackendUnreachable) {
+            throw IOException("Simulated backend unreachable (debug fault injection)")
+        }
+        return chain.proceed(chain.request())
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/NetworkModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import com.glycemicgpt.mobile.data.remote.AuthInterceptor
 import com.glycemicgpt.mobile.data.remote.BaseUrlInterceptor
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.ReachabilityInterceptor
+import com.glycemicgpt.mobile.data.remote.SimulateUnreachableInterceptor
 import com.glycemicgpt.mobile.data.remote.TokenRefreshInterceptor
 import com.glycemicgpt.mobile.data.remote.InstantAdapter
 import com.squareup.moshi.Moshi
@@ -40,6 +41,7 @@ object NetworkModule {
         baseUrlInterceptor: BaseUrlInterceptor,
         tokenRefreshInterceptor: TokenRefreshInterceptor,
         reachabilityInterceptor: ReachabilityInterceptor,
+        simulateUnreachableInterceptor: SimulateUnreachableInterceptor,
     ): OkHttpClient {
         val logging = HttpLoggingInterceptor().apply {
             level = if (BuildConfig.DEBUG) {
@@ -55,6 +57,9 @@ object NetworkModule {
             // Below auth/token so a config-time throw from BaseUrlInterceptor is not counted as a
             // backend outage; wraps the real network call so connect/timeout failures are.
             .addInterceptor(reachabilityInterceptor)
+            // Below reachability so an injected debug fault is recorded like a real transport
+            // failure; kept separate so the chat client (which drops reachability) still gets it.
+            .addInterceptor(simulateUnreachableInterceptor)
             .addInterceptor(logging)
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(15, TimeUnit.SECONDS)
@@ -86,6 +91,8 @@ object NetworkModule {
         val chatClient = client.newBuilder()
             // Drop reachability tracking too: a 90s LLM inference that times out is not a signal the
             // backend is unreachable, so it must not count toward NetworkMonitor's failure threshold.
+            // SimulateUnreachableInterceptor deliberately stays, so the debug fault-injection
+            // toggle also exercises chat requests.
             .apply { interceptors().removeAll { it is HttpLoggingInterceptor || it is ReachabilityInterceptor } }
             .readTimeout(90, TimeUnit.SECONDS)
             .dispatcher(Dispatcher())

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegraded.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegraded.kt
@@ -1,0 +1,73 @@
+package com.glycemicgpt.mobile.presentation.alerts
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.service.AlertStreamState
+
+/** testTag for the honest "server alerts paused" banner. */
+const val TAG_ALERTING_DEGRADED_BANNER = "alerting_degraded_banner"
+
+/**
+ * Whether server-pushed alerting is degraded: the alert SSE stream is not connected, or we can't
+ * reach the backend at all. Either way no new server alerts arrive, and the UI must say so.
+ *
+ * Pure so the visibility rule is unit-testable. Deliberately pessimistic on disagreement between
+ * the two signals — the SSE read timeout is minutes long, so [NetworkStatus] usually notices an
+ * outage first; conversely a stream stuck reconnecting is degraded even while HTTP still works.
+ */
+fun isAlertingDegraded(networkStatus: NetworkStatus, streamState: AlertStreamState): Boolean =
+    networkStatus != NetworkStatus.REACHABLE || streamState != AlertStreamState.CONNECTED
+
+/**
+ * The honest alerting-degraded banner: server-pushed alerts are paused and no new alerts will
+ * arrive until reconnected. It must NOT claim any device/local alert floor — none exists yet, and
+ * implying one would give a false sense of safety. Cached past alerts remain visible below it.
+ */
+@Composable
+fun AlertingDegradedBanner(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(TAG_ALERTING_DEGRADED_BANNER),
+        color = MaterialTheme.colorScheme.errorContainer,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.CloudOff,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = "Server alerts paused — no new alerts will arrive until the connection " +
+                    "is restored. Alerts below are from before the disconnect.",
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
@@ -26,11 +26,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -46,7 +50,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AlertsScreen(
     viewModel: AlertsViewModel = hiltViewModel(),
@@ -54,32 +57,79 @@ fun AlertsScreen(
     val uiState by viewModel.uiState.collectAsState()
     val alerts by viewModel.alerts.collectAsState()
     val glucoseUnit by viewModel.glucoseUnit.collectAsState()
+    val alertingDegraded by viewModel.alertingDegraded.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
 
-    PullToRefreshBox(
-        isRefreshing = uiState.isLoading,
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    AlertsContent(
+        uiState = uiState,
+        alerts = alerts,
+        glucoseUnit = glucoseUnit,
+        alertingDegraded = alertingDegraded,
+        snackbarHostState = snackbarHostState,
         onRefresh = viewModel::refreshAlerts,
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        if (alerts.isEmpty() && !uiState.isLoading) {
-            EmptyAlertsState()
-        } else {
-            LazyColumn(
+        onAcknowledge = viewModel::acknowledgeAlert,
+    )
+}
+
+/** Stateless alerts surface, split from [AlertsScreen] so UI tests can drive degraded states. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AlertsContent(
+    uiState: AlertsUiState,
+    alerts: List<AlertEntity>,
+    glucoseUnit: GlucoseUnit,
+    alertingDegraded: Boolean,
+    snackbarHostState: SnackbarHostState,
+    onRefresh: () -> Unit,
+    onAcknowledge: (serverId: String) -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            if (alertingDegraded) {
+                AlertingDegradedBanner(
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
+                )
+            }
+            PullToRefreshBox(
+                isRefreshing = uiState.isLoading,
+                onRefresh = onRefresh,
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                    .fillMaxWidth()
+                    .weight(1f),
             ) {
-                item { Spacer(Modifier.height(8.dp)) }
-                items(alerts, key = { it.serverId }) { alert ->
-                    AlertCard(
-                        alert = alert,
-                        glucoseUnit = glucoseUnit,
-                        onAcknowledge = { viewModel.acknowledgeAlert(alert.serverId) },
-                    )
+                if (alerts.isEmpty() && !uiState.isLoading) {
+                    EmptyAlertsState()
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        item { Spacer(Modifier.height(8.dp)) }
+                        items(alerts, key = { it.serverId }) { alert ->
+                            AlertCard(
+                                alert = alert,
+                                glucoseUnit = glucoseUnit,
+                                onAcknowledge = { onAcknowledge(alert.serverId) },
+                            )
+                        }
+                        item { Spacer(Modifier.height(8.dp)) }
+                    }
                 }
-                item { Spacer(Modifier.height(8.dp)) }
             }
         }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
     }
 }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -4,21 +4,27 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
+import com.glycemicgpt.mobile.service.AlertStreamStateHolder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.io.IOException
 import javax.inject.Inject
 
 data class AlertsUiState(
     val isLoading: Boolean = false,
+    /** User-facing failure copy for a refresh/acknowledge, surfaced as a snackbar then cleared.
+     *  Never a raw exception message. */
     val error: String? = null,
 )
 
@@ -27,6 +33,8 @@ class AlertsViewModel @Inject constructor(
     private val alertRepository: AlertRepository,
     private val alertNotificationManager: AlertNotificationManager,
     private val appSettingsStore: AppSettingsStore,
+    networkMonitor: NetworkMonitor,
+    alertStreamStateHolder: AlertStreamStateHolder,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AlertsUiState())
@@ -38,6 +46,17 @@ class AlertsViewModel @Inject constructor(
     /** The user's glucose display unit, for rendering alert values. Alert detection stays mg/dL. */
     val glucoseUnit: StateFlow<GlucoseUnit> = appSettingsStore.glucoseUnitFlow()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), appSettingsStore.glucoseUnit)
+
+    /**
+     * Whether server-pushed alerting is degraded (backend unreachable or the alert stream is not
+     * connected). Drives the honest [AlertingDegradedBanner] — cached alerts still display, but no
+     * new alerts arrive until reconnected.
+     */
+    val alertingDegraded: StateFlow<Boolean> = combine(
+        networkMonitor.status,
+        alertStreamStateHolder.state,
+    ) { network, stream -> isAlertingDegraded(network, stream) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     init {
         viewModelScope.launch { alertRepository.cleanupOldAlerts() }
@@ -55,7 +74,7 @@ class AlertsViewModel @Inject constructor(
                     Timber.w(e, "Failed to fetch alerts")
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        error = e.message,
+                        error = refreshErrorMessage(e),
                     )
                 }
         }
@@ -69,12 +88,22 @@ class AlertsViewModel @Inject constructor(
                 }
                 .onFailure { e ->
                     Timber.w(e, "Failed to acknowledge alert")
-                    _uiState.value = _uiState.value.copy(error = e.message)
+                    _uiState.value = _uiState.value.copy(error = acknowledgeErrorMessage(e))
                 }
         }
     }
 
     fun clearError() {
         _uiState.value = _uiState.value.copy(error = null)
+    }
+
+    private fun refreshErrorMessage(e: Throwable): String = when (e) {
+        is IOException -> "Can't reach your server — showing saved alerts."
+        else -> "Couldn't refresh alerts. Try again."
+    }
+
+    private fun acknowledgeErrorMessage(e: Throwable): String = when (e) {
+        is IOException -> "Couldn't acknowledge the alert. Check your connection and try again."
+        else -> "Couldn't acknowledge the alert. Try again."
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -56,7 +56,13 @@ class AlertsViewModel @Inject constructor(
         networkMonitor.status,
         alertStreamStateHolder.state,
     ) { network, stream -> isAlertingDegraded(network, stream) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            // Seed from the real current state, not an optimistic false — a safety banner must
+            // never default to "healthy" while the combine spins up.
+            isAlertingDegraded(networkMonitor.status.value, alertStreamStateHolder.state.value),
+        )
 
     init {
         viewModelScope.launch { alertRepository.cleanupOldAlerts() }
@@ -98,7 +104,8 @@ class AlertsViewModel @Inject constructor(
     }
 
     private fun refreshErrorMessage(e: Throwable): String = when (e) {
-        is IOException -> "Can't reach your server — showing saved alerts."
+        // Neutral about cache contents — the list below may be empty.
+        is IOException -> "Can't reach your server — alerts may be out of date."
         else -> "Couldn't refresh alerts. Try again."
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/chat/AiChatScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/chat/AiChatScreen.kt
@@ -102,8 +102,9 @@ fun AiChatScreen(
     }
 }
 
+/** Internal so the offline UI test can use it as the positive control for the spinner matcher. */
 @Composable
-private fun LoadingContent() {
+internal fun LoadingContent() {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/chat/AiChatScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/chat/AiChatScreen.kt
@@ -156,8 +156,10 @@ private fun NoProviderContent(modifier: Modifier = Modifier) {
     }
 }
 
+/** Terminal offline state for chat: a clear message + Retry, never a stuck spinner. Internal so
+ *  UI tests can assert the degraded rendering directly. */
 @Composable
-private fun OfflineContent(onRetry: () -> Unit) {
+internal fun OfflineContent(onRetry: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/chat/AiChatViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/chat/AiChatViewModel.kt
@@ -310,7 +310,8 @@ class AiChatViewModel @Inject constructor(
             e.message?.contains("401") == true -> "Session expired. Please sign in again"
             e.message?.let { Regex("HTTP 5\\d{2}").containsMatchIn(it) } == true ->
                 "Server error. Please try again later"
-            else -> e.message ?: "Failed to get response"
+            // Never surface a raw exception message for unexpected failures.
+            else -> "Couldn't get a response. Please try again"
         }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsScreen.kt
@@ -71,53 +71,13 @@ fun CommonFoodsScreen(
         onBack = onBack,
     ) { padding ->
       Box(modifier = Modifier.padding(padding).fillMaxSize()) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .testTag("common_foods_screen"),
-        ) {
-            when {
-                uiState.disabled -> MealCenteredMessage(
-                    "Meal intelligence is turned off for this server.",
-                    modifier = Modifier.testTag("common_foods_disabled"),
-                )
-                uiState.isLoading -> MealCenteredSpinner()
-                else -> {
-                    VerifyBeforeDosingQualifier(modifier = Modifier.padding(16.dp))
-                    uiState.errorMessage?.let { error ->
-                        Text(
-                            text = error,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                        )
-                    }
-                    if (uiState.items.isEmpty()) {
-                        MealCenteredMessage(
-                            "No common foods yet. Save a meal as a common food to build your list.",
-                            modifier = Modifier.testTag("common_foods_empty"),
-                        )
-                    } else {
-                        LazyColumn(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .testTag("common_foods_list"),
-                            contentPadding = PaddingValues(16.dp),
-                            verticalArrangement = Arrangement.spacedBy(12.dp),
-                        ) {
-                            items(uiState.items, key = { it.id }) { food ->
-                                CommonFoodItem(
-                                    food = food,
-                                    onReLog = { reLogging = food },
-                                    onEdit = { viewModel.startEdit(food) },
-                                    onDelete = { viewModel.delete(food.id) },
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        CommonFoodsBody(
+            uiState = uiState,
+            onRetry = viewModel::load,
+            onReLog = { reLogging = it },
+            onEdit = viewModel::startEdit,
+            onDelete = viewModel::delete,
+        )
         SnackbarHost(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter),
@@ -137,6 +97,71 @@ fun CommonFoodsScreen(
 
     reLogging?.let { food ->
         ReLogDialog(food = food, onDismiss = { reLogging = null })
+    }
+}
+
+/** Stateless body, split from [CommonFoodsScreen] so UI tests can drive offline/degraded states. */
+@Composable
+internal fun CommonFoodsBody(
+    uiState: CommonFoodsUiState,
+    onRetry: () -> Unit,
+    onReLog: (CommonFood) -> Unit,
+    onEdit: (CommonFood) -> Unit,
+    onDelete: (commonFoodId: String) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("common_foods_screen"),
+    ) {
+        when {
+            uiState.disabled -> MealCenteredMessage(
+                "Meal intelligence is turned off for this server.",
+                modifier = Modifier.testTag("common_foods_disabled"),
+            )
+            uiState.isLoading -> MealCenteredSpinner()
+            // Nothing cached to show: a clear terminal failure state with Retry, never a
+            // misleading "No common foods yet." while the backend is unreachable.
+            uiState.errorMessage != null && uiState.items.isEmpty() -> MealCenteredError(
+                message = uiState.errorMessage,
+                onRetry = onRetry,
+                modifier = Modifier.testTag("common_foods_error"),
+            )
+            else -> {
+                VerifyBeforeDosingQualifier(modifier = Modifier.padding(16.dp))
+                uiState.errorMessage?.let { error ->
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                }
+                if (uiState.items.isEmpty()) {
+                    MealCenteredMessage(
+                        "No common foods yet. Save a meal as a common food to build your list.",
+                        modifier = Modifier.testTag("common_foods_empty"),
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("common_foods_list"),
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(uiState.items, key = { it.id }) { food ->
+                            CommonFoodItem(
+                                food = food,
+                                onReLog = { onReLog(food) },
+                                onEdit = { onEdit(food) },
+                                onDelete = { onDelete(food.id) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModel.kt
@@ -8,10 +8,12 @@ import com.glycemicgpt.mobile.data.meal.CommonFood
 import com.glycemicgpt.mobile.data.meal.MealException
 import com.glycemicgpt.mobile.data.repository.MealRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.io.IOException
 import javax.inject.Inject
@@ -37,14 +39,23 @@ class CommonFoodsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(CommonFoodsUiState())
     val uiState: StateFlow<CommonFoodsUiState> = _uiState.asStateFlow()
 
+    private var loadJob: Job? = null
+
     init {
         load()
     }
 
     fun load() {
+        // Cancel any in-flight load so a slow failing request can't resolve after a newer one
+        // succeeded and clobber the screen with a stale full-screen error.
+        loadJob?.cancel()
         _uiState.update { it.copy(isLoading = true, errorMessage = null) }
-        viewModelScope.launch {
-            repository.listCommonFoods()
+        loadJob = viewModelScope.launch {
+            val result = repository.listCommonFoods()
+            // A repository that wraps errors in Result can swallow the CancellationException,
+            // so a superseded load could still reach here — never let it write state.
+            if (!isActive) return@launch
+            result
                 .onSuccess { items ->
                     _uiState.update { it.copy(isLoading = false, items = items, disabled = false) }
                 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModel.kt
@@ -49,7 +49,9 @@ class CommonFoodsViewModel @Inject constructor(
         // Cancel any in-flight load so a slow failing request can't resolve after a newer one
         // succeeded and clobber the screen with a stale full-screen error.
         loadJob?.cancel()
-        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        // Reset disabled too: after a prior FeatureDisabled response, an offline retry must show
+        // the honest offline state, not a stale "feature disabled" one. FeatureDisabled re-sets it.
+        _uiState.update { it.copy(isLoading = true, errorMessage = null, disabled = false) }
         loadJob = viewModelScope.launch {
             val result = repository.listCommonFoods()
             // A repository that wraps errors in Result can swallow the CancellationException,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModel.kt
@@ -121,14 +121,19 @@ class CommonFoodsViewModel @Inject constructor(
 
     private fun CommonFoodsUiState.withError(e: Throwable): CommonFoodsUiState = when (e) {
         is MealException.FeatureDisabled -> copy(disabled = true, errorMessage = null)
-        is IOException -> copy(errorMessage = "Check your connection and try again.")
-        else -> copy(errorMessage = e.message ?: "Couldn't load your common foods.")
+        is IOException -> copy(
+            errorMessage = "Can't reach your server — your common foods aren't available right now.",
+        )
+        is MealException -> copy(errorMessage = e.message ?: "Couldn't load your common foods.")
+        // Never surface a raw exception message for unexpected failures.
+        else -> copy(errorMessage = "Couldn't load your common foods.")
     }
 
     private fun editMessageFor(e: Throwable): String = when (e) {
         is MealException.NameConflict -> e.message ?: "A common food with that name already exists."
         is MealException -> e.message ?: "Couldn't save your changes."
         is IOException -> "Check your connection and try again."
-        else -> e.message ?: "Couldn't save your changes."
+        // Never surface a raw exception message for unexpected failures.
+        else -> "Couldn't save your changes."
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealComponents.kt
@@ -15,12 +15,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -605,5 +608,47 @@ fun MealCenteredMessage(message: String, modifier: Modifier = Modifier) {
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(32.dp),
         )
+    }
+}
+
+/**
+ * Full-screen centered load-failure state with a Retry action, shared across the meal screens.
+ * The terminal state for a backend-only screen that couldn't load (offline, server down): a clear
+ * message instead of an endless spinner, a misleading empty state, or a raw exception string.
+ */
+@Composable
+fun MealCenteredError(message: String, onRetry: () -> Unit, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(32.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.CloudOff,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(48.dp),
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(8.dp))
+            TextButton(
+                onClick = onRetry,
+                modifier = Modifier.testTag("meal_error_retry"),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text("Retry")
+            }
+        }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryScreen.kt
@@ -49,54 +49,75 @@ fun MealHistoryScreen(
 
     DetailScaffold(title = "Meal History", onBack = onBack) { padding ->
       Box(modifier = Modifier.padding(padding).fillMaxSize()) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .testTag("meal_history_screen"),
-        ) {
-            when {
-                uiState.disabled -> MealCenteredMessage(
-                    "Meal intelligence is turned off for this server.",
-                    modifier = Modifier.testTag("meal_history_disabled"),
-                )
-                uiState.isLoading -> MealCenteredSpinner()
-                else -> {
-                    // Persistent safety qualifier above the (scrolling) list.
-                    VerifyBeforeDosingQualifier(modifier = Modifier.padding(16.dp))
-                    uiState.errorMessage?.let { error ->
-                        Text(
-                            text = error,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                        )
-                    }
-                    if (uiState.records.isEmpty()) {
-                        MealCenteredMessage(
-                            "No meals logged yet.",
-                            modifier = Modifier.testTag("meal_history_empty"),
-                        )
-                    } else {
-                        LazyColumn(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .testTag("meal_history_list"),
-                            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
-                            verticalArrangement = Arrangement.spacedBy(12.dp),
-                        ) {
-                            items(uiState.records, key = { it.id }) { record ->
-                                MealHistoryItem(record = record, onDelete = { viewModel.delete(record.id) })
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        MealHistoryBody(
+            uiState = uiState,
+            onRetry = viewModel::load,
+            onDelete = viewModel::delete,
+        )
         SnackbarHost(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter),
         )
       }
+    }
+}
+
+/** Stateless body, split from [MealHistoryScreen] so UI tests can drive offline/degraded states. */
+@Composable
+internal fun MealHistoryBody(
+    uiState: MealHistoryUiState,
+    onRetry: () -> Unit,
+    onDelete: (recordId: String) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("meal_history_screen"),
+    ) {
+        when {
+            uiState.disabled -> MealCenteredMessage(
+                "Meal intelligence is turned off for this server.",
+                modifier = Modifier.testTag("meal_history_disabled"),
+            )
+            uiState.isLoading -> MealCenteredSpinner()
+            // Nothing cached to show: a clear terminal failure state with Retry, never a
+            // misleading "No meals logged yet." while the backend is unreachable.
+            uiState.errorMessage != null && uiState.records.isEmpty() -> MealCenteredError(
+                message = uiState.errorMessage,
+                onRetry = onRetry,
+                modifier = Modifier.testTag("meal_history_error"),
+            )
+            else -> {
+                // Persistent safety qualifier above the (scrolling) list.
+                VerifyBeforeDosingQualifier(modifier = Modifier.padding(16.dp))
+                uiState.errorMessage?.let { error ->
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                }
+                if (uiState.records.isEmpty()) {
+                    MealCenteredMessage(
+                        "No meals logged yet.",
+                        modifier = Modifier.testTag("meal_history_empty"),
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("meal_history_list"),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(uiState.records, key = { it.id }) { record ->
+                            MealHistoryItem(record = record, onDelete = { onDelete(record.id) })
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModel.kt
@@ -6,10 +6,12 @@ import com.glycemicgpt.mobile.data.meal.FoodRecord
 import com.glycemicgpt.mobile.data.meal.MealException
 import com.glycemicgpt.mobile.data.repository.MealRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.io.IOException
 import javax.inject.Inject
@@ -32,14 +34,23 @@ class MealHistoryViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(MealHistoryUiState())
     val uiState: StateFlow<MealHistoryUiState> = _uiState.asStateFlow()
 
+    private var loadJob: Job? = null
+
     init {
         load()
     }
 
     fun load() {
+        // Cancel any in-flight load so a slow failing request can't resolve after a newer one
+        // succeeded and clobber the screen with a stale full-screen error.
+        loadJob?.cancel()
         _uiState.update { it.copy(isLoading = true, errorMessage = null) }
-        viewModelScope.launch {
-            repository.listFoodRecords()
+        loadJob = viewModelScope.launch {
+            val result = repository.listFoodRecords()
+            // A repository that wraps errors in Result can swallow the CancellationException,
+            // so a superseded load could still reach here — never let it write state.
+            if (!isActive) return@launch
+            result
                 .onSuccess { records ->
                     _uiState.update {
                         it.copy(isLoading = false, records = records, disabled = false)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModel.kt
@@ -73,7 +73,11 @@ class MealHistoryViewModel @Inject constructor(
 
     private fun MealHistoryUiState.withError(e: Throwable): MealHistoryUiState = when (e) {
         is MealException.FeatureDisabled -> copy(disabled = true, errorMessage = null)
-        is IOException -> copy(errorMessage = "Check your connection and try again.")
-        else -> copy(errorMessage = e.message ?: "Couldn't load your meal history.")
+        is IOException -> copy(
+            errorMessage = "Can't reach your server — your meal history isn't available right now.",
+        )
+        is MealException -> copy(errorMessage = e.message ?: "Couldn't load your meal history.")
+        // Never surface a raw exception message for unexpected failures.
+        else -> copy(errorMessage = "Couldn't load your meal history.")
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModel.kt
@@ -44,7 +44,9 @@ class MealHistoryViewModel @Inject constructor(
         // Cancel any in-flight load so a slow failing request can't resolve after a newer one
         // succeeded and clobber the screen with a stale full-screen error.
         loadJob?.cancel()
-        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        // Reset disabled too: after a prior FeatureDisabled response, an offline retry must show
+        // the honest offline state, not a stale "feature disabled" one. FeatureDisabled re-sets it.
+        _uiState.update { it.copy(isLoading = true, errorMessage = null, disabled = false) }
         loadJob = viewModelScope.launch {
             val result = repository.listFoodRecords()
             // A repository that wraps errors in Result can swallow the CancellationException,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/meal/MealLogScreen.kt
@@ -899,26 +899,13 @@ private fun MealUnavailableMessage(title: String, body: String, tag: String) {
 
 @Composable
 private fun OfflineRetry(onRetry: () -> Unit) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(
-            modifier = Modifier.padding(32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Icon(
-                imageVector = Icons.Default.Warning,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(48.dp),
-            )
-            Text(
-                text = "Couldn't reach the server",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Button(onClick = onRetry) { Text("Retry") }
-        }
-    }
+    // One offline look across the whole meal feature: the same terminal-state composable the
+    // history and common-foods screens use.
+    MealCenteredError(
+        message = "Can't reach your server — meal logging isn't available right now.",
+        onRetry = onRetry,
+        modifier = Modifier.testTag("meal_log_offline"),
+    )
 }
 
 @Composable

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
@@ -303,6 +303,13 @@ class AlertStreamService : Service() {
                 Timber.d("Reconnecting alert stream in %d ms (attempt %d)", backoffMs, attempt)
                 delay(backoffMs)
 
+                // Another path (a service restart, an earlier retry) may have already restored a
+                // healthy stream while this retry was sleeping — don't tear it down again.
+                if (alertStreamStateHolder.state.value == AlertStreamState.CONNECTED) {
+                    Timber.d("Reconnect skipped; stream already connected")
+                    return@launch
+                }
+
                 if (authTokenStore.hasActiveSession()) {
                     connectToStream()
                 } else {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
@@ -58,6 +58,7 @@ class AlertStreamService : Service() {
     @Inject lateinit var authTokenStore: AuthTokenStore
     @Inject lateinit var alertRepository: AlertRepository
     @Inject lateinit var alertNotificationManager: AlertNotificationManager
+    @Inject lateinit var alertStreamStateHolder: AlertStreamStateHolder
     @Inject lateinit var moshi: Moshi
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -94,6 +95,7 @@ class AlertStreamService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
+        alertStreamStateHolder.onStreamStopped()
         eventSource?.cancel()
         reconnectJob?.cancel()
         sseClient.dispatcher.executorService.shutdownNow()
@@ -115,10 +117,12 @@ class AlertStreamService : Service() {
 
         val baseUrl = authTokenStore.getBaseUrl() ?: run {
             Timber.w("No base URL configured, cannot connect alert stream")
+            alertStreamStateHolder.onStreamStopped()
             return
         }
         val token = authTokenStore.getRawToken() ?: run {
             Timber.w("No auth token available, cannot connect alert stream")
+            alertStreamStateHolder.onStreamStopped()
             return
         }
 
@@ -140,6 +144,7 @@ class AlertStreamService : Service() {
             object : EventSourceListener() {
                 override fun onOpen(eventSource: EventSource, response: Response) {
                     Timber.d("Alert SSE stream connected (status=%d)", response.code)
+                    alertStreamStateHolder.onStreamOpened()
                     connectionOpenedAtMs = System.currentTimeMillis()
                     // Don't reset reconnectAttempt here -- only reset after
                     // STABLE_CONNECTION_MS to prevent rapid connect/fail cycles
@@ -180,12 +185,14 @@ class AlertStreamService : Service() {
                         reconnectAttempt.set(5.coerceAtLeast(attempt))
                     }
 
+                    alertStreamStateHolder.onStreamRetrying()
                     scheduleReconnect()
                 }
 
                 override fun onClosed(eventSource: EventSource) {
                     if (connectionGeneration.get() != gen) return
                     Timber.d("Alert SSE stream closed by server")
+                    alertStreamStateHolder.onStreamRetrying()
                     scheduleReconnect()
                 }
             },
@@ -274,6 +281,7 @@ class AlertStreamService : Service() {
                     connectToStream()
                 } else {
                     Timber.d("No active session, stopping alert stream service")
+                    alertStreamStateHolder.onStreamStopped()
                     stopSelf()
                 }
             } finally {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
@@ -62,7 +62,17 @@ class AlertStreamService : Service() {
     @Inject lateinit var moshi: Moshi
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Written on the main thread (connectToStream/onDestroy) but the surrounding lifecycle races
+    // OkHttp-thread callbacks; without @Volatile a stale null read could leak a live connection
+    // or open a duplicate one. Mutation is additionally confined to the @Synchronized
+    // connectToStream/shutDownStream pair so only one connection transition runs at a time.
+    @Volatile
     private var eventSource: EventSource? = null
+
+    /** Set once in [shutDownStream]; blocks any late reconnect from resurrecting the stream. */
+    @Volatile
+    private var destroyed = false
     private val reconnectAttempt = AtomicInteger(0)
     private val reconnectScheduled = AtomicBoolean(false)
     private var reconnectJob: Job? = null
@@ -109,12 +119,7 @@ class AlertStreamService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
-        // Invalidate the live connection's callbacks BEFORE cancelling it: cancel() delivers an
-        // async onFailure on an OkHttp thread, and without the bump its generation would still
-        // match, letting it clobber the DISCONNECTED written below back to RECONNECTING.
-        connectionGeneration.incrementAndGet()
-        eventSource?.cancel()
-        alertStreamStateHolder.onStreamStopped()
+        shutDownStream()
         reconnectJob?.cancel()
         sseClient.dispatcher.executorService.shutdownNow()
         try {
@@ -128,7 +133,37 @@ class AlertStreamService : Service() {
         super.onDestroy()
     }
 
+    /**
+     * Tear down the stream for good. Synchronized against [connectToStream] so a reconnect
+     * coroutine that already resumed from its backoff delay (cooperative cancellation can be too
+     * late) cannot open a new connection after this ran — [destroyed] makes it bail instead.
+     */
+    @Synchronized
+    private fun shutDownStream() {
+        destroyed = true
+        // Invalidate the live connection's callbacks BEFORE cancelling it: cancel() delivers an
+        // async onFailure on an OkHttp thread, and without the bump its generation would still
+        // match, letting it clobber the DISCONNECTED written below back to RECONNECTING.
+        connectionGeneration.incrementAndGet()
+        eventSource?.cancel()
+        eventSource = null
+        alertStreamStateHolder.onStreamStopped()
+    }
+
+    /**
+     * Synchronized: callable from the main thread ([onStartCommand]) and the reconnect coroutine
+     * (IO dispatcher). Without mutual exclusion two overlapping calls each cancel-and-rebuild, and
+     * the losing call's freshly opened EventSource is overwritten in [eventSource] with no
+     * remaining reference — an orphaned live connection (the generation guard only silences its
+     * callbacks, it does not close the socket). The body never blocks (newEventSource connects
+     * asynchronously), so holding the monitor is cheap.
+     */
+    @Synchronized
     private fun connectToStream() {
+        if (destroyed) {
+            Timber.d("connectToStream skipped; service is shut down")
+            return
+        }
         // Invalidate the previous connection's callbacks before cancelling it, so its async
         // onFailure can't flip the state holder after we've already decided what comes next
         // (including the early-return DISCONNECTED paths below).

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
@@ -75,7 +75,11 @@ class AlertStreamService : Service() {
     private val sseClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(2, TimeUnit.MINUTES)
+            // The server heartbeats every 30s; 75s (2.5 intervals) tolerates one fully missed
+            // heartbeat + jitter while bounding how long a silently dead stream can look
+            // CONNECTED — this is the worst-case delay before the alerting-degraded banner
+            // appears when the backend dies without closing the socket.
+            .readTimeout(75, TimeUnit.SECONDS)
             .build()
     }
 
@@ -87,16 +91,30 @@ class AlertStreamService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         startForeground(NOTIFICATION_ID, buildNotification())
-        connectToStream()
-        Timber.d("AlertStreamService started")
+        // A redundant start() (Settings opening, a re-login refresh) must not tear down a healthy
+        // stream: the silent cancel-and-reconnect was invisible before the alerting-degraded
+        // banner existed, but now it would flash "server alerts paused" for the seconds the
+        // reconnect takes. A broken stream is never CONNECTED, so real recovery still proceeds.
+        if (eventSource == null ||
+            alertStreamStateHolder.state.value != AlertStreamState.CONNECTED
+        ) {
+            connectToStream()
+            Timber.d("AlertStreamService started")
+        } else {
+            Timber.d("AlertStreamService start ignored; stream already connected")
+        }
         return START_STICKY
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
-        alertStreamStateHolder.onStreamStopped()
+        // Invalidate the live connection's callbacks BEFORE cancelling it: cancel() delivers an
+        // async onFailure on an OkHttp thread, and without the bump its generation would still
+        // match, letting it clobber the DISCONNECTED written below back to RECONNECTING.
+        connectionGeneration.incrementAndGet()
         eventSource?.cancel()
+        alertStreamStateHolder.onStreamStopped()
         reconnectJob?.cancel()
         sseClient.dispatcher.executorService.shutdownNow()
         try {
@@ -111,6 +129,10 @@ class AlertStreamService : Service() {
     }
 
     private fun connectToStream() {
+        // Invalidate the previous connection's callbacks before cancelling it, so its async
+        // onFailure can't flip the state holder after we've already decided what comes next
+        // (including the early-return DISCONNECTED paths below).
+        connectionGeneration.incrementAndGet()
         // Cancel any existing connection without triggering another reconnect
         eventSource?.cancel()
         eventSource = null
@@ -143,6 +165,10 @@ class AlertStreamService : Service() {
             request,
             object : EventSourceListener() {
                 override fun onOpen(eventSource: EventSource, response: Response) {
+                    // Same stale-generation guard as onFailure/onClosed — this is the one callback
+                    // that could flip the holder to a false CONNECTED (banner hidden), so it gets
+                    // the guard even though a cancelled EventSource shouldn't emit onOpen.
+                    if (connectionGeneration.get() != gen) return
                     Timber.d("Alert SSE stream connected (status=%d)", response.code)
                     alertStreamStateHolder.onStreamOpened()
                     connectionOpenedAtMs = System.currentTimeMillis()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamStateHolder.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamStateHolder.kt
@@ -1,0 +1,48 @@
+package com.glycemicgpt.mobile.service
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Connection state of the server-pushed alert stream (the SSE connection held by
+ * [AlertStreamService]).
+ *
+ * - [CONNECTED] — the stream is open; server-pushed alerts are flowing.
+ * - [RECONNECTING] — the stream dropped and a reconnect is scheduled (backoff inside the service).
+ * - [DISCONNECTED] — the stream is not running: the service is stopped, there is no session, or no
+ *   connection has been established yet this process.
+ *
+ * Anything other than [CONNECTED] means **no new server alerts arrive** — the UI must say so
+ * honestly. There is no device/local alert floor yet, so the degraded surface must never imply one.
+ */
+enum class AlertStreamState { CONNECTED, DISCONNECTED, RECONNECTING }
+
+/**
+ * Observable [AlertStreamState], the seam between [AlertStreamService] (an Android Service that
+ * ViewModels cannot observe directly) and the UI surfaces that must react to the stream dropping.
+ * The service drives the transitions; ViewModels collect [state].
+ */
+@Singleton
+class AlertStreamStateHolder @Inject constructor() {
+
+    private val _state = MutableStateFlow(AlertStreamState.DISCONNECTED)
+    val state: StateFlow<AlertStreamState> = _state.asStateFlow()
+
+    /** The SSE stream opened — server-pushed alerts are flowing again. */
+    fun onStreamOpened() {
+        _state.value = AlertStreamState.CONNECTED
+    }
+
+    /** The stream dropped or closed and the service has scheduled a reconnect. */
+    fun onStreamRetrying() {
+        _state.value = AlertStreamState.RECONNECTING
+    }
+
+    /** The stream is not running (service destroyed, no session, or no base URL/token). */
+    fun onStreamStopped() {
+        _state.value = AlertStreamState.DISCONNECTED
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/ReachabilityInterceptorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/ReachabilityInterceptorTest.kt
@@ -1,7 +1,5 @@
 package com.glycemicgpt.mobile.data.remote
 
-import com.glycemicgpt.mobile.BuildConfig
-import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import io.mockk.every
 import io.mockk.mockk
@@ -13,15 +11,13 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.IOException
 
 class ReachabilityInterceptorTest {
 
     private val networkMonitor = mockk<NetworkMonitor>(relaxed = true)
-    private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true)
-    private val interceptor = ReachabilityInterceptor(networkMonitor, appSettingsStore)
+    private val interceptor = ReachabilityInterceptor(networkMonitor)
 
     private val request = Request.Builder().url("http://localhost/api/health").build()
 
@@ -46,7 +42,6 @@ class ReachabilityInterceptorTest {
 
     @Test
     fun `a successful response records backend reachable and passes it through`() {
-        every { appSettingsStore.simulateBackendUnreachable } returns false
         val response = okResponse()
 
         val result = interceptor.intercept(chainReturning(response))
@@ -58,8 +53,6 @@ class ReachabilityInterceptorTest {
 
     @Test
     fun `a server error still counts as reachable - the server answered`() {
-        every { appSettingsStore.simulateBackendUnreachable } returns false
-
         interceptor.intercept(chainReturning(okResponse(code = 503)))
 
         verify(exactly = 1) { networkMonitor.recordBackendSuccess() }
@@ -68,7 +61,6 @@ class ReachabilityInterceptorTest {
 
     @Test
     fun `a transport failure records a backend failure and rethrows`() {
-        every { appSettingsStore.simulateBackendUnreachable } returns false
         val boom = IOException("connect timed out")
 
         val thrown = assertThrows(IOException::class.java) {
@@ -82,7 +74,6 @@ class ReachabilityInterceptorTest {
 
     @Test
     fun `a canceled call is not counted as a backend failure`() {
-        every { appSettingsStore.simulateBackendUnreachable } returns false
         val canceled = IOException("Canceled")
 
         assertThrows(IOException::class.java) {
@@ -94,18 +85,15 @@ class ReachabilityInterceptorTest {
     }
 
     @Test
-    fun `debug fault injection short-circuits before the network and records a failure`() {
-        // Guarded by BuildConfig.DEBUG, which is true for the debug unit-test variant.
-        assertTrue("expected the debug variant for this test", BuildConfig.DEBUG)
-        every { appSettingsStore.simulateBackendUnreachable } returns true
-        val chain = mockk<Interceptor.Chain> {
-            every { request() } returns request
+    fun `a simulated fault from the interceptor below is recorded like a real transport failure`() {
+        // On the main client SimulateUnreachableInterceptor sits below this one, so its injected
+        // IOException must propagate up through the reachability accounting.
+        val injected = IOException("Simulated backend unreachable (debug fault injection)")
+
+        assertThrows(IOException::class.java) {
+            interceptor.intercept(chainThrowing(injected))
         }
 
-        assertThrows(IOException::class.java) { interceptor.intercept(chain) }
-
         verify(exactly = 1) { networkMonitor.recordBackendFailure() }
-        // proceed() must never be reached when the fault is injected.
-        verify(exactly = 0) { chain.proceed(any()) }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/SimulateUnreachableInterceptorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/SimulateUnreachableInterceptorTest.kt
@@ -1,0 +1,60 @@
+package com.glycemicgpt.mobile.data.remote
+
+import com.glycemicgpt.mobile.BuildConfig
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+class SimulateUnreachableInterceptorTest {
+
+    private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true)
+    private val interceptor = SimulateUnreachableInterceptor(appSettingsStore)
+
+    private val request = Request.Builder().url("http://localhost/api/health").build()
+
+    private fun okResponse(): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body("".toResponseBody(null))
+        .build()
+
+    @Test
+    fun `fault off passes the request through untouched`() {
+        every { appSettingsStore.simulateBackendUnreachable } returns false
+        val response = okResponse()
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(any()) } returns response
+        }
+
+        assertEquals(response, interceptor.intercept(chain))
+    }
+
+    @Test
+    fun `debug fault injection short-circuits before the network`() {
+        // Guarded by BuildConfig.DEBUG, which is true for the debug unit-test variant.
+        assertTrue("expected the debug variant for this test", BuildConfig.DEBUG)
+        every { appSettingsStore.simulateBackendUnreachable } returns true
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+        }
+
+        assertThrows(IOException::class.java) { interceptor.intercept(chain) }
+
+        // proceed() must never be reached when the fault is injected.
+        verify(exactly = 0) { chain.proceed(any()) }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutCgmFreshnessTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutCgmFreshnessTest.kt
@@ -1,0 +1,87 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import com.glycemicgpt.mobile.data.local.entity.CgmReadingEntity
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutDataDto
+import com.glycemicgpt.mobile.data.remote.dto.NightscoutGlucoseReadingDto
+import com.glycemicgpt.mobile.domain.freshness.Freshness
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * AC5 verification (NO Nightscout integration change): a Nightscout-followed CGM value that stops
+ * refreshing while the backend is down ages and de-emphasises through the SAME timestamp-based
+ * staleness mechanism as a BLE reading.
+ *
+ * The invariant that makes this true is pinned here: the NS mapper stores the reading's REAL
+ * capture timestamp (not the sync/fetch time) into the shared `cgm_readings` table, and the
+ * freshness classifier is source-agnostic — it sees only that timestamp's age. No source-specific
+ * or "aggressive" staleness logic exists or is needed.
+ */
+class NightscoutCgmFreshnessTest {
+
+    private val now = Instant.parse("2026-03-01T12:00:00Z")
+
+    private fun nsData(readingAt: Instant) = NightscoutDataDto(
+        connectionId = "c1",
+        // fetchedAt is "just now" — if the mapper ever stamped sync time instead of the reading's
+        // capture time, the aged assertions below would fail.
+        fetchedAt = now,
+        effectiveLimitPerArray = 500,
+        glucoseReadings = listOf(
+            NightscoutGlucoseReadingDto(
+                nsId = "g-1",
+                readingTimestamp = readingAt,
+                value = 120,
+                trend = "Flat",
+                trendRate = 0.0f,
+                source = "nightscout:c1",
+            ),
+        ),
+        pumpEvents = emptyList(),
+    )
+
+    private fun classify(entity: CgmReadingEntity): Freshness =
+        FreshnessPolicy.CGM.classify(now.toEpochMilli() - entity.timestampMs)
+
+    @Test
+    fun `mapper stores the reading's real capture timestamp, not the sync time`() {
+        val readingAt = now.minusSeconds(20 * 60)
+
+        val entity = NightscoutDataMapper.toCgmEntities(nsData(readingAt)).single()
+
+        assertEquals(readingAt.toEpochMilli(), entity.timestampMs)
+    }
+
+    @Test
+    fun `frozen nightscout reading ages to TOO_STALE like any other source`() {
+        // 20 minutes without a refresh: past the 15-minute TOO_STALE bound.
+        val entity = NightscoutDataMapper.toCgmEntities(nsData(now.minusSeconds(20 * 60))).single()
+
+        assertEquals(Freshness.TOO_STALE, classify(entity))
+    }
+
+    @Test
+    fun `nightscout and BLE readings of the same age classify identically`() {
+        val readingAt = now.minusSeconds(8 * 60) // past STALE, below TOO_STALE
+
+        val nsEntity = NightscoutDataMapper.toCgmEntities(nsData(readingAt)).single()
+        val bleEntity = CgmReadingEntity(
+            glucoseMgDl = 120,
+            trendArrow = "FLAT",
+            source = "",
+            timestampMs = readingAt.toEpochMilli(),
+        )
+
+        assertEquals(Freshness.STALE, classify(nsEntity))
+        assertEquals(classify(bleEntity), classify(nsEntity))
+    }
+
+    @Test
+    fun `fresh nightscout reading classifies FRESH`() {
+        val entity = NightscoutDataMapper.toCgmEntities(nsData(now.minusSeconds(60))).single()
+
+        assertEquals(Freshness.FRESH, classify(entity))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegradedTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegradedTest.kt
@@ -1,0 +1,40 @@
+package com.glycemicgpt.mobile.presentation.alerts
+
+import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.service.AlertStreamState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The banner-visibility rule (AC4): the ONLY non-degraded combination is backend reachable + SSE
+ * stream connected. Every other combination means no new server alerts arrive, so the honest
+ * banner must show.
+ */
+class AlertingDegradedTest {
+
+    @Test
+    fun `reachable and connected is the only golden combination`() {
+        assertFalse(isAlertingDegraded(NetworkStatus.REACHABLE, AlertStreamState.CONNECTED))
+    }
+
+    @Test
+    fun `stream not connected is degraded even while backend is reachable`() {
+        assertTrue(isAlertingDegraded(NetworkStatus.REACHABLE, AlertStreamState.DISCONNECTED))
+        assertTrue(isAlertingDegraded(NetworkStatus.REACHABLE, AlertStreamState.RECONNECTING))
+    }
+
+    @Test
+    fun `backend unreachable is degraded even while the stream still reports connected`() {
+        // The SSE read timeout is minutes long; NetworkMonitor notices an outage first. The banner
+        // must not wait for the stream to time out.
+        assertTrue(isAlertingDegraded(NetworkStatus.BACKEND_UNREACHABLE, AlertStreamState.CONNECTED))
+    }
+
+    @Test
+    fun `device offline is always degraded`() {
+        for (stream in AlertStreamState.entries) {
+            assertTrue(isAlertingDegraded(NetworkStatus.OFFLINE, stream))
+        }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -171,7 +171,7 @@ class AlertsViewModelTest {
 
         // Terminal: not loading, honest copy, no raw exception text.
         assertFalse(vm.uiState.value.isLoading)
-        assertEquals("Can't reach your server — showing saved alerts.", vm.uiState.value.error)
+        assertEquals("Can't reach your server — alerts may be out of date.", vm.uiState.value.error)
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -2,9 +2,12 @@ package com.glycemicgpt.mobile.presentation.alerts
 
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.network.NetworkStatus
 import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
+import com.glycemicgpt.mobile.service.AlertStreamStateHolder
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -33,9 +36,12 @@ class AlertsViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val alertsFlow = MutableStateFlow<List<AlertEntity>>(emptyList())
+    private val networkStatusFlow = MutableStateFlow(NetworkStatus.REACHABLE)
     private lateinit var repository: AlertRepository
     private lateinit var notificationManager: AlertNotificationManager
     private lateinit var appSettingsStore: AppSettingsStore
+    private lateinit var networkMonitor: NetworkMonitor
+    private lateinit var alertStreamStateHolder: AlertStreamStateHolder
 
     @Before
     fun setUp() {
@@ -49,6 +55,10 @@ class AlertsViewModelTest {
             every { glucoseUnit } returns GlucoseUnit.MGDL
             every { glucoseUnitFlow() } returns flowOf(GlucoseUnit.MGDL)
         }
+        networkMonitor = mockk(relaxed = true) {
+            every { status } returns networkStatusFlow
+        }
+        alertStreamStateHolder = AlertStreamStateHolder()
     }
 
     @After
@@ -56,7 +66,13 @@ class AlertsViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = AlertsViewModel(repository, notificationManager, appSettingsStore)
+    private fun createViewModel() = AlertsViewModel(
+        repository,
+        notificationManager,
+        appSettingsStore,
+        networkMonitor,
+        alertStreamStateHolder,
+    )
 
     private fun makeAlert(
         serverId: String = "alert-1",
@@ -134,15 +150,28 @@ class AlertsViewModelTest {
     }
 
     @Test
-    fun `refreshAlerts sets error on failure`() = runTest {
+    fun `refreshAlerts sets user-facing error on failure, never the raw exception message`() = runTest {
         coEvery { repository.fetchPendingAlerts() } returns
-            Result.failure(RuntimeException("Network error"))
+            Result.failure(RuntimeException("java.net.SocketException: raw internals"))
 
         val vm = createViewModel()
         advanceUntilIdle()
 
-        assertEquals("Network error", vm.uiState.value.error)
+        assertEquals("Couldn't refresh alerts. Try again.", vm.uiState.value.error)
         assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `refreshAlerts offline failure reaches a terminal state with connection copy`() = runTest {
+        coEvery { repository.fetchPendingAlerts() } returns
+            Result.failure(java.io.IOException("connect timed out"))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // Terminal: not loading, honest copy, no raw exception text.
+        assertFalse(vm.uiState.value.isLoading)
+        assertEquals("Can't reach your server — showing saved alerts.", vm.uiState.value.error)
     }
 
     @Test
@@ -186,9 +215,9 @@ class AlertsViewModelTest {
     }
 
     @Test
-    fun `acknowledgeAlert sets error on failure`() = runTest {
+    fun `acknowledgeAlert sets user-facing error on failure, never the raw exception message`() = runTest {
         coEvery { repository.acknowledgeAlert("alert-1") } returns
-            Result.failure(RuntimeException("Forbidden"))
+            Result.failure(RuntimeException("Acknowledge failed: HTTP 403"))
 
         val vm = createViewModel()
         advanceUntilIdle()
@@ -196,7 +225,7 @@ class AlertsViewModelTest {
         vm.acknowledgeAlert("alert-1")
         advanceUntilIdle()
 
-        assertEquals("Forbidden", vm.uiState.value.error)
+        assertEquals("Couldn't acknowledge the alert. Try again.", vm.uiState.value.error)
     }
 
     @Test
@@ -207,9 +236,79 @@ class AlertsViewModelTest {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        assertEquals("fail", vm.uiState.value.error)
+        assertEquals("Couldn't refresh alerts. Try again.", vm.uiState.value.error)
 
         vm.clearError()
         assertNull(vm.uiState.value.error)
+    }
+
+    // -- alertingDegraded (AC4 banner input) -----------------------------------
+
+    @Test
+    fun `alerting is not degraded when backend reachable and stream connected`() = runTest {
+        alertStreamStateHolder.onStreamOpened()
+        val vm = createViewModel()
+
+        val job = backgroundScope.launch(testDispatcher) { vm.alertingDegraded.collect { } }
+        advanceUntilIdle()
+
+        assertFalse(vm.alertingDegraded.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `alerting degrades when the backend becomes unreachable`() = runTest {
+        alertStreamStateHolder.onStreamOpened()
+        val vm = createViewModel()
+
+        val job = backgroundScope.launch(testDispatcher) { vm.alertingDegraded.collect { } }
+        advanceUntilIdle()
+        assertFalse(vm.alertingDegraded.value)
+
+        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+        advanceUntilIdle()
+
+        assertTrue(vm.alertingDegraded.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `alerting degrades when the stream drops and recovers on reconnect`() = runTest {
+        alertStreamStateHolder.onStreamOpened()
+        val vm = createViewModel()
+
+        val job = backgroundScope.launch(testDispatcher) { vm.alertingDegraded.collect { } }
+        advanceUntilIdle()
+        assertFalse(vm.alertingDegraded.value)
+
+        alertStreamStateHolder.onStreamRetrying()
+        advanceUntilIdle()
+        assertTrue(vm.alertingDegraded.value)
+
+        alertStreamStateHolder.onStreamOpened()
+        advanceUntilIdle()
+        assertFalse(vm.alertingDegraded.value)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `cached alerts still display while alerting is degraded`() = runTest {
+        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+        coEvery { repository.fetchPendingAlerts() } returns
+            Result.failure(java.io.IOException("unreachable"))
+        alertsFlow.value = listOf(makeAlert())
+
+        val vm = createViewModel()
+        val degradedJob = backgroundScope.launch(testDispatcher) { vm.alertingDegraded.collect { } }
+        val alertsJob = backgroundScope.launch(testDispatcher) { vm.alerts.collect { } }
+        advanceUntilIdle()
+
+        assertTrue(vm.alertingDegraded.value)
+        assertEquals(1, vm.alerts.value.size)
+        assertFalse(vm.uiState.value.isLoading)
+
+        degradedJob.cancel()
+        alertsJob.cancel()
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/chat/AiChatViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/chat/AiChatViewModelTest.kt
@@ -154,6 +154,23 @@ class AiChatViewModelTest {
     }
 
     @Test
+    fun `sendMessage never surfaces a raw exception message on unexpected failures`() = runTest {
+        coEvery { repository.checkProviderConfigured() } returns Result.success(Unit)
+        coEvery { repository.sendMessage(any()) } returns
+            Result.failure(IllegalStateException("moshi: expected BEGIN_OBJECT at path $.data"))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onInputChanged("test")
+        vm.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals("Couldn't get a response. Please try again", vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isSending)
+    }
+
+    @Test
     fun `sendMessage ignores blank input`() = runTest {
         coEvery { repository.checkProviderConfigured() } returns Result.success(Unit)
 
@@ -286,7 +303,7 @@ class AiChatViewModelTest {
         vm.onInputChanged("test")
         vm.sendMessage()
         advanceUntilIdle()
-        assertEquals("fail", vm.uiState.value.error)
+        assertEquals("Couldn't get a response. Please try again", vm.uiState.value.error)
 
         vm.clearError()
         assertNull(vm.uiState.value.error)

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModelTest.kt
@@ -52,7 +52,7 @@ class CommonFoodsViewModelTest {
     @Test
     fun `offline load failure reaches a terminal state with honest copy`() = runTest(testDispatcher) {
         coEvery { repository.listCommonFoods(any(), any()) } returns
-            Result.failure(java.io.IOException("failed to connect to /192.168.1.10:8000"))
+            Result.failure(java.io.IOException("failed to connect to backend host"))
         val vm = CommonFoodsViewModel(repository)
         advanceUntilIdle()
 
@@ -73,6 +73,27 @@ class CommonFoodsViewModelTest {
 
         assertEquals(false, vm.uiState.value.isLoading)
         assertEquals("Couldn't load your common foods.", vm.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `offline retry after a disabled response shows the honest offline state, not disabled`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.failure(MealException.FeatureDisabled())
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.disabled)
+
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.failure(java.io.IOException("unreachable"))
+        vm.load()
+        advanceUntilIdle()
+
+        // The stale disabled flag must not mask the offline Retry state (AC3 honesty).
+        assertEquals(false, vm.uiState.value.disabled)
+        assertEquals(
+            "Can't reach your server — your common foods aren't available right now.",
+            vm.uiState.value.errorMessage,
+        )
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModelTest.kt
@@ -76,6 +76,26 @@ class CommonFoodsViewModelTest {
     }
 
     @Test
+    fun `stale slow failing load cannot clobber a newer successful load`() = runTest(testDispatcher) {
+        // First load hangs (offline, long timeout)...
+        coEvery { repository.listCommonFoods(any(), any()) } coAnswers {
+            kotlinx.coroutines.delay(30_000)
+            Result.failure(java.io.IOException("timeout"))
+        }
+        val vm = CommonFoodsViewModel(repository)
+        testScheduler.advanceTimeBy(1_000)
+
+        // ...then the user retries after reconnecting and the retry succeeds (empty list).
+        coEvery { repository.listCommonFoods(any(), any()) } returns Result.success(emptyList())
+        vm.load()
+        advanceUntilIdle()
+
+        // The superseded failure must not take over the loaded screen as a full-screen error.
+        assertNull(vm.uiState.value.errorMessage)
+        assertEquals(false, vm.uiState.value.isLoading)
+    }
+
+    @Test
     fun `retry after reconnect clears the error and loads foods`() = runTest(testDispatcher) {
         coEvery { repository.listCommonFoods(any(), any()) } returns
             Result.failure(java.io.IOException("unreachable"))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/CommonFoodsViewModelTest.kt
@@ -50,6 +50,49 @@ class CommonFoodsViewModelTest {
     }
 
     @Test
+    fun `offline load failure reaches a terminal state with honest copy`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.failure(java.io.IOException("failed to connect to /192.168.1.10:8000"))
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+
+        // Terminal: not loading, honest offline copy, never the raw exception message.
+        assertEquals(false, vm.uiState.value.isLoading)
+        assertEquals(
+            "Can't reach your server — your common foods aren't available right now.",
+            vm.uiState.value.errorMessage,
+        )
+    }
+
+    @Test
+    fun `unexpected load failure never surfaces the raw exception message`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.failure(IllegalStateException("moshi: expected BEGIN_OBJECT at path $.data"))
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals(false, vm.uiState.value.isLoading)
+        assertEquals("Couldn't load your common foods.", vm.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `retry after reconnect clears the error and loads foods`() = runTest(testDispatcher) {
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.failure(java.io.IOException("unreachable"))
+        val vm = CommonFoodsViewModel(repository)
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.errorMessage != null)
+
+        coEvery { repository.listCommonFoods(any(), any()) } returns
+            Result.success(listOf(food("a", "pasta")))
+        vm.load()
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.errorMessage)
+        assertEquals(1, vm.uiState.value.items.size)
+    }
+
+    @Test
     fun `edit validates carbs before calling the API`() = runTest(testDispatcher) {
         coEvery { repository.listCommonFoods(any(), any()) } returns
             Result.success(listOf(food("a", "pasta")))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModelTest.kt
@@ -67,6 +67,49 @@ class MealHistoryViewModelTest {
     }
 
     @Test
+    fun `offline load failure reaches a terminal state with honest copy`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.failure(java.io.IOException("failed to connect to /192.168.1.10:8000"))
+        val vm = MealHistoryViewModel(repository)
+        advanceUntilIdle()
+
+        // Terminal: not loading, honest offline copy, never the raw exception message.
+        assertFalse(vm.uiState.value.isLoading)
+        assertEquals(
+            "Can't reach your server — your meal history isn't available right now.",
+            vm.uiState.value.errorMessage,
+        )
+    }
+
+    @Test
+    fun `unexpected load failure never surfaces the raw exception message`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.failure(IllegalStateException("moshi: expected BEGIN_OBJECT at path $.data"))
+        val vm = MealHistoryViewModel(repository)
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isLoading)
+        assertEquals("Couldn't load your meal history.", vm.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `retry after reconnect clears the error and loads records`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.failure(java.io.IOException("unreachable"))
+        val vm = MealHistoryViewModel(repository)
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.errorMessage != null)
+
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.success(listOf(record("a")))
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(null, vm.uiState.value.errorMessage)
+        assertEquals(1, vm.uiState.value.records.size)
+    }
+
+    @Test
     fun `delete removes the record from the list`() = runTest(testDispatcher) {
         coEvery { repository.listFoodRecords(any(), any()) } returns
             Result.success(listOf(record("a"), record("b")))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModelTest.kt
@@ -69,7 +69,7 @@ class MealHistoryViewModelTest {
     @Test
     fun `offline load failure reaches a terminal state with honest copy`() = runTest(testDispatcher) {
         coEvery { repository.listFoodRecords(any(), any()) } returns
-            Result.failure(java.io.IOException("failed to connect to /192.168.1.10:8000"))
+            Result.failure(java.io.IOException("failed to connect to backend host"))
         val vm = MealHistoryViewModel(repository)
         advanceUntilIdle()
 
@@ -90,6 +90,27 @@ class MealHistoryViewModelTest {
 
         assertFalse(vm.uiState.value.isLoading)
         assertEquals("Couldn't load your meal history.", vm.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `offline retry after a disabled response shows the honest offline state, not disabled`() = runTest(testDispatcher) {
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.failure(MealException.FeatureDisabled())
+        val vm = MealHistoryViewModel(repository)
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.disabled)
+
+        coEvery { repository.listFoodRecords(any(), any()) } returns
+            Result.failure(java.io.IOException("unreachable"))
+        vm.load()
+        advanceUntilIdle()
+
+        // The stale disabled flag must not mask the offline Retry state (AC3 honesty).
+        assertFalse(vm.uiState.value.disabled)
+        assertEquals(
+            "Can't reach your server — your meal history isn't available right now.",
+            vm.uiState.value.errorMessage,
+        )
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/meal/MealHistoryViewModelTest.kt
@@ -93,6 +93,26 @@ class MealHistoryViewModelTest {
     }
 
     @Test
+    fun `stale slow failing load cannot clobber a newer successful load`() = runTest(testDispatcher) {
+        // First load hangs (offline, long timeout)...
+        coEvery { repository.listFoodRecords(any(), any()) } coAnswers {
+            kotlinx.coroutines.delay(30_000)
+            Result.failure(java.io.IOException("timeout"))
+        }
+        val vm = MealHistoryViewModel(repository)
+        testScheduler.advanceTimeBy(1_000)
+
+        // ...then the user retries after reconnecting and the retry succeeds (empty list).
+        coEvery { repository.listFoodRecords(any(), any()) } returns Result.success(emptyList())
+        vm.load()
+        advanceUntilIdle()
+
+        // The superseded failure must not take over the loaded screen as a full-screen error.
+        assertEquals(null, vm.uiState.value.errorMessage)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
     fun `retry after reconnect clears the error and loads records`() = runTest(testDispatcher) {
         coEvery { repository.listFoodRecords(any(), any()) } returns
             Result.failure(java.io.IOException("unreachable"))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertStreamStateHolderTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertStreamStateHolderTest.kt
@@ -1,0 +1,52 @@
+package com.glycemicgpt.mobile.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AlertStreamStateHolderTest {
+
+    @Test
+    fun `initial state is DISCONNECTED`() {
+        assertEquals(AlertStreamState.DISCONNECTED, AlertStreamStateHolder().state.value)
+    }
+
+    @Test
+    fun `stream opening flips to CONNECTED`() {
+        val holder = AlertStreamStateHolder()
+
+        holder.onStreamOpened()
+
+        assertEquals(AlertStreamState.CONNECTED, holder.state.value)
+    }
+
+    @Test
+    fun `stream failure flips to RECONNECTING`() {
+        val holder = AlertStreamStateHolder()
+        holder.onStreamOpened()
+
+        holder.onStreamRetrying()
+
+        assertEquals(AlertStreamState.RECONNECTING, holder.state.value)
+    }
+
+    @Test
+    fun `stream stop flips to DISCONNECTED`() {
+        val holder = AlertStreamStateHolder()
+        holder.onStreamOpened()
+
+        holder.onStreamStopped()
+
+        assertEquals(AlertStreamState.DISCONNECTED, holder.state.value)
+    }
+
+    @Test
+    fun `recovery after retrying returns to CONNECTED`() {
+        val holder = AlertStreamStateHolder()
+
+        holder.onStreamOpened()
+        holder.onStreamRetrying()
+        holder.onStreamOpened()
+
+        assertEquals(AlertStreamState.CONNECTED, holder.state.value)
+    }
+}


### PR DESCRIPTION
## Summary

When the backend is unreachable, every read screen now reaches a terminal state — cached data marked stale via the 57.2 freshness substrate, or an honest offline state with Retry. No screen blanks, spins forever, or shows a raw exception string.

Linear: GLY-109 (Story 57.3, Epic 57 Mobile Self-Reliance). Depends on 57.2 (merged) and reuses its NetworkMonitor, Freshness model, and debug fault-injection toggle — no second reachability or staleness path.

## Changes

- **Alert stream state**: new `AlertStreamStateHolder` singleton exposes the SSE connection state (`CONNECTED`/`DISCONNECTED`/`RECONNECTING`), driven by `AlertStreamService` with generation-guarded transitions on every callback and teardown path. `onStartCommand` is now idempotent (a redundant start no longer tears down a healthy stream), stale delayed reconnects are skipped, and the SSE read timeout is 75s (2.5x the server's 30s heartbeat) to bound how long a silently dead stream can look connected.
- **Honest alerting-degraded banner** (`alerting_degraded_banner`) on the Alerts screen: shown whenever the backend is unreachable or the stream is not connected. Copy states plainly that server-pushed alerts are paused and no new alerts arrive until reconnected. It deliberately makes no device/local-floor claim (that is story 57.9 and does not exist yet); a UI test pins the absence of any such wording. Cached alerts stay visible below it.
- **Backend-only screens degrade honestly**: meal history and common foods render a centered offline state with Retry when a load fails with nothing cached, instead of a misleading empty state; the whole meal feature now shares one offline look. Superseded loads are cancelled so a slow failing request can never clobber a newer successful load. Chat already had an offline state; its raw-message error fallback is fixed.
- **No raw exception strings in the UI**: `e.message` surfaces replaced with fixed user copy in the alerts, meal, and chat view models (also a small security win).
- **Debug harness**: fault injection split into `SimulateUnreachableInterceptor` so the toggle also covers the long-timeout chat client while keeping reachability accounting identical.
- **Nightscout (verification only, no integration change)**: a test pins that NS-followed CGM readings keep their real capture timestamp and age through the identical timestamp-based staleness as BLE.

## Testing

- `testDebugUnitTest`, `lintDebug`, `assembleDebug` green (full suite, all modules)
- 14 new instrumented Compose tests green on emulator (degraded renders, zero indeterminate-spinner assertions with positive controls, banner honesty pin)
- Full per-screen E2E matrix on emulator (golden / backend-down / recovery for home, alerts, meal history, common foods, chat, bolus history) using the 57.2 fault toggle, plus a real outage cycle (`docker compose stop api`): banner appeared in <=12s via the stream state and cleared on SSE backoff reconnect
- Adversarial + senior-engineer reviews: all HIGH/MEDIUM findings fixed; CodeRabbit CLI clean; security review PASS
- No Sentry gate (mobile-only, no backend change)

## Scope

READ resilience only — offline writes are 57.6/57.7, the local alert floor is 57.9, Nightscout stays backend-dependent (57.11 cut).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer offline/degraded states across alerts, chat, and meal screens, including retry actions and visible connection status messaging.
  * Alerts now show a “Server alerts paused” banner when delivery is degraded, while still keeping cached alerts visible.

* **Bug Fixes**
  * Improved loading and error handling so spinners don’t persist in terminal failure states.
  * Updated error messages to be more user-friendly and avoid exposing raw technical details.
  * Fixed stale retries so newer successful loads aren’t overwritten by earlier failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->