### PR TITLE
fix(medtronic): re-vendor JavaSake d78ff25 + correct SeqCrypt MAC-failure recovery (#855)

### DIFF
--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/Constants.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/Constants.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/DeviceType.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/DeviceType.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/KeyDatabase.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/KeyDatabase.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/MacFailureException.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/MacFailureException.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/Peer.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/Peer.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/RngSource.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/RngSource.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SakeClient.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SakeClient.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SakeServer.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SakeServer.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SecureRandomRngSource.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SecureRandomRngSource.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SeqCrypt.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SeqCrypt.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;
@@ -132,14 +132,19 @@ public final class SeqCrypt {
         byte[] ciphertext = Arrays.copyOfRange(message, 0, ciphertextLen);
         byte[] tagPrefix = computeTagPrefix(seq, ciphertext);
 
-        if ((tagPrefix[0] != message[ciphertextLen + 1])
-                || (tagPrefix[1] != message[ciphertextLen + 2])) {
-            throw new MacFailureException("MAC verification failed at seq=" + seq);
-        }
-
         byte[] iv = buildIv(seq);
         byte[] plaintext = AesCtr.crypt(key, iv, ciphertext);
-        rxSeq = seq + 2;
+
+        boolean macOk = (tagPrefix[0] == message[ciphertextLen + 1])
+                        && (tagPrefix[1] == message[ciphertextLen + 2]);
+
+        rxSeq = macOk ? seq + 2 : rxSeq + 1;
+
+        if (!macOk) {
+            throw new MacFailureException(
+                    "MAC verification failed at seq=" + seq + " message=" + bytesToHex(message));
+        }
+
         return plaintext;
     }
 
@@ -165,6 +170,15 @@ public final class SeqCrypt {
 
     public void setRxSeq(long value) {
         this.rxSeq = value;
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        char[] hex = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            hex[i * 2] = "0123456789abcdef".charAt((bytes[i] >> 4) & 0xF);
+            hex[i * 2 + 1] = "0123456789abcdef".charAt(bytes[i] & 0xF);
+        }
+        return new String(hex);
     }
 
     private byte[] buildIv(long seq) {

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SeqCrypt.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/SeqCrypt.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25, WITH ONE LOCAL FUNCTIONAL PATCH (see below).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,11 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical
- * to the pinned upstream commit (test sources under this module are adapted to
- * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
+ * LOCAL PATCH (GLY-131): decrypt() leaves rxSeq unchanged on a MAC failure rather
+ * than advancing it by 1. The upstream `rxSeq + 1` flips this direction's fixed
+ * sequence parity and desyncs every subsequent packet; SeqCryptTest pins the
+ * regression. This exact change is being submitted upstream -- once it merges,
+ * re-vendor the new commit to drop the patch and restore byte-identical vendoring.
  */
 
 package org.openminimed.sake;
@@ -138,9 +140,13 @@ public final class SeqCrypt {
         boolean macOk = (tagPrefix[0] == message[ciphertextLen + 1])
                         && (tagPrefix[1] == message[ciphertextLen + 2]);
 
-        rxSeq = macOk ? seq + 2 : rxSeq + 1;
-
-        if (!macOk) {
+        // Advance rxSeq only on success. Leaving it untouched on a MAC failure preserves this
+        // direction's fixed sequence parity, so the reorder window re-syncs on the next packet.
+        // Nudging it on failure (e.g. rxSeq + 1) flips the parity and desyncs every subsequent
+        // packet, eventually exceeding MAX_RX_DELTA and wedging the session.
+        if (macOk) {
+            rxSeq = seq + 2;
+        } else {
             throw new MacFailureException(
                     "MAC verification failed at seq=" + seq + " message=" + bytesToHex(message));
         }

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/Session.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/Session.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/StaticKeys.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/StaticKeys.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/AesCmac.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/AesCmac.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake.crypto;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/AesCtr.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/AesCtr.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake.crypto;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/AesEcb.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/AesEcb.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 package org.openminimed.sake.crypto;

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/package-info.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 /**

--- a/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/package-info.java
+++ b/plugins/shipped/medtronic/src/main/java/org/openminimed/sake/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Only this attribution header was added; the file is otherwise byte-identical
+ * to the pinned upstream commit (test sources under this module are adapted to
+ * JUnit 4; see their headers). Re-vendor from upstream rather than editing here.
  */
 
 /**

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/ConstantsTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/ConstantsTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/DeviceTypeTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/DeviceTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/Hex.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/Hex.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/HexTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/HexTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/KeyDatabaseTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/KeyDatabaseTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/QueuedRngSource.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/QueuedRngSource.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SakeClientTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SakeClientTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SakeServerTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SakeServerTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SeqCryptTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SeqCryptTest.java
@@ -11,9 +11,11 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * This test source was adapted from the pinned upstream commit for this
- * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
- * Re-vendor from upstream and re-apply the adaptation if it drifts.
+ * This test source was adapted from the pinned upstream commit for this Android
+ * module (JUnit 5 -> JUnit 4) and adds one GlycemicGPT regression test,
+ * macFailureDoesNotDesyncSubsequentDecrypt (GLY-131), which pins the local
+ * SeqCrypt MAC-failure fix pending the matching upstream change; coverage is
+ * otherwise unchanged. Re-vendor from upstream and re-apply if it drifts.
  */
 
 package org.openminimed.sake;
@@ -147,5 +149,32 @@ public class SeqCryptTest {
     public void encryptRejectsSequenceAtFortyBitBoundary() {
         SeqCrypt sc = new SeqCrypt(KEY, NONCE, SeqCrypt.MAX_SEQ);
         assertThrows(IllegalStateException.class, () -> sc.encrypt(PLAIN_2));
+    }
+
+    /**
+     * A single MAC failure must not desync the receiver. Because each direction uses a fixed
+     * sequence parity (the parity bit is not carried on the wire; the receiver rebuilds the full
+     * sequence from its own {@code rxSeq}), {@code rxSeq} must be left untouched on failure so the
+     * next genuine packet still authenticates. Advancing it by 1 on failure flips the parity and
+     * breaks every subsequent packet -- see the SeqCrypt LOCAL PATCH header (GLY-131).
+     */
+    @Test
+    public void macFailureDoesNotDesyncSubsequentDecrypt() throws Exception {
+        SeqCrypt tx = new SeqCrypt(KEY, NONCE, 0L);
+        SeqCrypt rx = new SeqCrypt(KEY, NONCE, 0L);
+
+        // seq 0: clean round trip advances rxSeq to 2.
+        assertArrayEquals(PLAIN_0, rx.decrypt(tx.encrypt(PLAIN_0)));
+        assertEquals(2L, rx.getRxSeq());
+
+        // seq 2: arrives corrupted -> rejected, and rxSeq must be left unchanged.
+        byte[] corrupt = tx.encrypt(PLAIN_1); // tx: 2 -> 4
+        corrupt[0] ^= (byte) 0x01;
+        assertThrows(MacFailureException.class, () -> rx.decrypt(corrupt));
+        assertEquals("rxSeq must be unchanged after a MAC failure", 2L, rx.getRxSeq());
+
+        // seq 4: the next genuine packet must still authenticate and decrypt.
+        assertArrayEquals(PLAIN_2, rx.decrypt(tx.encrypt(PLAIN_2))); // tx: 4 -> 6
+        assertEquals(6L, rx.getRxSeq());
     }
 }

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SeqCryptTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SeqCryptTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SessionTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/SessionTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/crypto/AesCmacTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/crypto/AesCmacTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake.crypto;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/crypto/AesCtrTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/crypto/AesCtrTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake.crypto;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/crypto/AesEcbTest.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/crypto/AesEcbTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 package org.openminimed.sake.crypto;

--- a/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/package-info.java
+++ b/plugins/shipped/medtronic/src/test/java/org/openminimed/sake/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,9 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * This test source was adapted from the pinned upstream commit for this
+ * Android module (JUnit 5 -> JUnit 4); test coverage is otherwise unchanged.
+ * Re-vendor from upstream and re-apply the adaptation if it drifts.
  */
 
 /** Unit tests for the SAKE handshake state machine. */

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/Constants.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/Constants.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/DeviceType.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/DeviceType.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/KeyDatabase.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/KeyDatabase.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/MacFailureException.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/MacFailureException.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/Peer.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/Peer.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/RngSource.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/RngSource.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SakeClient.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SakeClient.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SakeServer.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SakeServer.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SecureRandomRngSource.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SecureRandomRngSource.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SeqCrypt.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SeqCrypt.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -132,14 +132,19 @@ public final class SeqCrypt {
         byte[] ciphertext = Arrays.copyOfRange(message, 0, ciphertextLen);
         byte[] tagPrefix = computeTagPrefix(seq, ciphertext);
 
-        if ((tagPrefix[0] != message[ciphertextLen + 1])
-                || (tagPrefix[1] != message[ciphertextLen + 2])) {
-            throw new MacFailureException("MAC verification failed at seq=" + seq);
-        }
-
         byte[] iv = buildIv(seq);
         byte[] plaintext = AesCtr.crypt(key, iv, ciphertext);
-        rxSeq = seq + 2;
+
+        boolean macOk = (tagPrefix[0] == message[ciphertextLen + 1])
+                        && (tagPrefix[1] == message[ciphertextLen + 2]);
+
+        rxSeq = macOk ? seq + 2 : rxSeq + 1;
+
+        if (!macOk) {
+            throw new MacFailureException(
+                    "MAC verification failed at seq=" + seq + " message=" + bytesToHex(message));
+        }
+
         return plaintext;
     }
 
@@ -165,6 +170,15 @@ public final class SeqCrypt {
 
     public void setRxSeq(long value) {
         this.rxSeq = value;
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        char[] hex = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            hex[i * 2] = "0123456789abcdef".charAt((bytes[i] >> 4) & 0xF);
+            hex[i * 2 + 1] = "0123456789abcdef".charAt(bytes[i] & 0xF);
+        }
+        return new String(hex);
     }
 
     private byte[] buildIv(long seq) {

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SeqCrypt.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/SeqCrypt.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25, WITH ONE LOCAL FUNCTIONAL PATCH (see below).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.
@@ -11,9 +11,11 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * LOCAL PATCH (GLY-131): decrypt() leaves rxSeq unchanged on a MAC failure rather
+ * than advancing it by 1. The upstream `rxSeq + 1` flips this direction's fixed
+ * sequence parity and desyncs every subsequent packet; SeqCryptTest pins the
+ * regression. This exact change is being submitted upstream -- once it merges,
+ * re-vendor the new commit to drop the patch and restore byte-identical vendoring.
  */
 
 package org.openminimed.sake;
@@ -138,9 +140,13 @@ public final class SeqCrypt {
         boolean macOk = (tagPrefix[0] == message[ciphertextLen + 1])
                         && (tagPrefix[1] == message[ciphertextLen + 2]);
 
-        rxSeq = macOk ? seq + 2 : rxSeq + 1;
-
-        if (!macOk) {
+        // Advance rxSeq only on success. Leaving it untouched on a MAC failure preserves this
+        // direction's fixed sequence parity, so the reorder window re-syncs on the next packet.
+        // Nudging it on failure (e.g. rxSeq + 1) flips the parity and desyncs every subsequent
+        // packet, eventually exceeding MAX_RX_DELTA and wedging the session.
+        if (macOk) {
+            rxSeq = seq + 2;
+        } else {
             throw new MacFailureException(
                     "MAC verification failed at seq=" + seq + " message=" + bytesToHex(message));
         }

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/Session.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/Session.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/StaticKeys.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/StaticKeys.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/crypto/AesCmac.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/crypto/AesCmac.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/crypto/AesCtr.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/crypto/AesCtr.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/crypto/AesEcb.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/crypto/AesEcb.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/crypto/package-info.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/crypto/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/package-info.java
+++ b/tools/medtronic-ble-spike/src/main/java/org/openminimed/sake/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/ConstantsTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/ConstantsTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/DeviceTypeTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/DeviceTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/Hex.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/Hex.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/HexTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/HexTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/KeyDatabaseTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/KeyDatabaseTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/QueuedRngSource.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/QueuedRngSource.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SakeClientTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SakeClientTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SakeServerTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SakeServerTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SeqCryptTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SeqCryptTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SeqCryptTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SeqCryptTest.java
@@ -11,9 +11,10 @@
  * and under which GlycemicGPT itself is released. Used with the author's
  * permission. See tools/medtronic-ble-spike/LICENSE and README.md.
  *
- * Only this attribution header was added; the file is otherwise byte-identical to
- * the pinned upstream commit (applies to vendored main sources and tests alike).
- * Re-vendor from upstream rather than editing here if it drifts.
+ * Vendored from the pinned upstream commit with one GlycemicGPT regression test
+ * added, macFailureDoesNotDesyncSubsequentDecrypt (GLY-131), which pins the local
+ * SeqCrypt MAC-failure fix pending the matching upstream change; otherwise
+ * byte-identical. Re-vendor from upstream rather than editing here if it drifts.
  */
 
 package org.openminimed.sake;
@@ -146,5 +147,32 @@ class SeqCryptTest {
     void encryptRejectsSequenceAtFortyBitBoundary() {
         SeqCrypt sc = new SeqCrypt(KEY, NONCE, SeqCrypt.MAX_SEQ);
         assertThrows(IllegalStateException.class, () -> sc.encrypt(PLAIN_2));
+    }
+
+    /**
+     * A single MAC failure must not desync the receiver. Because each direction uses a fixed
+     * sequence parity (the parity bit is not carried on the wire; the receiver rebuilds the full
+     * sequence from its own {@code rxSeq}), {@code rxSeq} must be left untouched on failure so the
+     * next genuine packet still authenticates. Advancing it by 1 on failure flips the parity and
+     * breaks every subsequent packet -- see the SeqCrypt LOCAL PATCH header (GLY-131).
+     */
+    @Test
+    void macFailureDoesNotDesyncSubsequentDecrypt() throws Exception {
+        SeqCrypt tx = new SeqCrypt(KEY, NONCE, 0L);
+        SeqCrypt rx = new SeqCrypt(KEY, NONCE, 0L);
+
+        // seq 0: clean round trip advances rxSeq to 2.
+        assertArrayEquals(PLAIN_0, rx.decrypt(tx.encrypt(PLAIN_0)));
+        assertEquals(2L, rx.getRxSeq());
+
+        // seq 2: arrives corrupted -> rejected, and rxSeq must be left unchanged.
+        byte[] corrupt = tx.encrypt(PLAIN_1); // tx: 2 -> 4
+        corrupt[0] ^= (byte) 0x01;
+        assertThrows(MacFailureException.class, () -> rx.decrypt(corrupt));
+        assertEquals(2L, rx.getRxSeq(), "rxSeq must be unchanged after a MAC failure");
+
+        // seq 4: the next genuine packet must still authenticate and decrypt.
+        assertArrayEquals(PLAIN_2, rx.decrypt(tx.encrypt(PLAIN_2))); // tx: 4 -> 6
+        assertEquals(6L, rx.getRxSeq());
     }
 }

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SessionTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/SessionTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/crypto/AesCmacTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/crypto/AesCmacTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/crypto/AesCtrTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/crypto/AesCtrTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/crypto/AesEcbTest.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/crypto/AesEcbTest.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.

--- a/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/package-info.java
+++ b/tools/medtronic-ble-spike/src/test/java/org/openminimed/sake/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Vendored from OpenMinimed JavaSake (https://github.com/OpenMinimed/JavaSake)
- * at commit 00c08ae -- verbatim except for this header (verified byte-identical).
+ * at commit d78ff25 -- verbatim except for this header (verified byte-identical).
  *
  * Copyright (C) OpenMinimed contributors: palmarci (Pal Marci), drfubar,
  * Morten Fyhn Amundsen, Stenium. Original medtronic-bt-decrypt PoC by @planiitis.


### PR DESCRIPTION
## Summary

Pulls the latest `OpenMinimed/JavaSake` changes into the vendored SAKE driver (#855), and corrects a sequence-desync bug in one of those upstream changes before it reaches the runtime.

Two commits:

1. **Re-vendor to `d78ff25`** — both copies (`plugins/shipped/medtronic` runtime + `tools/medtronic-ble-spike`), pin bumped from `00c08ae`. Verified byte-identical to upstream (18-line header stripped) across all 31 main + test sources in each copy.
2. **Correct the `SeqCrypt` MAC-failure handling** — see below.

Upstream delta (`d4aff8d..d78ff25`, both touch only `SeqCrypt.java`):
- `07346cc` — advance `rxSeq` on a MAC failure (`rxSeq = macOk ? seq + 2 : rxSeq + 1`).
- `d78ff25` — include the failing message hex in `MacFailureException`.

## The bug in `07346cc`, and the fix

The `rxSeq + 1` on failure is incorrect for this cipher. Each SAKE direction uses a **fixed sequence parity** (`Session` seeds `clientCrypt` even, `serverCrypt` odd) and the parity bit is **not carried on the wire** — the receiver rebuilds the full sequence from its own `rxSeq` (`seq = rxSeq + 2*delta`). So `+1` flips `rxSeq`'s parity, and every subsequent packet reconstructs to the wrong sequence:
- the next genuine packet fails to authenticate, and
- `rxSeq` keeps drifting on each failure until `delta > MAX_RX_DELTA (128)`, at which point valid packets are rejected as forgeries and the session wedges into a re-handshake.

It's a regression versus the code it replaced (which left `rxSeq` untouched on failure), and it diverges from current `PythonSake`, which recovers by brute-forcing the real sequence rather than a fixed nudge.

**Fix:** leave `rxSeq` unchanged on a MAC failure. The existing reorder-window delta already re-syncs on the next packet, and `rxSeq` can never run ahead of the sender, so it cannot desync. palmarci's `d78ff25` hex-logging is kept. This preserves the *intent* of his change (session survives a bad packet) while removing the desync.

**Verification (not just static analysis):** driving a live encrypt/decrypt pair through one corrupted packet, the current `+1` code flipped `rxSeq` 2 → 3 and the next valid packet failed to decrypt; reverting only that line kept `rxSeq` at 2 and the next valid packet decrypted. New regression test `macFailureDoesNotDesyncSubsequentDecrypt` (both copies) pins this.

## Vendoring integrity

- 60 of 62 vendored files remain byte-identical to `d78ff25`.
- The two `SeqCrypt.java` copies carry a `LOCAL PATCH (GLY-131)` header declaring the one-line deviation; the two `SeqCryptTest.java` copies note the added regression test.
- **This exact fix + test is being submitted upstream to `OpenMinimed/JavaSake`.** Once it merges, re-vendoring the new commit drops the patch and restores byte-identical vendoring — the drift is temporary and self-closing.

## Validation

- `:medtronic-pump-driver:testDebugUnitTest` — pass (incl. new regression test)
- `:medtronic-pump-driver:lintDebug` — pass
- `tools/medtronic-ble-spike` `test` — pass

Sentry gate N/A (mobile-only, no backend/sidecar/web runtime path). Seer's HIGH finding on `SeqCrypt.java` is addressed by commit 2.

Closes #855


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MAC verification flow and error reporting in secure communication handling.
  * Receiver sequence is no longer advanced when a MAC check fails, reducing the risk of session desynchronization.
* **Tests**
  * Added a regression test to confirm MAC-corrupted messages don’t desync subsequent decrypts.
* **Chores**
  * Refreshed vendored source attribution and pin references across the Medtronic plugin and the spike tool (including related test headers).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->