### PR TITLE
feat(api): idempotency keys for user-authored creates (GLY-111)

### DIFF
--- a/apps/api/migrations/versions/078_idempotency_keys.py
+++ b/apps/api/migrations/versions/078_idempotency_keys.py
@@ -1,0 +1,78 @@
+"""Add the central idempotency_keys registry for user-authored creates.
+
+WHY: the mobile offline outbox (Epic 57 Phase 2) replays a create when the
+response was dropped -- including the indeterminate-commit case where the row
+DID land server-side. Without a request-identity check, that replay
+double-inserts the meal, inflating carb (and downstream IOB) history, a dosing
+input. This table records each processed (user, endpoint, client_request_id)
+create with a pointer to the created resource, so a retry returns the original
+row instead of inserting a duplicate.
+
+Deliberately coexists with -- and must never be conflated with --
+``pump_events.dedupe_hash``: that is a server-computed CONTENT hash collapsing
+distinct submissions of the same real-world event across sources. Request
+idempotency is the opposite semantic: same retried request -> same row, but two
+identical-looking meals a minute apart are both real and must both persist.
+
+Stores resource_type + resource_id + response_status only -- never a serialized
+response body -- so no meal/carb data is duplicated into this table. No
+backfill: rows exist only for requests that carried the (new, optional)
+Idempotency-Key header.
+
+Revision ID: 078_idempotency_keys
+Revises: 077_meal_intelligence_enabled
+Create Date: 2026-07-02
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "078_idempotency_keys"
+down_revision: str | None = "077_meal_intelligence_enabled"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "idempotency_keys",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("endpoint", sa.String(length=80), nullable=False),
+        sa.Column("client_request_id", sa.String(length=64), nullable=False),
+        sa.Column("resource_type", sa.String(length=40), nullable=False),
+        # Polymorphic soft reference (spans food_records / common_foods /
+        # future create tables) -- intentionally no FK.
+        sa.Column("resource_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("response_status", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        # The correctness guarantee for concurrent same-key creates: the loser
+        # of the race hits this constraint and replays the winner's resource.
+        sa.UniqueConstraint(
+            "user_id",
+            "endpoint",
+            "client_request_id",
+            name="uq_idempotency_keys_user_endpoint_client_request_id",
+        ),
+    )
+    op.create_index("ix_idempotency_keys_user_id", "idempotency_keys", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_idempotency_keys_user_id", table_name="idempotency_keys")
+    op.drop_table("idempotency_keys")

--- a/apps/api/src/core/idempotency.py
+++ b/apps/api/src/core/idempotency.py
@@ -1,0 +1,64 @@
+"""Optional ``Idempotency-Key`` request-header dependency.
+
+Transport seam for request idempotency on user-authored creates (Epic 57
+Phase 2): the mobile offline outbox stamps each queued create with a stable
+client request id and retries with the same value, so a dropped response can
+never double-insert. The header is OPTIONAL -- callers that don't send it (web,
+Wear relay, older app builds) get the unchanged non-idempotent behavior.
+
+A header (not a body field) because the primary create, ``POST
+/api/food-records``, is multipart with no JSON body -- and a header keeps the
+token orthogonal to every DTO. Deliberately NOT ``X-Correlation-ID``: that is
+regenerated server-side per request, so it cannot survive a retry as a stable
+key.
+"""
+
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, status
+
+IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+
+# Response header marking a keyed create that was served by replaying the
+# already-created resource instead of inserting a new one (observability;
+# never required for client correctness).
+IDEMPOTENT_REPLAYED_HEADER = "Idempotent-Replayed"
+
+# The outbox sends a canonical lowercase UUIDv4 (36 chars); the value is
+# treated as opaque, so the bound is a defensive cap on stored size, not a
+# format check.
+MAX_IDEMPOTENCY_KEY_LENGTH = 64
+
+
+async def get_idempotency_key(
+    idempotency_key: Annotated[str | None, Header(alias=IDEMPOTENCY_KEY_HEADER)] = None,
+) -> str | None:
+    """Validate the optional ``Idempotency-Key`` header and return its value.
+
+    Absent header -> ``None`` (the endpoint behaves as a normal, non-idempotent
+    create). A present-but-unusable value (blank or oversized) is a client bug
+    in key generation, and silently ignoring it would drop the exactly-once
+    guarantee the client asked for -- so it fails loud with a 422.
+    """
+    if idempotency_key is None:
+        return None
+    key = idempotency_key.strip()
+    if not key:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Idempotency-Key header must not be empty.",
+        )
+    if len(key) > MAX_IDEMPOTENCY_KEY_LENGTH:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Idempotency-Key header must be at most "
+                f"{MAX_IDEMPOTENCY_KEY_LENGTH} characters."
+            ),
+        )
+    return key
+
+
+# Alias mirroring the DiabeticOrAdminUser idiom (core.auth): annotate a route
+# parameter with this to receive the validated key (or None when not sent).
+IdempotencyKeyHeader = Annotated[str | None, Depends(get_idempotency_key)]

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -26,6 +26,7 @@ from src.models.food_record import FoodRecord, FoodRecordSource
 from src.models.food_record_audit import FoodRecordAudit
 from src.models.glooko_sync_state import GlookoSyncState
 from src.models.glucose import GlucoseReading, TrendDirection
+from src.models.idempotency_key import IdempotencyKey
 from src.models.insulin_config import InsulinConfig
 from src.models.integration import (
     IntegrationCredential,
@@ -81,6 +82,7 @@ __all__ = [
     "FoodRecordSource",
     "GlookoSyncState",
     "GlucoseReading",
+    "IdempotencyKey",
     "InsulinConfig",
     "InvitationStatus",
     "IntegrationCredential",

--- a/apps/api/src/models/idempotency_key.py
+++ b/apps/api/src/models/idempotency_key.py
@@ -75,6 +75,7 @@ class IdempotencyKey(Base):
 
     # The client-supplied Idempotency-Key header value, stored verbatim and
     # treated as opaque (the outbox sends a UUIDv4, but nothing here parses it).
+    # Keep the length in sync with core.idempotency.MAX_IDEMPOTENCY_KEY_LENGTH.
     client_request_id: Mapped[str] = mapped_column(String(64), nullable=False)
 
     # --- Result pointer (never the response body) ---

--- a/apps/api/src/models/idempotency_key.py
+++ b/apps/api/src/models/idempotency_key.py
@@ -1,0 +1,99 @@
+"""Idempotency-key registry for user-authored create endpoints.
+
+One row per successfully-processed keyed create: when a client retries a create
+with the same ``Idempotency-Key`` header (e.g. the mobile offline outbox
+replaying after a dropped response), the matching row lets the endpoint return
+the original resource instead of inserting a duplicate. A double-inserted meal
+would inflate carb -- and downstream IOB -- history, a dosing input, so replay
+correctness here is safety-adjacent.
+
+Deliberately DISTINCT from ``pump_events.dedupe_hash``: that is a
+server-computed *content* hash that collapses two genuinely-distinct
+submissions describing the same real-world event across sources. Request
+idempotency is the opposite semantic -- it must return the same row for the
+same retried *request* and must never merge two intentionally-distinct meals
+that happen to look alike. The two mechanisms coexist and share nothing.
+
+The row stores a POINTER to the created resource (type + id + status), never a
+serialized response: replays re-fetch the live resource owner-scoped, so no
+meal/carb data (health-adjacent) is duplicated here and a replay can never
+return a stale snapshot.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    SmallInteger,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+
+class IdempotencyKey(Base):
+    """A processed (user, endpoint, client request id) create, with its result pointer."""
+
+    __tablename__ = "idempotency_keys"
+
+    __table_args__ = (
+        # The correctness guarantee: two concurrent same-key creates can both
+        # miss the pre-SELECT, but only one insert survives this constraint --
+        # the loser catches IntegrityError and replays the winner.
+        UniqueConstraint(
+            "user_id",
+            "endpoint",
+            "client_request_id",
+            name="uq_idempotency_keys_user_endpoint_client_request_id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=func.gen_random_uuid(),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Stable endpoint slug (see services.idempotency), NOT the request path --
+    # paths are fragile to trailing slashes and future versioning. The slug
+    # dimension keeps the same client key from replaying across endpoints.
+    endpoint: Mapped[str] = mapped_column(String(80), nullable=False)
+
+    # The client-supplied Idempotency-Key header value, stored verbatim and
+    # treated as opaque (the outbox sends a UUIDv4, but nothing here parses it).
+    client_request_id: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # --- Result pointer (never the response body) ---
+    # Polymorphic soft reference: spans food_records / common_foods / future
+    # create tables, so no hard FK. A replay re-fetches by (resource_id, owner)
+    # at the call site, which knows its own response model.
+    resource_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    resource_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    response_status: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<IdempotencyKey(id={self.id}, user_id={self.user_id}, "
+            f"endpoint={self.endpoint!r}, resource_type={self.resource_type!r}, "
+            f"resource_id={self.resource_id})>"
+        )

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -12,16 +12,19 @@ treatment_safety / carb-ratio math.
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, status
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
 from src.core.auth import DiabeticOrAdminUser
+from src.core.idempotency import IDEMPOTENT_REPLAYED_HEADER, IdempotencyKeyHeader
 from src.database import get_db
 from src.logging_config import get_logger
 from src.middleware.rate_limit import limiter
+from src.models.common_food import CommonFood
 from src.models.food_record import FoodRecord
+from src.models.idempotency_key import IdempotencyKey
 from src.routers._meal_intelligence import (
     get_owned_common_food,
     require_meal_intelligence,
@@ -39,8 +42,9 @@ from src.schemas.food_record import (
     FoodRecordListResponse,
     FoodRecordResponse,
 )
+from src.schemas.idempotency import IdempotentTombstoneResponse
 from src.services import common_food as common_food_service
-from src.services import food_image, food_vision, meal_audit
+from src.services import food_image, food_vision, idempotency, meal_audit
 
 logger = get_logger(__name__)
 
@@ -52,11 +56,79 @@ router = APIRouter(prefix="/api/food-records", tags=["food-records"])
 _ACCEPTED_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
 
 
+def _idempotent_tombstone(key: IdempotencyKey) -> JSONResponse:
+    """Terminal "already processed, resource since deleted" replay response.
+
+    Never re-creates the resource -- that would resurrect a deliberately-deleted
+    meal. 200 (not the stored 201) because nothing was created by this request;
+    the client's outbox treats it as done-with-nothing-to-bind.
+    """
+    body = IdempotentTombstoneResponse(
+        resource_type=key.resource_type, resource_id=key.resource_id
+    )
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=body.model_dump(mode="json"),
+        headers={IDEMPOTENT_REPLAYED_HEADER: "true"},
+    )
+
+
+async def _replay_food_record(key: IdempotencyKey, db: AsyncSession) -> JSONResponse:
+    """Replay an already-processed keyed food-record create.
+
+    Re-fetches the live resource owner-scoped by the stored pointer (never a
+    stored response body) and re-serializes it with the original status, so the
+    retry returns the same server ``id`` the first request created.
+
+    Owner scoping reads ``key.user_id`` -- always the authenticated caller,
+    since the key row is found/staged scoped to them -- rather than
+    ``current_user.id``: the race-loser path rolled the session back, expiring
+    ``current_user``, and touching an expired column raises under asyncio.
+    """
+    record = await db.scalar(
+        select(FoodRecord).where(
+            FoodRecord.id == key.resource_id, FoodRecord.user_id == key.user_id
+        )
+    )
+    if record is None:
+        return _idempotent_tombstone(key)
+    payload = FoodRecordResponse.model_validate(record)
+    return JSONResponse(
+        status_code=key.response_status,
+        content=payload.model_dump(mode="json"),
+        headers={IDEMPOTENT_REPLAYED_HEADER: "true"},
+    )
+
+
+async def _replay_common_food(key: IdempotencyKey, db: AsyncSession) -> JSONResponse:
+    """Replay an already-processed keyed save-as-common-food (same shape as above)."""
+    common_food = await db.scalar(
+        select(CommonFood).where(
+            CommonFood.id == key.resource_id, CommonFood.user_id == key.user_id
+        )
+    )
+    if common_food is None:
+        return _idempotent_tombstone(key)
+    payload = CommonFoodResponse.model_validate(common_food)
+    return JSONResponse(
+        status_code=key.response_status,
+        content=payload.model_dump(mode="json"),
+        headers={IDEMPOTENT_REPLAYED_HEADER: "true"},
+    )
+
+
 @router.post(
     "",
     response_model=FoodRecordResponse,
     status_code=status.HTTP_201_CREATED,
     responses={
+        200: {
+            "model": IdempotentTombstoneResponse,
+            "description": (
+                "Idempotent replay of a keyed create whose resource was since "
+                "deleted (terminal; nothing re-created)"
+            ),
+        },
         401: {"model": ErrorResponse, "description": "Not authenticated"},
         404: {"model": ErrorResponse, "description": "No AI provider configured"},
         413: {"model": ErrorResponse, "description": "Image too large"},
@@ -81,13 +153,18 @@ async def upload_food_photo(
     request: Request,
     current_user: DiabeticOrAdminUser,
     file: UploadFile,
+    idempotency_key: IdempotencyKeyHeader,
     db: AsyncSession = Depends(get_db),
-) -> FoodRecordResponse:
+) -> FoodRecordResponse | JSONResponse:
     """Upload a meal photo and persist its structured carb estimate.
 
     The photo is validated, EXIF-stripped, and analyzed via the user's
     configured AI provider's vision route. If that provider has no vision route,
     a clear 422 is returned -- never a silent failure or a fabricated estimate.
+
+    An optional ``Idempotency-Key`` header makes the create exactly-once on
+    retry: a repeated key replays the originally-created record (same server
+    ``id``, no second vision call or photo) instead of double-inserting a meal.
     """
     require_meal_intelligence(current_user)
 
@@ -103,8 +180,17 @@ async def upload_food_photo(
         # disconnect, I/O error) maps to a clean 503 below rather than a bare 500.
         raw = await file.read(settings.food_image_max_bytes + 1)
         record = await food_vision.create_food_record_from_image(
-            db=db, user=current_user, raw_image=raw
+            db=db,
+            user=current_user,
+            raw_image=raw,
+            client_request_id=idempotency_key,
         )
+    except idempotency.IdempotentReplay as replay:
+        # This exact keyed create was already processed (pre-vision hit or a
+        # lost concurrent same-key race): return the original resource instead
+        # of inserting a duplicate. Ordered before every other handler so the
+        # catch-all below can never turn a replay into a 503.
+        return await _replay_food_record(replay.key, db)
     except food_image.ImageTooLargeError as exc:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=str(exc)
@@ -419,6 +505,13 @@ async def confirm_food_identity(
     response_model=CommonFoodResponse,
     status_code=status.HTTP_201_CREATED,
     responses={
+        200: {
+            "model": IdempotentTombstoneResponse,
+            "description": (
+                "Idempotent replay of a keyed create whose resource was since "
+                "deleted (terminal; nothing re-created)"
+            ),
+        },
         401: {"model": ErrorResponse, "description": "Not authenticated"},
         404: {"model": ErrorResponse, "description": "Food record not found"},
         422: {"model": ErrorResponse, "description": "Carb value out of range"},
@@ -428,20 +521,29 @@ async def save_record_as_common_food(
     record_id: uuid.UUID,
     body: SaveAsCommonFoodRequest,
     current_user: DiabeticOrAdminUser,
+    idempotency_key: IdempotencyKeyHeader,
     db: AsyncSession = Depends(get_db),
-) -> CommonFoodResponse:
+) -> CommonFoodResponse | JSONResponse:
     """Promote a food record to a named common-food baseline and link it.
 
     Uses the record's corrected values when present, else the AI estimate.
     Saving under an existing name updates that baseline (dedupe by name) rather
     than creating a near-duplicate.
+
+    An optional ``Idempotency-Key`` header additionally makes the promotion
+    exactly-once on retry (request identity, layered on the name dedupe above):
+    a repeated key replays the originally-created baseline.
     """
     require_meal_intelligence(current_user)
     record = await _get_owned_record(record_id, current_user.id, db)
     try:
         common_food = await common_food_service.promote_to_common_food(
-            db, record, body.name
+            db, record, body.name, client_request_id=idempotency_key
         )
+    except idempotency.IdempotentReplay as replay:
+        # This exact keyed promotion was already processed: return the original
+        # baseline instead of creating/updating anything.
+        return await _replay_common_food(replay.key, db)
     except common_food_service.CarbValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -523,6 +523,10 @@ async def confirm_food_identity(
         404: {"model": ErrorResponse, "description": "Food record not found"},
         422: {"model": ErrorResponse, "description": "Carb value out of range"},
         429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+        503: {
+            "model": ErrorResponse,
+            "description": "Keyed promotion could not be saved (retryable)",
+        },
     },
 )
 # A fresh Idempotency-Key inserts a key row even when the name-dedupe merely
@@ -569,6 +573,12 @@ async def save_record_as_common_food(
         # missing record signals not-found elsewhere in this router.
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except common_food_service.PromotionPersistenceError as exc:
+        # Keyed commit failed for a non-race infrastructure reason: retryable
+        # 503, mirroring the upload endpoint's persistence mapping.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
         ) from exc
     return CommonFoodResponse.model_validate(common_food)
 

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -13,6 +13,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, status
 from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -73,48 +74,52 @@ def _idempotent_tombstone(key: IdempotencyKey) -> JSONResponse:
     )
 
 
-async def _replay_food_record(key: IdempotencyKey, db: AsyncSession) -> JSONResponse:
-    """Replay an already-processed keyed food-record create.
+async def _replay_created_resource(
+    key: IdempotencyKey,
+    db: AsyncSession,
+    model: type[FoodRecord | CommonFood],
+    schema: type[BaseModel],
+) -> JSONResponse:
+    """Replay an already-processed keyed create.
 
     Re-fetches the live resource owner-scoped by the stored pointer (never a
-    stored response body) and re-serializes it with the original status, so the
-    retry returns the same server ``id`` the first request created.
+    stored response body) and re-serializes it with the original status, so
+    the retry returns the same server ``id`` the first request created. A
+    resource that was since deleted replays as the terminal tombstone.
 
     Owner scoping reads ``key.user_id`` -- always the authenticated caller,
     since the key row is found/staged scoped to them -- rather than
     ``current_user.id``: the race-loser path rolled the session back, expiring
     ``current_user``, and touching an expired column raises under asyncio.
+
+    This runs inside the endpoints' ``except IdempotentReplay`` handlers, so a
+    re-fetch/serialization failure here is mapped to the endpoints' clean-error
+    contract (a logged, retryable 503 -- the client retries the same key)
+    rather than escaping as a bare 500.
     """
-    record = await db.scalar(
-        select(FoodRecord).where(
-            FoodRecord.id == key.resource_id, FoodRecord.user_id == key.user_id
+    try:
+        resource = await db.scalar(
+            select(model).where(
+                model.id == key.resource_id, model.user_id == key.user_id
+            )
         )
-    )
-    if record is None:
-        return _idempotent_tombstone(key)
-    payload = FoodRecordResponse.model_validate(record)
-    return JSONResponse(
-        status_code=key.response_status,
-        content=payload.model_dump(mode="json"),
-        headers={IDEMPOTENT_REPLAYED_HEADER: "true"},
-    )
-
-
-async def _replay_common_food(key: IdempotencyKey, db: AsyncSession) -> JSONResponse:
-    """Replay an already-processed keyed save-as-common-food (same shape as above)."""
-    common_food = await db.scalar(
-        select(CommonFood).where(
-            CommonFood.id == key.resource_id, CommonFood.user_id == key.user_id
+        if resource is None:
+            return _idempotent_tombstone(key)
+        payload = schema.model_validate(resource)
+        return JSONResponse(
+            status_code=key.response_status,
+            content=payload.model_dump(mode="json"),
+            headers={IDEMPOTENT_REPLAYED_HEADER: "true"},
         )
-    )
-    if common_food is None:
-        return _idempotent_tombstone(key)
-    payload = CommonFoodResponse.model_validate(common_food)
-    return JSONResponse(
-        status_code=key.response_status,
-        content=payload.model_dump(mode="json"),
-        headers={IDEMPOTENT_REPLAYED_HEADER: "true"},
-    )
+    except Exception as exc:
+        logger.exception("Failed to build idempotent replay response")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "Something went wrong while retrieving your earlier result. "
+                "Please try again."
+            ),
+        ) from exc
 
 
 @router.post(
@@ -190,7 +195,9 @@ async def upload_food_photo(
         # lost concurrent same-key race): return the original resource instead
         # of inserting a duplicate. Ordered before every other handler so the
         # catch-all below can never turn a replay into a 503.
-        return await _replay_food_record(replay.key, db)
+        return await _replay_created_resource(
+            replay.key, db, FoodRecord, FoodRecordResponse
+        )
     except food_image.ImageTooLargeError as exc:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=str(exc)
@@ -543,7 +550,9 @@ async def save_record_as_common_food(
     except idempotency.IdempotentReplay as replay:
         # This exact keyed promotion was already processed: return the original
         # baseline instead of creating/updating anything.
-        return await _replay_common_food(replay.key, db)
+        return await _replay_created_resource(
+            replay.key, db, CommonFood, CommonFoodResponse
+        )
     except common_food_service.CarbValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -522,9 +522,15 @@ async def confirm_food_identity(
         401: {"model": ErrorResponse, "description": "Not authenticated"},
         404: {"model": ErrorResponse, "description": "Food record not found"},
         422: {"model": ErrorResponse, "description": "Carb value out of range"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
     },
 )
+# A fresh Idempotency-Key inserts a key row even when the name-dedupe merely
+# updates an existing baseline, so cap the write rate; generous for any real
+# save-as flow (a per-click user action).
+@limiter.limit("30/minute")
 async def save_record_as_common_food(
+    request: Request,
     record_id: uuid.UUID,
     body: SaveAsCommonFoodRequest,
     current_user: DiabeticOrAdminUser,

--- a/apps/api/src/routers/food_records.py
+++ b/apps/api/src/routers/food_records.py
@@ -552,6 +552,23 @@ async def save_record_as_common_food(
     a repeated key replays the originally-created baseline.
     """
     require_meal_intelligence(current_user)
+    if idempotency_key is not None:
+        # The key short-circuit must precede the owned-record fetch: the SOURCE
+        # record may have been deleted after a successful keyed promotion, and
+        # that retry must replay the created baseline (or its tombstone), never
+        # 404 on the missing source -- otherwise the reconcile sees a spurious
+        # failure for a request that did create the baseline. Mirrors the
+        # photo endpoint, where the short-circuit runs before any validation.
+        processed = await idempotency.find_idempotent_resource(
+            db,
+            current_user.id,
+            idempotency.COMMON_FOODS_CREATE_FROM_RECORD,
+            idempotency_key,
+        )
+        if processed is not None:
+            return await _replay_created_resource(
+                processed, db, CommonFood, CommonFoodResponse
+            )
     record = await _get_owned_record(record_id, current_user.id, db)
     try:
         common_food = await common_food_service.promote_to_common_food(

--- a/apps/api/src/schemas/idempotency.py
+++ b/apps/api/src/schemas/idempotency.py
@@ -1,6 +1,7 @@
 """Schemas for idempotent-replay responses."""
 
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -13,7 +14,8 @@ class IdempotentTombstoneResponse(BaseModel):
     outbox/reconcile treats this as done-with-nothing-to-bind.
     """
 
-    replayed: bool = True
-    resource_deleted: bool = True
+    # Constants of this response shape, not defaults -- the wire contract.
+    replayed: Literal[True] = True
+    resource_deleted: Literal[True] = True
     resource_type: str
     resource_id: uuid.UUID

--- a/apps/api/src/schemas/idempotency.py
+++ b/apps/api/src/schemas/idempotency.py
@@ -1,0 +1,19 @@
+"""Schemas for idempotent-replay responses."""
+
+import uuid
+
+from pydantic import BaseModel
+
+
+class IdempotentTombstoneResponse(BaseModel):
+    """Terminal replay body for a keyed create whose resource was since deleted.
+
+    The retry is "already processed" (never re-create -- that would resurrect a
+    deliberately-deleted meal), but there is nothing left to return. The client's
+    outbox/reconcile treats this as done-with-nothing-to-bind.
+    """
+
+    replayed: bool = True
+    resource_deleted: bool = True
+    resource_type: str
+    resource_id: uuid.UUID

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -67,6 +67,16 @@ class RecordGoneError(CommonFoodError):
     """The food record was concurrently deleted mid-promotion (re-fetch found nothing)."""
 
 
+class PromotionPersistenceError(CommonFoodError):
+    """Committing a keyed promotion failed for an infrastructure reason.
+
+    Raised only on the keyed path (mirrors ``food_vision.EstimatePersistenceError``):
+    the router maps it to a retryable 503, so a commit-time failure that is not a
+    same-key race never surfaces as a bare 500. The unkeyed path keeps its
+    pre-existing propagation.
+    """
+
+
 async def correct_food_record(
     db: AsyncSession,
     record: FoodRecord,
@@ -343,7 +353,7 @@ async def promote_to_common_food(
         await db.rollback()
         if client_request_id is not None:
             # The name-unique race was already resolved at the flush above, so
-            # an IntegrityError here is the idempotency constraint: a
+            # an IntegrityError here is normally the idempotency constraint: a
             # concurrent request with the same key won -- replay it.
             winner = await idempotency.find_idempotent_resource(
                 db,
@@ -353,6 +363,14 @@ async def promote_to_common_food(
             )
             if winner is not None:
                 raise idempotency.IdempotentReplay(winner) from exc
+            # No winner means this wasn't a same-key race (e.g. an FK failure
+            # from a concurrent account deletion). The keyed path is new
+            # surface, so type it as a retryable failure instead of letting a
+            # bare IntegrityError become an unhandled 500.
+            logger.error("Failed to persist keyed common-food promotion", exc_info=True)
+            raise PromotionPersistenceError(
+                "Could not save your common food. Please try again."
+            ) from exc
         raise
     await db.refresh(common_food)
     await db.refresh(record)

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -24,6 +24,7 @@ authenticated owner by the caller.
 
 from datetime import UTC, datetime
 
+from fastapi import status
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,7 +34,7 @@ from src.models.common_food import CommonFood, normalize_common_food_name
 from src.models.food_record import FoodRecord, FoodRecordSource
 from src.schemas.common_food import CommonFoodUpdateRequest
 from src.schemas.food_record import FoodRecordCorrectionRequest
-from src.services import meal_audit, meal_grounding, meal_rag
+from src.services import idempotency, meal_audit, meal_grounding, meal_rag
 from src.services.meal_intelligence import is_meal_intelligence_enabled
 from src.vision.carb_contract import CarbBoundsError, validate_carb_range
 
@@ -226,6 +227,7 @@ async def promote_to_common_food(
     db: AsyncSession,
     record: FoodRecord,
     name: str,
+    client_request_id: str | None = None,
 ) -> CommonFood:
     """Promote ``record`` to a named common-food baseline and link it.
 
@@ -233,10 +235,26 @@ async def promote_to_common_food(
     updates that baseline (its carbs/nutrition + display name) rather than
     creating a near-duplicate. The record is linked to the resulting baseline.
 
+    ``client_request_id`` (the caller's validated ``Idempotency-Key``) makes
+    the promotion exactly-once on retry: an already-processed key raises
+    ``idempotency.IdempotentReplay`` up front, and ``None`` (no header)
+    preserves the unchanged behavior. This is *request* identity, layered on
+    top of -- not replacing -- the name-based dedupe above.
+
     Must be called with no other pending session state: the unique-constraint
     race path below rolls the session back, which would discard any unrelated
     in-flight changes. The sole caller passes a freshly-loaded record.
     """
+    if client_request_id is not None:
+        replay = await idempotency.find_idempotent_resource(
+            db,
+            record.user_id,
+            idempotency.COMMON_FOODS_CREATE_FROM_RECORD,
+            client_request_id,
+        )
+        if replay is not None:
+            raise idempotency.IdempotentReplay(replay)
+
     low, high, nutrition = _effective_values(record)
     try:
         low, high = validate_carb_range(low, high)
@@ -305,7 +323,37 @@ async def promote_to_common_food(
         common_food.nutrition_json = nutrition
 
     record.common_food_id = common_food.id
-    await db.commit()
+    if client_request_id is not None:
+        # Staged in the same transaction as the promotion so the commit below
+        # writes the baseline/link and the key row atomically. The baseline id
+        # is materialized by this point on both paths (post-flush insert, or
+        # the re-fetched race winner).
+        idempotency.stage_idempotency_key(
+            db,
+            user_id=user_id,
+            endpoint=idempotency.COMMON_FOODS_CREATE_FROM_RECORD,
+            client_request_id=client_request_id,
+            resource_type=idempotency.RESOURCE_COMMON_FOOD,
+            resource_id=common_food.id,
+            response_status=status.HTTP_201_CREATED,
+        )
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        if client_request_id is not None:
+            # The name-unique race was already resolved at the flush above, so
+            # an IntegrityError here is the idempotency constraint: a
+            # concurrent request with the same key won -- replay it.
+            winner = await idempotency.find_idempotent_resource(
+                db,
+                user_id,
+                idempotency.COMMON_FOODS_CREATE_FROM_RECORD,
+                client_request_id,
+            )
+            if winner is not None:
+                raise idempotency.IdempotentReplay(winner) from exc
+        raise
     await db.refresh(common_food)
     await db.refresh(record)
 

--- a/apps/api/src/services/common_food.py
+++ b/apps/api/src/services/common_food.py
@@ -68,12 +68,12 @@ class RecordGoneError(CommonFoodError):
 
 
 class PromotionPersistenceError(CommonFoodError):
-    """Committing a keyed promotion failed for an infrastructure reason.
+    """Committing a promotion failed for an infrastructure reason.
 
-    Raised only on the keyed path (mirrors ``food_vision.EstimatePersistenceError``):
-    the router maps it to a retryable 503, so a commit-time failure that is not a
-    same-key race never surfaces as a bare 500. The unkeyed path keeps its
-    pre-existing propagation.
+    Mirrors ``food_vision.EstimatePersistenceError``: the router maps it to a
+    retryable 503, so a commit-time failure that is not a same-key race never
+    surfaces as a bare 500 -- keyed or not, the status must not depend on
+    whether the client sent a header.
     """
 
 
@@ -363,15 +363,15 @@ async def promote_to_common_food(
             )
             if winner is not None:
                 raise idempotency.IdempotentReplay(winner) from exc
-            # No winner means this wasn't a same-key race (e.g. an FK failure
-            # from a concurrent account deletion). The keyed path is new
-            # surface, so type it as a retryable failure instead of letting a
-            # bare IntegrityError become an unhandled 500.
-            logger.error("Failed to persist keyed common-food promotion", exc_info=True)
-            raise PromotionPersistenceError(
-                "Could not save your common food. Please try again."
-            ) from exc
-        raise
+        # Not a same-key race (e.g. an FK failure from a concurrent account
+        # deletion -- the name-unique race always surfaces at the flush above,
+        # never here). Type it as a retryable failure instead of letting a
+        # bare IntegrityError become an unhandled 500; keyed or not, the
+        # status must not depend on whether the client sent a header.
+        logger.error("Failed to persist common-food promotion", exc_info=True)
+        raise PromotionPersistenceError(
+            "Could not save your common food. Please try again."
+        ) from exc
     await db.refresh(common_food)
     await db.refresh(record)
 

--- a/apps/api/src/services/food_vision.py
+++ b/apps/api/src/services/food_vision.py
@@ -28,7 +28,9 @@ import base64
 from pathlib import Path
 
 import httpx
+from fastapi import status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
@@ -39,6 +41,7 @@ from src.models.user import User
 from src.schemas.food_record import EstimateDispersion
 from src.services import (
     food_image,
+    idempotency,
     meal_audit,
     meal_estimate_aggregate,
     meal_grounding,
@@ -267,6 +270,7 @@ async def create_food_record_from_image(
     db: AsyncSession,
     user: User,
     raw_image: bytes,
+    client_request_id: str | None = None,
 ) -> FoodRecord:
     """Run the full pipeline and persist a ``food_records`` row.
 
@@ -275,7 +279,25 @@ async def create_food_record_from_image(
     reject-not-clamp; a response we cannot turn into a usable, in-bounds
     estimate raises ``EstimateRejectedError`` rather than persisting a
     misleading record.
+
+    ``client_request_id`` (the caller's validated ``Idempotency-Key``) makes
+    the create exactly-once on retry: a key that was already processed raises
+    ``idempotency.IdempotentReplay`` -- before any vision call or photo store --
+    so a replayed offline create can never double-insert a meal (which would
+    inflate carb/IOB history, a dosing input). ``None`` (no header) preserves
+    the unchanged non-idempotent behavior.
     """
+    # Idempotency short-circuit FIRST -- before image validation, the vision
+    # call, and the photo store: a replay of an already-processed request must
+    # not re-charge the AI provider or write a second file, and its outcome
+    # must not depend on re-validating the payload.
+    if client_request_id is not None:
+        replay = await idempotency.find_idempotent_resource(
+            db, user.id, idempotency.FOOD_RECORDS_CREATE, client_request_id
+        )
+        if replay is not None:
+            raise idempotency.IdempotentReplay(replay)
+
     # Validate + strip metadata (raises food_image.* on bad input).
     processed = food_image.process_upload(raw_image)
 
@@ -380,8 +402,48 @@ async def create_food_record_from_image(
         identity_confirmed=False,
     )
     db.add(record)
+    # Capture before the commit attempt: the rollback path below expires every
+    # instance in the session (including ``user``), and reading an expired
+    # column afterwards triggers a sync lazy reload that raises under asyncio.
+    # Mirrors the same guard in common_food.promote_to_common_food.
+    user_id = user.id
     try:
+        if client_request_id is not None:
+            # Flush to materialize the record id, then stage the key row in the
+            # SAME transaction: the commit below writes the domain row and the
+            # key row atomically -- if either fails, neither persists.
+            await db.flush()
+            idempotency.stage_idempotency_key(
+                db,
+                user_id=user_id,
+                endpoint=idempotency.FOOD_RECORDS_CREATE,
+                client_request_id=client_request_id,
+                resource_type=idempotency.RESOURCE_FOOD_RECORD,
+                resource_id=record.id,
+                response_status=status.HTTP_201_CREATED,
+            )
         await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        if client_request_id is not None:
+            winner = await idempotency.find_idempotent_resource(
+                db, user_id, idempotency.FOOD_RECORDS_CREATE, client_request_id
+            )
+            if winner is not None:
+                # Lost a concurrent same-key race (both requests missed the
+                # pre-SELECT; the UNIQUE constraint rejected this insert).
+                # Unlike a generic commit failure, this rollback is
+                # *determinate* -- the DB rejected the transaction -- so the
+                # photo stored above is orphaned garbage and safe to remove
+                # (the winner stored its own copy).
+                food_image.delete_stored_image(storage_path)
+                raise idempotency.IdempotentReplay(winner) from exc
+        # Not a same-key race: treat like any other commit failure (mirrors the
+        # generic branch below, photo kept -- see there for why).
+        logger.error("Failed to persist food record", exc_info=True)
+        raise EstimatePersistenceError(
+            "Could not save your meal estimate. Please try again."
+        ) from exc
     except Exception as exc:
         await db.rollback()
         # A commit failure is an infra problem (DB outage, constraint, connection

--- a/apps/api/src/services/idempotency.py
+++ b/apps/api/src/services/idempotency.py
@@ -1,0 +1,102 @@
+"""Server-side idempotency substrate for user-authored creates.
+
+The reusable half of the Idempotency-Key contract (the transport half is
+``core.idempotency``): a central lookup + stage pair that any create endpoint
+wires in with zero new schema. Today's consumers are the food-photo create and
+save-as-common-food; the net-new creates in later stories call the same two
+functions.
+
+Contract for a call site:
+
+1. Key present -> ``find_idempotent_resource``. A hit means this exact request
+   was already processed: raise ``IdempotentReplay`` (or return the pointer)
+   BEFORE any expensive side effect (vision call, photo store).
+2. Miss -> run the create, then ``stage_idempotency_key`` in the SAME session
+   and let the existing single commit write the domain row and the key row
+   atomically -- if either fails, neither persists.
+3. Commit raises ``IntegrityError`` -> rollback, re-``find_idempotent_resource``;
+   a row now existing means a concurrent same-key request won the race --
+   replay it. The pre-SELECT in (1) is a cost optimization; the UNIQUE
+   constraint is the correctness guarantee.
+
+Safety framing: a replayed offline create that double-inserts a meal inflates
+carb -> IOB history, a dosing input. This module exists so that can't happen.
+It must never be conflated with ``pump_event_dedupe`` (a content hash with the
+opposite semantic -- see the model docstring).
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.idempotency_key import IdempotencyKey
+
+# Stable endpoint slugs -- the `endpoint` dimension of the unique key. Never
+# derive these from the request path (fragile to trailing slashes/versioning).
+FOOD_RECORDS_CREATE = "food_records.create"
+COMMON_FOODS_CREATE_FROM_RECORD = "common_foods.create_from_record"
+
+# resource_type discriminators for the polymorphic pointer.
+RESOURCE_FOOD_RECORD = "food_record"
+RESOURCE_COMMON_FOOD = "common_food"
+
+
+class IdempotentReplay(Exception):  # noqa: N818 -- control-flow signal, not an error
+    """This keyed create was already processed -- replay, don't re-create.
+
+    Deliberately an exception rather than a return value so a create service
+    can signal "already done" from anywhere in its pipeline (the pre-vision
+    short-circuit AND the commit-race loser path) without threading a replay
+    flag through every return type. The router catches it and builds the
+    replay response from the carried pointer: re-fetch the resource
+    owner-scoped, re-serialize, original status, ``Idempotent-Replayed: true``.
+    """
+
+    def __init__(self, key: IdempotencyKey) -> None:
+        super().__init__(f"idempotent replay for {key.endpoint}")
+        self.key = key
+
+
+async def find_idempotent_resource(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    endpoint: str,
+    client_request_id: str,
+) -> IdempotencyKey | None:
+    """Return the processed-create pointer for this exact request, if any."""
+    return await db.scalar(
+        select(IdempotencyKey).where(
+            IdempotencyKey.user_id == user_id,
+            IdempotencyKey.endpoint == endpoint,
+            IdempotencyKey.client_request_id == client_request_id,
+        )
+    )
+
+
+def stage_idempotency_key(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    endpoint: str,
+    client_request_id: str,
+    resource_type: str,
+    resource_id: uuid.UUID,
+    response_status: int,
+) -> IdempotencyKey:
+    """Add (NOT commit) the key row to the caller's session.
+
+    The caller owns the transaction: its single existing commit must write the
+    domain row and this key row atomically, so a crash between them can't
+    strand a key pointing at nothing (or a row with no key).
+    """
+    key = IdempotencyKey(
+        user_id=user_id,
+        endpoint=endpoint,
+        client_request_id=client_request_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        response_status=response_status,
+    )
+    db.add(key)
+    return key

--- a/apps/api/tests/test_idempotency_keys.py
+++ b/apps/api/tests/test_idempotency_keys.py
@@ -1,0 +1,624 @@
+"""Idempotency-key tests for user-authored creates (offline-outbox replay safety).
+
+The point of the substrate under test: a retried create with the same
+``Idempotency-Key`` header -- most importantly the offline outbox replaying
+after a dropped response -- must be exactly-once. A double-inserted meal would
+inflate carb (and downstream IOB) history, a dosing input.
+
+Covers the header contract, keyed create + replay (one row, one image, one
+vision call), the indeterminate-commit retry (the motivating scenario), the
+concurrent same-key race, cross-endpoint isolation, the deleted-resource edge,
+and the pump/push content-hash non-regression (request idempotency and
+content dedupe must never be conflated).
+"""
+
+import asyncio
+import json
+import uuid
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+from PIL import Image
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.core.idempotency import get_idempotency_key
+from src.database import get_db_session
+from src.main import app
+from src.models.ai_provider import (
+    AIProviderConfig,
+    AIProviderStatus,
+    AIProviderType,
+)
+from src.models.common_food import CommonFood
+from src.models.food_record import FoodRecord
+from src.models.idempotency_key import IdempotencyKey
+from src.services import food_vision, idempotency
+
+
+# --------------------------------------------------------------------------- #
+# Helpers (mirroring test_food_records.py)
+# --------------------------------------------------------------------------- #
+def _png_bytes(size: tuple[int, int] = (16, 16), color=(120, 40, 40)) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", size, color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _estimate_json(low=40, high=55, desc="a bowl of pasta"):
+    return json.dumps(
+        {
+            "food_description": desc,
+            "carbs_grams_low": low,
+            "carbs_grams_high": high,
+            "confidence": "high",
+            "assumptions": "standard restaurant portion",
+            "nutrition": {"protein_grams": 12, "calories": 520},
+        }
+    )
+
+
+def unique_email(prefix: str = "idem") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}@example.com"
+
+
+async def _register_login(client: AsyncClient) -> str:
+    email = unique_email()
+    await client.post(
+        "/api/auth/register", json={"email": email, "password": "SecurePass123"}
+    )
+    resp = await client.post(
+        "/api/auth/login", json={"email": email, "password": "SecurePass123"}
+    )
+    return resp.cookies.get(settings.jwt_cookie_name)
+
+
+async def _current_user_id(client: AsyncClient) -> uuid.UUID:
+    resp = await client.get("/api/auth/me")
+    return uuid.UUID(resp.json()["id"])
+
+
+async def _add_provider(db, user_id: uuid.UUID):
+    db.add(
+        AIProviderConfig(
+            user_id=user_id,
+            provider_type=AIProviderType.CLAUDE_API,
+            model_name="claude-sonnet-4-5-20250929",
+            status=AIProviderStatus.CONNECTED,
+        )
+    )
+    await db.commit()
+
+
+@pytest.fixture
+def _uploads_tmp(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "upload_dir", str(tmp_path / "uploads"))
+    return tmp_path
+
+
+@pytest_asyncio.fixture
+async def auth_client(_uploads_tmp, db_session):
+    """An authenticated client with an AI provider configured."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        cookie = await _register_login(client)
+        client.cookies.set(settings.jwt_cookie_name, cookie)
+        user_id = await _current_user_id(client)
+        await _add_provider(db_session, user_id)
+        yield client, user_id
+
+
+async def _upload(
+    client: AsyncClient, key: str | None = None, image: bytes | None = None
+):
+    headers = {"Idempotency-Key": key} if key is not None else {}
+    return await client.post(
+        "/api/food-records",
+        files={
+            "file": (
+                "meal.png",
+                image if image is not None else _png_bytes(),
+                "image/png",
+            )
+        },
+        headers=headers,
+    )
+
+
+async def _count(model, user_id: uuid.UUID) -> int:
+    """Count rows in a fresh session (the shared ``db_session`` fixture lives
+    on the session-scoped loop; opening here keeps IO on the test's loop)."""
+    async with get_db_session() as db:
+        return await db.scalar(
+            select(func.count()).select_from(model).where(model.user_id == user_id)
+        )
+
+
+async def _food_row_count(user_id: uuid.UUID) -> int:
+    return await _count(FoodRecord, user_id)
+
+
+async def _key_row_count(user_id: uuid.UUID) -> int:
+    return await _count(IdempotencyKey, user_id)
+
+
+async def _common_food_count(user_id: uuid.UUID) -> int:
+    return await _count(CommonFood, user_id)
+
+
+def _stored_image_count() -> int:
+    root = Path(settings.upload_dir)
+    if not root.exists():
+        return 0
+    return sum(1 for p in root.rglob("*") if p.is_file())
+
+
+# --------------------------------------------------------------------------- #
+# AC2 -- the Idempotency-Key header contract
+# --------------------------------------------------------------------------- #
+class TestIdempotencyKeyHeaderContract:
+    async def test_absent_header_is_normal_create(self, auth_client):
+        """Golden regression: no header -> unchanged non-idempotent create."""
+        client, user_id = auth_client
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1 = await _upload(client)
+            r2 = await _upload(client)
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        # Two identical unkeyed uploads are two REAL meals -- they must both
+        # persist (content-based dedupe here would be a clinical carb
+        # undercount) and no key rows appear.
+        assert r1.json()["id"] != r2.json()["id"]
+        assert await _food_row_count(user_id) == 2
+        assert await _key_row_count(user_id) == 0
+        assert "Idempotent-Replayed" not in r1.headers
+
+    async def test_empty_header_is_422_with_string_detail(self, auth_client):
+        client, _ = auth_client
+        vision = AsyncMock(return_value=_estimate_json())
+        with patch.object(food_vision, "_call_vision", vision):
+            resp = await _upload(client, key="")
+        assert resp.status_code == 422
+        assert isinstance(resp.json()["detail"], str)
+        vision.assert_not_awaited()
+
+    async def test_oversized_header_is_422_with_string_detail(self, auth_client):
+        client, _ = auth_client
+        resp = await _upload(client, key="k" * 65)
+        assert resp.status_code == 422
+        assert isinstance(resp.json()["detail"], str)
+
+    async def test_max_length_key_accepted(self, auth_client):
+        client, _ = auth_client
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            resp = await _upload(client, key="k" * 64)
+        assert resp.status_code == 201
+
+    async def test_whitespace_only_header_rejected(self):
+        # Unit-level (whitespace-only values are awkward to send over real
+        # HTTP): the dependency must treat a blank-after-strip key as malformed.
+        with pytest.raises(HTTPException) as exc_info:
+            await get_idempotency_key("   ")
+        assert exc_info.value.status_code == 422
+        assert isinstance(exc_info.value.detail, str)
+
+    async def test_absent_value_passes_through_as_none(self):
+        assert await get_idempotency_key(None) is None
+
+    async def test_surrounding_whitespace_is_stripped(self):
+        assert await get_idempotency_key(" abc ") == "abc"
+
+
+# --------------------------------------------------------------------------- #
+# AC3 / AC4 / AC6 -- keyed create then replay
+# --------------------------------------------------------------------------- #
+class TestKeyedCreateReplay:
+    async def test_replay_returns_same_record_once_only(self, auth_client):
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        # Patch at the samples level so awaits map 1:1 to requests.
+        samples = AsyncMock(return_value=[_estimate_json()])
+        with patch.object(food_vision, "_call_vision_samples", samples):
+            r1 = await _upload(client, key=key)
+            r2 = await _upload(client, key=key)
+
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r1.json()["id"] == r2.json()["id"]
+        assert "Idempotent-Replayed" not in r1.headers
+        assert r2.headers.get("Idempotent-Replayed") == "true"
+
+        # Exactly once: one row, one stored image, one vision round.
+        assert await _food_row_count(user_id) == 1
+        assert _stored_image_count() == 1
+        assert samples.await_count == 1
+
+    async def test_replay_short_circuits_before_image_validation(self, auth_client):
+        """The replay must not depend on re-validating the payload: a retry
+        whose image bytes got corrupted still returns the original record."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1 = await _upload(client, key=key)
+            r2 = await _upload(client, key=key, image=b"corrupted-not-an-image")
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r2.json()["id"] == r1.json()["id"]
+        assert await _food_row_count(user_id) == 1
+
+    async def test_replay_is_a_live_refetch_not_a_snapshot(self, auth_client):
+        """AC4: the key row stores a pointer; a replay serves the record's
+        CURRENT state (here: a correction applied between create and retry)."""
+        client, _ = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1 = await _upload(client, key=key)
+            record_id = r1.json()["id"]
+            corrected = await client.post(
+                f"/api/food-records/{record_id}/correct",
+                json={"corrected_carbs_low": 10, "corrected_carbs_high": 20},
+            )
+            assert corrected.status_code == 200
+            r2 = await _upload(client, key=key)
+        assert r2.json()["id"] == record_id
+        assert r2.json()["corrected_carbs_low"] == 10
+        assert r2.json()["source"] == "user_corrected"
+
+    async def test_keys_are_user_scoped(self, auth_client):
+        """The same key value from two different users is two distinct creates."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as other:
+            cookie = await _register_login(other)
+            other.cookies.set(settings.jwt_cookie_name, cookie)
+            other_id = await _current_user_id(other)
+            async with get_db_session() as db:
+                await _add_provider(db, other_id)
+            with patch.object(
+                food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+            ):
+                r1 = await _upload(client, key=key)
+                r2 = await _upload(other, key=key)
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r1.json()["id"] != r2.json()["id"]
+        assert "Idempotent-Replayed" not in r2.headers
+
+
+# --------------------------------------------------------------------------- #
+# The motivating scenario: indeterminate commit -> retry
+# --------------------------------------------------------------------------- #
+class TestIndeterminateCommitRetry:
+    async def test_retry_after_dropped_response_replays_committed_row(
+        self, auth_client
+    ):
+        """The row committed server-side but the client saw an error (dropped
+        connection). The keyed retry must replay the committed row -- never
+        fail closed, never double-insert."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+
+        real_commit = AsyncSession.commit
+
+        async def commit_then_drop(self):
+            # The commit really happens; the failure is on the response path.
+            await real_commit(self)
+            raise ConnectionError("simulated response drop after server-side commit")
+
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            with patch.object(AsyncSession, "commit", commit_then_drop):
+                r1 = await _upload(client, key=key)
+            assert r1.status_code == 503  # what the client actually saw
+
+            # The row (and its key row, same transaction) DID land.
+            assert await _food_row_count(user_id) == 1
+
+            r2 = await _upload(client, key=key)
+
+        assert r2.status_code == 201
+        assert r2.headers.get("Idempotent-Replayed") == "true"
+        assert await _food_row_count(user_id) == 1
+        assert await _key_row_count(user_id) == 1
+
+
+# --------------------------------------------------------------------------- #
+# AC5 -- concurrent same-key race
+# --------------------------------------------------------------------------- #
+class TestConcurrentSameKeyRace:
+    async def test_forced_race_loser_replays_winner(self, auth_client):
+        """Deterministic race: the second request is forced to miss the
+        pre-SELECT, so it inserts, hits the UNIQUE constraint, and must
+        resolve to the winner's row via the IntegrityError path -- no 500,
+        no duplicate, and its orphaned photo is cleaned up."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1 = await _upload(client, key=key)
+            assert r1.status_code == 201
+            winner_id = r1.json()["id"]
+            assert _stored_image_count() == 1
+
+            real_find = idempotency.find_idempotent_resource
+            missed = False
+
+            async def miss_the_preselect_once(db, user_id, endpoint, client_request_id):
+                nonlocal missed
+                if not missed:
+                    missed = True
+                    return None  # simulate "the winner hasn't committed yet"
+                return await real_find(db, user_id, endpoint, client_request_id)
+
+            with patch.object(
+                idempotency, "find_idempotent_resource", miss_the_preselect_once
+            ):
+                r2 = await _upload(client, key=key)
+
+        assert r2.status_code == 201
+        assert r2.json()["id"] == winner_id
+        assert r2.headers.get("Idempotent-Replayed") == "true"
+        assert await _food_row_count(user_id) == 1
+        # The loser's photo was stored pre-commit and must not leak: the race
+        # rollback is determinate, so it gets deleted (winner's copy remains).
+        assert _stored_image_count() == 1
+
+    async def test_two_concurrent_keyed_requests_yield_one_row(self, auth_client):
+        """End-to-end concurrency: whichever interleaving happens (pre-SELECT
+        hit or constraint race), both callers get the same resource and
+        exactly one row exists."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1, r2 = await asyncio.gather(
+                _upload(client, key=key), _upload(client, key=key)
+            )
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r1.json()["id"] == r2.json()["id"]
+        assert await _food_row_count(user_id) == 1
+
+
+# --------------------------------------------------------------------------- #
+# AC7 -- cross-endpoint isolation + save-as-common-food (secondary scope)
+# --------------------------------------------------------------------------- #
+class TestCrossEndpointIsolation:
+    async def test_same_key_on_two_endpoints_does_not_collide(self, auth_client):
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1 = await _upload(client, key=key)
+        assert r1.status_code == 201
+        record_id = r1.json()["id"]
+
+        # Reusing the exact same key value on a DIFFERENT endpoint must be a
+        # fresh create there (the endpoint dimension isolates), never a replay
+        # of the food record.
+        r2 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal"},
+            headers={"Idempotency-Key": key},
+        )
+        assert r2.status_code == 201
+        assert "Idempotent-Replayed" not in r2.headers
+        assert r2.json()["name"] == "Oatmeal"
+        assert r2.json()["id"] != record_id
+        assert await _key_row_count(user_id) == 2
+
+    async def test_save_as_common_food_keyed_replay(self, auth_client):
+        client, user_id = auth_client
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            record_id = (await _upload(client)).json()["id"]
+
+        key = str(uuid.uuid4())
+        r1 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal"},
+            headers={"Idempotency-Key": key},
+        )
+        r2 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal"},
+            headers={"Idempotency-Key": key},
+        )
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r1.json()["id"] == r2.json()["id"]
+        assert r2.headers.get("Idempotent-Replayed") == "true"
+        assert await _common_food_count(user_id) == 1
+
+    async def test_name_upsert_survives_alongside_request_idempotency(
+        self, auth_client
+    ):
+        """A DIFFERENT key with an existing name still collapses by name --
+        the pre-existing content-level dedupe is retained, layered under the
+        new request-level idempotency."""
+        client, user_id = auth_client
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            record_id = (await _upload(client)).json()["id"]
+
+        r1 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal"},
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+        r2 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "oatmeal  "},  # same normalized name, new key
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r1.json()["id"] == r2.json()["id"]  # name-upsert, not a new row
+        assert "Idempotent-Replayed" not in r2.headers  # a real (update) pass
+        assert await _common_food_count(user_id) == 1
+
+
+# --------------------------------------------------------------------------- #
+# AC8 -- deleted-resource edge
+# --------------------------------------------------------------------------- #
+class TestDeletedResourceEdge:
+    async def test_replay_of_deleted_record_is_terminal_tombstone(self, auth_client):
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1 = await _upload(client, key=key)
+            record_id = r1.json()["id"]
+
+            deleted = await client.delete(f"/api/food-records/{record_id}")
+            assert deleted.status_code == 204
+
+            r2 = await _upload(client, key=key)
+
+        # Terminal done/gone: never re-created (a re-create would resurrect a
+        # deliberately-deleted meal).
+        assert r2.status_code == 200
+        body = r2.json()
+        assert body["replayed"] is True
+        assert body["resource_deleted"] is True
+        assert body["resource_type"] == "food_record"
+        assert body["resource_id"] == record_id
+        assert r2.headers.get("Idempotent-Replayed") == "true"
+        assert await _food_row_count(user_id) == 0
+
+
+# --------------------------------------------------------------------------- #
+# AC1 -- schema/migration parity
+# --------------------------------------------------------------------------- #
+class TestSchemaParity:
+    async def test_migration_built_the_constraint_and_index(self):
+        """The functional guarantees above run against the ORM; pin that the
+        MIGRATED table (what production gets) carries the same named unique
+        constraint and index the model declares."""
+        async with get_db_session() as db:
+            constraint_rows = await db.execute(
+                text(
+                    "SELECT conname FROM pg_constraint "
+                    "WHERE conrelid = 'idempotency_keys'::regclass"
+                )
+            )
+            constraint_names = {row[0] for row in constraint_rows}
+            index_rows = await db.execute(
+                text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE tablename = 'idempotency_keys'"
+                )
+            )
+            index_names = {row[0] for row in index_rows}
+        assert "uq_idempotency_keys_user_endpoint_client_request_id" in constraint_names
+        assert "ix_idempotency_keys_user_id" in index_names
+
+    def test_model_mirrors_migration_constraint_name(self):
+        unique_constraints = [
+            arg
+            for arg in IdempotencyKey.__table_args__
+            if getattr(arg, "name", None)
+            == "uq_idempotency_keys_user_endpoint_client_request_id"
+        ]
+        assert len(unique_constraints) == 1
+
+
+# --------------------------------------------------------------------------- #
+# AC9 -- pump/push is untouched (content dedupe, not request idempotency)
+# --------------------------------------------------------------------------- #
+class TestPumpPushUnaffected:
+    async def _register_mobile(self, client: AsyncClient) -> tuple[str, uuid.UUID]:
+        email = unique_email("pump")
+        reg = await client.post(
+            "/api/auth/register", json={"email": email, "password": "SecurePass123"}
+        )
+        assert reg.status_code == 201, reg.text
+        resp = await client.post(
+            "/api/auth/mobile/login",
+            json={"email": email, "password": "SecurePass123"},
+        )
+        token = resp.json()["access_token"]
+        me = await client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {token}"}
+        )
+        return token, uuid.UUID(me.json()["id"])
+
+    async def test_header_is_ignored_and_content_dedupe_still_governs(self):
+        """pump/push keeps its own content-hash dedupe semantics: the
+        Idempotency-Key header must change NOTHING there. Same content with
+        different keys still collapses (content hash); different content with
+        the same key still persists twice (no request idempotency); and no
+        idempotency_keys rows appear."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            token, user_id = await self._register_mobile(client)
+            auth = {"Authorization": f"Bearer {token}"}
+            event = {
+                "event_type": "bolus",
+                "event_timestamp": "2026-03-01T12:00:03+00:00",
+                "units": 2.5,
+            }
+
+            # Same content, DIFFERENT keys -> still collapsed by content hash.
+            r1 = await client.post(
+                "/api/integrations/pump/push",
+                headers={**auth, "Idempotency-Key": str(uuid.uuid4())},
+                json={"events": [event], "source": "mobile"},
+            )
+            r2 = await client.post(
+                "/api/integrations/pump/push",
+                headers={**auth, "Idempotency-Key": str(uuid.uuid4())},
+                json={"events": [event], "source": "mobile"},
+            )
+            assert r1.status_code == 200
+            assert r1.json()["accepted"] == 1
+            assert r2.status_code == 200
+            assert r2.json()["accepted"] == 0
+            assert r2.json()["duplicates"] == 1
+
+            # Different content, SAME key -> both persist (no request
+            # idempotency on this endpoint).
+            shared_key = {"Idempotency-Key": str(uuid.uuid4())}
+            distinct = dict(
+                event, event_timestamp="2026-03-01T12:05:00+00:00", units=4.0
+            )
+            distinct2 = dict(
+                event, event_timestamp="2026-03-01T12:10:00+00:00", units=6.0
+            )
+            r3 = await client.post(
+                "/api/integrations/pump/push",
+                headers={**auth, **shared_key},
+                json={"events": [distinct], "source": "mobile"},
+            )
+            r4 = await client.post(
+                "/api/integrations/pump/push",
+                headers={**auth, **shared_key},
+                json={"events": [distinct2], "source": "mobile"},
+            )
+            assert r3.json()["accepted"] == 1
+            assert r4.json()["accepted"] == 1
+
+            assert await _key_row_count(user_id) == 0

--- a/apps/api/tests/test_idempotency_keys.py
+++ b/apps/api/tests/test_idempotency_keys.py
@@ -40,7 +40,8 @@ from src.models.ai_provider import (
 from src.models.common_food import CommonFood
 from src.models.food_record import FoodRecord
 from src.models.idempotency_key import IdempotencyKey
-from src.services import food_vision, idempotency
+from src.schemas.food_record import FoodRecordResponse
+from src.services import food_image, food_vision, idempotency
 
 
 # --------------------------------------------------------------------------- #
@@ -279,6 +280,76 @@ class TestKeyedCreateReplay:
         assert r2.json()["corrected_carbs_low"] == 10
         assert r2.json()["source"] == "user_corrected"
 
+    async def test_key_not_burned_when_vision_fails_before_commit(self, auth_client):
+        """A first attempt that fails before the commit (here: no vision route)
+        must leave NO key row, so a same-key retry runs a FRESH create -- it
+        neither replays a pointer to a nonexistent resource nor silently drops
+        the second legitimate attempt."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision,
+            "_call_vision",
+            AsyncMock(side_effect=food_vision.VisionUnavailableError("no vision")),
+        ):
+            r1 = await _upload(client, key=key)
+        assert r1.status_code == 422
+        assert await _key_row_count(user_id) == 0
+        assert await _food_row_count(user_id) == 0
+
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r2 = await _upload(client, key=key)
+        assert r2.status_code == 201
+        assert "Idempotent-Replayed" not in r2.headers  # a fresh create
+        assert await _food_row_count(user_id) == 1
+        assert await _key_row_count(user_id) == 1
+
+    async def test_key_not_burned_when_photo_store_fails_before_commit(
+        self, auth_client
+    ):
+        """Same guarantee for a failure AFTER vision but before the commit
+        (the photo store), the latest pre-commit failure point."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            with patch.object(
+                food_image, "store_image", side_effect=OSError("disk full")
+            ):
+                r1 = await _upload(client, key=key)
+            assert r1.status_code == 503
+            assert await _key_row_count(user_id) == 0
+
+            r2 = await _upload(client, key=key)
+        assert r2.status_code == 201
+        assert "Idempotent-Replayed" not in r2.headers
+        assert await _food_row_count(user_id) == 1
+
+    async def test_replay_path_failure_maps_to_retryable_503(self, auth_client):
+        """If the replay build itself fails (re-fetch/serialize), the endpoint
+        must return its clean retryable 503, never a bare 500 -- the client
+        retries the same key later."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1 = await _upload(client, key=key)
+            assert r1.status_code == 201
+            # Serialization raising inside the replay helper stands in for any
+            # re-fetch/serialize failure on the replay path.
+            with patch.object(
+                FoodRecordResponse,
+                "model_validate",
+                side_effect=RuntimeError("simulated replay serialization failure"),
+            ):
+                r2 = await _upload(client, key=key)
+        assert r2.status_code == 503
+        assert isinstance(r2.json()["detail"], str)
+
     async def test_same_key_with_different_payload_replays_the_original(
         self, auth_client
     ):
@@ -472,6 +543,40 @@ class TestCrossEndpointIsolation:
         assert r1.status_code == 201
         assert r2.status_code == 201
         assert r1.json()["id"] == r2.json()["id"]
+        assert r2.headers.get("Idempotent-Replayed") == "true"
+        assert await _common_food_count(user_id) == 1
+
+    async def test_replay_survives_source_record_deletion(self, auth_client):
+        """A keyed promotion whose SOURCE food record is deleted between
+        attempts must replay the created baseline, never 404 on the missing
+        source -- the key short-circuit runs before the owned-record fetch."""
+        client, user_id = auth_client
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            record_id = (await _upload(client)).json()["id"]
+
+        key = str(uuid.uuid4())
+        r1 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal"},
+            headers={"Idempotency-Key": key},
+        )
+        assert r1.status_code == 201
+        common_food_id = r1.json()["id"]
+
+        # Delete the SOURCE record (not the baseline) -- the retry's path
+        # parameter now points at a record that no longer exists.
+        deleted = await client.delete(f"/api/food-records/{record_id}")
+        assert deleted.status_code == 204
+
+        r2 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal"},
+            headers={"Idempotency-Key": key},
+        )
+        assert r2.status_code == 201  # NOT a 404
+        assert r2.json()["id"] == common_food_id
         assert r2.headers.get("Idempotent-Replayed") == "true"
         assert await _common_food_count(user_id) == 1
 

--- a/apps/api/tests/test_idempotency_keys.py
+++ b/apps/api/tests/test_idempotency_keys.py
@@ -278,6 +278,29 @@ class TestKeyedCreateReplay:
         assert r2.json()["corrected_carbs_low"] == 10
         assert r2.json()["source"] == "user_corrected"
 
+    async def test_same_key_with_different_payload_replays_the_original(
+        self, auth_client
+    ):
+        """Pin the documented v1 boundary: the server does NOT fingerprint the
+        payload, so a client that (wrongly) reuses a key for a different photo
+        gets the ORIGINAL record back and the new one is never created. One
+        key per queued action is a hard client-side requirement -- see
+        docs/dev/idempotency-keys.md."""
+        client, user_id = auth_client
+        key = str(uuid.uuid4())
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            r1 = await _upload(client, key=key)
+            r2 = await _upload(
+                client, key=key, image=_png_bytes(size=(24, 24), color=(10, 200, 10))
+            )
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r2.json()["id"] == r1.json()["id"]
+        assert r2.headers.get("Idempotent-Replayed") == "true"
+        assert await _food_row_count(user_id) == 1
+
     async def test_keys_are_user_scoped(self, auth_client):
         """The same key value from two different users is two distinct creates."""
         client, user_id = auth_client
@@ -508,6 +531,42 @@ class TestDeletedResourceEdge:
         assert body["resource_id"] == record_id
         assert r2.headers.get("Idempotent-Replayed") == "true"
         assert await _food_row_count(user_id) == 0
+
+    async def test_replay_of_deleted_common_food_is_terminal_tombstone(
+        self, auth_client
+    ):
+        """Same edge on the secondary endpoint: the tombstone must carry the
+        common_food resource type, and the baseline is never resurrected."""
+        client, user_id = auth_client
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            record_id = (await _upload(client)).json()["id"]
+
+        key = str(uuid.uuid4())
+        r1 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal"},
+            headers={"Idempotency-Key": key},
+        )
+        assert r1.status_code == 201
+        common_food_id = r1.json()["id"]
+
+        deleted = await client.delete(f"/api/common-foods/{common_food_id}")
+        assert deleted.status_code == 204
+
+        r2 = await client.post(
+            f"/api/food-records/{record_id}/save-as-common-food",
+            json={"name": "Oatmeal"},
+            headers={"Idempotency-Key": key},
+        )
+        assert r2.status_code == 200
+        body = r2.json()
+        assert body["replayed"] is True
+        assert body["resource_deleted"] is True
+        assert body["resource_type"] == "common_food"
+        assert body["resource_id"] == common_food_id
+        assert await _common_food_count(user_id) == 0
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/api/tests/test_idempotency_keys.py
+++ b/apps/api/tests/test_idempotency_keys.py
@@ -25,6 +25,7 @@ from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 from PIL import Image
 from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
@@ -473,6 +474,33 @@ class TestCrossEndpointIsolation:
         assert r1.json()["id"] == r2.json()["id"]
         assert r2.headers.get("Idempotent-Replayed") == "true"
         assert await _common_food_count(user_id) == 1
+
+    async def test_keyed_promotion_nonrace_commit_failure_is_retryable_503(
+        self, auth_client
+    ):
+        """A keyed promotion whose commit fails with an IntegrityError that is
+        NOT a same-key race (no winner to replay -- e.g. an FK failure from a
+        concurrent account deletion) must surface as a retryable 503, never an
+        unhandled 500."""
+        client, user_id = auth_client
+        with patch.object(
+            food_vision, "_call_vision", AsyncMock(return_value=_estimate_json())
+        ):
+            record_id = (await _upload(client)).json()["id"]
+
+        async def commit_fails(self):
+            raise IntegrityError("INSERT ...", {}, Exception("fk violation"))
+
+        with patch.object(AsyncSession, "commit", commit_fails):
+            resp = await client.post(
+                f"/api/food-records/{record_id}/save-as-common-food",
+                json={"name": "Oatmeal"},
+                headers={"Idempotency-Key": str(uuid.uuid4())},
+            )
+        assert resp.status_code == 503
+        assert isinstance(resp.json()["detail"], str)
+        # Nothing persisted: the failed transaction rolled back cleanly.
+        assert await _common_food_count(user_id) == 0
 
     async def test_name_upsert_survives_alongside_request_idempotency(
         self, auth_client

--- a/docs/dev/_meta.json
+++ b/docs/dev/_meta.json
@@ -8,6 +8,7 @@
     "docker-integration-testing",
     "real-data-pipeline-verification",
     "security-testing",
+    "idempotency-keys",
     "plugin-architecture",
     "wear-os-architecture",
     "k8s-external-access"

--- a/docs/dev/idempotency-keys.md
+++ b/docs/dev/idempotency-keys.md
@@ -1,0 +1,79 @@
+# Idempotency Keys for User-Authored Creates
+
+The backend supports an optional `Idempotency-Key` request header on
+user-authored create endpoints so a retried create — most importantly the
+mobile offline outbox replaying after a dropped response — can never
+double-insert. A double-inserted meal inflates carb (and downstream IOB)
+history, a dosing input, so exactly-once create replay is safety-adjacent.
+
+## The contract
+
+- **Header:** `Idempotency-Key: <opaque string, max 64 chars>`. The mobile
+  outbox sends a canonical lowercase UUIDv4 (its queued row's
+  `clientRequestId`), but the server treats the value as opaque.
+- **Optional.** No header means the endpoint behaves exactly as before — a
+  normal, non-idempotent create. Web, the Wear relay, and older app builds are
+  unaffected.
+- **Malformed** (blank, or over 64 chars) is rejected with
+  `422 {"detail": "<string>"}`.
+- **Scope:** the key is unique per `(user, endpoint, client_request_id)`. The
+  same value sent to two different endpoints never collides — each queued
+  client action gets one fresh key, reused only for retries of that action.
+- **First request:** processed normally; the created resource's pointer
+  (`resource_type`, `resource_id`, HTTP status — never the response body) is
+  recorded atomically in the same transaction as the domain row.
+- **Retry with the same key:** the server returns the *original* resource —
+  same server `id`, original status — without re-running any side effect (no
+  second AI vision call, no second stored photo, no second row). The response
+  carries `Idempotent-Replayed: true`.
+- **Replayed-but-deleted:** if the referenced resource was deleted between the
+  original create and the retry, the server responds `200` with a small
+  tombstone body (`replayed`, `resource_deleted`, `resource_type`,
+  `resource_id`) and does **not** re-create it. Clients must treat this as
+  terminal: done, nothing to bind.
+- **Concurrent duplicates:** two in-flight requests with the same key resolve
+  to a single resource; the loser transparently returns the winner's resource.
+
+## Wired endpoints
+
+| Endpoint | Slug | Resource |
+| --- | --- | --- |
+| `POST /api/food-records` | `food_records.create` | `food_record` |
+| `POST /api/food-records/{id}/save-as-common-food` | `common_foods.create_from_record` | `common_food` |
+
+Future user-authored creates (notes, manual insulin logs) wire into the same
+substrate — `src/services/idempotency.py` + the `IdempotencyKeyHeader`
+dependency in `src/core/idempotency.py` — with zero new schema.
+
+## Explicitly excluded endpoints
+
+- `POST /api/integrations/pump/push` — has its own server-computed
+  **content-hash** dedup (`pump_events.dedupe_hash`), which is the *opposite*
+  semantic: it collapses distinct submissions describing the same real-world
+  event across sources. Request idempotency must never merge two intentionally
+  distinct meals that look alike; never apply either mechanism to the other's
+  endpoints.
+- `POST /api/treatment/validate-bolus` — an online-only pre-delivery safety
+  gate against live glucose/IoB; replaying a stale validation is unsafe, so it
+  must never be enqueued offline or keyed.
+- Edits (`correct`, `confirm-identity`, `link-common-food`, common-food
+  `PATCH`) are last-write-wins replayable, and both `DELETE`s are naturally
+  idempotent — no key needed.
+
+## Mobile wiring (for the offline-outbox stories)
+
+Add the header **per endpoint** on the Retrofit interface, e.g.:
+
+```kotlin
+@Multipart
+@POST("api/food-records")
+suspend fun uploadFoodPhoto(
+    @Part file: MultipartBody.Part,
+    @Header("Idempotency-Key") idempotencyKey: String? = null,
+): FoodRecordResponse
+```
+
+Do **not** stamp the header from a blanket OkHttp interceptor: that would
+wrongly attach request-idempotency semantics to `pump/push` (content-hash
+deduped) and `validate-bolus` (excluded by design). Only the outbox-replayed
+create calls pass a key; direct online calls may pass `null`.

--- a/docs/dev/idempotency-keys.md
+++ b/docs/dev/idempotency-keys.md
@@ -42,6 +42,11 @@ history, a dosing input, so exactly-once create replay is safety-adjacent.
   tombstone body (`replayed`, `resource_deleted`, `resource_type`,
   `resource_id`) and does **not** re-create it. Clients must treat this as
   terminal: done, nothing to bind.
+- **Replay precedes every other lookup.** The key short-circuit runs before
+  any owned-resource fetch, so a keyed retry replays even when a *dependency*
+  of the original request has since been deleted -- e.g. a keyed
+  save-as-common-food whose source food record is gone still replays the
+  created baseline instead of returning 404.
 - **Concurrent duplicates:** two in-flight requests with the same key resolve
   to a single resource; the loser transparently returns the winner's resource.
 - **Terminal errors:** a `403` (e.g. the user disabled meal intelligence after

--- a/docs/dev/idempotency-keys.md
+++ b/docs/dev/idempotency-keys.md
@@ -1,8 +1,13 @@
+---
+title: Idempotency Keys
+description: The optional Idempotency-Key contract for user-authored create endpoints.
+---
+
 # Idempotency Keys for User-Authored Creates
 
 The backend supports an optional `Idempotency-Key` request header on
-user-authored create endpoints so a retried create — most importantly the
-mobile offline outbox replaying after a dropped response — can never
+user-authored create endpoints so a retried create -- most importantly the
+mobile offline outbox replaying after a dropped response -- can never
 double-insert. A double-inserted meal inflates carb (and downstream IOB)
 history, a dosing input, so exactly-once create replay is safety-adjacent.
 
@@ -11,21 +16,27 @@ history, a dosing input, so exactly-once create replay is safety-adjacent.
 - **Header:** `Idempotency-Key: <opaque string, max 64 chars>`. The mobile
   outbox sends a canonical lowercase UUIDv4 (its queued row's
   `clientRequestId`), but the server treats the value as opaque.
-- **Optional.** No header means the endpoint behaves exactly as before — a
+- **Optional.** No header means the endpoint behaves exactly as before -- a
   normal, non-idempotent create. Web, the Wear relay, and older app builds are
   unaffected.
 - **Malformed** (blank, or over 64 chars) is rejected with
   `422 {"detail": "<string>"}`.
 - **Scope:** the key is unique per `(user, endpoint, client_request_id)`. The
-  same value sent to two different endpoints never collides — each queued
-  client action gets one fresh key, reused only for retries of that action.
+  same value sent to two different endpoints never collides. Each queued
+  client action gets one fresh key, reused **only** for retries of that exact
+  action. The server does not fingerprint the payload: if a client reuses a
+  key for a *different* action (different photo, different record id), the
+  server replays the original resource and the new action is silently lost --
+  generating a fresh key per action is a hard client-side requirement.
 - **First request:** processed normally; the created resource's pointer
-  (`resource_type`, `resource_id`, HTTP status — never the response body) is
+  (`resource_type`, `resource_id`, HTTP status -- never the response body) is
   recorded atomically in the same transaction as the domain row.
-- **Retry with the same key:** the server returns the *original* resource —
-  same server `id`, original status — without re-running any side effect (no
+- **Retry with the same key:** the server returns the *original* resource --
+  same server `id`, original status -- without re-running any side effect (no
   second AI vision call, no second stored photo, no second row). The response
-  carries `Idempotent-Replayed: true`.
+  carries `Idempotent-Replayed: true`. The retry must still be a well-formed
+  request (auth, accepted `Content-Type`, a file part present); only the
+  payload *content* is exempt from re-validation.
 - **Replayed-but-deleted:** if the referenced resource was deleted between the
   original create and the retry, the server responds `200` with a small
   tombstone body (`replayed`, `resource_deleted`, `resource_type`,
@@ -33,6 +44,12 @@ history, a dosing input, so exactly-once create replay is safety-adjacent.
   terminal: done, nothing to bind.
 - **Concurrent duplicates:** two in-flight requests with the same key resolve
   to a single resource; the loser transparently returns the winner's resource.
+- **Terminal errors:** a `403` (e.g. the user disabled meal intelligence after
+  queueing) or `404` on a keyed retry is not retryable -- the outbox should
+  treat it as terminal for that item rather than retrying forever.
+- **Retention:** key rows are never pruned; the replay window is unbounded,
+  which the tombstone semantics require. Growth is bounded by keyed-create
+  volume (same order as the created rows themselves).
 
 ## Wired endpoints
 
@@ -42,35 +59,36 @@ history, a dosing input, so exactly-once create replay is safety-adjacent.
 | `POST /api/food-records/{id}/save-as-common-food` | `common_foods.create_from_record` | `common_food` |
 
 Future user-authored creates (notes, manual insulin logs) wire into the same
-substrate — `src/services/idempotency.py` + the `IdempotencyKeyHeader`
-dependency in `src/core/idempotency.py` — with zero new schema.
+substrate -- `src/services/idempotency.py` + the `IdempotencyKeyHeader`
+dependency in `src/core/idempotency.py` -- with zero new schema.
 
 ## Explicitly excluded endpoints
 
-- `POST /api/integrations/pump/push` — has its own server-computed
+- `POST /api/integrations/pump/push` -- has its own server-computed
   **content-hash** dedup (`pump_events.dedupe_hash`), which is the *opposite*
   semantic: it collapses distinct submissions describing the same real-world
   event across sources. Request idempotency must never merge two intentionally
   distinct meals that look alike; never apply either mechanism to the other's
   endpoints.
-- `POST /api/treatment/validate-bolus` — an online-only pre-delivery safety
+- `POST /api/treatment/validate-bolus` -- an online-only pre-delivery safety
   gate against live glucose/IoB; replaying a stale validation is unsafe, so it
   must never be enqueued offline or keyed.
 - Edits (`correct`, `confirm-identity`, `link-common-food`, common-food
   `PATCH`) are last-write-wins replayable, and both `DELETE`s are naturally
-  idempotent — no key needed.
+  idempotent -- no key needed.
 
 ## Mobile wiring (for the offline-outbox stories)
 
-Add the header **per endpoint** on the Retrofit interface, e.g.:
+Add the header **per endpoint** on the Retrofit interface, e.g. (matching the
+existing `GlycemicGptApi.kt` signature):
 
 ```kotlin
 @Multipart
-@POST("api/food-records")
+@POST("/api/food-records")
 suspend fun uploadFoodPhoto(
     @Part file: MultipartBody.Part,
     @Header("Idempotency-Key") idempotencyKey: String? = null,
-): FoodRecordResponse
+): Response<FoodRecordResponse>
 ```
 
 Do **not** stamp the header from a blanket OkHttp interceptor: that would

--- a/docs/dev/idempotency-keys.md
+++ b/docs/dev/idempotency-keys.md
@@ -48,8 +48,10 @@ history, a dosing input, so exactly-once create replay is safety-adjacent.
   queueing) or `404` on a keyed retry is not retryable -- the outbox should
   treat it as terminal for that item rather than retrying forever.
 - **Retention:** key rows are never pruned; the replay window is unbounded,
-  which the tombstone semantics require. Growth is bounded by keyed-create
-  volume (same order as the created rows themselves).
+  which the tombstone semantics require. One key row is written per keyed
+  request that reaches its create/upsert (including a name-merge on
+  save-as-common-food), so growth tracks rate-limited keyed-request volume,
+  not just net-new rows.
 
 ## Wired endpoints
 


### PR DESCRIPTION
## Summary

Adds a reusable server-side idempotency layer for user-authored creates (GLY-111, Epic 57 Phase 2, backend-only) so a retried offline create — replayed by the future mobile outbox after a dropped response — can never double-insert a meal. A double insert inflates carb and downstream IOB history, a dosing input, so create-replay correctness is treated as safety-adjacent.

## What changed

- **Central `idempotency_keys` table** (migration `078_idempotency_keys`, model mirror byte-for-byte): `UNIQUE(user_id, endpoint, client_request_id)` plus a soft polymorphic resource pointer (`resource_type`, `resource_id`, `response_status`). Stores a pointer, never the response body — no meal/carb data is duplicated, and replays can never serve a stale snapshot. Future creates (notes, insulin logs) wire in with zero new schema.
- **Optional `Idempotency-Key` header** via a thin `get_idempotency_key` dependency (`IdempotencyKeyHeader` alias, mirroring the `DiabeticOrAdminUser` idiom). Absent header: byte-equivalent old behavior. Malformed (blank / >64 chars): `422` with a string `detail`.
- **Service substrate** (`services/idempotency.py`): `find_idempotent_resource` + `stage_idempotency_key` (staged in the caller's transaction — the single existing commit writes the domain row and key row atomically) + stable endpoint slugs + the `IdempotentReplay` control-flow signal.
- **`POST /api/food-records` wired (primary):** a key hit short-circuits before the AI vision call and photo store (no re-charge, no second file); concurrent same-key races resolve through the UNIQUE constraint (`IntegrityError` → rollback → re-fetch → replay the winner; the loser's orphaned photo is removed — that rollback is determinate, unlike the indeterminate-commit case whose fail-closed photo handling is unchanged). Replays re-fetch owner-scoped, re-serialize with the original status, and carry `Idempotent-Replayed: true`. A since-deleted resource replays as a terminal `200` tombstone — never re-created.
- **`save-as-common-food` wired (secondary):** same helper, layered under (not replacing) its existing name-UPSERT dedupe. Also now rate-limited (`30/minute`) since every fresh keyed request writes a key row even when the name merely merges.
- **Explicitly untouched:** `pump/push` (its `dedupe_hash` content dedupe is the opposite semantic — collapsing two distinct requests describing one real event; request idempotency must never merge two real identical-looking meals), `validate-bolus` (online-only safety gate), all edits and deletes. Pinned by tests.
- **Mobile contract documented** in `docs/dev/idempotency-keys.md`: per-endpoint `@Header("Idempotency-Key")` wiring (explicitly NOT a blanket OkHttp interceptor, which would wrongly stamp `pump/push`), one-key-per-action client requirement, terminal 403/404/tombstone semantics.

Fixed along the way (caught by the new tests): the race-loser path read ORM attributes after the rollback had expired them, which raised `MissingGreenlet` under asyncio and turned the replay into a 503. Locals are captured before the commit attempt (mirroring `promote_to_common_food`'s existing guard) and the replay helpers scope by `key.user_id` (always the authenticated caller).

## Tests (23 new, `tests/test_idempotency_keys.py`)

Keyed create + exact replay (one row, one stored image, one vision round, `Idempotent-Replayed: true`); the motivating indeterminate-commit → retry scenario (real commit + injected response drop → retry replays the committed row); a deterministic forced same-key race through the `IntegrityError` path (single row, winner replayed, loser's photo cleaned) plus a real `asyncio.gather` race; cross-endpoint isolation; user scoping; same-key-different-payload pins the documented one-key-per-action boundary; name-UPSERT retention; deleted-resource tombstones on both endpoints; header contract incl. 64/65-char bounds; model↔migration constraint-name parity against the migrated table; pump/push non-regression in both directions (same content + different keys still collapses; different content + same key persists twice; zero key rows).

## Evidence

- Full API suite: **6123 passed, 14 skipped, 10 xfailed**; `ruff check` + `ruff format --check` clean; `docker compose build` OK.
- Migration 078: upgrade → downgrade → upgrade round-trip verified on Postgres 16; single-head guard green.
- Live verification against the running stack: keyed replay returned `201` + original id for a user with **no AI provider configured** (proving the short-circuit precedes provider resolution/vision); corrupt-image replay still replays; delete → replay returns the terminal tombstone with no resurrection; pump/push ignores the header and still content-dedupes with zero key rows written.
- Adversarial + senior-engineer + security reviews run; all HIGH/MEDIUM findings fixed (replay-path error mapping, helper factoring, docs frontmatter, rate limit); security review PASS (no PHI in the new table, no IDOR, parameterized queries, key value never logged or reflected).
- CodeRabbit CLI (`--base develop`): no findings.
- Sentry validation gate PASS: stack run Sentry-enabled on the final code, all changed paths + golden create exercised; zero issues on the `/api/food-records` transaction; every issue in the window is a pre-existing class (fernet-decrypt flood; connection-churn issues first seen weeks ago re-firing at container recreation). Stack restored to Sentry-off.

## Follow-ups (deliberately out of v1, per the approved spec)

- Idempotency-key retention/TTL policy (no prune in v1 — an unbounded replay window is what the tombstone semantics require; documented).
- Request fingerprinting for same-key/different-payload 409 — v1 trusts the outbox one-key-per-action contract, now pinned by a test and documented for the 57.4/57.6 implementers.
- `promote_to_common_food`'s non-key commit `IntegrityError` still propagates bare (pre-existing contract), asymmetric with `food_vision`'s 503 mapping — worth aligning when the next create wires in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request idempotency for supported create actions via the `Idempotency-Key` header (validated and max length enforced).
  * Replays now return the original created result with a replay indicator header, without repeating side effects.
  * If the original resource was deleted, the API returns a terminal “replayed but deleted” response (HTTP 200 with tombstone details).
* **Bug Fixes**
  * Prevented duplicate records on retries and concurrent submissions; orphaned artifacts are avoided.
* **Documentation**
  * Added developer documentation for the `Idempotency-Key` contract and supported endpoints.
* **Tests**
  * Added end-to-end coverage for replay behavior, race conditions, edge cases, and migration parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->