### PR TITLE
Feat/GitHub copilot sdk provider

### DIFF
--- a/apps/api/migrations/versions/078_add_copilot_subscription_provider.py
+++ b/apps/api/migrations/versions/078_add_copilot_subscription_provider.py
@@ -1,0 +1,34 @@
+"""Add copilot_subscription AI provider type.
+
+Adds the 'copilot_subscription' value to the aiprovidertype enum for the
+GitHub Copilot SDK subscription provider, routed through the managed sidecar
+like claude_subscription / chatgpt_subscription.
+
+Revision ID: 078_add_copilot_subscription
+Revises: 077_meal_intelligence_enabled
+"""
+
+from alembic import op
+
+revision = "078_add_copilot_subscription"
+down_revision = "077_meal_intelligence_enabled"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add the new enum value - must run outside transaction for PostgreSQL
+    # ALTER TYPE ... ADD VALUE IF NOT EXISTS is non-transactional
+    op.execute("COMMIT")
+    op.execute(
+        "ALTER TYPE aiprovidertype ADD VALUE IF NOT EXISTS 'copilot_subscription'"
+    )
+
+
+def downgrade() -> None:
+    # PostgreSQL cannot remove enum values. Any rows referencing
+    # 'copilot_subscription' must be reassigned before downgrading further,
+    # matching the note in migration 028_expand_ai_provider_types.
+    op.execute(
+        "DELETE FROM ai_provider_configs WHERE provider_type = 'copilot_subscription'"
+    )

--- a/apps/api/migrations/versions/079_add_copilot_subscription_provider.py
+++ b/apps/api/migrations/versions/079_add_copilot_subscription_provider.py
@@ -4,14 +4,14 @@ Adds the 'copilot_subscription' value to the aiprovidertype enum for the
 GitHub Copilot SDK subscription provider, routed through the managed sidecar
 like claude_subscription / chatgpt_subscription.
 
-Revision ID: 078_add_copilot_subscription
-Revises: 077_meal_intelligence_enabled
+Revision ID: 079_add_copilot_subscription
+Revises: 078_idempotency_keys
 """
 
 from alembic import op
 
-revision = "078_add_copilot_subscription"
-down_revision = "077_meal_intelligence_enabled"
+revision = "079_add_copilot_subscription"
+down_revision = "078_idempotency_keys"
 branch_labels = None
 depends_on = None
 

--- a/apps/api/src/core/encryption.py
+++ b/apps/api/src/core/encryption.py
@@ -116,3 +116,35 @@ def decrypt_credential(encrypted: str) -> str:
         raise ValueError(
             "Failed to decrypt credential - invalid key or corrupted data"
         ) from e
+
+
+def encrypt_optional_credential(plaintext: str) -> str:
+    """Encrypt a credential that may legitimately be absent (e.g. a public,
+    read-only Nightscout instance with no API_SECRET).
+
+    `""` is treated as the sentinel for "no credential" and passed through
+    unencrypted rather than run through Fernet: encrypting an empty string
+    would still produce a non-empty ciphertext, which would then make a
+    `has_credential`-style check based on "is the stored value non-empty"
+    incorrectly report `True` for a connection that has no real credential.
+
+    Args:
+        plaintext: The credential value to encrypt, or "" for none.
+
+    Returns:
+        The encrypted value as a base64-encoded string, or "" unchanged.
+    """
+    return encrypt_credential(plaintext) if plaintext else ""
+
+
+def decrypt_optional_credential(encrypted: str) -> str:
+    """Inverse of `encrypt_optional_credential` -- "" passes through as "".
+
+    Args:
+        encrypted: The encrypted credential as a base64-encoded string,
+            or "" if none was ever set.
+
+    Returns:
+        The decrypted plaintext value, or "" unchanged.
+    """
+    return decrypt_credential(encrypted) if encrypted else ""

--- a/apps/api/src/models/ai_provider.py
+++ b/apps/api/src/models/ai_provider.py
@@ -33,6 +33,7 @@ class AIProviderType(str, enum.Enum):
     # Subscription proxies (unlimited usage via proxy)
     CLAUDE_SUBSCRIPTION = "claude_subscription"
     CHATGPT_SUBSCRIPTION = "chatgpt_subscription"
+    COPILOT_SUBSCRIPTION = "copilot_subscription"
 
     # Self-hosted / generic OpenAI-compatible endpoint
     OPENAI_COMPATIBLE = "openai_compatible"

--- a/apps/api/src/routers/ai.py
+++ b/apps/api/src/routers/ai.py
@@ -1,8 +1,8 @@
 """Story 5.1 / 14.2 / 15.2 / 15.4: AI provider configuration router.
 
 API endpoints for configuring AI provider with API key management.
-Supports 5 provider types: claude_api, openai_api, claude_subscription,
-chatgpt_subscription, and openai_compatible.
+Supports 6 provider types: claude_api, openai_api, claude_subscription,
+chatgpt_subscription, copilot_subscription, and openai_compatible.
 
 Story 15.2: Subscription auth endpoints for sidecar token management.
 Story 15.4: Subscription configure endpoint (no API key needed).
@@ -597,6 +597,7 @@ async def subscription_auth_status(
         sidecar_available=True,
         claude=auth_data.get("claude"),
         codex=auth_data.get("codex"),
+        copilot=auth_data.get("copilot"),
     )
 
 
@@ -720,4 +721,5 @@ async def subscription_sidecar_health(
         "status": health.get("status", "unknown"),
         "claude_auth": health.get("claude_auth", False),
         "codex_auth": health.get("codex_auth", False),
+        "copilot_auth": health.get("copilot_auth", False),
     }

--- a/apps/api/src/routers/nightscout.py
+++ b/apps/api/src/routers/nightscout.py
@@ -15,7 +15,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import DiabeticOrAdminUser
-from src.core.encryption import decrypt_credential, encrypt_credential
+from src.core.encryption import decrypt_optional_credential, encrypt_optional_credential
 from src.core.units import GlucoseUnit, GlucoseUnitSource
 from src.database import get_db
 from src.logging_config import get_logger
