### PR TITLE
fix(mobile): offline sessions survive access-token expiry; spaced refresh retries (GLY-131 spike)

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -119,15 +119,21 @@ class AuthManager @Inject constructor(
     /**
      * Schedules a coroutine that refreshes the access token before it expires.
      * Re-schedules itself after each successful refresh.
+     *
+     * @param minDelayMs floor for the computed delay. The failure branches of
+     *   [performRefresh] reschedule with [TRANSIENT_RETRY_DELAY_MS]: the stored
+     *   expiry is already in the past there, so the natural delay is 0 and a
+     *   transient failure (device offline, backend down) would otherwise spin
+     *   refresh attempts back-to-back until connectivity returns.
      */
-    fun scheduleProactiveRefresh(scope: CoroutineScope) {
+    fun scheduleProactiveRefresh(scope: CoroutineScope, minDelayMs: Long = 0) {
         refreshJob?.cancel()
         refreshJob = scope.launch {
             val expiresAt = authTokenStore.getTokenExpiresAtMs()
             if (expiresAt <= 0) return@launch
 
             val refreshAt = expiresAt - AuthTokenStore.PROACTIVE_REFRESH_WINDOW_MS
-            val delayMs = (refreshAt - System.currentTimeMillis()).coerceAtLeast(0)
+            val delayMs = (refreshAt - System.currentTimeMillis()).coerceAtLeast(minDelayMs)
 
             Timber.d("Proactive refresh scheduled in ${delayMs / 1000}s")
             delay(delayMs)
@@ -187,7 +193,7 @@ class AuthManager @Inject constructor(
                     val raw = authTokenStore.getRawToken()
                     if (raw != null) {
                         _authState.value = AuthState.Authenticated
-                        scheduleProactiveRefresh(scope)
+                        scheduleProactiveRefresh(scope, TRANSIENT_RETRY_DELAY_MS)
                     }
                 }
                 is RefreshOutcome.NetworkFailure -> {
@@ -197,7 +203,7 @@ class AuthManager @Inject constructor(
                     val raw = authTokenStore.getRawToken()
                     if (raw != null) {
                         _authState.value = AuthState.Authenticated
-                        scheduleProactiveRefresh(scope)
+                        scheduleProactiveRefresh(scope, TRANSIENT_RETRY_DELAY_MS)
                     } else {
                         _authState.value = AuthState.Expired()
                     }
@@ -402,8 +408,18 @@ class AuthManager @Inject constructor(
             }
         }
 
-        // All attempts exhausted without obtaining a token
-        if (authTokenStore.getToken() == null && _authState.value !is AuthState.Expired) {
+        // All attempts exhausted without obtaining a token. If a transient
+        // failure left us Authenticated on a stored (possibly expired) access
+        // token, keep it: the session is intact, we're just unable to reach
+        // the server -- typically because the device is offline. Downgrading
+        // to Expired here would show a false "session expired" banner and
+        // prompt a re-login that cannot succeed without connectivity. The
+        // proactive timer keeps retrying, and the 401 interceptor recovers
+        // the session on the first request after reconnect.
+        if (authTokenStore.getToken() == null &&
+            _authState.value !is AuthState.Expired &&
+            _authState.value !is AuthState.Authenticated
+        ) {
             Timber.w("Startup refresh exhausted all attempts without obtaining a token")
             _authState.value = AuthState.Expired()
         }
@@ -446,5 +462,17 @@ class AuthManager @Inject constructor(
     private fun onRefreshFailedLocked() {
         refreshJob?.cancel()
         _authState.value = AuthState.Expired()
+    }
+
+    companion object {
+        /**
+         * Retry spacing for proactive-refresh reschedules after a transient
+         * failure (network IO error or server 5xx). The access token's stored
+         * expiry is in the past by then, so without a floor the reschedule
+         * delay computes to 0 and refresh attempts spin back-to-back for as
+         * long as the failure persists (e.g. the whole time the device is
+         * offline).
+         */
+        const val TRANSIENT_RETRY_DELAY_MS = 60_000L
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -54,9 +54,10 @@ class AuthManager @Inject constructor(
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unauthenticated)
     val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
-    // Volatile because refreshJob is mutated under refreshMutex by the
-    // refresh paths (scheduleProactiveRefresh) but read without the mutex
-    // by onLogout / onRefreshFailed (UI thread). Without @Volatile a stale
+    // Volatile because refreshJob is mutated from mixed lock contexts:
+    // under refreshMutex by the refresh outcome branches, but lock-free by
+    // validateOnStartup / onLoginSuccess (scheduling) and onLogout /
+    // onRefreshFailed (cancellation, UI thread). Without @Volatile a stale
     // read could miss cancelling the live job.
     @Volatile
     private var refreshJob: Job? = null
@@ -119,14 +120,17 @@ class AuthManager @Inject constructor(
     /**
      * Schedules a coroutine that refreshes the access token before it expires.
      * Re-schedules itself after each successful refresh.
-     *
-     * @param minDelayMs floor for the computed delay. The failure branches of
-     *   [performRefresh] reschedule with [TRANSIENT_RETRY_DELAY_MS]: the stored
-     *   expiry is already in the past there, so the natural delay is 0 and a
-     *   transient failure (device offline, backend down) would otherwise spin
-     *   refresh attempts back-to-back until connectivity returns.
      */
-    fun scheduleProactiveRefresh(scope: CoroutineScope, minDelayMs: Long = 0) {
+    fun scheduleProactiveRefresh(scope: CoroutineScope) {
+        scheduleRefresh(scope, minDelayMs = 0)
+    }
+
+    /**
+     * Schedules the next refresh attempt no earlier than [minDelayMs] from now.
+     * The transient-failure branches of [performRefresh] pass
+     * [TRANSIENT_RETRY_DELAY_MS] -- see that constant for why a floor is needed.
+     */
+    private fun scheduleRefresh(scope: CoroutineScope, minDelayMs: Long) {
         refreshJob?.cancel()
         refreshJob = scope.launch {
             val expiresAt = authTokenStore.getTokenExpiresAtMs()
@@ -193,7 +197,7 @@ class AuthManager @Inject constructor(
                     val raw = authTokenStore.getRawToken()
                     if (raw != null) {
                         _authState.value = AuthState.Authenticated
-                        scheduleProactiveRefresh(scope, TRANSIENT_RETRY_DELAY_MS)
+                        scheduleRefresh(scope, TRANSIENT_RETRY_DELAY_MS)
                     }
                 }
                 is RefreshOutcome.NetworkFailure -> {
@@ -203,7 +207,7 @@ class AuthManager @Inject constructor(
                     val raw = authTokenStore.getRawToken()
                     if (raw != null) {
                         _authState.value = AuthState.Authenticated
-                        scheduleProactiveRefresh(scope, TRANSIENT_RETRY_DELAY_MS)
+                        scheduleRefresh(scope, TRANSIENT_RETRY_DELAY_MS)
                     } else {
                         _authState.value = AuthState.Expired()
                     }
@@ -323,6 +327,16 @@ class AuthManager @Inject constructor(
                         val loginResponse = loginAdapter.fromJson(responseBody)
                             ?: return@use RefreshOutcome.ServerError
 
+                        // Logout can land while the refresh call is in flight
+                        // (it clears the store without taking the mutex).
+                        // Persisting the rotated tokens would resurrect the
+                        // logged-out session on the next cold start -- discard
+                        // them and report the session dead instead.
+                        if (_authState.value is AuthState.Unauthenticated) {
+                            Timber.w("Discarding refreshed tokens: logout occurred during refresh")
+                            return@use RefreshOutcome.Expired
+                        }
+
                         val expiresAtMs = System.currentTimeMillis() + (loginResponse.expiresIn * 1000L)
                         authTokenStore.saveCredentials(
                             baseUrl,
@@ -384,7 +398,9 @@ class AuthManager @Inject constructor(
      * failure shouldn't immediately destroy the session.
      *
      * Checks for actual token acquisition (not just auth state) to determine
-     * whether to retry, since transient 5xx errors leave state as [AuthState.Refreshing].
+     * whether to retry: transient failures leave state as [AuthState.Refreshing]
+     * (no stored access token to fall back on) or [AuthState.Authenticated] on
+     * a stale token (stored token present).
      */
     private suspend fun performRefreshWithRetry(
         scope: CoroutineScope,
@@ -408,18 +424,18 @@ class AuthManager @Inject constructor(
             }
         }
 
-        // All attempts exhausted without obtaining a token. If a transient
-        // failure left us Authenticated on a stored (possibly expired) access
-        // token, keep it: the session is intact, we're just unable to reach
-        // the server -- typically because the device is offline. Downgrading
-        // to Expired here would show a false "session expired" banner and
-        // prompt a re-login that cannot succeed without connectivity. The
-        // proactive timer keeps retrying, and the 401 interceptor recovers
-        // the session on the first request after reconnect.
-        if (authTokenStore.getToken() == null &&
-            _authState.value !is AuthState.Expired &&
-            _authState.value !is AuthState.Authenticated
-        ) {
+        // All attempts exhausted without obtaining a token. Only flip to
+        // Expired from Refreshing (transient failures with no stored access
+        // token to fall back on) -- if a transient failure left us
+        // Authenticated on a stored stale token, keep it: the session is
+        // intact, we're just unable to reach the server, typically because
+        // the device is offline. Downgrading to Expired there would show a
+        // false "session expired" banner and prompt a re-login that cannot
+        // succeed without connectivity. The transient-retry timer keeps
+        // trying, and the 401 interceptor recovers the session on the first
+        // request after reconnect. The positive Refreshing check also leaves
+        // Expired and Unauthenticated (logout during the retry window) alone.
+        if (authTokenStore.getToken() == null && _authState.value is AuthState.Refreshing) {
             Timber.w("Startup refresh exhausted all attempts without obtaining a token")
             _authState.value = AuthState.Expired()
         }
@@ -460,19 +476,24 @@ class AuthManager @Inject constructor(
      * locked or unlocked contexts.
      */
     private fun onRefreshFailedLocked() {
+        // Logout wins: a late 401 or an in-flight refresh failure landing
+        // after onLogout() must not overwrite the deliberate sign-out with
+        // a "session expired" banner.
+        if (_authState.value is AuthState.Unauthenticated) return
         refreshJob?.cancel()
         _authState.value = AuthState.Expired()
     }
 
     companion object {
         /**
-         * Retry spacing for proactive-refresh reschedules after a transient
-         * failure (network IO error or server 5xx). The access token's stored
-         * expiry is in the past by then, so without a floor the reschedule
-         * delay computes to 0 and refresh attempts spin back-to-back for as
-         * long as the failure persists (e.g. the whole time the device is
-         * offline).
+         * Retry spacing for refresh reschedules after a transient failure
+         * (network IO error or server 5xx). The access token's stored expiry
+         * is in the past by then, so without a floor the reschedule delay
+         * computes to 0 and refresh attempts spin back-to-back for as long
+         * as the failure persists (e.g. the whole time the device is
+         * offline). See also [AuthTokenStore.PROACTIVE_REFRESH_WINDOW_MS],
+         * the other half of the refresh timer's scheduling policy.
          */
-        const val TRANSIENT_RETRY_DELAY_MS = 60_000L
+        internal const val TRANSIENT_RETRY_DELAY_MS = 60 * 1000L
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -62,6 +62,21 @@ class AuthManager @Inject constructor(
     @Volatile
     private var refreshJob: Job? = null
     private val refreshMutex = Mutex()
+
+    /**
+     * Monotonic counter bumped by [onLogout] BEFORE the caller clears the
+     * token store. A refresh call in flight across a logout compares its
+     * entry snapshot against this counter and discards its result on
+     * mismatch. Together with the bump-then-clear ordering in
+     * [com.glycemicgpt.mobile.data.repository.AuthRepository.logout] this
+     * closes the resurrection race completely: a rotated token can only be
+     * persisted if the save completed before the bump -- in which case the
+     * logout's subsequent store clear wipes it.
+     *
+     * Single writer (logout, UI thread); volatile is sufficient.
+     */
+    @Volatile
+    private var sessionGeneration = 0L
     /** Retained scope for scheduling proactive refreshes from non-coroutine contexts. */
     @Volatile
     private var retainedScope: CoroutineScope? = null
@@ -73,6 +88,12 @@ class AuthManager @Inject constructor(
 
         /** Server rejected the refresh token (401/403) -- session is dead. */
         object Expired : RefreshOutcome()
+
+        /** A logout landed while the refresh was in flight -- the result
+         *  belongs to the previous session and was dropped. The store and
+         *  auth state must be left alone: they are owned by the logout (or
+         *  by a newer login) now. */
+        object Discarded : RefreshOutcome()
 
         /** Server returned 5xx -- session preserved for retry. */
         object ServerError : RefreshOutcome()
@@ -180,14 +201,25 @@ class AuthManager @Inject constructor(
             }
 
             _authState.value = AuthState.Refreshing
-            when (val outcome = refreshUnderLock()) {
+            val generation = sessionGeneration
+            when (val outcome = refreshUnderLock(generation)) {
                 is RefreshOutcome.Success -> {
+                    if (sessionGeneration != generation) {
+                        // Logout raced this refresh; its store clear is the
+                        // final word. Don't repaint Authenticated over it.
+                        Timber.w("Ignoring refresh success after logout")
+                        return
+                    }
                     _authState.value = AuthState.Authenticated
                     scheduleProactiveRefresh(scope)
                 }
                 is RefreshOutcome.Expired -> {
                     authTokenStore.clearToken()
                     onRefreshFailedLocked()
+                }
+                is RefreshOutcome.Discarded -> {
+                    // Logout raced this refresh; state and store now belong
+                    // to the logout (or a newer login). Touch nothing.
                 }
                 is RefreshOutcome.ServerError -> {
                     // 5xx response -- preserve tokens for retry. If we have a
@@ -261,8 +293,15 @@ class AuthManager @Inject constructor(
 
             // No valid token stored, or stored token is the same one that
             // just got rejected -- need to actually refresh.
-            return when (val outcome = refreshUnderLock()) {
+            val generation = sessionGeneration
+            return when (val outcome = refreshUnderLock(generation)) {
                 is RefreshOutcome.Success -> {
+                    if (sessionGeneration != generation) {
+                        // Logout raced this refresh -- don't hand the caller
+                        // a token for a session the user just ended.
+                        Timber.w("Ignoring interceptor refresh success after logout")
+                        return null
+                    }
                     // Update state + reschedule proactive timer in-place so
                     // we don't need a separate callback round-trip from the
                     // interceptor.
@@ -274,6 +313,8 @@ class AuthManager @Inject constructor(
                     onRefreshFailedLocked()
                     null
                 }
+                // Logout raced this refresh; hand the 401 back untouched.
+                is RefreshOutcome.Discarded -> null
                 // Transient failures (5xx, network) -- preserve session, hand
                 // the 401 back to the caller. Don't change auth state from
                 // here; the proactive timer will retry on its schedule. (The
@@ -290,8 +331,12 @@ class AuthManager @Inject constructor(
     /**
      * Performs the actual refresh network call and persists the result.
      * MUST be called with [refreshMutex] held.
+     *
+     * @param generation the caller's [sessionGeneration] snapshot from
+     *   before the network call; a mismatch on return means a logout landed
+     *   mid-flight and the rotated tokens must be discarded.
      */
-    private suspend fun refreshUnderLock(): RefreshOutcome {
+    private suspend fun refreshUnderLock(generation: Long): RefreshOutcome {
         val refreshToken = authTokenStore.getRefreshToken()
             ?: return RefreshOutcome.Expired
 
@@ -333,10 +378,14 @@ class AuthManager @Inject constructor(
                         // (it clears the store without taking the mutex).
                         // Persisting the rotated tokens would resurrect the
                         // logged-out session on the next cold start -- discard
-                        // them and report the session dead instead.
-                        if (_authState.value is AuthState.Unauthenticated) {
+                        // them and report the session dead instead. The
+                        // generation check makes this airtight (see
+                        // [sessionGeneration]): a save that slips through can
+                        // only have completed before the logout's bump, and
+                        // the logout's subsequent store clear wipes it.
+                        if (_authState.value is AuthState.Unauthenticated || sessionGeneration != generation) {
                             Timber.w("Discarding refreshed tokens: logout occurred during refresh")
-                            return@use RefreshOutcome.Expired
+                            return@use RefreshOutcome.Discarded
                         }
 
                         val expiresAtMs = System.currentTimeMillis() + (loginResponse.expiresIn * 1000L)
@@ -453,8 +502,13 @@ class AuthManager @Inject constructor(
         scheduleProactiveRefresh(effectiveScope)
     }
 
-    /** Called on logout to reset state. */
+    /**
+     * Called on logout to reset state. MUST be called BEFORE the token store
+     * is cleared (see [sessionGeneration] for why the ordering closes the
+     * refresh-in-flight resurrection race).
+     */
     fun onLogout() {
+        sessionGeneration++
         refreshJob?.cancel()
         refreshJob = null
         retainedScope = null

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -209,7 +209,9 @@ class AuthManager @Inject constructor(
                         _authState.value = AuthState.Authenticated
                         scheduleRefresh(scope, TRANSIENT_RETRY_DELAY_MS)
                     } else {
-                        _authState.value = AuthState.Expired()
+                        // Route through the shared failure path so the
+                        // logout-wins guard applies here too.
+                        onRefreshFailedLocked()
                     }
                 }
             }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -126,6 +126,12 @@ class AuthRepository @Inject constructor(
 
     fun logout(scope: CoroutineScope) {
         AlertStreamService.stop(appContext)
+        // Ordering is load-bearing: onLogout() bumps the session generation
+        // BEFORE the store is cleared, so a token refresh in flight either
+        // sees the bump and discards its result, or persisted before it and
+        // gets wiped by the clear below. Reversing this reopens the
+        // logged-out-session resurrection race (see AuthManager.sessionGeneration).
+        authManager.onLogout()
         // Clear token before async unregisterDevice -- unregistration is best-effort.
         // Server-side cleanup handles orphaned device registrations.
         authTokenStore.clearToken()
@@ -139,7 +145,6 @@ class AuthRepository @Inject constructor(
         // Meal intelligence is per-account; reset to the default (ON) so a stale
         // value can't carry over to the next account before its reconcile lands.
         appSettingsStore.mealIntelligenceEnabled = true
-        authManager.onLogout()
         scope.launch {
             deviceRepository.unregisterDevice()
                 .onFailure { e -> Timber.w(e, "Device unregistration failed") }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -495,6 +495,45 @@ class AuthManagerTest {
         verify(exactly = 0) { authTokenStore.saveRefreshToken(any()) }
     }
 
+    @Test
+    fun `refresh success is discarded when logout lands mid-flight even after a new login`() = runTest {
+        // The hard interleaving: logout AND a new login complete while the
+        // old session's refresh call is on the wire. The auth state is
+        // Authenticated again by the time the response arrives, so only the
+        // session-generation check can tell the result belongs to the
+        // previous session.
+        every { authTokenStore.getToken() } returns null
+        every { authTokenStore.getRefreshToken() } returns "old-session-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        val body = """
+            {
+                "access_token": "old-session-access",
+                "refresh_token": "old-session-rotated",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "user": {"id": "1", "email": "user@test.com", "role": "user"}
+            }
+        """.trimIndent()
+        lateinit var manager: AuthManager
+        val call = mockk<Call> {
+            every { execute() } answers {
+                manager.onLogout()
+                manager.onLoginSuccess(testScope)
+                fakeResponse(200, body)
+            }
+        }
+        every { refreshClientProvider.refreshClient } returns mockk { every { newCall(any()) } returns call }
+
+        manager = createManager()
+        val token = manager.refreshForInterceptor(null)
+
+        assertNull(token)
+        verify(exactly = 0) { authTokenStore.saveCredentials(any(), any(), any(), any()) }
+        verify(exactly = 0) { authTokenStore.saveRefreshToken(any()) }
+        // The new login's state survives untouched.
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+    }
+
     // --- onLoginSuccess / onLogout ---
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -22,6 +22,7 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -75,6 +76,10 @@ class AuthManagerTest {
 
     @After
     fun tearDown() {
+        // Transient refresh failures arm a self-rescheduling retry chain on
+        // testScope; cancel it so no test leaks virtual-time work into the
+        // scheduler (advancing past it would otherwise never idle).
+        testScope.coroutineContext.cancelChildren()
         Dispatchers.resetMain()
     }
 
@@ -132,6 +137,52 @@ class AuthManagerTest {
 
         // After 3 attempts (0..2), should give up and set Expired
         assertTrue(manager.authState.value is AuthState.Expired)
+    }
+
+    // Offline tolerance (GLY-131): transient refresh failures with a stored
+    // stale token must not masquerade as a dead session.
+
+    @Test
+    fun `validateOnStartup keeps Authenticated after network-error retries exhausted with raw token`() {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getToken() } returns null // Access token expired
+        every { authTokenStore.getRawToken() } returns "stale-access-token"
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() - 1_000
+        every { refreshClientProvider.refreshClient } returns mockClientThrowing(IOException("Network unreachable"))
+
+        val manager = createManager()
+        manager.validateOnStartup(testScope)
+        // Drive through the startup backoffs (1s + 2s) but stop short of the
+        // 60s transient-retry tick; advanceUntilIdle would chase that
+        // self-rescheduling chain forever.
+        testScope.testScheduler.advanceTimeBy(10_000)
+        testScope.testScheduler.runCurrent()
+
+        // Device offline with an intact session: stay Authenticated on the
+        // stale token (stale-data mode) instead of flipping to Expired --
+        // the "session expired" banner would be false and un-actionable
+        // without connectivity.
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+        verify(exactly = 0) { authTokenStore.clearToken() }
+    }
+
+    @Test
+    fun `validateOnStartup keeps Authenticated after 500 retries exhausted with raw token`() {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getToken() } returns null // Access token expired
+        every { authTokenStore.getRawToken() } returns "stale-access-token"
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() - 1_000
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(500))
+
+        val manager = createManager()
+        manager.validateOnStartup(testScope)
+        testScope.testScheduler.advanceTimeBy(10_000)
+        testScope.testScheduler.runCurrent()
+
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+        verify(exactly = 0) { authTokenStore.clearToken() }
     }
 
     // --- performRefresh (also covers the validateOnStartup->performRefresh delegation path) ---
@@ -308,44 +359,8 @@ class AuthManagerTest {
         assertTrue(manager.authState.value is AuthState.Expired)
     }
 
-    // --- offline tolerance (GLY-131): transient refresh failures must not
-    // masquerade as a dead session or spin retries back-to-back ---
-
-    @Test
-    fun `validateOnStartup keeps Authenticated after network-error retries exhausted with raw token`() {
-        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
-        every { authTokenStore.isRefreshTokenExpired() } returns false
-        every { authTokenStore.getToken() } returns null // Access token expired
-        every { authTokenStore.getRawToken() } returns "stale-access-token"
-        every { refreshClientProvider.refreshClient } returns mockClientThrowing(IOException("Network unreachable"))
-
-        val manager = createManager()
-        manager.validateOnStartup(testScope)
-        testScope.testScheduler.advanceUntilIdle()
-
-        // Device offline with an intact session: stay Authenticated on the
-        // stale token (stale-data mode) instead of flipping to Expired --
-        // the "session expired" banner would be false and un-actionable
-        // without connectivity.
-        assertEquals(AuthState.Authenticated, manager.authState.value)
-        verify(exactly = 0) { authTokenStore.clearToken() }
-    }
-
-    @Test
-    fun `validateOnStartup keeps Authenticated after 500 retries exhausted with raw token`() {
-        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
-        every { authTokenStore.isRefreshTokenExpired() } returns false
-        every { authTokenStore.getToken() } returns null // Access token expired
-        every { authTokenStore.getRawToken() } returns "stale-access-token"
-        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(500))
-
-        val manager = createManager()
-        manager.validateOnStartup(testScope)
-        testScope.testScheduler.advanceUntilIdle()
-
-        assertEquals(AuthState.Authenticated, manager.authState.value)
-        verify(exactly = 0) { authTokenStore.clearToken() }
-    }
+    // --- transient-retry scheduling (GLY-131): failed refreshes must be
+    // spaced by the backoff floor, not spun back-to-back ---
 
     @Test
     fun `transient refresh failure reschedules with backoff floor instead of immediately`() = runTest {
@@ -359,23 +374,125 @@ class AuthManagerTest {
         val call = mockk<Call> { every { execute() } throws IOException("Network unreachable") }
         every { refreshClientProvider.refreshClient } returns mockk { every { newCall(any()) } returns call }
 
+        try {
+            val manager = createManager()
+            manager.performRefresh(testScope)
+            verify(exactly = 1) { call.execute() }
+
+            // Just before the floor elapses: no retry yet.
+            testScope.testScheduler.advanceTimeBy(AuthManager.TRANSIENT_RETRY_DELAY_MS - 1)
+            testScope.testScheduler.runCurrent()
+            verify(exactly = 1) { call.execute() }
+
+            // Once the floor elapses: exactly one spaced retry.
+            testScope.testScheduler.advanceTimeBy(2)
+            testScope.testScheduler.runCurrent()
+            verify(exactly = 2) { call.execute() }
+        } finally {
+            // Each failed retry re-arms the chain; cancel it before runTest's
+            // cleanup tries to advance the scheduler to idle (tearDown would
+            // be too late for that).
+            testScope.coroutineContext.cancelChildren()
+        }
+    }
+
+    @Test
+    fun `server-error refresh failure also reschedules with the backoff floor`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getToken() } returns null // Access token expired
+        every { authTokenStore.getRawToken() } returns "stale-access-token"
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() - 1_000
+        val call = mockk<Call> { every { execute() } answers { fakeResponse(502) } }
+        every { refreshClientProvider.refreshClient } returns mockk { every { newCall(any()) } returns call }
+
+        try {
+            val manager = createManager()
+            manager.performRefresh(testScope)
+            verify(exactly = 1) { call.execute() }
+
+            testScope.testScheduler.advanceTimeBy(AuthManager.TRANSIENT_RETRY_DELAY_MS - 1)
+            testScope.testScheduler.runCurrent()
+            verify(exactly = 1) { call.execute() }
+
+            testScope.testScheduler.advanceTimeBy(2)
+            testScope.testScheduler.runCurrent()
+            verify(exactly = 2) { call.execute() }
+        } finally {
+            testScope.coroutineContext.cancelChildren()
+        }
+    }
+
+    @Test
+    fun `preserved offline session still logs out when the retry gets a genuine 401`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getToken() } returns null // Access token expired
+        every { authTokenStore.getRawToken() } returns "stale-access-token"
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() - 1_000
+        // First attempt fails offline; the device then reconnects and the
+        // scheduled retry hits a server that has revoked the refresh token.
+        val call = mockk<Call> {
+            every { execute() } throws IOException("Network unreachable") andThenAnswer { fakeResponse(401) }
+        }
+        every { refreshClientProvider.refreshClient } returns mockk { every { newCall(any()) } returns call }
+
         val manager = createManager()
         manager.performRefresh(testScope)
-        verify(exactly = 1) { call.execute() }
+        // Offline: session preserved on the stale token.
+        assertEquals(AuthState.Authenticated, manager.authState.value)
 
-        // Just before the floor elapses: no retry yet.
-        testScope.testScheduler.advanceTimeBy(AuthManager.TRANSIENT_RETRY_DELAY_MS - 1)
+        testScope.testScheduler.advanceTimeBy(AuthManager.TRANSIENT_RETRY_DELAY_MS + 1)
         testScope.testScheduler.runCurrent()
-        verify(exactly = 1) { call.execute() }
 
-        // Once the floor elapses: exactly one spaced retry.
-        testScope.testScheduler.advanceTimeBy(2)
-        testScope.testScheduler.runCurrent()
-        verify(exactly = 2) { call.execute() }
+        // Genuine rejection after reconnect: the preserved session must NOT
+        // outlive it -- prompt logout, tokens cleared.
+        assertTrue(manager.authState.value is AuthState.Expired)
+        verify { authTokenStore.clearToken() }
+    }
 
-        // Each failed retry schedules the next one, so cancel the chain --
-        // otherwise runTest's cleanup keeps advancing it forever.
-        testScope.coroutineContext.cancelChildren()
+    // --- logout vs in-flight refresh (GLY-131 review finding) ---
+
+    @Test
+    fun `onRefreshFailed after logout keeps Unauthenticated`() {
+        val manager = createManager()
+        manager.onLoginSuccess(testScope)
+        manager.onLogout()
+        manager.onRefreshFailed()
+
+        // Logout wins: a late 401 must not repaint the deliberate sign-out
+        // as a "session expired" banner.
+        assertEquals(AuthState.Unauthenticated, manager.authState.value)
+    }
+
+    @Test
+    fun `refresh success after logout discards rotated tokens`() = runTest {
+        // Simulates logout landing while a refresh call is in flight: the
+        // store was cleared, but this refresh already read the old token.
+        every { authTokenStore.getToken() } returns null
+        every { authTokenStore.getRefreshToken() } returns "in-flight-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        val body = """
+            {
+                "access_token": "resurrected-access",
+                "refresh_token": "resurrected-refresh",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "user": {"id": "1", "email": "user@test.com", "role": "user"}
+            }
+        """.trimIndent()
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(200, body))
+
+        val manager = createManager()
+        manager.onLogout()
+        val token = manager.refreshForInterceptor(null)
+
+        // The rotated tokens must not be persisted -- storing them would
+        // auto-log the signed-out user back in on the next cold start.
+        assertNull(token)
+        assertEquals(AuthState.Unauthenticated, manager.authState.value)
+        verify(exactly = 0) { authTokenStore.saveCredentials(any(), any(), any(), any()) }
+        verify(exactly = 0) { authTokenStore.saveRefreshToken(any()) }
     }
 
     // --- onLoginSuccess / onLogout ---
@@ -402,6 +519,10 @@ class AuthManagerTest {
     @Test
     fun `onRefreshFailed sets Expired`() {
         val manager = createManager()
+        // Establish a live session first: from Unauthenticated (no session /
+        // just logged out) there is nothing to expire and the state must
+        // stay put -- see `onRefreshFailed after logout keeps Unauthenticated`.
+        manager.onLoginSuccess(testScope)
         manager.onRefreshFailed()
 
         assertTrue(manager.authState.value is AuthState.Expired)
@@ -510,6 +631,9 @@ class AuthManagerTest {
         every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(401))
 
         val manager = createManager()
+        // A live session must exist for the 401 to expire it; from
+        // Unauthenticated the logout-wins guard keeps the state put.
+        manager.onLoginSuccess(testScope)
         val result = manager.refreshForInterceptor(null)
 
         assertEquals(null, result)

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -305,6 +306,76 @@ class AuthManagerTest {
         manager.performRefresh(testScope)
 
         assertTrue(manager.authState.value is AuthState.Expired)
+    }
+
+    // --- offline tolerance (GLY-131): transient refresh failures must not
+    // masquerade as a dead session or spin retries back-to-back ---
+
+    @Test
+    fun `validateOnStartup keeps Authenticated after network-error retries exhausted with raw token`() {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getToken() } returns null // Access token expired
+        every { authTokenStore.getRawToken() } returns "stale-access-token"
+        every { refreshClientProvider.refreshClient } returns mockClientThrowing(IOException("Network unreachable"))
+
+        val manager = createManager()
+        manager.validateOnStartup(testScope)
+        testScope.testScheduler.advanceUntilIdle()
+
+        // Device offline with an intact session: stay Authenticated on the
+        // stale token (stale-data mode) instead of flipping to Expired --
+        // the "session expired" banner would be false and un-actionable
+        // without connectivity.
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+        verify(exactly = 0) { authTokenStore.clearToken() }
+    }
+
+    @Test
+    fun `validateOnStartup keeps Authenticated after 500 retries exhausted with raw token`() {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getToken() } returns null // Access token expired
+        every { authTokenStore.getRawToken() } returns "stale-access-token"
+        every { refreshClientProvider.refreshClient } returns mockClientReturning(fakeResponse(500))
+
+        val manager = createManager()
+        manager.validateOnStartup(testScope)
+        testScope.testScheduler.advanceUntilIdle()
+
+        assertEquals(AuthState.Authenticated, manager.authState.value)
+        verify(exactly = 0) { authTokenStore.clearToken() }
+    }
+
+    @Test
+    fun `transient refresh failure reschedules with backoff floor instead of immediately`() = runTest {
+        every { authTokenStore.getRefreshToken() } returns "valid-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns false
+        every { authTokenStore.getToken() } returns null // Access token expired
+        every { authTokenStore.getRawToken() } returns "stale-access-token"
+        // Stored expiry is in the past, so the natural proactive delay
+        // computes to 0 -- without the floor the retry would run immediately.
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() - 1_000
+        val call = mockk<Call> { every { execute() } throws IOException("Network unreachable") }
+        every { refreshClientProvider.refreshClient } returns mockk { every { newCall(any()) } returns call }
+
+        val manager = createManager()
+        manager.performRefresh(testScope)
+        verify(exactly = 1) { call.execute() }
+
+        // Just before the floor elapses: no retry yet.
+        testScope.testScheduler.advanceTimeBy(AuthManager.TRANSIENT_RETRY_DELAY_MS - 1)
+        testScope.testScheduler.runCurrent()
+        verify(exactly = 1) { call.execute() }
+
+        // Once the floor elapses: exactly one spaced retry.
+        testScope.testScheduler.advanceTimeBy(2)
+        testScope.testScheduler.runCurrent()
+        verify(exactly = 2) { call.execute() }
+
+        // Each failed retry schedules the next one, so cancel the chain --
+        // otherwise runTest's cleanup keeps advancing it forever.
+        testScope.coroutineContext.cancelChildren()
     }
 
     // --- onLoginSuccess / onLogout ---

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -21,6 +21,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -209,6 +210,19 @@ class AuthRepositoryTest {
         // so a stale value can't carry into the next account before its reconcile.
         verify { appSettingsStore.mealIntelligenceEnabled = true }
         verify { authManager.onLogout() }
+    }
+
+    @Test
+    fun `logout notifies AuthManager before clearing the token store`() {
+        repository.logout(testScope)
+
+        // Load-bearing ordering: the session-generation bump in onLogout()
+        // must precede the store clear, or a refresh in flight can persist
+        // rotated tokens that survive the logout (session resurrection).
+        verifyOrder {
+            authManager.onLogout()
+            authTokenStore.clearToken()
+        }
     }
 
     @Test


### PR DESCRIPTION
## GLY-131 spike outcome

Spike question: **does token expiry / a background 401 lock the user out of offline (BLE-direct) reads?**

**Answer: NO for access-token expiry** — read surfaces render from Room independent of auth state, offline produces IOExceptions (never 401s), and refresh failures are classified transport-vs-rejection correctly. Verified live on the emulator. But the spike found two adjacent offline-auth bugs (fixed here) and one real lockout path at the refresh-token 30-day boundary (written up for its own story, below).

## Bugs fixed

1. **False "Session expired" banner on offline cold start.** `performRefreshWithRetry` flipped state to `Expired()` after 3 transient failures even when the `NetworkFailure`/`ServerError` branches had deliberately preserved `Authenticated` on a stored stale token. Offline users were told their session died and prompted to re-login — which cannot succeed without connectivity. Now only the `Refreshing` state (no stored access token to fall back on) reaches the exhaustion flip; genuine 401/403 rejection is untouched.
2. **Zero-delay refresh hot loop while offline.** After a transient refresh failure the stored token expiry is already in the past, so `scheduleProactiveRefresh`'s delay computed to 0 and refresh attempts spun back-to-back (one failed TCP connect per iteration) for as long as the device stayed offline. Failure-branch reschedules now go through a private `scheduleRefresh` seam with a 60s floor (`TRANSIENT_RETRY_DELAY_MS`).
3. **Logout-race guards (review findings).** Rotated tokens from a refresh in flight during logout are discarded instead of persisted (prevented session resurrection on next cold start), and `onRefreshFailedLocked` no longer repaints a deliberate sign-out as "session expired".

Genuine revocation still logs out promptly: a real 401/403 from the refresh endpoint clears the session on both the proactive and interceptor paths, pinned by a new end-to-end test (offline-preserved session + reconnect + 401 → `Expired` + `clearToken`).

## Evidence (emulator, debug build, local docker backend)

- **Offline + expired access token, cold start:** Home renders the cached CGM hero with the honest "Too old" badge and the red Offline chip; no session-expired banner; no onboarding redirect. Logcat: 3 startup attempts ("preserving session"), then retries at exactly 60s spacing (01:40:12 → 01:41:12 → 01:42:12).
- **Reconnect:** first 60s tick after airplane-mode off → "Token refreshed successfully"; session self-heals with no user action.
- **Genuine revocation while online** (user deactivated server-side → real 401): "Token refresh rejected with HTTP 401, clearing session" + the session-expired banner. Security posture preserved.

## Spike findings for PM (out of scope here, needs its own story)

**A real offline lockout exists at the refresh-token boundary** (30-day TTL, `apps/api/src/config.py:48`): `hasActiveSession()` (refresh-token validity, checked locally) gates the NavHost start destination, so a device offline past the refresh token's expiry cold-starts into Onboarding — local pump reads locked behind a login that cannot succeed offline. If the app is running at the moment of expiry, `clearToken()` also wipes the tokens, making it permanent. Recommended fix (product decision): key the start destination on `onboardingComplete` alone and let the existing Expired banner prompt re-auth; local Room reads should not require a live session. A second follow-up from review: there is no honest "auth degraded" signal when the backend is reachable but refresh persistently fails with non-401 errors (e.g. proxy misroute) — the session correctly survives, but silently.

Also noted: the 57.2 `SimulateUnreachableInterceptor` debug toggle does not cover the refresh client (`RefreshClientProvider` builds a separate OkHttpClient), so refresh-path faults need real airplane mode; consider adding the fault injection there in a 57.13 story.

## Gates

- Unit tests: full `testDebugUnitTest` green (AuthManagerTest 33 tests incl. 8 new)
- `lintDebug` + `assembleDebug` green
- Adversarial review: 0 HIGH, 3 MEDIUM → fixed (one documented as follow-up above)
- Senior code-quality review: 0 HIGH, 2 MEDIUM → fixed
- CodeRabbit CLI (`--base develop`): no findings
- Security review of the diff: PASS (net security improvement; residual logout TOCTOU narrowed, noted as follow-up)
- Sentry gate: N/A (mobile-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in session reliability across refresh failures, retries, and logout/in-flight race conditions.
  * Ensured logout always takes precedence: in-flight refreshes can’t restore or persist credentials after sign-out.
  * Adjusted transient refresh retry timing to enforce a minimum backoff (prevents immediate re-fires).
  * Preserved valid sessions more consistently during offline or temporary server issues, only expiring when appropriate.

* **Tests**
  * Expanded coverage for offline tolerance, transient retry backoff timing (IO and 5xx), and logout precedence—including mid-flight refresh and new-login interleavings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->