@@ -179,10 +179,15 @@ async def create_connection(
     fails, returns 400 and persists nothing -- the user fixes their
     URL/credential and re-submits.
     """
+    # Credential is optional (public, read-only Nightscout instances don't
+    # need one); normalize the schema's `None` to "" once here so every
+    # downstream consumer (client, encryption) only ever sees a plain str,
+    # with "" as the uniform "no credential" sentinel.
+    credential_value = request.credential or ""
     outcome = await test_connection(
         base_url=request.base_url,
         auth_type=request.auth_type,
-        credential=request.credential,
+        credential=credential_value,
         api_version=request.api_version,
     )
 
@@ -210,7 +215,7 @@ async def create_connection(
         name=request.name,
         base_url=request.base_url,
         auth_type=request.auth_type,
-        encrypted_credential=encrypt_credential(request.credential),
+        encrypted_credential=encrypt_optional_credential(credential_value),
         api_version=outcome.api_version_detected or request.api_version,
         sync_interval_minutes=request.sync_interval_minutes,
         initial_sync_window_days=request.initial_sync_window_days,
@@ -322,7 +327,7 @@ async def update_connection(
     cred_for_test = (
         request.credential
         if request.credential is not None
-        else decrypt_credential(conn.encrypted_credential)
+        else decrypt_optional_credential(conn.encrypted_credential)
     )
 
     # Re-test if anything that affects what the server sees changed.
@@ -377,7 +382,7 @@ async def update_connection(
     if request.base_url is not None:
         conn.base_url = request.base_url
     if request.credential is not None:
-        conn.encrypted_credential = encrypt_credential(request.credential)
+        conn.encrypted_credential = encrypt_optional_credential(request.credential)
 
     await db.commit()
     await db.refresh(conn)
@@ -462,7 +467,7 @@ async def run_test(
     outcome = await test_connection(
         base_url=conn.base_url,
         auth_type=conn.auth_type,
-        credential=decrypt_credential(conn.encrypted_credential),
+        credential=decrypt_optional_credential(conn.encrypted_credential),
         api_version=conn.api_version,
     )
     # _outcome_to_status returns OK when outcome.ok; no need for a guard.

--- a/apps/api/src/schemas/ai_provider.py
+++ b/apps/api/src/schemas/ai_provider.py
@@ -276,12 +276,14 @@ class AIChatResponse(BaseModel):
 _SUBSCRIPTION_TYPES = {
     AIProviderType.CLAUDE_SUBSCRIPTION,
     AIProviderType.CHATGPT_SUBSCRIPTION,
+    AIProviderType.COPILOT_SUBSCRIPTION,
 }
 
 # Map sidecar provider names to AIProviderType
 SIDECAR_PROVIDER_MAP: dict[str, AIProviderType] = {
     "claude": AIProviderType.CLAUDE_SUBSCRIPTION,
     "codex": AIProviderType.CHATGPT_SUBSCRIPTION,
+    "copilot": AIProviderType.COPILOT_SUBSCRIPTION,
 }
 
 
@@ -293,7 +295,7 @@ class SubscriptionConfigureRequest(BaseModel):
     """
 
     sidecar_provider: str = Field(
-        ..., description="Sidecar provider name: 'claude' or 'codex'"
+        ..., description="Sidecar provider name: 'claude', 'codex', or 'copilot'"
     )
     model_name: str | None = Field(
         default=None,
@@ -313,19 +315,21 @@ class SubscriptionConfigureRequest(BaseModel):
 
 # ── Story 15.2: Subscription Auth Schemas ──
 
-VALID_SIDECAR_PROVIDERS = {"claude", "codex"}
+VALID_SIDECAR_PROVIDERS = {"claude", "codex", "copilot"}
 
 
 class SubscriptionAuthStartRequest(BaseModel):
     """Request to start sidecar auth for a subscription provider."""
 
-    provider: str = Field(..., description="Sidecar provider name: 'claude' or 'codex'")
+    provider: str = Field(
+        ..., description="Sidecar provider name: 'claude', 'codex', or 'copilot'"
+    )
 
     @model_validator(mode="after")
     def validate_provider(self) -> "SubscriptionAuthStartRequest":
         if self.provider not in VALID_SIDECAR_PROVIDERS:
             raise ValueError(
-                f"Invalid provider '{self.provider}'. Must be 'claude' or 'codex'."
+                f"Invalid provider '{self.provider}'. Must be 'claude', 'codex', or 'copilot'."
             )
         return self
 
@@ -341,7 +345,9 @@ class SubscriptionAuthStartResponse(BaseModel):
 class SubscriptionAuthTokenRequest(BaseModel):
     """Request to submit a token to the sidecar."""
 
-    provider: str = Field(..., description="Sidecar provider name: 'claude' or 'codex'")
+    provider: str = Field(
+        ..., description="Sidecar provider name: 'claude', 'codex', or 'copilot'"
+    )
     token: str = Field(
         ...,
         min_length=10,
@@ -353,7 +359,7 @@ class SubscriptionAuthTokenRequest(BaseModel):
     def validate_provider(self) -> "SubscriptionAuthTokenRequest":
         if self.provider not in VALID_SIDECAR_PROVIDERS:
             raise ValueError(
-                f"Invalid provider '{self.provider}'. Must be 'claude' or 'codex'."
+                f"Invalid provider '{self.provider}'. Must be 'claude', 'codex', or 'copilot'."
             )
         return self
 
@@ -369,13 +375,15 @@ class SubscriptionAuthTokenResponse(BaseModel):
 class SubscriptionAuthRevokeRequest(BaseModel):
     """Request to revoke sidecar auth for a subscription provider."""
 
-    provider: str = Field(..., description="Sidecar provider name: 'claude' or 'codex'")
+    provider: str = Field(
+        ..., description="Sidecar provider name: 'claude', 'codex', or 'copilot'"
+    )
 
     @model_validator(mode="after")
     def validate_provider(self) -> "SubscriptionAuthRevokeRequest":
         if self.provider not in VALID_SIDECAR_PROVIDERS:
             raise ValueError(
-                f"Invalid provider '{self.provider}'. Must be 'claude' or 'codex'."
+                f"Invalid provider '{self.provider}'. Must be 'claude', 'codex', or 'copilot'."
             )
         return self
 
@@ -386,3 +394,4 @@ class SubscriptionAuthStatusResponse(BaseModel):
     sidecar_available: bool
     claude: dict | None = None
     codex: dict | None = None
+    copilot: dict | None = None

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -83,11 +83,14 @@ class NightscoutConnectionCreate(BaseModel):
         default=NightscoutAuthType.AUTO,
         description="secret | token | auto (auto-detect)",
     )
-    credential: str = Field(
-        ...,
-        min_length=1,
+    credential: str | None = Field(
+        default=None,
         max_length=_MAX_CREDENTIAL_LEN,
-        description="API_SECRET (v1) or bearer token (v3)",
+        description=(
+            "API_SECRET (v1) or bearer token (v3). Optional: leave unset for a "
+            "public, read-only Nightscout instance that doesn't require "
+            "authentication (AUTH_DEFAULT_ROLE=readable)."
+        ),
     )
     api_version: NightscoutApiVersion = Field(
         default=NightscoutApiVersion.AUTO,
@@ -110,6 +113,16 @@ class NightscoutConnectionCreate(BaseModel):
     def _check_base_url(cls, v: str) -> str:
         return _normalize_base_url(v)
 
+    @field_validator("credential")
+    @classmethod
+    def _normalize_credential(cls, v: str | None) -> str | None:
+        # Treat whitespace-only input the same as omitted -- a public
+        # Nightscout instance has no credential to enter.
+        if v is None:
+            return None
+        stripped = v.strip()
+        return stripped or None
+
     @field_validator("initial_sync_window_days")
     @classmethod
     def _check_window(cls, v: int) -> int:
@@ -126,6 +139,13 @@ class NightscoutConnectionUpdate(BaseModel):
 
     All fields optional. Setting `credential` triggers a re-test on the
     server side (Story 43.1 AC4).
+
+    `credential` semantics: omitted (absent from the JSON body / Python
+    `None`) means "leave the stored credential unchanged"; an explicit
+    empty string `""` clears it, making the connection credential-less
+    (for a public, read-only Nightscout instance). This mirrors
+    `NightscoutConnectionCreate`, where omitting `credential` entirely
+    means "no credential" from the start.
     """
 
     name: str | None = Field(default=None, min_length=1, max_length=120)
@@ -133,7 +153,6 @@ class NightscoutConnectionUpdate(BaseModel):
     auth_type: NightscoutAuthType | None = None
     credential: str | None = Field(
         default=None,
-        min_length=1,
         max_length=_MAX_CREDENTIAL_LEN,
     )
     api_version: NightscoutApiVersion | None = None

--- a/apps/api/src/schemas/nightscout.py
+++ b/apps/api/src/schemas/nightscout.py
@@ -169,6 +169,16 @@ class NightscoutConnectionUpdate(BaseModel):
     def _check_base_url(cls, v: str | None) -> str | None:
         return None if v is None else _normalize_base_url(v)
 
+    @field_validator("credential")
+    @classmethod
+    def _normalize_credential(cls, v: str | None) -> str | None:
+        # Strip stray copy-paste whitespace, mirroring
+        # NightscoutConnectionCreate -- but preserve the tri-state PATCH
+        # semantics: None stays None ("leave unchanged"), and a
+        # whitespace-only value becomes the explicit "" ("clear the
+        # credential"), NOT None.
+        return None if v is None else v.strip()
+
     @field_validator("initial_sync_window_days")
     @classmethod
     def _check_window(cls, v: int | None) -> int | None:

--- a/apps/api/src/services/ai_client.py
+++ b/apps/api/src/services/ai_client.py
@@ -29,6 +29,7 @@ DEFAULT_MODELS: dict[AIProviderType, str] = {
     AIProviderType.OPENAI_API: "gpt-4o",
     AIProviderType.CLAUDE_SUBSCRIPTION: "claude-sonnet-4-5-20250929",
     AIProviderType.CHATGPT_SUBSCRIPTION: "gpt-4o",
+    AIProviderType.COPILOT_SUBSCRIPTION: "copilot-claude-sonnet-4.5",
     AIProviderType.OPENAI_COMPATIBLE: "",  # Must be specified by user
     # Legacy values
     AIProviderType.CLAUDE: "claude-sonnet-4-5-20250929",
@@ -40,6 +41,7 @@ _OPENAI_SDK_TYPES = {
     AIProviderType.OPENAI_API,
     AIProviderType.CLAUDE_SUBSCRIPTION,
     AIProviderType.CHATGPT_SUBSCRIPTION,
+    AIProviderType.COPILOT_SUBSCRIPTION,
     AIProviderType.OPENAI_COMPATIBLE,
     AIProviderType.OPENAI,  # Legacy
 }
@@ -54,6 +56,7 @@ _ANTHROPIC_SDK_TYPES = {
 _SUBSCRIPTION_TYPES = {
     AIProviderType.CLAUDE_SUBSCRIPTION,
     AIProviderType.CHATGPT_SUBSCRIPTION,
+    AIProviderType.COPILOT_SUBSCRIPTION,
 }
 
 

--- a/apps/api/src/services/ai_provider.py
+++ b/apps/api/src/services/ai_provider.py
@@ -38,6 +38,7 @@ _OPENAI_SDK_TYPES = {
     AIProviderType.OPENAI_API,
     AIProviderType.CLAUDE_SUBSCRIPTION,
     AIProviderType.CHATGPT_SUBSCRIPTION,
+    AIProviderType.COPILOT_SUBSCRIPTION,
     AIProviderType.OPENAI_COMPATIBLE,
     AIProviderType.OPENAI,  # Legacy
 }
@@ -52,6 +53,7 @@ _ANTHROPIC_SDK_TYPES = {
 _VALIDATION_MODELS: dict[AIProviderType, str] = {
     AIProviderType.CLAUDE_SUBSCRIPTION: "claude-sonnet-4-5-20250929",
     AIProviderType.CHATGPT_SUBSCRIPTION: "gpt-4o",
+    AIProviderType.COPILOT_SUBSCRIPTION: "copilot-claude-sonnet-4.5",
     AIProviderType.OPENAI_COMPATIBLE: "gpt-4o",
     AIProviderType.OPENAI_API: "gpt-4o",
 }

--- a/apps/api/src/services/integrations/nightscout/client.py
+++ b/apps/api/src/services/integrations/nightscout/client.py
@@ -252,11 +252,20 @@ class NightscoutClient:
     # -- auth + headers ----------------------------------------------------
 
     def _v1_headers(self) -> dict[str, str]:
+        # No credential configured -- public, read-only Nightscout instances
+        # (AUTH_DEFAULT_ROLE=readable) don't require one. Omit the header
+        # entirely rather than sending a hash of an empty string: an absent
+        # header is the unambiguous "anonymous" request the server expects.
+        if not self._credential:
+            return {}
         # SHA-1 of the credential -- safe to send regardless of input
         # bytes; output is always [0-9a-f]{40}.
         return {"api-secret": _sha1_api_secret(self._credential)}
 
     def _v3_headers(self) -> dict[str, str]:
+        # See _v1_headers: no credential means an anonymous request.
+        if not self._credential:
+            return {}
         # Reject control bytes in the credential before interpolating
         # into the header. h11's LocalProtocolError quotes the entire
         # offending header value (including the credential!) into its
@@ -316,7 +325,15 @@ class NightscoutClient:
                 # invariant. `from None` breaks the exception chain
                 # so the original `exc.args` are not preserved on
                 # the traceback either.
-                msg = str(exc).replace(self._credential, "<redacted>")
+                # Guard against an empty credential: str.replace("", X)
+                # would insert X between every character of the message,
+                # corrupting it -- only scrub when there's something to
+                # scrub (a public, credential-less connection has "").
+                msg = (
+                    str(exc).replace(self._credential, "<redacted>")
+                    if self._credential
+                    else str(exc)
+                )
                 raise NightscoutNetworkError(msg) from None
 
             if resp.status_code == 429:
@@ -459,7 +476,13 @@ class NightscoutClient:
                 ok=False,
                 api_version_detected=NightscoutApiVersion.V1,
                 auth_validated=False,
-                error="Authentication rejected by Nightscout v1 (bad API_SECRET?)",
+                error=(
+                    "Nightscout v1 requires authentication, but no API_SECRET "
+                    "is configured for this connection. Add one, or confirm "
+                    "the instance is meant to be public (AUTH_DEFAULT_ROLE)."
+                    if not self._credential
+                    else "Authentication rejected by Nightscout v1 (bad API_SECRET?)"
+                ),
             )
         if resp.status_code == 404:
             return ConnectionTestOutcome(
@@ -509,7 +532,13 @@ class NightscoutClient:
                 ok=False,
                 api_version_detected=NightscoutApiVersion.V3,
                 auth_validated=False,
-                error="Authentication rejected by Nightscout v3 (bad token?)",
+                error=(
+                    "Nightscout v3 requires authentication, but no token is "
+                    "configured for this connection. Add one, or confirm "
+                    "the instance is meant to be public (AUTH_DEFAULT_ROLE)."
+                    if not self._credential
+                    else "Authentication rejected by Nightscout v3 (bad token?)"
+                ),
             )
         if status_resp.status_code == 404:
             return ConnectionTestOutcome(ok=False, error="v3 status endpoint not found")

--- a/apps/api/src/services/integrations/nightscout/evaluate.py
+++ b/apps/api/src/services/integrations/nightscout/evaluate.py
@@ -321,6 +321,32 @@ def _detect_uploaders(
     return found
 
 
+def _normalize_units(raw: str | None) -> str | None:
+    """Normalize a Nightscout profile `units` string to our canonical
+    "mg/dl" / "mmol" Literal.
+
+    Real-world Nightscout profile documents are free text here -- the
+    admin UI's `<select>` options and years of manual JSON edits have
+    left installations with "mg/dl", "mg/dL", "mgdl", "mg-dl", "mmol",
+    "mmol/l", "mmol/L", "mmol/litre", etc. all in the wild (confirmed
+    against a live instance: an "mg/dL" value 500'd this endpoint
+    before this normalization existed). Mirrors the accepted-variant
+    list in `onboarding_derive._classify_units` so both modules agree
+    on what counts as a recognized unit string. Case-insensitive;
+    returns None for anything unrecognized so the caller's
+    malformed-profile fallback handles it gracefully instead of a
+    schema validation crash.
+    """
+    if not raw:
+        return None
+    normalized = raw.strip().lower()
+    if normalized in ("mg/dl", "mgdl", "mg-dl"):
+        return "mg/dl"
+    if normalized in ("mmol", "mmol/l", "mmol/litre", "mmoll"):
+        return "mmol"
+    return None
+
+
 def _summarize_profile(
     profile_records: list[dict[str, Any]],
 ) -> tuple[bool, NightscoutDiscoveryProfileSummary | None]:
@@ -356,19 +382,27 @@ def _summarize_profile(
     target_low_value = _safe_min_segment_value(target_low_segments)
     target_high_value = _safe_max_segment_value(target_high_segments)
 
-    summary = NightscoutDiscoveryProfileSummary(
-        target_low=target_low_value,
-        target_high=target_high_value,
-        dia_hours=active.dia,
-        units=active.units or profile.units,
-        timezone=active.timezone,
-        carb_ratio_schedule=_to_segment_dtos(active.carbratio),
-        isf_schedule=_to_segment_dtos(active.sens),
-        basal_schedule=_to_segment_dtos(active.basal),
-        target_low_schedule=_to_segment_dtos(target_low_segments),
-        target_high_schedule=_to_segment_dtos(target_high_segments),
-        is_malformed=False,
-    )
+    try:
+        summary = NightscoutDiscoveryProfileSummary(
+            target_low=target_low_value,
+            target_high=target_high_value,
+            dia_hours=active.dia,
+            units=_normalize_units(active.units or profile.units),
+            timezone=active.timezone,
+            carb_ratio_schedule=_to_segment_dtos(active.carbratio),
+            isf_schedule=_to_segment_dtos(active.sens),
+            basal_schedule=_to_segment_dtos(active.basal),
+            target_low_schedule=_to_segment_dtos(target_low_segments),
+            target_high_schedule=_to_segment_dtos(target_high_segments),
+            is_malformed=False,
+        )
+    except Exception:  # noqa: BLE001 - AC11 graceful degrade
+        # Defense in depth alongside `_normalize_units`: any other
+        # unexpected field shape (not just units) degrades to the
+        # "malformed" panel instead of a 500, matching the parse-failure
+        # handling above.
+        logger.info("nightscout_evaluate_profile_summary_invalid")
+        return False, NightscoutDiscoveryProfileSummary(is_malformed=True)
     return True, summary
 
 

--- a/apps/api/src/services/integrations/nightscout/evaluate.py
+++ b/apps/api/src/services/integrations/nightscout/evaluate.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from src.core.encryption import decrypt_credential
+from src.core.encryption import decrypt_optional_credential
 from src.logging_config import get_logger
 from src.models.nightscout_connection import NightscoutConnection
 from src.schemas.nightscout import (
@@ -85,7 +85,7 @@ async def evaluate_nightscout_for_connection(
     # policy still applies, so an operator who fixes the cipher
     # state can retry immediately.
     try:
-        credential = decrypt_credential(conn.encrypted_credential)
+        credential = decrypt_optional_credential(conn.encrypted_credential)
     except Exception:  # noqa: BLE001 -- defense for any cipher fault
         logger.warning(
             "nightscout_evaluate_decrypt_failed",

--- a/apps/api/src/services/integrations/nightscout/sync.py
+++ b/apps/api/src/services/integrations/nightscout/sync.py
@@ -44,7 +44,7 @@ from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.core.encryption import decrypt_credential
+from src.core.encryption import decrypt_optional_credential
 from src.logging_config import get_logger
 from src.models.nightscout_connection import (
     NightscoutConnection,
@@ -229,7 +229,7 @@ async def _do_sync(session: AsyncSession, conn: NightscoutConnection) -> SyncRes
         async with await NightscoutClient.create(
             base_url=conn.base_url,
             auth_type=conn.auth_type,
-            credential=decrypt_credential(conn.encrypted_credential),
+            credential=decrypt_optional_credential(conn.encrypted_credential),
             api_version=conn.api_version,
         ) as client:
             entries = await client.fetch_entries(

--- a/apps/api/src/services/sidecar.py
+++ b/apps/api/src/services/sidecar.py
@@ -50,8 +50,8 @@ async def get_sidecar_health() -> dict | None:
 async def get_sidecar_auth_status() -> dict | None:
     """GET /auth/status on the sidecar.
 
-    Returns ``{"claude": {"authenticated": bool}, "codex": {"authenticated": bool}}``
-    or ``None`` if the sidecar is unreachable.
+    Returns ``{"claude": {"authenticated": bool}, "codex": {"authenticated": bool},
+    "copilot": {"authenticated": bool}}`` or ``None`` if the sidecar is unreachable.
     """
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
@@ -114,7 +114,7 @@ async def submit_sidecar_token(provider: str, token: str) -> dict | None:
         return None
 
 
-_VALID_SIDECAR_PROVIDERS = {"claude", "codex"}
+_VALID_SIDECAR_PROVIDERS = {"claude", "codex", "copilot"}
 
 
 async def validate_sidecar_connection(provider: str) -> tuple[bool, str | None]:
@@ -124,7 +124,7 @@ async def validate_sidecar_connection(provider: str) -> tuple[bool, str | None]:
     subscription providers.
 
     Args:
-        provider: Sidecar provider name ("claude" or "codex").
+        provider: Sidecar provider name ("claude", "codex", or "copilot").
 
     Returns:
         Tuple of (success, error_message).

--- a/apps/api/tests/test_ai_provider.py
+++ b/apps/api/tests/test_ai_provider.py
@@ -1001,6 +1001,31 @@ class TestSubscriptionConfigure:
         assert data["sidecar_provider"] == "codex"
 
     @patch("src.routers.ai.validate_sidecar_connection")
+    async def test_configure_copilot_subscription_via_sidecar(self, mock_validate):
+        """Test configuring GitHub Copilot subscription via copilot sidecar."""
+        mock_validate.return_value = (True, None)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            session_cookie = await register_and_login(client)
+
+            response = await client.post(
+                "/api/ai/subscription/configure",
+                json={"sidecar_provider": "copilot"},
+                cookies={settings.jwt_cookie_name: session_cookie},
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["provider_type"] == "copilot_subscription"
+        assert data["sidecar_provider"] == "copilot"
+        assert data["masked_api_key"] == "sidecar-managed"
+        assert data["status"] == "connected"
+        assert data["base_url"] is None  # Auto-routed via AI_SIDECAR_URL
+
+    @patch("src.routers.ai.validate_sidecar_connection")
     async def test_configure_subscription_rejects_unauthenticated_sidecar(
         self, mock_validate
     ):

--- a/apps/api/tests/test_nightscout_client.py
+++ b/apps/api/tests/test_nightscout_client.py
@@ -124,6 +124,17 @@ class TestAuthHeaders:
         c = _make_client(auth_type=NightscoutAuthType.TOKEN, credential="abc.def.ghi")
         assert c._v3_headers() == {"Authorization": "Bearer abc.def.ghi"}
 
+    def test_v1_headers_empty_when_no_credential(self):
+        # Public, read-only Nightscout instances (AUTH_DEFAULT_ROLE=readable)
+        # need no api-secret header at all -- an absent header, not a hash
+        # of an empty string, is the "anonymous" request the server expects.
+        c = _make_client(auth_type=NightscoutAuthType.SECRET, credential="")
+        assert c._v1_headers() == {}
+
+    def test_v3_headers_empty_when_no_credential(self):
+        c = _make_client(auth_type=NightscoutAuthType.TOKEN, credential="")
+        assert c._v3_headers() == {}
+
     def test_sha1_helper_matches_nightscout_protocol(self):
         # The Nightscout test instance uses this exact secret. The
         # SHA-1 below was independently verified against the running
@@ -256,6 +267,21 @@ class TestErrorMapping:
             await c._request("GET", "/api/v3/version")
         assert secret not in str(exc_info.value)
         assert "<redacted>" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_network_error_message_not_corrupted_with_no_credential(self):
+        """Regression test: `str.replace(self._credential, ...)` on an empty
+        credential would insert "<redacted>" between every character of the
+        message (`"".replace("", X)` matches everywhere). A public
+        connection with no credential must still surface a readable error."""
+        c = _make_client(credential="")
+        err = httpx.ConnectError("connection refused")
+        with (
+            patch.object(c._client, "request", new=AsyncMock(side_effect=err)),
+            pytest.raises(NightscoutNetworkError) as exc_info,
+        ):
+            await c._request("GET", "/api/v1/status.json")
+        assert str(exc_info.value) == "connection refused"
 
     def test_v3_headers_reject_control_chars_in_credential(self):
         """Pre-flight rejection of credentials with embedded CRLF/etc.

--- a/apps/api/tests/test_nightscout_connection.py
+++ b/apps/api/tests/test_nightscout_connection.py
@@ -251,6 +251,71 @@ async def test_create_connection_credential_is_encrypted_in_db(http_client):
         await _cleanup_nightscout_users([email])
 
 
+@pytest.mark.asyncio
+async def test_create_connection_without_credential_succeeds(http_client):
+    """A public, read-only Nightscout instance (AUTH_DEFAULT_ROLE=readable)
+    has no API_SECRET/token to enter -- `credential` must be optional, not
+    silently required by the wire schema."""
+    email = _unique_email("ns_no_cred")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        with _patch_test_connection(_ok_outcome()):
+            resp = await http_client.post(
+                "/api/integrations/nightscout",
+                cookies=cookies,
+                json={
+                    "name": "Public instance",
+                    "base_url": "https://public-ns.example.com",
+                    "api_version": "v1",
+                },
+            )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["connection"]["has_credential"] is False
+        connection_id = body["connection"]["id"]
+
+        # Stored value round-trips as "", not a Fernet ciphertext of "" --
+        # otherwise has_credential (bool(encrypted_credential)) would
+        # incorrectly report True forever.
+        async with get_session_maker()() as db:
+            row = (
+                await db.execute(
+                    NightscoutConnection.__table__.select().where(
+                        NightscoutConnection.id == uuid.UUID(connection_id)
+                    )
+                )
+            ).first()
+            assert row is not None
+            assert row.encrypted_credential == ""
+    finally:
+        await _cleanup_nightscout_users([email])
+
+
+@pytest.mark.asyncio
+async def test_create_connection_with_blank_credential_treated_as_none(http_client):
+    """A whitespace-only credential (stray spaces from copy-paste) is
+    normalized to "no credential" rather than stored/sent as literal
+    whitespace."""
+    email = _unique_email("ns_blank_cred")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        with _patch_test_connection(_ok_outcome()):
+            resp = await http_client.post(
+                "/api/integrations/nightscout",
+                cookies=cookies,
+                json={
+                    "name": "Blank credential",
+                    "base_url": "https://public-ns2.example.com",
+                    "credential": "   ",
+                    "api_version": "v1",
+                },
+            )
+        assert resp.status_code == 201
+        assert resp.json()["connection"]["has_credential"] is False
+    finally:
+        await _cleanup_nightscout_users([email])
+
+
 # ---------------------------------------------------------------------------
 # GET list / single + RBAC
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_nightscout_connection.py
+++ b/apps/api/tests/test_nightscout_connection.py
@@ -538,6 +538,58 @@ async def test_patch_failed_retest_does_not_persist_bad_credential(
 
 
 @pytest.mark.asyncio
+async def test_patch_credential_whitespace_is_stripped(http_client):
+    """PATCH mirrors Create's whitespace normalization: a padded credential
+    is stripped before test/storage, and a whitespace-only value collapses
+    to the explicit "" (clear the credential) -- NOT to None ("leave
+    unchanged")."""
+    email = _unique_email("ns_patch_ws")
+    cookies = await _register_and_login(http_client, email)
+    try:
+        with _patch_test_connection(_ok_outcome()):
+            resp = await http_client.post(
+                "/api/integrations/nightscout",
+                cookies=cookies,
+                json={
+                    "name": "Whitespace patch",
+                    "base_url": "https://ns.example.com",
+                    "auth_type": "secret",
+                    "credential": "old-secret",
+                    "api_version": "v1",
+                },
+            )
+        cid = resp.json()["connection"]["id"]
+
+        # Padded credential -> stripped value is what gets re-tested.
+        with patch(
+            "src.routers.nightscout.test_connection",
+            new=AsyncMock(return_value=_ok_outcome()),
+        ) as mock_test:
+            resp = await http_client.patch(
+                f"/api/integrations/nightscout/{cid}",
+                cookies=cookies,
+                json={"credential": "  padded-secret  "},
+            )
+        assert resp.status_code == 200
+        assert mock_test.call_args.kwargs["credential"] == "padded-secret"
+
+        # Whitespace-only credential -> explicit clear, not "leave unchanged".
+        with patch(
+            "src.routers.nightscout.test_connection",
+            new=AsyncMock(return_value=_ok_outcome()),
+        ):
+            resp = await http_client.patch(
+                f"/api/integrations/nightscout/{cid}",
+                cookies=cookies,
+                json={"credential": "   "},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["connection"]["has_credential"] is False
+    finally:
+        await _cleanup_nightscout_users([email])
+
+
+@pytest.mark.asyncio
 async def test_patch_empty_body_rejected(http_client):
     email = _unique_email("ns_patch_empty")
     cookies = await _register_and_login(http_client, email)

--- a/apps/api/tests/test_nightscout_evaluate.py
+++ b/apps/api/tests/test_nightscout_evaluate.py
@@ -286,6 +286,54 @@ async def test_orchestrator_happy_path_with_loop_profile():
 
 
 @pytest.mark.asyncio
+async def test_orchestrator_normalizes_mixed_case_units():
+    """Regression test: a live Nightscout instance returned "mg/dL"
+    (mixed case) for profile units and 500'd the endpoint before
+    `_normalize_units` existed -- the strict Literal schema field
+    rejected anything that wasn't exactly "mg/dl" or "mmol"."""
+    conn = _mk_conn()
+    client_mock = _mk_client_mock(
+        recent_entries=[_xdrip_entry() for _ in range(20)],
+        oldest_entries=[_xdrip_entry("2024-08-12T00:00:00.000Z") for _ in range(100)],
+        treatments=[],
+        devicestatus=[],
+        profile=[_loop_profile(units="mg/dL")],
+    )
+    with _patch_test(_ok_outcome()), _patch_client(client_mock):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.status_ok is True
+    assert report.has_profile is True
+    assert report.profile_summary is not None
+    assert report.profile_summary.is_malformed is False
+    assert report.profile_summary.units == "mg/dl"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_unknown_units_string_yields_none_not_500():
+    """An unrecognized units string is not a parse failure -- the rest of
+    the profile (targets, DIA, schedules) is still valid and useful, so
+    the summary reports `units=None` rather than flipping the whole
+    profile to `is_malformed=True`."""
+    conn = _mk_conn()
+    client_mock = _mk_client_mock(
+        recent_entries=[],
+        oldest_entries=[],
+        treatments=[],
+        devicestatus=[],
+        profile=[_loop_profile(units="furlongs-per-fortnight")],
+    )
+    with _patch_test(_ok_outcome()), _patch_client(client_mock):
+        report = await evaluate_nightscout_for_connection(conn)
+
+    assert report.status_ok is True
+    assert report.has_profile is True
+    assert report.profile_summary is not None
+    assert report.profile_summary.is_malformed is False
+    assert report.profile_summary.units is None
+
+
+@pytest.mark.asyncio
 async def test_orchestrator_status_ok_false_when_test_fails():
     conn = _mk_conn()
     with _patch_test(_fail_outcome("auth rejected")):

--- a/apps/web/src/app/dashboard/settings/ai-provider/page.tsx
+++ b/apps/web/src/app/dashboard/settings/ai-provider/page.tsx
@@ -68,6 +68,14 @@ interface ProviderOption {
 const SUBSCRIPTION_SIDECAR_MAP: Record<string, SidecarProviderName> = {
   claude_subscription: "claude",
   chatgpt_subscription: "codex",
+  copilot_subscription: "copilot",
+};
+
+// Human-readable label for each sidecar provider, used across the auth UI
+const SIDECAR_PROVIDER_LABELS: Record<SidecarProviderName, string> = {
+  claude: "Claude",
+  codex: "ChatGPT",
+  copilot: "GitHub Copilot",
 };
 
 const SUBSCRIPTION_PROVIDERS: ProviderOption[] = [
@@ -94,6 +102,18 @@ const SUBSCRIPTION_PROVIDERS: ProviderOption[] = [
     apiKeyHint: "",
     modelPlaceholder: "gpt-4o",
     pricingHint: "Unlimited usage with your subscription",
+  },
+  {
+    value: "copilot_subscription",
+    label: "GitHub Copilot",
+    description: "Use your GitHub Copilot subscription via the built-in AI sidecar.",
+    requiresBaseUrl: false,
+    requiresApiKey: false,
+    requiresModelName: false,
+    apiKeyPlaceholder: "not-needed",
+    apiKeyHint: "",
+    modelPlaceholder: "copilot-claude-sonnet-4.5",
+    pricingHint: "Uses your existing GitHub Copilot subscription",
   },
 ];
 
@@ -145,6 +165,7 @@ const ALL_PROVIDERS = [...SUBSCRIPTION_PROVIDERS, ...API_PROVIDERS, ...SELF_HOST
 const PROVIDER_LABELS: Record<AIProviderType, string> = {
   claude_subscription: "Claude Subscription",
   chatgpt_subscription: "ChatGPT Subscription",
+  copilot_subscription: "GitHub Copilot",
   claude_api: "Claude API (Anthropic)",
   openai_api: "OpenAI API",
   openai_compatible: "Custom OpenAI-Compatible",
@@ -934,9 +955,7 @@ export default function AIProviderPage() {
 
                 {/* Current auth status for this provider */}
                 {subscriptionAuth?.sidecar_available && sidecarProvider && (() => {
-                  const providerAuth = sidecarProvider === "claude"
-                    ? subscriptionAuth.claude
-                    : subscriptionAuth.codex;
+                  const providerAuth = subscriptionAuth[sidecarProvider];
                   const isAuthed = providerAuth?.authenticated === true;
                   // Check if DB config already matches this sidecar provider
                   const isAlreadyConfigured = config?.sidecar_provider === sidecarProvider;
@@ -948,7 +967,7 @@ export default function AIProviderPage() {
                           <div className="flex items-center gap-2">
                             <CheckCircle2 className="h-5 w-5 text-green-400" />
                             <span className="text-green-400 font-medium text-sm">
-                              {sidecarProvider === "claude" ? "Claude" : "ChatGPT"} subscription connected via sidecar
+                              {SIDECAR_PROVIDER_LABELS[sidecarProvider]} subscription connected via sidecar
                             </span>
                           </div>
                           {!confirmRevoke ? (
@@ -1006,9 +1025,7 @@ export default function AIProviderPage() {
 
                 {/* Token paste form (shown when not authenticated) */}
                 {(!subscriptionAuth?.sidecar_available ||
-                  !(sidecarProvider === "claude"
-                    ? subscriptionAuth?.claude?.authenticated
-                    : subscriptionAuth?.codex?.authenticated)) && (
+                  !(sidecarProvider && subscriptionAuth?.[sidecarProvider]?.authenticated)) && (
                   <div className="space-y-3">
                     {!authInstructions ? (
                       <button
@@ -1021,7 +1038,7 @@ export default function AIProviderPage() {
                         ) : (
                           <Key className="h-4 w-4" />
                         )}
-                        Sign in with {sidecarProvider === "claude" ? "Claude" : "ChatGPT"}
+                        Sign in with {sidecarProvider ? SIDECAR_PROVIDER_LABELS[sidecarProvider] : ""}
                       </button>
                     ) : (
                       <>

--- a/apps/web/src/components/integrations/nightscout-integrations-section.tsx
+++ b/apps/web/src/components/integrations/nightscout-integrations-section.tsx
@@ -171,8 +171,8 @@ export function NightscoutIntegrationsSection({
     e.preventDefault();
     if (isCreating) return;
     setCreateError(null);
-    if (!name.trim() || !baseUrl.trim() || !credential.trim()) {
-      setCreateError("Name, base URL, and credential are all required");
+    if (!name.trim() || !baseUrl.trim()) {
+      setCreateError("Name and base URL are required");
       return;
     }
     setIsCreating(true);
@@ -180,7 +180,7 @@ export function NightscoutIntegrationsSection({
       await onCreate({
         name: name.trim(),
         base_url: baseUrl.trim(),
-        credential,
+        credential: credential.trim() || undefined,
         auth_type: authType,
         api_version: apiVersion,
       });
@@ -780,7 +780,7 @@ export function NightscoutIntegrationsSection({
                     htmlFor="ns-credential"
                     className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-1"
                   >
-                    API_SECRET or bearer token
+                    API_SECRET or bearer token (optional)
                   </label>
                   <div className="relative">
                     <input
@@ -824,7 +824,9 @@ export function NightscoutIntegrationsSection({
                   <p className="text-xs text-slate-500 mt-1">
                     Use the Nightscout API_SECRET (the longer string from your
                     instance config) or a bearer token issued by your Nightscout
-                    deployment.
+                    deployment. Leave blank if your instance is public /
+                    read-only (AUTH_DEFAULT_ROLE=readable) and doesn&apos;t
+                    require one.
                   </p>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/apps/web/src/components/integrations/nightscout-onboarding-wizard.tsx
+++ b/apps/web/src/components/integrations/nightscout-onboarding-wizard.tsx
@@ -455,10 +455,10 @@ export function NightscoutOnboardingWizard() {
       e.preventDefault();
       if (state.isCreating) return;
       const { name, base_url, credential } = state.form;
-      if (!name.trim() || !base_url.trim() || !credential.trim()) {
+      if (!name.trim() || !base_url.trim()) {
         dispatch({
           type: "form/submitError",
-          message: "Name, base URL, and credential are all required.",
+          message: "Name and base URL are required.",
         });
         return;
       }
@@ -467,7 +467,7 @@ export function NightscoutOnboardingWizard() {
         const created = await createNightscoutConnection({
           name: name.trim(),
           base_url: base_url.trim(),
-          credential: state.form.credential,
+          credential: credential.trim() || undefined,
           auth_type: state.form.auth_type,
           api_version: state.form.api_version,
         });
@@ -773,7 +773,7 @@ function CredentialsStep({
             />
           </Field>
         </div>
-        <Field id={credId} label="API_SECRET or bearer token">
+        <Field id={credId} label="API_SECRET or bearer token (optional)">
           <div className="relative">
             <input
               id={credId}
@@ -803,6 +803,10 @@ function CredentialsStep({
               )}
             </button>
           </div>
+          <p className="text-xs text-slate-500 mt-1">
+            Leave blank if your Nightscout instance is public / read-only
+            (AUTH_DEFAULT_ROLE=readable) and doesn&apos;t require one.
+          </p>
           <p className="text-xs text-slate-500 mt-1">
             Use your Nightscout API_SECRET (the longer config string) or a
             bearer token issued by your deployment.

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2080,7 +2080,7 @@ export interface NightscoutConnectionCreate {
   name: string;
   base_url: string;
   auth_type?: NightscoutAuthType;
-  credential: string;
+  credential?: string;
   api_version?: NightscoutApiVersion;
   sync_interval_minutes?: number;
   initial_sync_window_days?: number;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2432,6 +2432,7 @@ export type AIProviderType =
   | "openai_api"
   | "claude_subscription"
   | "chatgpt_subscription"
+  | "copilot_subscription"
   | "openai_compatible"
   | "claude" // Legacy - may appear in existing DB rows
   | "openai"; // Legacy - may appear in existing DB rows
@@ -2532,7 +2533,7 @@ export async function deleteAIProvider(): Promise<AIProviderDeleteResponse> {
 
 // ── Story 15.4: Subscription Configure ──
 
-export type SidecarProviderName = "claude" | "codex";
+export type SidecarProviderName = "claude" | "codex" | "copilot";
 
 export interface SubscriptionConfigureRequest {
   sidecar_provider: SidecarProviderName;
@@ -2580,6 +2581,7 @@ export interface SubscriptionAuthStatusResponse {
   sidecar_available: boolean;
   claude?: { authenticated: boolean };
   codex?: { authenticated: boolean };
+  copilot?: { authenticated: boolean };
 }
 
 export interface SidecarHealthResponse {
@@ -2587,6 +2589,7 @@ export interface SidecarHealthResponse {
   status: string;
   claude_auth?: boolean;
   codex_auth?: boolean;
+  copilot_auth?: boolean;
 }
 
 export async function startSubscriptionAuth(

--- a/docs/concepts/byoai.md
+++ b/docs/concepts/byoai.md
@@ -12,6 +12,7 @@ If you don't want to read the whole page, here's the short version:
 - **You want strongest privacy and have the hardware to run a local model** → Option 5 (local AI). Nothing leaves your network. Free.
 - **You already pay for Claude (Pro / Max)** → Option 1. No additional cost. Best AI quality among cloud options.
 - **You already pay for ChatGPT (Plus / Team)** → Option 2. No additional cost.
+- **You already pay for GitHub Copilot** → Option 6. No additional cost; also works with an ambient `copilot` CLI login on a self-hosted box, not just a pasted token.
 - **You don't have either subscription and want a vendor-supported cloud path** → Option 3 (Claude API key) or Option 4 (OpenAI API key). You pay per token directly to the vendor.
 - **You want one credential that works across many models** → Option 5 also covers OpenAI-compatible router services like [OpenRouter](https://openrouter.ai/) (untested by the project but should work since it speaks the OpenAI-compatible API).
 
@@ -31,9 +32,9 @@ Three reasons:
 2. **Privacy.** Your AI conversations go directly between your platform and your chosen provider. The project's servers are not in the path.
 3. **Choice.** You can use a premium cloud model (Claude Opus, GPT-4-class), a cheaper model for cost savings, an AI router for access to many models with one credential, or a fully local model for maximum privacy. The platform doesn't lock you into any one provider.
 
-## Five real options
+## Six real options
 
-GlycemicGPT supports five distinct ways to provide an AI credential. They differ in cost model, privacy properties, and quality.
+GlycemicGPT supports six distinct ways to provide an AI credential. They differ in cost model, privacy properties, and quality.
 
 ### Option 1: Existing Claude subscription (Pro / Max)
 
@@ -135,6 +136,21 @@ This option points GlycemicGPT at any URL that speaks the OpenAI Chat Completion
 > produce a silent low-quality estimate. See [Local AI Vision](local-ai-vision.md)
 > for which models clear the bar, how to verify one yourself, and why cloud is the
 > verified path for photos today.
+
+### Option 6: GitHub Copilot subscription
+
+If you already pay for GitHub Copilot (Individual, Business, or Enterprise), you can route GlycemicGPT through it via the official `@github/copilot-sdk`, the same runtime that powers GitHub's own Copilot CLI -- no separate API key, no extra billing.
+
+How it works: the sidecar drives a Copilot session over the SDK rather than spawning a bare CLI process, and it supports two ways to authenticate:
+
+- **Token paste** (the same pattern as Options 1 / 2): generate a GitHub token with Copilot access on your host machine and paste it into GlycemicGPT.
+- **Ambient CLI login**: if you're self-hosting on a box where you've already run `copilot` interactively and signed in, the sidecar picks up that login automatically -- no token to copy at all.
+
+- **Cost:** included in your existing Copilot subscription
+- **Privacy:** your messages go to GitHub Copilot's backend, which routes to the underlying model provider (Anthropic, OpenAI, or Google depending on which model you pick). Read [GitHub Copilot's Trust Center](https://resources.github.com/copilot-trust-center/) and your plan's data-handling terms.
+- **Quality:** whichever model your Copilot plan and policy allow -- Claude, GPT, and Gemini families are all selectable, at whatever versions your account's model catalog currently offers (the catalog is account/policy-dependent and changes over time, so don't hardcode an expectation of a specific model id being available).
+
+This is the same "note on the subscription-token options" caveat from Options 1 / 2 applies here too: using a Copilot credential from a self-hosted background service is a different shape of usage than the SDK's primary "you, on your machine" design point, and GitHub's terms of service govern whether that's an acceptable use for your plan -- read them and decide for yourself.
 
 ## Realistic cost ranges
 

--- a/docs/concepts/byoai.md
+++ b/docs/concepts/byoai.md
@@ -150,7 +150,7 @@ How it works: the sidecar drives a Copilot session over the SDK rather than spaw
 - **Privacy:** your messages go to GitHub Copilot's backend, which routes to the underlying model provider (Anthropic, OpenAI, or Google depending on which model you pick). Read [GitHub Copilot's Trust Center](https://resources.github.com/copilot-trust-center/) and your plan's data-handling terms.
 - **Quality:** whichever model your Copilot plan and policy allow -- Claude, GPT, and Gemini families are all selectable, at whatever versions your account's model catalog currently offers (the catalog is account/policy-dependent and changes over time, so don't hardcode an expectation of a specific model id being available).
 
-This is the same "note on the subscription-token options" caveat from Options 1 / 2 applies here too: using a Copilot credential from a self-hosted background service is a different shape of usage than the SDK's primary "you, on your machine" design point, and GitHub's terms of service govern whether that's an acceptable use for your plan -- read them and decide for yourself.
+The same "note on the subscription-token options" caveat from Options 1 / 2 applies here too: using a Copilot credential from a self-hosted background service is a different shape of usage than the SDK's primary "you, on your machine" design point, and GitHub's terms of service govern whether that's an acceptable use for your plan -- read them and decide for yourself.
 
 ## Realistic cost ranges
 

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,6 +1,11 @@
 # AI Sidecar Container
 # Bundles Claude Code CLI + Codex CLI + Express proxy server
 #
+# The GitHub Copilot provider is different: `@github/copilot-sdk` (an npm
+# dependency, installed below via `npm install`) pulls in a platform-specific
+# `@github/copilot-<platform>` optional dependency that ships the `copilot`
+# runtime binary directly, so no separate global install step is needed here.
+#
 # Build: docker build -t glycemicgpt-ai-sidecar .
 # Run:   docker run -p 3456:3456 glycemicgpt-ai-sidecar
 

--- a/sidecar/package-lock.json
+++ b/sidecar/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "glycemicgpt-ai-sidecar",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glycemicgpt-ai-sidecar",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "dependencies": {
+        "@github/copilot-sdk": "^1.0.5",
         "@sentry/node": "^10.53.1",
         "express": "^4.21.0"
       },
@@ -525,6 +526,182 @@
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^2.2.0",
         "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.68.tgz",
+      "integrity": "sha512-2VPcTlW0RAEsfeS0Ma2ICCkfXgpxy3NL7+SReR8gzvEEPiokSRf0k5JBPlgMbBEFvocSRcJ01S8KvBm84Dw+Fw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.68",
+        "@github/copilot-darwin-x64": "1.0.68",
+        "@github/copilot-linux-arm64": "1.0.68",
+        "@github/copilot-linux-x64": "1.0.68",
+        "@github/copilot-linuxmusl-arm64": "1.0.68",
+        "@github/copilot-linuxmusl-x64": "1.0.68",
+        "@github/copilot-win32-arm64": "1.0.68",
+        "@github/copilot-win32-x64": "1.0.68"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.68.tgz",
+      "integrity": "sha512-0G26AL9dlrwTa5IRTxPEnkX6Kz20CuetIwXzABmWwiXYcsR9rswM/NYICR3k53TOa0zL7aqFPnl98CW7J5XbZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.68.tgz",
+      "integrity": "sha512-RoClWH4CPH19pv5jrR0E6pBU6ljgrzL7idb7tV2pPtMYGTuwqW//XrIEE4n/5NVZmhzEiVBeq04THzOBeV493A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.68.tgz",
+      "integrity": "sha512-SXSOz/2xPeUM/ndKypBiQv+QGYaEM7oGytl1i+Yx4tJnOoIwLkkTmIaWUbBNn0n5DTEjUcWyDqHzxxo/42FKRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.68.tgz",
+      "integrity": "sha512-YdG1chniWyps7XEJ2YHUOJkcOc6BpDQZby/zOKCVdswzRXx7d3WiZ2P9lfDimBBmXXJEJ81Fqhv2ZK5eOmGlUw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.68.tgz",
+      "integrity": "sha512-LTYZFOHpeLg4rCtsq3A/LMZxxRKFcCLmhnt8F7ovNYLNDJMkh3xdYanoXP0C0PO3uyUMiNJ+p5YXhZiBuo2yfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.68.tgz",
+      "integrity": "sha512-oOMXZ9HPJAJaKSrXZIYuond4uOiUkK1uRhVPI3Cs74n7uEVKPWpNlTN+j/O754dnBa1+HJcuZSDMulTbnOgirg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.5.tgz",
+      "integrity": "sha512-N6Yk2DcpM9orYXWGBcQs5R0FdiVYrCn7UHQ206cUkfJengKYjgcd3f78BvVB6Dot3j0TvO04FnQ85K9/kbRRag==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.67",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.68.tgz",
+      "integrity": "sha512-ZDqpJMP9Y5vqwvRxnIvZrVl8ibx/P66m3JTXQuzv6pitq7rkMEuNKscZ7cjJYN4N+BCOF5++5LKw8O1WHzXAAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.68.tgz",
+      "integrity": "sha512-eplj/Y2B+amMLJ37oNE6G8gx85j8ucAuJz+CjzpzprNiBUq45lFL8ukGeDtaLMRvIeYAEDYdz5yUzu2XtCE7mA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1977,6 +2154,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -3439,6 +3625,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3463,6 +3658,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -13,6 +13,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@github/copilot-sdk": "^1.0.5",
     "@sentry/node": "^10.53.1",
     "express": "^4.21.0"
   },

--- a/sidecar/src/auth/oauth-server.ts
+++ b/sidecar/src/auth/oauth-server.ts
@@ -14,15 +14,18 @@ import { Router, type Request, type Response } from "express";
 import {
   readClaudeToken,
   readCodexAuth,
+  readCopilotToken,
   revokeClaudeToken,
   revokeCodexAuth,
+  revokeCopilotToken,
   storeClaudeToken,
   storeCodexAuth,
+  storeCopilotToken,
 } from "./token-store.js";
 
 export const authRouter = Router();
 
-const VALID_PROVIDERS = new Set(["claude", "codex"]);
+const VALID_PROVIDERS = new Set(["claude", "codex", "copilot"]);
 
 /** Maximum token length to accept (prevents abuse) */
 const MAX_TOKEN_LENGTH = 5000;
@@ -33,6 +36,7 @@ const MIN_TOKEN_LENGTH = 10;
 authRouter.get("/status", (_req: Request, res: Response) => {
   const claudeToken = readClaudeToken();
   const codexAuth = readCodexAuth();
+  const copilotToken = readCopilotToken();
 
   res.json({
     claude: {
@@ -40,6 +44,9 @@ authRouter.get("/status", (_req: Request, res: Response) => {
     },
     codex: {
       authenticated: !!(codexAuth && (codexAuth as Record<string, unknown>).accessToken),
+    },
+    copilot: {
+      authenticated: !!copilotToken,
     },
   });
 });
@@ -56,14 +63,17 @@ authRouter.post("/start", (req: Request, res: Response) => {
 
   if (!provider || !VALID_PROVIDERS.has(provider)) {
     res.status(400).json({
-      error: "Invalid provider. Must be 'claude' or 'codex'.",
+      error: "Invalid provider. Must be 'claude', 'codex', or 'copilot'.",
     });
     return;
   }
 
-  const instructions = provider === "claude"
-    ? "Run 'npx @anthropic-ai/claude-code setup-token' on your host machine to obtain a token."
-    : "Run 'npx @openai/codex login' on your host machine to obtain a token.";
+  const instructions =
+    provider === "claude"
+      ? "Run 'npx @anthropic-ai/claude-code setup-token' on your host machine to obtain a token."
+      : provider === "codex"
+        ? "Run 'npx @openai/codex login' on your host machine to obtain a token."
+        : "Run 'gh auth token' (or generate a fine-grained PAT with Copilot access) on your host machine to obtain a token.";
 
   res.json({
     provider,
@@ -82,7 +92,7 @@ authRouter.post("/token", (req: Request, res: Response) => {
   const { provider, token } = req.body as { provider?: string; token?: string };
 
   if (!provider || !VALID_PROVIDERS.has(provider)) {
-    res.status(400).json({ error: "Invalid provider. Must be 'claude' or 'codex'." });
+    res.status(400).json({ error: "Invalid provider. Must be 'claude', 'codex', or 'copilot'." });
     return;
   }
 
@@ -103,8 +113,10 @@ authRouter.post("/token", (req: Request, res: Response) => {
   try {
     if (provider === "claude") {
       storeClaudeToken(trimmed);
-    } else {
+    } else if (provider === "codex") {
       storeCodexAuth({ accessToken: trimmed });
+    } else {
+      storeCopilotToken(trimmed);
     }
     res.json({ success: true, provider });
   } catch {
@@ -120,7 +132,7 @@ authRouter.post("/revoke", (req: Request, res: Response) => {
 
   if (!provider || !VALID_PROVIDERS.has(provider)) {
     res.status(400).json({
-      error: "Invalid provider. Must be 'claude' or 'codex'.",
+      error: "Invalid provider. Must be 'claude', 'codex', or 'copilot'.",
     });
     return;
   }
@@ -128,8 +140,10 @@ authRouter.post("/revoke", (req: Request, res: Response) => {
   try {
     if (provider === "claude") {
       revokeClaudeToken();
-    } else {
+    } else if (provider === "codex") {
       revokeCodexAuth();
+    } else {
+      revokeCopilotToken();
     }
     res.json({ revoked: true, provider });
   } catch {

--- a/sidecar/src/auth/oauth-server.ts
+++ b/sidecar/src/auth/oauth-server.ts
@@ -14,7 +14,6 @@ import { Router, type Request, type Response } from "express";
 import {
   readClaudeToken,
   readCodexAuth,
-  readCopilotToken,
   revokeClaudeToken,
   revokeCodexAuth,
   revokeCopilotToken,
@@ -22,6 +21,7 @@ import {
   storeCodexAuth,
   storeCopilotToken,
 } from "./token-store.js";
+import { copilot } from "../providers/index.js";
 
 export const authRouter = Router();
 
@@ -32,11 +32,19 @@ const MAX_TOKEN_LENGTH = 5000;
 /** Minimum token length for basic validation */
 const MIN_TOKEN_LENGTH = 10;
 
-/** GET /auth/status - Check current authentication state */
-authRouter.get("/status", (_req: Request, res: Response) => {
+/**
+ * GET /auth/status - Check current authentication state.
+ *
+ * Copilot's status goes through copilot.checkAuth() (async) rather than a
+ * plain token-file read like Claude/Codex: unlike those two, Copilot also
+ * accepts ambient `copilot` CLI login as a valid credential (see
+ * providers/copilot.ts), so a status check based only on the stored-token
+ * file would under-report "authenticated" for that path.
+ */
+authRouter.get("/status", async (_req: Request, res: Response) => {
   const claudeToken = readClaudeToken();
   const codexAuth = readCodexAuth();
-  const copilotToken = readCopilotToken();
+  const copilotState = await copilot.checkAuth();
 
   res.json({
     claude: {
@@ -46,7 +54,7 @@ authRouter.get("/status", (_req: Request, res: Response) => {
       authenticated: !!(codexAuth && (codexAuth as Record<string, unknown>).accessToken),
     },
     copilot: {
-      authenticated: !!copilotToken,
+      authenticated: copilotState.authenticated,
     },
   });
 });

--- a/sidecar/src/auth/token-store.ts
+++ b/sidecar/src/auth/token-store.ts
@@ -81,3 +81,26 @@ export function revokeCodexAuth(): void {
     if (existsSync(path)) unlinkSync(path);
   } catch { /* already gone */ }
 }
+
+/** Store a Copilot GitHub token */
+export function storeCopilotToken(token: string): void {
+  ensureDir();
+  writeFileSync(join(TOKEN_DIR, "copilot_token"), token, { mode: 0o600 });
+}
+
+/** Read the stored Copilot GitHub token */
+export function readCopilotToken(): string | null {
+  const path = join(TOKEN_DIR, "copilot_token");
+  try {
+    if (existsSync(path)) return readFileSync(path, "utf-8").trim();
+  } catch { /* unreadable */ }
+  return null;
+}
+
+/** Remove the stored Copilot GitHub token */
+export function revokeCopilotToken(): void {
+  const path = join(TOKEN_DIR, "copilot_token");
+  try {
+    if (existsSync(path)) unlinkSync(path);
+  } catch { /* already gone */ }
+}

--- a/sidecar/src/health.ts
+++ b/sidecar/src/health.ts
@@ -6,13 +6,14 @@
  */
 
 import type { Request, Response } from "express";
-import { claude, codex } from "./providers/index.js";
+import { claude, codex, copilot } from "./providers/index.js";
 
 export interface HealthResponse {
   status: "ok" | "degraded";
   uptime_seconds: number;
   claude_auth: boolean;
   codex_auth: boolean;
+  copilot_auth: boolean;
   version: string;
 }
 
@@ -22,18 +23,20 @@ export async function healthHandler(
   _req: Request,
   res: Response,
 ): Promise<void> {
-  const [claudeState, codexState] = await Promise.all([
+  const [claudeState, codexState, copilotState] = await Promise.all([
     claude.checkAuth(),
     codex.checkAuth(),
+    copilot.checkAuth(),
   ]);
 
   const response: HealthResponse = {
-    status: claudeState.authenticated || codexState.authenticated
+    status: claudeState.authenticated || codexState.authenticated || copilotState.authenticated
       ? "ok"
       : "degraded",
     uptime_seconds: Math.floor((Date.now() - startTime) / 1000),
     claude_auth: claudeState.authenticated,
     codex_auth: codexState.authenticated,
+    copilot_auth: copilotState.authenticated,
     version: process.env.npm_package_version || "0.1.0",
   };
 

--- a/sidecar/src/providers/copilot.ts
+++ b/sidecar/src/providers/copilot.ts
@@ -1,0 +1,225 @@
+/**
+ * GitHub Copilot CLI SDK provider.
+ *
+ * Unlike claude.ts / codex.ts (which spawn their CLIs as bare subprocesses and
+ * parse stdout), this drives the official `@github/copilot-sdk`, which manages
+ * the `copilot` runtime over JSON-RPC and bundles the CLI binary as a normal
+ * npm dependency (`@github/copilot`) — no separate global install needed.
+ *
+ * Authentication: the SDK supports two paths, and this provider accepts both:
+ *   1. An explicit GitHub token (COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN
+ *      env var, or a token pasted via the sidecar's token-paste flow and
+ *      persisted at TOKEN_DIR/copilot_token) — the deployed-container path,
+ *      mirroring the Claude/Codex providers.
+ *   2. Ambient "logged-in user" credentials from an interactive `copilot`
+ *      login (the SDK's `useLoggedInUser` default) — useful for local
+ *      development where the host's own Copilot CLI session is reused.
+ *
+ * Every request creates and tears down its own session; this provider does not
+ * keep a long-lived client running between calls.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  CopilotClient,
+  type PermissionRequest,
+  type PermissionRequestResult,
+} from "@github/copilot-sdk";
+import type {
+  AIProvider,
+  ChatMessage,
+  ProviderAuthState,
+  ProviderResult,
+} from "./types.js";
+
+const TOKEN_DIR = process.env.TOKEN_DIR || "/home/sidecar/.config/sidecar";
+const COPILOT_TOKEN_FILE = join(TOKEN_DIR, "copilot_token");
+
+/** Session timeout (2 minutes), matching the Claude/Codex subprocess providers. */
+const SESSION_TIMEOUT_MS = 120_000;
+/** Maximum combined prompt size (chars) — same ceiling as the other providers. */
+const MAX_PROMPT_LENGTH = 100_000;
+/**
+ * Default model when the caller doesn't specify one. Deliberately a Claude
+ * model rather than a bare "gpt-5" id: Copilot's model catalog is
+ * account/policy-dependent and evolves over time (verified live against
+ * `client.listModels()` during development — plain "gpt-5" was not present,
+ * only versioned ids like "gpt-5.5"), so this picks a widely available,
+ * stable-sounding default rather than guessing at a moving target.
+ */
+const DEFAULT_MODEL = "claude-sonnet-4.5";
+
+/** Read an explicitly configured GitHub token, preferring env vars over the stored file. */
+function getExplicitToken(): string | null {
+  const envToken =
+    process.env.COPILOT_GITHUB_TOKEN || process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (envToken) return envToken;
+
+  try {
+    if (existsSync(COPILOT_TOKEN_FILE)) {
+      return readFileSync(COPILOT_TOKEN_FILE, "utf-8").trim();
+    }
+  } catch {
+    // File unreadable — treat as unconfigured
+  }
+  return null;
+}
+
+/**
+ * Best-effort signal that an interactive `copilot` CLI login exists on this
+ * host, for the ambient "logged-in user" auth path. This can't cheaply verify
+ * the credentials are still valid without spawning a session — the same
+ * limitation the Claude/Codex providers accept for their own stored tokens —
+ * so actual validity is resolved lazily by the SDK on first use.
+ */
+function hasAmbientLogin(): boolean {
+  const home = process.env.COPILOT_HOME || join(homedir(), ".copilot");
+  return existsSync(join(home, "config.json"));
+}
+
+/** Resolve a caller-supplied model name to a Copilot model id, stripping the `copilot-` selector prefix. */
+export function resolveModel(model?: string): string {
+  if (!model) return DEFAULT_MODEL;
+  const trimmed = model.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower === "copilot") return DEFAULT_MODEL;
+  const withoutPrefix = lower.startsWith("copilot-") ? trimmed.slice("copilot-".length) : trimmed;
+  return withoutPrefix || DEFAULT_MODEL;
+}
+
+/**
+ * Split chat messages into a system prompt (installed via `systemMessage:
+ * { mode: "replace" }`) and the user-facing conversation turns, mirroring
+ * claude.ts's splitSystemPrompt so the app's persona replaces the CLI's
+ * default agent identity rather than leaking in as disownable quoted text.
+ */
+function splitSystemPrompt(messages: ChatMessage[]): {
+  systemPrompt: string;
+  conversation: string;
+} {
+  const systemParts: string[] = [];
+  const turnParts: string[] = [];
+  for (const m of messages) {
+    if (m.role === "system") {
+      systemParts.push(m.content);
+    } else if (m.role === "assistant") {
+      turnParts.push(`[Assistant]: ${m.content}`);
+    } else {
+      turnParts.push(m.content);
+    }
+  }
+  const systemPrompt = systemParts.join("\n\n").trim();
+  const conversation = turnParts.join("\n\n");
+  const total = systemPrompt.length + conversation.length;
+  if (total > MAX_PROMPT_LENGTH) {
+    throw new Error(`Prompt too long (${total} chars, max ${MAX_PROMPT_LENGTH})`);
+  }
+  return { systemPrompt, conversation };
+}
+
+/**
+ * Deny every tool-call request. The sidecar only needs plain chat
+ * completions from Copilot, never file writes, shell commands, URL
+ * fetches, or other agentic side effects — paired with `availableTools: []`
+ * on the session, which keeps tools from being offered to the model at all.
+ */
+function denyAllTools(request: PermissionRequest): PermissionRequestResult {
+  return {
+    kind: "reject",
+    feedback: `Tool execution ("${request.kind}") is disabled for this integration.`,
+  };
+}
+
+export class CopilotProvider implements AIProvider {
+  async checkAuth(): Promise<ProviderAuthState> {
+    const token = getExplicitToken();
+    const ambient = !token && hasAmbientLogin();
+    return {
+      authenticated: !!token || ambient,
+      provider: "copilot",
+      message: token
+        ? "Copilot GitHub token configured"
+        : ambient
+          ? "Using ambient GitHub Copilot CLI login"
+          : "No Copilot authentication found",
+    };
+  }
+
+  async complete(messages: ChatMessage[], model?: string): Promise<ProviderResult> {
+    return this.run(messages, model);
+  }
+
+  async stream(
+    messages: ChatMessage[],
+    model?: string,
+    onChunk?: (text: string) => void,
+  ): Promise<ProviderResult> {
+    return this.run(messages, model, onChunk);
+  }
+
+  private async run(
+    messages: ChatMessage[],
+    model: string | undefined,
+    onChunk?: (text: string) => void,
+  ): Promise<ProviderResult> {
+    const token = getExplicitToken();
+    const cliModel = resolveModel(model);
+    const { systemPrompt, conversation } = splitSystemPrompt(messages);
+
+    const client = new CopilotClient({
+      ...(token ? { gitHubToken: token } : {}),
+    });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await client.start();
+      const session = await client.createSession({
+        clientName: "glycemicgpt-ai-sidecar",
+        model: cliModel,
+        streaming: !!onChunk,
+        availableTools: [],
+        onPermissionRequest: denyAllTools,
+        ...(systemPrompt
+          ? { systemMessage: { mode: "replace" as const, content: systemPrompt } }
+          : {}),
+      });
+
+      let content = "";
+      try {
+        await new Promise<void>((resolve, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error("AI provider request timed out"));
+          }, SESSION_TIMEOUT_MS);
+
+          session.on("assistant.message_delta", (event) => {
+            onChunk?.(event.data.deltaContent);
+          });
+          session.on("assistant.message", (event) => {
+            content = event.data.content;
+          });
+          session.on("session.error", (event) => {
+            reject(new Error(event.data.message || "Copilot session error"));
+          });
+          session.on("session.idle", () => resolve());
+
+          // Listeners are registered above before sending so no early event is
+          // missed; send() only queues the message and resolves once it's
+          // accepted, so a rejection here means the message was never sent.
+          session.send({ prompt: conversation }).catch(reject);
+        });
+      } finally {
+        clearTimeout(timer);
+        await session.disconnect().catch(() => {});
+      }
+
+      if (!content) {
+        throw new Error("AI provider returned no usable output");
+      }
+      return { content, model: `copilot-${cliModel}` };
+    } finally {
+      await client.stop().catch(() => {});
+    }
+  }
+}

--- a/sidecar/src/providers/index.ts
+++ b/sidecar/src/providers/index.ts
@@ -7,10 +7,12 @@
 
 import { ClaudeProvider } from "./claude.js";
 import { CodexProvider } from "./codex.js";
+import { CopilotProvider } from "./copilot.js";
 import { AnthropicVisionProvider } from "./anthropic-vision.js";
 
 export const claude = new ClaudeProvider();
 export const codex = new CodexProvider();
+export const copilot = new CopilotProvider();
 /** Anthropic API-key vision path (direct Messages API). The Claude/ChatGPT
  * subscription vision paths live on the `claude` / `codex` providers above. */
 export const anthropicVision = new AnthropicVisionProvider();

--- a/sidecar/src/providers/types.ts
+++ b/sidecar/src/providers/types.ts
@@ -106,7 +106,7 @@ export interface ProviderResult {
 /** Provider authentication state */
 export interface ProviderAuthState {
   authenticated: boolean;
-  provider: "claude" | "codex";
+  provider: "claude" | "codex" | "copilot";
   /** Human-readable status message */
   message: string;
 }

--- a/sidecar/src/server.ts
+++ b/sidecar/src/server.ts
@@ -31,7 +31,7 @@ import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { healthHandler } from "./health.js";
 import { authRouter } from "./auth/oauth-server.js";
-import { claude, codex, anthropicVision } from "./providers/index.js";
+import { claude, codex, copilot, anthropicVision } from "./providers/index.js";
 import {
   InvalidImageError,
   parseImageDataUrl,
@@ -139,6 +139,15 @@ app.use((req, res, next) => {
   next();
 });
 
+/** True when a model name selects the Copilot SDK provider. */
+function isCopilotModel(model?: string): boolean {
+  if (!model) return false;
+  // Explicit selector prefix only: Copilot serves models named "gpt-5",
+  // "claude-sonnet-4.5", etc. that would otherwise collide with the Codex/
+  // Claude heuristics below, so selection must be unambiguous.
+  return model.toLowerCase().startsWith("copilot");
+}
+
 /** True when a model name selects the Codex/OpenAI provider. */
 function isCodexModel(model?: string): boolean {
   if (!model) return false;
@@ -151,16 +160,19 @@ function isCodexModel(model?: string): boolean {
 
 /** Choose the text provider based on model name */
 function getProvider(model?: string) {
+  if (isCopilotModel(model)) return copilot;
   return isCodexModel(model) ? codex : claude;
 }
 
 /**
  * Choose the vision runner for the active provider, by its sanctioned
  * mechanism. Codex/ChatGPT models use the Codex CLI; Claude models prefer the
- * Anthropic API-key path and fall back to the Claude subscription CLI. Returns
- * null when the selected provider has no configured vision mechanism.
+ * Anthropic API-key path and fall back to the Claude subscription CLI. Copilot
+ * models have no configured vision mechanism yet. Returns null when the
+ * selected provider has no configured vision mechanism.
  */
 function selectVisionRunner(model?: string): VisionRunner | null {
+  if (isCopilotModel(model)) return null;
   if (isCodexModel(model)) {
     return codex.supportsVision() ? codex : null;
   }
@@ -276,9 +288,10 @@ app.use("/auth", parseJsonStandard, authRouter);
 
 /** GET /v1/models - List available models */
 app.get("/v1/models", async (_req, res) => {
-  const [claudeAuth, codexAuth] = await Promise.all([
+  const [claudeAuth, codexAuth, copilotAuth] = await Promise.all([
     claude.checkAuth(),
     codex.checkAuth(),
+    copilot.checkAuth(),
   ]);
 
   const models: Array<{ id: string; object: string; owned_by: string }> = [];
@@ -296,6 +309,14 @@ app.get("/v1/models", async (_req, res) => {
       { id: "gpt-4o", object: "model", owned_by: "openai" },
       { id: "gpt-4-turbo", object: "model", owned_by: "openai" },
       { id: "o3-mini", object: "model", owned_by: "openai" },
+    );
+  }
+
+  if (copilotAuth.authenticated) {
+    models.push(
+      { id: "copilot-claude-sonnet-4.5", object: "model", owned_by: "github-copilot" },
+      { id: "copilot-claude-opus-4.8", object: "model", owned_by: "github-copilot" },
+      { id: "copilot-gpt-5.5", object: "model", owned_by: "github-copilot" },
     );
   }
 

--- a/sidecar/tests/copilot-provider.test.ts
+++ b/sidecar/tests/copilot-provider.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the GitHub Copilot SDK provider wrapper.
+ *
+ * These test the provider logic (auth detection, model resolution) without
+ * spawning the actual Copilot runtime — the same scope providers.test.ts
+ * uses for the Claude/Codex CLI wrappers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("CopilotProvider", () => {
+  let tokenDir: string;
+  let homeDir: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    tokenDir = mkdtempSync(join(tmpdir(), "copilot-token-test-"));
+    homeDir = mkdtempSync(join(tmpdir(), "copilot-home-test-"));
+    process.env.TOKEN_DIR = tokenDir;
+    process.env.COPILOT_HOME = join(homeDir, ".copilot-missing");
+    delete process.env.COPILOT_GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    rmSync(tokenDir, { recursive: true, force: true });
+    rmSync(homeDir, { recursive: true, force: true });
+    process.env = { ...originalEnv };
+  });
+
+  it("reports unauthenticated with no token and no ambient login", async () => {
+    const { CopilotProvider } = await import("../src/providers/copilot.js");
+    const state = await new CopilotProvider().checkAuth();
+    expect(state.authenticated).toBe(false);
+    expect(state.provider).toBe("copilot");
+  });
+
+  it("reports authenticated when COPILOT_GITHUB_TOKEN is set", async () => {
+    process.env.COPILOT_GITHUB_TOKEN = "test-copilot-token-dummy";
+    const { CopilotProvider } = await import("../src/providers/copilot.js");
+    const state = await new CopilotProvider().checkAuth();
+    expect(state.authenticated).toBe(true);
+  });
+
+  it("reports authenticated when GH_TOKEN is set", async () => {
+    process.env.GH_TOKEN = "test-gh-token-dummy";
+    const { CopilotProvider } = await import("../src/providers/copilot.js");
+    const state = await new CopilotProvider().checkAuth();
+    expect(state.authenticated).toBe(true);
+  });
+
+  it("reports authenticated when a token file exists", async () => {
+    writeFileSync(join(tokenDir, "copilot_token"), "test-copilot-file-token-dummy");
+    const { CopilotProvider } = await import("../src/providers/copilot.js");
+    const state = await new CopilotProvider().checkAuth();
+    expect(state.authenticated).toBe(true);
+  });
+
+  it("reports authenticated via ambient CLI login when no explicit token is configured", async () => {
+    const copilotHome = join(homeDir, ".copilot");
+    mkdirSync(copilotHome, { recursive: true });
+    writeFileSync(join(copilotHome, "config.json"), "{}");
+    process.env.COPILOT_HOME = copilotHome;
+    const { CopilotProvider } = await import("../src/providers/copilot.js");
+    const state = await new CopilotProvider().checkAuth();
+    expect(state.authenticated).toBe(true);
+    expect(state.message).toMatch(/ambient/i);
+  });
+
+  it("prefers an explicit token's message over the ambient login message", async () => {
+    const copilotHome = join(homeDir, ".copilot");
+    mkdirSync(copilotHome, { recursive: true });
+    writeFileSync(join(copilotHome, "config.json"), "{}");
+    process.env.COPILOT_HOME = copilotHome;
+    process.env.COPILOT_GITHUB_TOKEN = "test-copilot-token-dummy";
+    const { CopilotProvider } = await import("../src/providers/copilot.js");
+    const state = await new CopilotProvider().checkAuth();
+    expect(state.authenticated).toBe(true);
+    expect(state.message).toMatch(/token configured/i);
+  });
+
+  it("resolveModel strips the copilot- selector prefix", async () => {
+    const { resolveModel } = await import("../src/providers/copilot.js");
+    expect(resolveModel("copilot-gpt-5.5")).toBe("gpt-5.5");
+    expect(resolveModel("copilot-claude-sonnet-4.5")).toBe("claude-sonnet-4.5");
+  });
+
+  it("resolveModel treats a bare 'copilot' selector as the default model", async () => {
+    const { resolveModel } = await import("../src/providers/copilot.js");
+    expect(resolveModel("copilot")).toBe(resolveModel());
+  });
+
+  it("resolveModel passes through a plain model id unchanged", async () => {
+    const { resolveModel } = await import("../src/providers/copilot.js");
+    expect(resolveModel("gemini-3.1-pro-preview")).toBe("gemini-3.1-pro-preview");
+  });
+
+  it("resolveModel defaults when no model is given", async () => {
+    const { resolveModel } = await import("../src/providers/copilot.js");
+    expect(resolveModel()).toBeTruthy();
+    expect(resolveModel("")).toBe(resolveModel());
+  });
+});

--- a/sidecar/tests/health.test.ts
+++ b/sidecar/tests/health.test.ts
@@ -21,6 +21,13 @@ vi.mock("../src/providers/index.js", () => ({
       message: "No Codex authentication found",
     }),
   },
+  copilot: {
+    checkAuth: vi.fn().mockResolvedValue({
+      authenticated: false,
+      provider: "copilot",
+      message: "No Copilot authentication found",
+    }),
+  },
 }));
 
 function createMockRes() {
@@ -49,6 +56,7 @@ describe("healthHandler", () => {
         uptime_seconds: expect.any(Number),
         claude_auth: expect.any(Boolean),
         codex_auth: expect.any(Boolean),
+        copilot_auth: expect.any(Boolean),
         version: expect.any(String),
       }),
     );

--- a/sidecar/tests/server.test.ts
+++ b/sidecar/tests/server.test.ts
@@ -35,6 +35,11 @@ const mockCodexCheckAuth = vi.fn().mockResolvedValue({
   provider: "codex",
   message: "No Codex authentication found",
 });
+const mockCopilotCheckAuth = vi.fn().mockResolvedValue({
+  authenticated: false,
+  provider: "copilot",
+  message: "No Copilot authentication found",
+});
 // Vision runners: anthropicVision (API key), claude (subscription CLI), codex (CLI).
 const mockVisionSupports = vi.fn().mockReturnValue(true);
 const mockVisionComplete = vi.fn().mockResolvedValue({
@@ -71,21 +76,31 @@ vi.mock("../src/providers/index.js", () => ({
     supportsVision: mockVisionSupports,
     completeVision: mockVisionComplete,
   },
+  copilot: {
+    checkAuth: mockCopilotCheckAuth,
+    complete: vi.fn(),
+    stream: vi.fn(),
+  },
 }));
 
 // Mock the token store for auth routes
 const mockStoreClaudeToken = vi.fn();
 const mockStoreCodexAuth = vi.fn();
+const mockStoreCopilotToken = vi.fn();
 const mockReadClaudeToken = vi.fn().mockReturnValue(null);
 const mockReadCodexAuth = vi.fn().mockReturnValue(null);
+const mockReadCopilotToken = vi.fn().mockReturnValue(null);
 
 vi.mock("../src/auth/token-store.js", () => ({
   readClaudeToken: mockReadClaudeToken,
   readCodexAuth: mockReadCodexAuth,
+  readCopilotToken: mockReadCopilotToken,
   revokeClaudeToken: vi.fn(),
   revokeCodexAuth: vi.fn(),
+  revokeCopilotToken: vi.fn(),
   storeClaudeToken: mockStoreClaudeToken,
   storeCodexAuth: mockStoreCodexAuth,
+  storeCopilotToken: mockStoreCopilotToken,
 }));
 
 // Test helper: invoke Express app without HTTP


### PR DESCRIPTION
## 📋 Summary

Adds GitHub Copilot (Individual / Business / Enterprise subscription) as a supported BYOAI provider, routed through the managed AI sidecar via the official `@github/copilot-sdk` — the sixth provider option alongside Claude/ChatGPT subscriptions, API keys, and local models. Also fixes three real-world Nightscout integration bugs found while testing against live instances.

## 🔗 Related Issues

None — standalone contribution.

## 🏷️ Type of Change

- [x] ✨ New feature (non-breaking; adds functionality)
- [x] 🐛 Bug fix (non-breaking; fixes Nightscout issues found during live testing)

## 🔨 Changes Made

- **Copilot SDK provider (sidecar):** new TypeScript provider driving a Copilot session over `@github/copilot-sdk` with deny-all tool permissions; supports both pasted GitHub tokens and ambient `copilot` CLI login on self-hosted boxes. Auth/status endpoint reflects ambient-login state.
- **Backend:** `copilot_subscription` added to the `AIProviderType` enum + alembic migration (additive `ALTER TYPE ... ADD VALUE IF NOT EXISTS`, no schema/behavior change for existing rows).
- **Frontend:** Copilot selectable in AI provider settings.
- **Docs:** `docs/concepts/byoai.md` expanded to six provider options with cost/privacy/quality notes for Copilot.
- **Nightscout — credential-optional support:** public read-only instances (`AUTH_DEFAULT_ROLE=readable`) can now be connected with no API secret/token; auth headers are omitted entirely for anonymous requests; also fixes the empty-credential redaction bug where `str.replace("", "<redacted>")` corrupted every error message on credential-less connections.
- **Nightscout — profile units normalization:** mixed-case / variant unit strings ("mg/dL", "mmol/L", etc.) from real-world profile documents no longer 500 the onboarding discovery endpoint; unexpected profile shapes degrade gracefully instead of failing the whole sync.
- **Maintainer follow-ups on this branch:** copilot migration renumbered 078 → 079 and reparented onto `078_idempotency_keys` (develop merged another 078 off the same parent, producing two alembic heads); review nits addressed (byoai.md grammar, whitespace-strip normalizer on `NightscoutConnectionUpdate.credential` mirroring the Create schema, with test).

## 🧪 Test Plan

- [x] Unit tests pass (sidecar 125/125, backend suite green including Nightscout connection/client/evaluate coverage)
- [x] New tests added for new functionality (Copilot provider, credential-optional paths, header omission + redaction fix, units normalization, PATCH credential whitespace normalization)
- [x] Manual/visual testing performed (live Nightscout instance for the units/credential fixes; provider verified in settings UI — see screenshot)
- [x] Docker integration tested (if applicable) — note: SDK calls require the Copilot app/CLI to be installed and logged in, so ambient-login mode suits developer machines / self-hosted boxes rather than managed server environments.

## ✅ Checklist

- [x] Self-review completed
- [x] Code follows project style guidelines
- [x] No hardcoded secrets, API keys, or credentials
- [x] Changes generate no new warnings
- [x] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<img width="1557" height="843" alt="image" src="https://github.com/user-attachments/assets/9af9e081-4b96-4610-9384-80da9e0aad93" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub Copilot as a new subscription/provider option across the app.
  * Expanded the AI settings and documentation to show Copilot alongside existing provider choices.
  * Nightscout connections can now be created and updated without a credential for public/read-only instances.

* **Bug Fixes**
  * Improved handling of empty Nightscout credentials and made error messages more accurate.
  * Fixed Nightscout profile parsing to better handle unit formats and unexpected data without failing the whole sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
