### PR TITLE
fix(mobile): offline alarm acknowledgment silences locally and reconciles on reconnect (GLY-130)

### DIFF
--- a/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/13.json
+++ b/apps/mobile/app/schemas/com.glycemicgpt.mobile.data.local.AppDatabase/13.json
@@ -1,0 +1,620 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "778594de6fd662e9e841c762f8cb465f",
+    "entities": [
+      {
+        "tableName": "iob_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `iob` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iob",
+            "columnName": "iob",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_iob_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_iob_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "basal_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `rate` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `activityMode` TEXT NOT NULL, `source` TEXT NOT NULL DEFAULT '', `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityMode",
+            "columnName": "activityMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_basal_readings_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_basal_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "bolus_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `units` REAL NOT NULL, `isAutomated` INTEGER NOT NULL, `isCorrection` INTEGER NOT NULL, `correctionUnits` REAL NOT NULL DEFAULT 0.0, `mealUnits` REAL NOT NULL DEFAULT 0.0, `source` TEXT NOT NULL DEFAULT '', `category` TEXT NOT NULL DEFAULT '', `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "units",
+            "columnName": "units",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAutomated",
+            "columnName": "isAutomated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCorrection",
+            "columnName": "isCorrection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correctionUnits",
+            "columnName": "correctionUnits",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "mealUnits",
+            "columnName": "mealUnits",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bolus_events_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bolus_events_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          },
+          {
+            "name": "index_bolus_events_units_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "units",
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_bolus_events_units_timestampMs` ON `${TABLE_NAME}` (`units`, `timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "battery_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `percentage` INTEGER NOT NULL, `isCharging` INTEGER NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentage",
+            "columnName": "percentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCharging",
+            "columnName": "isCharging",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_battery_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reservoir_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `unitsRemaining` REAL NOT NULL, `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitsRemaining",
+            "columnName": "unitsRemaining",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reservoir_readings_timestampMs",
+            "unique": false,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reservoir_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sync_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eventType` TEXT NOT NULL, `eventTimestampMs` INTEGER NOT NULL, `payload` TEXT NOT NULL, `status` TEXT NOT NULL, `retryCount` INTEGER NOT NULL, `createdAtMs` INTEGER NOT NULL, `lastAttemptMs` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTimestampMs",
+            "columnName": "eventTimestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retryCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptMs",
+            "columnName": "lastAttemptMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_queue_status_createdAtMs",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "createdAtMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_queue_status_createdAtMs` ON `${TABLE_NAME}` (`status`, `createdAtMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "raw_history_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sequenceNumber` INTEGER NOT NULL, `rawBytesB64` TEXT NOT NULL, `eventTypeId` INTEGER NOT NULL, `pumpTimeSeconds` INTEGER NOT NULL, `sentToBackend` INTEGER NOT NULL, `createdAtMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceNumber",
+            "columnName": "sequenceNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawBytesB64",
+            "columnName": "rawBytesB64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTypeId",
+            "columnName": "eventTypeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pumpTimeSeconds",
+            "columnName": "pumpTimeSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentToBackend",
+            "columnName": "sentToBackend",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_raw_history_logs_sequenceNumber",
+            "unique": true,
+            "columnNames": [
+              "sequenceNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_raw_history_logs_sequenceNumber` ON `${TABLE_NAME}` (`sequenceNumber`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cgm_readings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `glucoseMgDl` INTEGER NOT NULL, `trendArrow` TEXT NOT NULL, `source` TEXT NOT NULL DEFAULT '', `timestampMs` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "glucoseMgDl",
+            "columnName": "glucoseMgDl",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trendArrow",
+            "columnName": "trendArrow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestampMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cgm_readings_timestampMs",
+            "unique": true,
+            "columnNames": [
+              "timestampMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cgm_readings_timestampMs` ON `${TABLE_NAME}` (`timestampMs`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `server_id` TEXT NOT NULL, `alert_type` TEXT NOT NULL, `severity` TEXT NOT NULL, `message` TEXT NOT NULL, `current_value` REAL NOT NULL, `predicted_value` REAL, `iob_value` REAL, `trend_rate` REAL, `patient_name` TEXT, `acknowledged` INTEGER NOT NULL, `ack_synced` INTEGER NOT NULL DEFAULT 0, `timestamp_ms` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertType",
+            "columnName": "alert_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentValue",
+            "columnName": "current_value",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "predictedValue",
+            "columnName": "predicted_value",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iobValue",
+            "columnName": "iob_value",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "trendRate",
+            "columnName": "trend_rate",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "patientName",
+            "columnName": "patient_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "acknowledged",
+            "columnName": "acknowledged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ackSynced",
+            "columnName": "ack_synced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "timestamp_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_alerts_timestamp_ms",
+            "unique": false,
+            "columnNames": [
+              "timestamp_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_alerts_timestamp_ms` ON `${TABLE_NAME}` (`timestamp_ms`)"
+          },
+          {
+            "name": "index_alerts_acknowledged",
+            "unique": false,
+            "columnNames": [
+              "acknowledged"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_alerts_acknowledged` ON `${TABLE_NAME}` (`acknowledged`)"
+          },
+          {
+            "name": "index_alerts_server_id",
+            "unique": true,
+            "columnNames": [
+              "server_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_alerts_server_id` ON `${TABLE_NAME}` (`server_id`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '778594de6fd662e9e841c762f8cb465f')"
+    ]
+  }
+}

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/Migration12To13Test.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/Migration12To13Test.kt
@@ -18,9 +18,10 @@ import org.junit.runner.RunWith
  *     real [DatabaseModule.ALL_MIGRATIONS], and asserts the result matches the exported `13.json` --
  *     so a wrong `ALTER TABLE` would fail here, not silently ship (the builder sets
  *     `fallbackToDestructiveMigration`, which would wipe the table).
- *  2. Existing alert rows written at v12 survive the upgrade with `ack_synced=0` -- the contract
- *     the reconcile pass relies on: a pre-migration acknowledged row is treated as unsynced and
- *     re-POSTed once to the idempotent ack endpoint, never dropped.
+ *  2. Existing alert rows written at v12 survive the upgrade with the right sync state: an
+ *     unacknowledged row is unsynced (nothing to push), while an acknowledged row is backfilled
+ *     as synced -- pre-13, `acknowledged` was only ever written after the server confirmed the
+ *     ack, so re-POSTing it would be redundant.
  *
  * Instrumented (needs real SQLite): run with `./gradlew :app:connectedDebugAndroidTest`.
  */
@@ -62,9 +63,9 @@ class Migration12To13Test {
             assertTrue("acked row should survive the migration", cursor.moveToNext())
             assertEquals("srv-acked", cursor.getString(0))
             assertEquals("local ack state must be preserved", 1, cursor.getInt(1))
-            // A pre-migration ack defaults to unsynced: the reconcile re-POSTs it once
-            // (idempotent endpoint) rather than assuming the server ever saw it.
-            assertEquals(0, cursor.getInt(2))
+            // Pre-13 semantics only ever set acknowledged after a server-confirmed ack, so the
+            // backfill marks it synced -- the reconcile must not re-POST pre-migration acks.
+            assertEquals("pre-migration ack is server-known, must backfill as synced", 1, cursor.getInt(2))
         }
     }
 

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/Migration12To13Test.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/data/local/Migration12To13Test.kt
@@ -1,0 +1,74 @@
+package com.glycemicgpt.mobile.data.local
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.glycemicgpt.mobile.di.DatabaseModule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the Room 12 -> 13 migration (GLY-130) that adds the `ack_synced` column to `alerts`.
+ * Guards two things at once:
+ *
+ *  1. `runMigrationsAndValidate` re-creates the v12 schema from the exported `12.json`, applies the
+ *     real [DatabaseModule.ALL_MIGRATIONS], and asserts the result matches the exported `13.json` --
+ *     so a wrong `ALTER TABLE` would fail here, not silently ship (the builder sets
+ *     `fallbackToDestructiveMigration`, which would wipe the table).
+ *  2. Existing alert rows written at v12 survive the upgrade with `ack_synced=0` -- the contract
+ *     the reconcile pass relies on: a pre-migration acknowledged row is treated as unsynced and
+ *     re-POSTed once to the idempotent ack endpoint, never dropped.
+ *
+ * Instrumented (needs real SQLite): run with `./gradlew :app:connectedDebugAndroidTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class Migration12To13Test {
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java,
+    )
+
+    @Test
+    fun migrate12To13_addsAckSyncedColumn_andPreservesExistingRows() {
+        // v12: alerts has no `ack_synced` column yet.
+        helper.createDatabase(TEST_DB, 12).use { db ->
+            db.execSQL(
+                "INSERT INTO alerts (server_id, alert_type, severity, message, current_value, " +
+                    "acknowledged, timestamp_ms) " +
+                    "VALUES ('srv-unacked', 'low_urgent', 'urgent', 'Low glucose', 55.0, 0, 1000)",
+            )
+            db.execSQL(
+                "INSERT INTO alerts (server_id, alert_type, severity, message, current_value, " +
+                    "acknowledged, timestamp_ms) " +
+                    "VALUES ('srv-acked', 'high_warning', 'warning', 'High glucose', 250.0, 1, 2000)",
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 13, true, *DatabaseModule.ALL_MIGRATIONS)
+
+        db.query(
+            "SELECT server_id, acknowledged, ack_synced FROM alerts ORDER BY timestamp_ms",
+        ).use { cursor ->
+            assertTrue("unacked row should survive the migration", cursor.moveToFirst())
+            assertEquals("srv-unacked", cursor.getString(0))
+            assertEquals(0, cursor.getInt(1))
+            assertEquals("new column must default to unsynced", 0, cursor.getInt(2))
+
+            assertTrue("acked row should survive the migration", cursor.moveToNext())
+            assertEquals("srv-acked", cursor.getString(0))
+            assertEquals("local ack state must be preserved", 1, cursor.getInt(1))
+            // A pre-migration ack defaults to unsynced: the reconcile re-POSTs it once
+            // (idempotent endpoint) rather than assuming the server ever saw it.
+            assertEquals(0, cursor.getInt(2))
+        }
+    }
+
+    private companion object {
+        const val TEST_DB = "migration-12-13-test"
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
@@ -17,6 +17,7 @@ import com.glycemicgpt.mobile.plugin.PluginRegistry
 import com.glycemicgpt.mobile.service.DataRetentionWorker
 import com.glycemicgpt.mobile.service.PumpConnectionService
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -79,7 +80,15 @@ class GlycemicGptApp : Application(), Configuration.Provider {
         appScope.launch {
             networkMonitor.status.collect { status ->
                 if (status == NetworkStatus.REACHABLE) {
-                    alertRepository.reconcilePendingAcks()
+                    try {
+                        alertRepository.reconcilePendingAcks()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // The reconcile is defensive and shouldn't throw, but a failure here
+                        // must never kill this app-lifetime collector (or the process).
+                        Timber.e(e, "Alert ack reconcile failed")
+                    }
                 }
             }
         }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/GlycemicGptApp.kt
@@ -9,6 +9,8 @@ import androidx.work.WorkManager
 import com.glycemicgpt.mobile.data.auth.AuthManager
 import com.glycemicgpt.mobile.data.local.PumpCredentialStore
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.glycemicgpt.mobile.logging.ReleaseTree
 import com.glycemicgpt.mobile.logging.SentryInitializer
 import com.glycemicgpt.mobile.plugin.PluginRegistry
@@ -18,6 +20,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -39,6 +42,9 @@ class GlycemicGptApp : Application(), Configuration.Provider {
 
     @Inject
     lateinit var networkMonitor: NetworkMonitor
+
+    @Inject
+    lateinit var alertRepository: AlertRepository
 
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
@@ -64,6 +70,19 @@ class GlycemicGptApp : Application(), Configuration.Provider {
         // Start observing device connectivity so the home screen can tell "offline" apart from
         // "backend unreachable". Backend reachability itself is fed by the OkHttp path.
         networkMonitor.start()
+
+        // Drain alert acknowledgements made while the backend was unreachable (GLY-130): every
+        // transition to REACHABLE — including the initial value on cold start, which is what
+        // reconciles acks that were pending when the process died — pushes locally-acknowledged,
+        // unsynced alerts to the server so they stop re-firing and re-escalating. StateFlow
+        // already conflates equal consecutive values, so each collected status is a transition.
+        appScope.launch {
+            networkMonitor.status.collect { status ->
+                if (status == NetworkStatus.REACHABLE) {
+                    alertRepository.reconcilePendingAcks()
+                }
+            }
+        }
 
         // Initialize the plugin system (discovers and creates all registered plugins)
         pluginRegistry.initialize()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppDatabase.kt
@@ -28,7 +28,7 @@ import com.glycemicgpt.mobile.data.local.entity.SyncQueueEntity
         CgmReadingEntity::class,
         AlertEntity::class,
     ],
-    version = 12,
+    version = 13,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/AlertDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/AlertDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -13,11 +14,50 @@ interface AlertDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(alert: AlertEntity): Long
 
+    /**
+     * REPLACE-insert that never downgrades a locally-acknowledged row (GLY-130 clobber guard).
+     *
+     * `acknowledged` is local/user-intent truth: when the server echo still says
+     * `acknowledged=false` (the ack POST hasn't landed yet) but the local row is already
+     * acknowledged, the local ack state is preserved — otherwise an SSE re-delivery or a pull
+     * would reset the row to unacknowledged and the alert would re-fire.
+     *
+     * Returns the entity actually persisted so callers can branch on the merged ack state.
+     */
+    @Transaction
+    suspend fun insertPreservingLocalAck(alert: AlertEntity): AlertEntity {
+        val existing = getByServerId(alert.serverId)
+        val merged = if (existing != null && existing.acknowledged && !alert.acknowledged) {
+            alert.copy(acknowledged = true, ackSynced = existing.ackSynced)
+        } else {
+            alert
+        }
+        insert(merged)
+        return merged
+    }
+
+    @Query("SELECT * FROM alerts WHERE server_id = :serverId LIMIT 1")
+    suspend fun getByServerId(serverId: String): AlertEntity?
+
     @Query("SELECT * FROM alerts ORDER BY timestamp_ms DESC LIMIT 100")
     fun observeRecentAlerts(): Flow<List<AlertEntity>>
 
-    @Query("UPDATE alerts SET acknowledged = 1 WHERE server_id = :serverId")
-    suspend fun markAcknowledged(serverId: String)
+    /** Mark the alert acknowledged locally with the server ack still pending. Runs
+     *  unconditionally at ack time — local silence must never wait on the network. */
+    @Query("UPDATE alerts SET acknowledged = 1, ack_synced = 0 WHERE server_id = :serverId")
+    suspend fun markAcknowledgedPending(serverId: String)
+
+    /** Record that the server accepted (or terminally rejected) the acknowledgement. */
+    @Query("UPDATE alerts SET ack_synced = 1 WHERE server_id = :serverId")
+    suspend fun markAckSynced(serverId: String)
+
+    /** Acknowledgements made locally that still need to reach the server, oldest first. */
+    @Query(
+        "SELECT server_id FROM alerts " +
+            "WHERE acknowledged = 1 AND ack_synced = 0 " +
+            "ORDER BY timestamp_ms ASC, id ASC",
+    )
+    suspend fun getPendingAckServerIds(): List<String>
 
     @Query(
         "SELECT server_id FROM alerts " +

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/AlertEntity.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/entity/AlertEntity.kt
@@ -24,6 +24,12 @@ data class AlertEntity(
     @ColumnInfo(name = "iob_value") val iobValue: Double? = null,
     @ColumnInfo(name = "trend_rate") val trendRate: Double? = null,
     @ColumnInfo(name = "patient_name") val patientName: String? = null,
+    /** Local/user-intent truth: the user has acknowledged this alert (silenced it). Set
+     *  unconditionally at ack time — it must never depend on the server POST landing. */
     val acknowledged: Boolean = false,
+    /** Whether the acknowledgement has reached the server. `acknowledged=1, ack_synced=0` rows
+     *  are pending and get re-POSTed by `AlertRepository.reconcilePendingAcks` until the
+     *  (idempotent) server ack lands or fails terminally. */
+    @ColumnInfo(name = "ack_synced", defaultValue = "0") val ackSynced: Boolean = false,
     @ColumnInfo(name = "timestamp_ms") val timestampMs: Long,
 )

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AlertRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AlertRepository.kt
@@ -5,7 +5,10 @@ import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.AlertResponse
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
+import java.io.IOException
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -16,16 +19,35 @@ class AlertRepository @Inject constructor(
     private val api: GlycemicGptApi,
 ) {
 
+    companion object {
+        /**
+         * Server-ack responses that will never succeed on retry: 404 (alert expired/unknown),
+         * 403 (not the owner), 422 (malformed id). The local acknowledgement already silenced
+         * the alarm, so these stop the reconcile from retrying forever; everything else
+         * (transport failures, 5xx, 401 before a token refresh) is transient and stays pending.
+         */
+        private val TERMINAL_ACK_CODES = setOf(403, 404, 422)
+    }
+
+    /** Serializes reconcile passes so the REACHABLE-transition trigger and the refresh path
+     *  don't both POST the same pending acks (harmless — the endpoint is idempotent — but noisy). */
+    private val reconcileMutex = Mutex()
+
     fun observeRecentAlerts(): Flow<List<AlertEntity>> = alertDao.observeRecentAlerts()
 
-    suspend fun saveAlert(response: AlertResponse) {
+    /**
+     * Persist a server-delivered alert and return the row actually stored. A locally-acknowledged
+     * row is never downgraded by a stale server echo (see [AlertDao.insertPreservingLocalAck]);
+     * callers must branch on the returned entity's `acknowledged`, not on the raw response.
+     */
+    suspend fun saveAlert(response: AlertResponse): AlertEntity {
         val timestampMs = try {
             Instant.parse(response.timestamp).toEpochMilli()
         } catch (e: Exception) {
             System.currentTimeMillis()
         }
 
-        alertDao.insert(
+        return alertDao.insertPreservingLocalAck(
             AlertEntity(
                 serverId = response.id,
                 alertType = response.alertType,
@@ -37,17 +59,76 @@ class AlertRepository @Inject constructor(
                 trendRate = response.trendRate,
                 patientName = response.patientName,
                 acknowledged = response.acknowledged,
+                // A server-acked alert has nothing left to sync.
+                ackSynced = response.acknowledged,
                 timestampMs = timestampMs,
             ),
         )
     }
 
-    suspend fun acknowledgeAlert(serverId: String): Result<Unit> = runCatching {
-        val response = api.acknowledgeAlert(serverId)
-        if (response.isSuccessful) {
-            alertDao.markAcknowledged(serverId)
-        } else {
-            throw RuntimeException("Acknowledge failed: HTTP ${response.code()}")
+    /**
+     * Acknowledge an alert: mark the local row first — unconditionally — then attempt the server
+     * POST. The local mark is the safety-critical half (it is what keeps the alarm silenceable
+     * offline) and must never depend on the network; the server ack is deferred to
+     * [reconcilePendingAcks] when the POST can't land now.
+     *
+     * The returned [Result] reflects only the server sync: callers use it to pick honest copy,
+     * never to gate local silencing.
+     */
+    suspend fun acknowledgeAlert(serverId: String): Result<Unit> {
+        alertDao.markAcknowledgedPending(serverId)
+        return runCatching {
+            val response = api.acknowledgeAlert(serverId)
+            when {
+                response.isSuccessful -> alertDao.markAckSynced(serverId)
+                response.code() in TERMINAL_ACK_CODES -> {
+                    // Retrying can't fix these; stop the reconcile from re-POSTing but still
+                    // surface the failure so the caller can show a real error.
+                    alertDao.markAckSynced(serverId)
+                    throw RuntimeException("Acknowledge failed: HTTP ${response.code()}")
+                }
+                else -> throw RuntimeException("Acknowledge failed: HTTP ${response.code()}")
+            }
+        }
+    }
+
+    /**
+     * Push every locally-acknowledged-but-unsynced alert to the server. Safe to call
+     * opportunistically (the endpoint is idempotent): on each pending row, 2xx or a terminal 4xx
+     * stamps `ack_synced=1`; transport failures and 5xx leave it pending for the next trigger.
+     */
+    suspend fun reconcilePendingAcks() {
+        reconcileMutex.withLock {
+            val pending = alertDao.getPendingAckServerIds()
+            if (pending.isEmpty()) return
+            Timber.d("Reconciling %d pending alert acknowledgement(s)", pending.size)
+            for (serverId in pending) {
+                try {
+                    val response = api.acknowledgeAlert(serverId)
+                    when {
+                        response.isSuccessful -> {
+                            alertDao.markAckSynced(serverId)
+                            Timber.d("Reconciled deferred ack for alert %s", serverId)
+                        }
+                        response.code() in TERMINAL_ACK_CODES -> {
+                            alertDao.markAckSynced(serverId)
+                            Timber.w(
+                                "Server rejected deferred ack for alert %s terminally (HTTP %d); not retrying",
+                                serverId, response.code(),
+                            )
+                        }
+                        else -> Timber.w(
+                            "Deferred ack for alert %s failed transiently (HTTP %d); will retry",
+                            serverId, response.code(),
+                        )
+                    }
+                } catch (e: IOException) {
+                    // Transport failure: the backend is (still) unreachable, so the remaining
+                    // POSTs would fail the same way — bail and wait for the next trigger.
+                    Timber.w(e, "Ack reconcile interrupted; %s stays pending", serverId)
+                    return
+                }
+            }
         }
     }
 
@@ -55,6 +136,9 @@ class AlertRepository @Inject constructor(
         alertDao.getLatestUnacknowledgedServerId()
 
     suspend fun fetchPendingAlerts(): Result<List<AlertResponse>> = runCatching {
+        // Push deferred acks before pulling so the pull can't briefly resurrect an alert the
+        // user already acknowledged offline.
+        reconcilePendingAcks()
         val response = api.getPendingAlerts()
         if (response.isSuccessful) {
             val alerts = response.body() ?: emptyList()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AlertRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AlertRepository.kt
@@ -3,15 +3,27 @@ package com.glycemicgpt.mobile.data.repository
 import com.glycemicgpt.mobile.data.local.dao.AlertDao
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.AcknowledgeResponse
 import com.glycemicgpt.mobile.data.remote.dto.AlertResponse
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import retrofit2.Response
 import timber.log.Timber
 import java.io.IOException
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
+
+/**
+ * The server answered an acknowledge POST with a non-2xx. [terminal] mirrors the
+ * terminal-code classification: `true` means retrying can never succeed (the row was stamped
+ * synced to stop the reconcile); `false` means the ack stays pending and will auto-retry.
+ * Callers use it to pick honest copy without re-deriving the classification.
+ */
+class AlertAckHttpException(val code: Int, val terminal: Boolean) :
+    RuntimeException("Acknowledge failed: HTTP $code")
 
 @Singleton
 class AlertRepository @Inject constructor(
@@ -29,8 +41,18 @@ class AlertRepository @Inject constructor(
         private val TERMINAL_ACK_CODES = setOf(403, 404, 422)
     }
 
-    /** Serializes reconcile passes so the REACHABLE-transition trigger and the refresh path
-     *  don't both POST the same pending acks (harmless — the endpoint is idempotent — but noisy). */
+    /** Outcome of one server-ack attempt; the single classification both ack paths share. */
+    private enum class AckOutcome { SYNCED, TERMINAL, TRANSIENT }
+
+    private fun ackOutcomeOf(response: Response<AcknowledgeResponse>): AckOutcome = when {
+        response.isSuccessful -> AckOutcome.SYNCED
+        response.code() in TERMINAL_ACK_CODES -> AckOutcome.TERMINAL
+        else -> AckOutcome.TRANSIENT
+    }
+
+    /** Serializes reconcile passes so the REACHABLE-transition trigger, the SSE-open trigger,
+     *  and the refresh path don't all POST the same pending acks (harmless — the endpoint is
+     *  idempotent — but noisy). */
     private val reconcileMutex = Mutex()
 
     fun observeRecentAlerts(): Flow<List<AlertEntity>> = alertDao.observeRecentAlerts()
@@ -67,57 +89,79 @@ class AlertRepository @Inject constructor(
     }
 
     /**
+     * The local-only half of [acknowledgeAlert]: mark the row acknowledged with the server sync
+     * pending, and never throw. `AlertActionReceiver` calls this before its notification-side
+     * silencing so the ack sticks in Room before any time is spent on other work — an SSE
+     * re-delivery landing mid-silence then can't pass the acknowledged-row guard and re-alarm.
+     */
+    suspend fun markAcknowledgedLocally(serverId: String) {
+        runCatching { alertDao.markAcknowledgedPending(serverId) }
+            .onFailure { e ->
+                if (e is CancellationException) throw e
+                Timber.e(e, "Failed to mark alert %s acknowledged locally", serverId)
+            }
+    }
+
+    /**
      * Acknowledge an alert: mark the local row first — unconditionally — then attempt the server
      * POST. The local mark is the safety-critical half (it is what keeps the alarm silenceable
      * offline) and must never depend on the network; the server ack is deferred to
      * [reconcilePendingAcks] when the POST can't land now.
      *
-     * The returned [Result] reflects only the server sync: callers use it to pick honest copy,
-     * never to gate local silencing.
+     * Never throws. The returned [Result] reflects only the server sync — a failure carries
+     * [AlertAckHttpException] (typed terminal-vs-transient) or the transport exception, so
+     * callers can pick honest copy without gating local silencing on it.
      */
-    suspend fun acknowledgeAlert(serverId: String): Result<Unit> {
+    suspend fun acknowledgeAlert(serverId: String): Result<Unit> = runCatching {
         alertDao.markAcknowledgedPending(serverId)
-        return runCatching {
-            val response = api.acknowledgeAlert(serverId)
-            when {
-                response.isSuccessful -> alertDao.markAckSynced(serverId)
-                response.code() in TERMINAL_ACK_CODES -> {
-                    // Retrying can't fix these; stop the reconcile from re-POSTing but still
-                    // surface the failure so the caller can show a real error.
-                    alertDao.markAckSynced(serverId)
-                    throw RuntimeException("Acknowledge failed: HTTP ${response.code()}")
-                }
-                else -> throw RuntimeException("Acknowledge failed: HTTP ${response.code()}")
+        val response = api.acknowledgeAlert(serverId)
+        when (ackOutcomeOf(response)) {
+            AckOutcome.SYNCED -> alertDao.markAckSynced(serverId)
+            AckOutcome.TERMINAL -> {
+                // Retrying can't fix these; stop the reconcile from re-POSTing but still
+                // surface the failure so the caller can show a real error.
+                alertDao.markAckSynced(serverId)
+                throw AlertAckHttpException(response.code(), terminal = true)
             }
+            AckOutcome.TRANSIENT ->
+                throw AlertAckHttpException(response.code(), terminal = false)
         }
     }
 
     /**
-     * Push every locally-acknowledged-but-unsynced alert to the server. Safe to call
-     * opportunistically (the endpoint is idempotent): on each pending row, 2xx or a terminal 4xx
-     * stamps `ack_synced=1`; transport failures and 5xx leave it pending for the next trigger.
+     * Push every locally-acknowledged-but-unsynced alert to the server. Never throws and is safe
+     * to call opportunistically (the endpoint is idempotent): on each pending row, 2xx or a
+     * terminal 4xx stamps `ack_synced=1`; transport failures, 5xx, and unexpected errors leave
+     * it pending for the next trigger. Triggers: NetworkMonitor's transition to REACHABLE, a
+     * fresh SSE stream connection, and the pull in [fetchPendingAlerts].
      */
     suspend fun reconcilePendingAcks() {
         reconcileMutex.withLock {
-            val pending = alertDao.getPendingAckServerIds()
+            val pending = try {
+                alertDao.getPendingAckServerIds()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Timber.e(e, "Could not read pending alert acks; skipping reconcile")
+                return
+            }
             if (pending.isEmpty()) return
             Timber.d("Reconciling %d pending alert acknowledgement(s)", pending.size)
             for (serverId in pending) {
                 try {
                     val response = api.acknowledgeAlert(serverId)
-                    when {
-                        response.isSuccessful -> {
+                    when (ackOutcomeOf(response)) {
+                        AckOutcome.SYNCED -> {
                             alertDao.markAckSynced(serverId)
                             Timber.d("Reconciled deferred ack for alert %s", serverId)
                         }
-                        response.code() in TERMINAL_ACK_CODES -> {
+                        AckOutcome.TERMINAL -> {
                             alertDao.markAckSynced(serverId)
                             Timber.w(
                                 "Server rejected deferred ack for alert %s terminally (HTTP %d); not retrying",
                                 serverId, response.code(),
                             )
                         }
-                        else -> Timber.w(
+                        AckOutcome.TRANSIENT -> Timber.w(
                             "Deferred ack for alert %s failed transiently (HTTP %d); will retry",
                             serverId, response.code(),
                         )
@@ -127,6 +171,13 @@ class AlertRepository @Inject constructor(
                     // POSTs would fail the same way — bail and wait for the next trigger.
                     Timber.w(e, "Ack reconcile interrupted; %s stays pending", serverId)
                     return
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Unexpected (malformed 2xx body, DB error): leave the row pending and move
+                    // on. The reconcile runs on app-lifetime scopes and must never take down
+                    // its caller.
+                    Timber.e(e, "Deferred ack for alert %s failed unexpectedly; will retry", serverId)
                 }
             }
         }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AlertRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AlertRepository.kt
@@ -126,6 +126,10 @@ class AlertRepository @Inject constructor(
             AckOutcome.TRANSIENT ->
                 throw AlertAckHttpException(response.code(), terminal = false)
         }
+    }.onFailure { e ->
+        // runCatching captures CancellationException too; rethrow so cancellation of the
+        // calling scope stays cooperative (the local mark has already landed by then).
+        if (e is CancellationException) throw e
     }
 
     /**

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
@@ -95,11 +95,24 @@ object DatabaseModule {
         }
     }
 
+    /**
+     * Migration 12->13: add an `ack_synced` column to alerts (GLY-130). `acknowledged` becomes
+     * local/user-intent truth (set unconditionally at ack time so an alarm is always silenceable
+     * offline); `ack_synced` tracks whether the server ack POST has landed. Existing rows default
+     * to unsynced, which is safe: the reconcile pass re-POSTs each once and the endpoint is
+     * idempotent.
+     */
+    private val MIGRATION_12_13 = object : Migration(12, 13) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE alerts ADD COLUMN ack_synced INTEGER NOT NULL DEFAULT 0")
+        }
+    }
+
     /** All schema migrations, in order. Single source of truth shared by the database builder
      *  and the instrumented migration tests. */
     internal val ALL_MIGRATIONS: Array<Migration> = arrayOf(
         MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11,
-        MIGRATION_11_12,
+        MIGRATION_11_12, MIGRATION_12_13,
     )
 
     /**

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/di/DatabaseModule.kt
@@ -98,13 +98,15 @@ object DatabaseModule {
     /**
      * Migration 12->13: add an `ack_synced` column to alerts (GLY-130). `acknowledged` becomes
      * local/user-intent truth (set unconditionally at ack time so an alarm is always silenceable
-     * offline); `ack_synced` tracks whether the server ack POST has landed. Existing rows default
-     * to unsynced, which is safe: the reconcile pass re-POSTs each once and the endpoint is
-     * idempotent.
+     * offline); `ack_synced` tracks whether the server ack POST has landed. Existing acknowledged
+     * rows are backfilled as synced: pre-13, `acknowledged` was only ever written after the
+     * server confirmed the ack (HTTP 2xx) or from a server-acked payload, so the server already
+     * knows about every one of them — no need to re-POST them on the first reconnect.
      */
     private val MIGRATION_12_13 = object : Migration(12, 13) {
         override fun migrate(db: SupportSQLiteDatabase) {
             db.execSQL("ALTER TABLE alerts ADD COLUMN ack_synced INTEGER NOT NULL DEFAULT 0")
+            db.execSQL("UPDATE alerts SET ack_synced = 1 WHERE acknowledged = 1")
         }
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.network.NetworkStatus
 import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
@@ -33,7 +34,7 @@ class AlertsViewModel @Inject constructor(
     private val alertRepository: AlertRepository,
     private val alertNotificationManager: AlertNotificationManager,
     private val appSettingsStore: AppSettingsStore,
-    networkMonitor: NetworkMonitor,
+    private val networkMonitor: NetworkMonitor,
     alertStreamStateHolder: AlertStreamStateHolder,
 ) : ViewModel() {
 
@@ -88,14 +89,14 @@ class AlertsViewModel @Inject constructor(
 
     fun acknowledgeAlert(serverId: String) {
         viewModelScope.launch {
-            alertRepository.acknowledgeAlert(serverId)
-                .onSuccess {
-                    alertNotificationManager.markAcknowledged(serverId)
-                }
-                .onFailure { e ->
-                    Timber.w(e, "Failed to acknowledge alert")
-                    _uiState.value = _uiState.value.copy(error = acknowledgeErrorMessage(e))
-                }
+            val result = alertRepository.acknowledgeAlert(serverId)
+            // The repository marks the row acknowledged locally regardless of the server POST,
+            // so the dedup id is cleared unconditionally too — the alert is silenced either way.
+            alertNotificationManager.markAcknowledged(serverId)
+            result.onFailure { e ->
+                Timber.w(e, "Alert acknowledged locally; server sync failed")
+                _uiState.value = _uiState.value.copy(error = acknowledgeFailureMessage(e))
+            }
         }
     }
 
@@ -109,8 +110,15 @@ class AlertsViewModel @Inject constructor(
         else -> "Couldn't refresh alerts. Try again."
     }
 
-    private fun acknowledgeErrorMessage(e: Throwable): String = when (e) {
-        is IOException -> "Couldn't acknowledge the alert. Check your connection and try again."
+    /**
+     * Honest copy for an acknowledge whose server sync didn't land. A transport failure (or a
+     * degraded [NetworkMonitor] status) means the ack was recorded locally and will reconcile on
+     * reconnect — that is a deferral, not an error. Anything else (a terminal 4xx, an unexpected
+     * 5xx) is a real failure worth surfacing as one.
+     */
+    private fun acknowledgeFailureMessage(e: Throwable): String = when {
+        e is IOException || networkMonitor.status.value != NetworkStatus.REACHABLE ->
+            "Acknowledged locally — will sync when reconnected."
         else -> "Couldn't acknowledge the alert. Try again."
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
-import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.data.repository.AlertAckHttpException
 import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
@@ -34,7 +34,7 @@ class AlertsViewModel @Inject constructor(
     private val alertRepository: AlertRepository,
     private val alertNotificationManager: AlertNotificationManager,
     private val appSettingsStore: AppSettingsStore,
-    private val networkMonitor: NetworkMonitor,
+    networkMonitor: NetworkMonitor,
     alertStreamStateHolder: AlertStreamStateHolder,
 ) : ViewModel() {
 
@@ -111,14 +111,16 @@ class AlertsViewModel @Inject constructor(
     }
 
     /**
-     * Honest copy for an acknowledge whose server sync didn't land. A transport failure (or a
-     * degraded [NetworkMonitor] status) means the ack was recorded locally and will reconcile on
-     * reconnect — that is a deferral, not an error. Anything else (a terminal 4xx, an unexpected
-     * 5xx) is a real failure worth surfacing as one.
+     * Honest copy for an acknowledge whose server sync didn't land, driven by the repository's
+     * actual classification rather than a parallel heuristic. A transport failure or a transient
+     * HTTP status means the ack is recorded locally and pending — it reconciles on the next
+     * trigger, so that is a deferral, not an error. A terminal rejection stopped retrying, so it
+     * is surfaced as a real sync failure (the alert stays dismissed on this device either way).
      */
     private fun acknowledgeFailureMessage(e: Throwable): String = when {
-        e is IOException || networkMonitor.status.value != NetworkStatus.REACHABLE ->
+        e is IOException || (e is AlertAckHttpException && !e.terminal) ->
             "Acknowledged locally — will sync when reconnected."
+        e is AlertAckHttpException -> "Couldn't sync this acknowledgment to the server."
         else -> "Couldn't acknowledge the alert. Try again."
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
@@ -47,9 +47,13 @@ class AlertActionReceiver : BroadcastReceiver() {
 
         GlobalScope.launch(Dispatchers.IO) {
             try {
-                // Silence first, unconditionally: these are pure local operations and the user
-                // just asked for quiet. They must complete before (and regardless of) any
-                // network attempt — an unreachable backend can never leave the alarm sounding.
+                // Make the ack stick in Room first — a local-only write — so an SSE re-delivery
+                // landing mid-silence hits the acknowledged-row guard instead of re-alarming.
+                alertRepository.markAcknowledgedLocally(serverId)
+
+                // Then silence, unconditionally: pure local operations, before (and regardless
+                // of) any network attempt — an unreachable backend can never leave the alarm
+                // sounding.
                 if (notificationId >= 0) {
                     alertNotificationManager.cancelNotification(notificationId)
                 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
@@ -15,8 +15,10 @@ import javax.inject.Inject
 /**
  * Handles the "Got It" action button on alert notifications.
  *
- * Acknowledges the alert on the backend and dismisses the notification
- * without requiring the user to open the app.
+ * Silences the alarm locally (cancel notification, restore alarm volume, clear the dedup id)
+ * and marks the alert acknowledged, all unconditionally — the local silence path must never
+ * depend on the network (GLY-130). The server acknowledgement is attempted afterwards and, if
+ * it can't land, deferred to [com.glycemicgpt.mobile.data.repository.AlertRepository.reconcilePendingAcks].
  *
  * Uses [GlobalScope] intentionally: BroadcastReceiver instances are short-lived
  * and may be garbage-collected after [onReceive] returns. The coroutine must
@@ -45,17 +47,25 @@ class AlertActionReceiver : BroadcastReceiver() {
 
         GlobalScope.launch(Dispatchers.IO) {
             try {
+                // Silence first, unconditionally: these are pure local operations and the user
+                // just asked for quiet. They must complete before (and regardless of) any
+                // network attempt — an unreachable backend can never leave the alarm sounding.
+                if (notificationId >= 0) {
+                    alertNotificationManager.cancelNotification(notificationId)
+                }
+                alertNotificationManager.restoreAlarmVolume()
+                alertNotificationManager.markAcknowledged(serverId)
+
                 alertRepository.acknowledgeAlert(serverId)
                     .onSuccess {
                         Timber.d("Alert acknowledged via notification: %s", serverId)
-                        alertNotificationManager.markAcknowledged(serverId)
-                        alertNotificationManager.restoreAlarmVolume()
-                        if (notificationId >= 0) {
-                            alertNotificationManager.cancelNotification(notificationId)
-                        }
                     }
                     .onFailure { e ->
-                        Timber.w(e, "Failed to acknowledge alert via notification: %s", serverId)
+                        Timber.w(
+                            e,
+                            "Alert %s acknowledged locally via notification; server sync deferred",
+                            serverId,
+                        )
                     }
             } finally {
                 pendingResult.finish()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
@@ -47,33 +47,43 @@ class AlertActionReceiver : BroadcastReceiver() {
 
         GlobalScope.launch(Dispatchers.IO) {
             try {
-                // Make the ack stick in Room first — a local-only write — so an SSE re-delivery
-                // landing mid-silence hits the acknowledged-row guard instead of re-alarming.
-                alertRepository.markAcknowledgedLocally(serverId)
-
-                // Then silence, unconditionally: pure local operations, before (and regardless
-                // of) any network attempt — an unreachable backend can never leave the alarm
-                // sounding.
-                if (notificationId >= 0) {
-                    alertNotificationManager.cancelNotification(notificationId)
-                }
-                alertNotificationManager.restoreAlarmVolume()
-                alertNotificationManager.markAcknowledged(serverId)
-
-                alertRepository.acknowledgeAlert(serverId)
-                    .onSuccess {
-                        Timber.d("Alert acknowledged via notification: %s", serverId)
-                    }
-                    .onFailure { e ->
-                        Timber.w(
-                            e,
-                            "Alert %s acknowledged locally via notification; server sync deferred",
-                            serverId,
-                        )
-                    }
+                handleAcknowledge(serverId, notificationId)
             } finally {
                 pendingResult.finish()
             }
         }
+    }
+
+    /**
+     * The acknowledge sequence, in safety-critical order (pinned by unit test — GLY-130):
+     * local Room mark first, then the local silence operations, and only then the server POST.
+     * Nothing before the POST may depend on it; its failure is logged and deferred to the
+     * reconcile, never allowed to gate silencing.
+     */
+    internal suspend fun handleAcknowledge(serverId: String, notificationId: Int) {
+        // Make the ack stick in Room first — a local-only write — so an SSE re-delivery
+        // landing mid-silence hits the acknowledged-row guard instead of re-alarming.
+        alertRepository.markAcknowledgedLocally(serverId)
+
+        // Then silence, unconditionally: pure local operations, before (and regardless
+        // of) any network attempt — an unreachable backend can never leave the alarm
+        // sounding.
+        if (notificationId >= 0) {
+            alertNotificationManager.cancelNotification(notificationId)
+        }
+        alertNotificationManager.restoreAlarmVolume()
+        alertNotificationManager.markAcknowledged(serverId)
+
+        alertRepository.acknowledgeAlert(serverId)
+            .onSuccess {
+                Timber.d("Alert acknowledged via notification: %s", serverId)
+            }
+            .onFailure { e ->
+                Timber.w(
+                    e,
+                    "Alert %s acknowledged locally via notification; server sync deferred",
+                    serverId,
+                )
+            }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
-import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.remote.dto.AlertResponse
 import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.squareup.moshi.Moshi
@@ -28,7 +27,6 @@ import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 import okhttp3.sse.EventSources
 import timber.log.Timber
-import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -279,28 +277,13 @@ class AlertStreamService : Service() {
         serviceScope.launch {
             try {
                 val alertResponse = adapter.fromJson(data) ?: return@launch
-                alertRepository.saveAlert(alertResponse)
+                // saveAlert merges the server echo with local ack state: a locally-acknowledged
+                // row is never downgraded, so branching on the returned entity (not the raw
+                // response) is what keeps an SSE re-delivery from re-alarming an alert the user
+                // already acknowledged offline (GLY-130).
+                val entity = alertRepository.saveAlert(alertResponse)
 
-                val timestampMs = try {
-                    Instant.parse(alertResponse.timestamp).toEpochMilli()
-                } catch (e: Exception) {
-                    System.currentTimeMillis()
-                }
-
-                if (!alertResponse.acknowledged) {
-                    val entity = AlertEntity(
-                        serverId = alertResponse.id,
-                        alertType = alertResponse.alertType,
-                        severity = alertResponse.severity,
-                        message = alertResponse.message,
-                        currentValue = alertResponse.currentValue,
-                        predictedValue = alertResponse.predictedValue,
-                        iobValue = alertResponse.iobValue,
-                        trendRate = alertResponse.trendRate,
-                        patientName = alertResponse.patientName,
-                        acknowledged = alertResponse.acknowledged,
-                        timestampMs = timestampMs,
-                    )
+                if (!entity.acknowledged) {
                     if (alertNotificationManager.shouldNotify(alertResponse.id)) {
                         val notifId = alertNotificationManager.stableNotificationId(entity)
                         alertNotificationManager.showAlertNotification(entity, notifId)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
@@ -205,6 +205,12 @@ class AlertStreamService : Service() {
                     Timber.d("Alert SSE stream connected (status=%d)", response.code)
                     alertStreamStateHolder.onStreamOpened()
                     connectionOpenedAtMs = System.currentTimeMillis()
+                    // A fresh stream connection proves the backend is reachable again — drain
+                    // any acks deferred while it wasn't. This covers phones whose only backend
+                    // traffic is this stream (the SSE client bypasses ReachabilityInterceptor,
+                    // so NetworkMonitor may never emit the REACHABLE transition) and lands the
+                    // ack before the server re-delivers the same still-unacked alert.
+                    serviceScope.launch { alertRepository.reconcilePendingAcks() }
                     // Don't reset reconnectAttempt here -- only reset after
                     // STABLE_CONNECTION_MS to prevent rapid connect/fail cycles
                     // from keeping backoff at 0.

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearChatRelayService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearChatRelayService.kt
@@ -61,8 +61,20 @@ class WearChatRelayService : WearableListenerService() {
             runBlocking {
                 val serverId = alertRepository.getLatestUnacknowledgedServerId()
                 if (serverId != null) {
+                    // acknowledgeAlert marks the row locally before the server POST, so the
+                    // watch's clearAlert below is truthful even when the backend is unreachable
+                    // — the alert can't re-fire; the server sync is deferred to the reconcile.
                     alertRepository.acknowledgeAlert(serverId)
-                    Timber.d("Acknowledged alert %s from watch dismiss", serverId)
+                        .onSuccess {
+                            Timber.d("Acknowledged alert %s from watch dismiss", serverId)
+                        }
+                        .onFailure { e ->
+                            Timber.w(
+                                e,
+                                "Alert %s acknowledged locally from watch dismiss; server sync deferred",
+                                serverId,
+                            )
+                        }
                 }
                 wearDataSender.clearAlert()
             }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
@@ -258,6 +258,27 @@ class AlertRepositoryTest {
     }
 
     @Test
+    fun `reconcile survives an unexpected per-alert failure - continues and leaves the row pending`() = runTest {
+        seedUnackedAlert(id = "a", timestamp = "2026-07-03T10:00:00Z")
+        seedUnackedAlert(id = "b", timestamp = "2026-07-03T10:05:00Z")
+        coEvery { api.acknowledgeAlert(any()) } throws IOException("offline")
+        repository.acknowledgeAlert("a")
+        repository.acknowledgeAlert("b")
+
+        // Non-IO, non-cancellation failure (e.g. a malformed 2xx body): unlike the IOException
+        // bail, the pass must move on to the remaining alerts and never throw to its
+        // app-lifetime caller.
+        coEvery { api.acknowledgeAlert("a") } throws IllegalStateException("malformed body")
+        coEvery { api.acknowledgeAlert("b") } returns ackSuccess("b")
+
+        repository.reconcilePendingAcks()
+
+        assertFalse("failed alert stays pending for the next trigger", dao.rows.getValue("a").ackSynced)
+        assertTrue("failure on one alert must not strand the rest", dao.rows.getValue("b").ackSynced)
+        assertEquals(listOf("a"), dao.getPendingAckServerIds())
+    }
+
+    @Test
     fun `reconcile with nothing pending makes no network calls`() = runTest {
         seedUnackedAlert()
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
@@ -63,12 +63,12 @@ class AlertRepositoryTest {
 
         override suspend fun getPendingAckServerIds(): List<String> =
             rows.values.filter { it.acknowledged && !it.ackSynced }
-                .sortedBy { it.timestampMs }
+                .sortedWith(compareBy({ it.timestampMs }, { it.id }))
                 .map { it.serverId }
 
         override suspend fun getLatestUnacknowledgedServerId(): String? =
             rows.values.filter { !it.acknowledged }
-                .maxByOrNull { it.timestampMs }
+                .maxWithOrNull(compareBy({ it.timestampMs }, { it.id }))
                 ?.serverId
 
         override suspend fun deleteOlderThan(cutoffMs: Long) {
@@ -129,6 +129,18 @@ class AlertRepositoryTest {
     }
 
     @Test
+    fun `markAcknowledgedLocally marks the row pending without touching the network`() = runTest {
+        seedUnackedAlert()
+
+        repository.markAcknowledgedLocally("alert-1")
+
+        val row = dao.rows.getValue("alert-1")
+        assertTrue(row.acknowledged)
+        assertFalse(row.ackSynced)
+        coVerify(exactly = 0) { api.acknowledgeAlert(any()) }
+    }
+
+    @Test
     fun `successful ack marks the row acknowledged and synced in one pass`() = runTest {
         seedUnackedAlert()
         coEvery { api.acknowledgeAlert("alert-1") } returns ackSuccess()
@@ -142,7 +154,7 @@ class AlertRepositoryTest {
     }
 
     @Test
-    fun `terminal 4xx marks synced to stop retries but still reports failure`() = runTest {
+    fun `terminal 4xx marks synced to stop retries but still reports a typed terminal failure`() = runTest {
         for (code in listOf(403, 404, 422)) {
             val id = "alert-$code"
             seedUnackedAlert(id = id)
@@ -153,12 +165,15 @@ class AlertRepositoryTest {
             val row = dao.rows.getValue(id)
             assertTrue(row.acknowledged)
             assertTrue("HTTP $code can never succeed on retry", row.ackSynced)
-            assertTrue("terminal rejection still surfaces as failure", result.isFailure)
+            val e = result.exceptionOrNull()
+            assertTrue("failure must be typed", e is AlertAckHttpException)
+            assertTrue("HTTP $code must classify as terminal", (e as AlertAckHttpException).terminal)
+            assertEquals(code, e.code)
         }
     }
 
     @Test
-    fun `transient 5xx leaves the row pending for the reconcile`() = runTest {
+    fun `transient 5xx leaves the row pending and reports a typed transient failure`() = runTest {
         seedUnackedAlert()
         coEvery { api.acknowledgeAlert("alert-1") } returns ackError(500)
 
@@ -167,7 +182,9 @@ class AlertRepositoryTest {
         val row = dao.rows.getValue("alert-1")
         assertTrue(row.acknowledged)
         assertFalse(row.ackSynced)
-        assertTrue(result.isFailure)
+        val e = result.exceptionOrNull()
+        assertTrue("failure must be typed", e is AlertAckHttpException)
+        assertFalse("HTTP 500 must classify as transient", (e as AlertAckHttpException).terminal)
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
@@ -1,0 +1,356 @@
+package com.glycemicgpt.mobile.data.repository
+
+import com.glycemicgpt.mobile.data.local.dao.AlertDao
+import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.AcknowledgeResponse
+import com.glycemicgpt.mobile.data.remote.dto.AlertResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.io.IOException
+
+/**
+ * Unit tests for the GLY-130 acknowledge state machine: the local mark must run before —
+ * and completely independently of — the server POST, and the `ack_synced` flag must classify
+ * server outcomes correctly (2xx/terminal-4xx stamp it, transport/5xx leave the row pending
+ * for [AlertRepository.reconcilePendingAcks]).
+ */
+class AlertRepositoryTest {
+
+    /**
+     * In-memory [AlertDao] keyed by `server_id`, mirroring the table's unique index and REPLACE
+     * semantics. A fake (not a mock) so the default-method clobber guard
+     * [AlertDao.insertPreservingLocalAck] runs its real merge logic against real state.
+     */
+    private class FakeAlertDao : AlertDao {
+        val rows = linkedMapOf<String, AlertEntity>()
+        private var nextId = 1L
+
+        override suspend fun insert(alert: AlertEntity): Long {
+            val id = if (alert.id != 0L) alert.id else nextId++
+            rows[alert.serverId] = alert.copy(id = id)
+            return id
+        }
+
+        override suspend fun getByServerId(serverId: String): AlertEntity? = rows[serverId]
+
+        override fun observeRecentAlerts(): Flow<List<AlertEntity>> = flowOf(rows.values.toList())
+
+        override suspend fun markAcknowledgedPending(serverId: String) {
+            rows[serverId]?.let {
+                rows[serverId] = it.copy(acknowledged = true, ackSynced = false)
+            }
+        }
+
+        override suspend fun markAckSynced(serverId: String) {
+            rows[serverId]?.let { rows[serverId] = it.copy(ackSynced = true) }
+        }
+
+        override suspend fun getPendingAckServerIds(): List<String> =
+            rows.values.filter { it.acknowledged && !it.ackSynced }
+                .sortedBy { it.timestampMs }
+                .map { it.serverId }
+
+        override suspend fun getLatestUnacknowledgedServerId(): String? =
+            rows.values.filter { !it.acknowledged }
+                .maxByOrNull { it.timestampMs }
+                ?.serverId
+
+        override suspend fun deleteOlderThan(cutoffMs: Long) {
+            rows.values.removeAll { it.timestampMs < cutoffMs }
+        }
+
+        override suspend fun deleteAll() = rows.clear()
+    }
+
+    private lateinit var dao: FakeAlertDao
+    private lateinit var api: GlycemicGptApi
+    private lateinit var repository: AlertRepository
+
+    @Before
+    fun setUp() {
+        dao = FakeAlertDao()
+        api = mockk()
+        repository = AlertRepository(dao, api)
+    }
+
+    private fun makeResponse(
+        id: String = "alert-1",
+        acknowledged: Boolean = false,
+        timestamp: String = "2026-07-03T10:00:00Z",
+    ) = AlertResponse(
+        id = id,
+        alertType = "low_urgent",
+        severity = "urgent",
+        currentValue = 55.0,
+        message = "Low glucose",
+        timestamp = timestamp,
+        acknowledged = acknowledged,
+    )
+
+    private suspend fun seedUnackedAlert(id: String = "alert-1", timestamp: String = "2026-07-03T10:00:00Z") {
+        repository.saveAlert(makeResponse(id = id, timestamp = timestamp))
+    }
+
+    private fun ackSuccess(id: String = "alert-1"): Response<AcknowledgeResponse> =
+        Response.success(AcknowledgeResponse(status = "acknowledged", alertId = id))
+
+    private fun ackError(code: Int): Response<AcknowledgeResponse> =
+        Response.error(code, "{}".toResponseBody("application/json".toMediaType()))
+
+    // -- acknowledgeAlert: the chokepoint state machine ---------------------------------------
+
+    @Test
+    fun `offline ack marks the row locally and leaves it pending - the safety fix`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } throws IOException("network unreachable")
+
+        val result = repository.acknowledgeAlert("alert-1")
+
+        val row = dao.rows.getValue("alert-1")
+        assertTrue("local mark must not depend on the network", row.acknowledged)
+        assertFalse("server ack did not land, must stay pending", row.ackSynced)
+        assertTrue("caller still learns the sync failed", result.isFailure)
+    }
+
+    @Test
+    fun `successful ack marks the row acknowledged and synced in one pass`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } returns ackSuccess()
+
+        val result = repository.acknowledgeAlert("alert-1")
+
+        val row = dao.rows.getValue("alert-1")
+        assertTrue(row.acknowledged)
+        assertTrue(row.ackSynced)
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `terminal 4xx marks synced to stop retries but still reports failure`() = runTest {
+        for (code in listOf(403, 404, 422)) {
+            val id = "alert-$code"
+            seedUnackedAlert(id = id)
+            coEvery { api.acknowledgeAlert(id) } returns ackError(code)
+
+            val result = repository.acknowledgeAlert(id)
+
+            val row = dao.rows.getValue(id)
+            assertTrue(row.acknowledged)
+            assertTrue("HTTP $code can never succeed on retry", row.ackSynced)
+            assertTrue("terminal rejection still surfaces as failure", result.isFailure)
+        }
+    }
+
+    @Test
+    fun `transient 5xx leaves the row pending for the reconcile`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } returns ackError(500)
+
+        val result = repository.acknowledgeAlert("alert-1")
+
+        val row = dao.rows.getValue("alert-1")
+        assertTrue(row.acknowledged)
+        assertFalse(row.ackSynced)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `401 is transient - a token refresh may fix it, so the row stays pending`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } returns ackError(401)
+
+        repository.acknowledgeAlert("alert-1")
+
+        assertFalse(dao.rows.getValue("alert-1").ackSynced)
+    }
+
+    // -- reconcilePendingAcks ------------------------------------------------------------------
+
+    @Test
+    fun `reconcile drains every pending ack on success`() = runTest {
+        seedUnackedAlert(id = "a", timestamp = "2026-07-03T10:00:00Z")
+        seedUnackedAlert(id = "b", timestamp = "2026-07-03T10:05:00Z")
+        coEvery { api.acknowledgeAlert(any()) } throws IOException("offline")
+        repository.acknowledgeAlert("a")
+        repository.acknowledgeAlert("b")
+
+        coEvery { api.acknowledgeAlert("a") } returns ackSuccess("a")
+        coEvery { api.acknowledgeAlert("b") } returns ackSuccess("b")
+        repository.reconcilePendingAcks()
+
+        assertTrue(dao.rows.getValue("a").ackSynced)
+        assertTrue(dao.rows.getValue("b").ackSynced)
+        assertTrue(dao.getPendingAckServerIds().isEmpty())
+    }
+
+    @Test
+    fun `reconcile marks a terminally rejected ack synced so it stops retrying`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } throws IOException("offline")
+        repository.acknowledgeAlert("alert-1")
+
+        coEvery { api.acknowledgeAlert("alert-1") } returns ackError(404)
+        repository.reconcilePendingAcks()
+
+        assertTrue(dao.rows.getValue("alert-1").ackSynced)
+    }
+
+    @Test
+    fun `reconcile leaves a transiently failed ack pending`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } throws IOException("offline")
+        repository.acknowledgeAlert("alert-1")
+
+        coEvery { api.acknowledgeAlert("alert-1") } returns ackError(503)
+        repository.reconcilePendingAcks()
+
+        assertFalse(dao.rows.getValue("alert-1").ackSynced)
+        assertEquals(listOf("alert-1"), dao.getPendingAckServerIds())
+    }
+
+    @Test
+    fun `reconcile bails on a transport failure without losing the remaining pending acks`() = runTest {
+        seedUnackedAlert(id = "a", timestamp = "2026-07-03T10:00:00Z")
+        seedUnackedAlert(id = "b", timestamp = "2026-07-03T10:05:00Z")
+        coEvery { api.acknowledgeAlert(any()) } throws IOException("offline")
+        repository.acknowledgeAlert("a")
+        repository.acknowledgeAlert("b")
+
+        repository.reconcilePendingAcks()
+
+        // The first POST failed at transport level; the pass stops (the backend is unreachable,
+        // the rest would fail identically) and both stay pending for the next trigger.
+        assertEquals(listOf("a", "b"), dao.getPendingAckServerIds())
+        coVerify(exactly = 3) { api.acknowledgeAlert(any()) } // 2 from acks + 1 from reconcile
+    }
+
+    @Test
+    fun `reconcile with nothing pending makes no network calls`() = runTest {
+        seedUnackedAlert()
+
+        repository.reconcilePendingAcks()
+
+        coVerify(exactly = 0) { api.acknowledgeAlert(any()) }
+    }
+
+    // -- saveAlert clobber guard (guard 1) ------------------------------------------------------
+
+    @Test
+    fun `saveAlert never downgrades a locally-acknowledged row on a stale server echo`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } throws IOException("offline")
+        repository.acknowledgeAlert("alert-1")
+
+        // SSE re-delivery of the same alert, still unacked server-side.
+        val persisted = repository.saveAlert(makeResponse(acknowledged = false))
+
+        assertTrue("local ack is user-intent truth", persisted.acknowledged)
+        assertFalse("still pending server sync", persisted.ackSynced)
+        assertTrue(dao.rows.getValue("alert-1").acknowledged)
+    }
+
+    @Test
+    fun `saveAlert with a server-acknowledged response needs no sync`() = runTest {
+        val persisted = repository.saveAlert(makeResponse(acknowledged = true))
+
+        assertTrue(persisted.acknowledged)
+        assertTrue("server already knows, nothing to reconcile", persisted.ackSynced)
+        assertTrue(dao.getPendingAckServerIds().isEmpty())
+    }
+
+    @Test
+    fun `saveAlert stores a fresh unacknowledged alert as-is`() = runTest {
+        val persisted = repository.saveAlert(makeResponse(acknowledged = false))
+
+        assertFalse(persisted.acknowledged)
+        assertFalse(persisted.ackSynced)
+        assertNotNull(dao.rows["alert-1"])
+    }
+
+    @Test
+    fun `saveAlert re-delivery refreshes non-ack fields while preserving the local ack`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } throws IOException("offline")
+        repository.acknowledgeAlert("alert-1")
+
+        val persisted = repository.saveAlert(
+            makeResponse(acknowledged = false).copy(message = "Low glucose - updated"),
+        )
+
+        assertEquals("Low glucose - updated", persisted.message)
+        assertTrue(persisted.acknowledged)
+    }
+
+    // -- getLatestUnacknowledgedServerId (the Wear dismiss lookup) ------------------------------
+
+    @Test
+    fun `a locally-acknowledged alert no longer resolves as the latest unacknowledged`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } throws IOException("offline")
+
+        assertEquals("alert-1", repository.getLatestUnacknowledgedServerId())
+        repository.acknowledgeAlert("alert-1")
+
+        assertNull(
+            "a watch dismiss must stick offline - no re-resolve, no re-fire",
+            repository.getLatestUnacknowledgedServerId(),
+        )
+    }
+
+    // -- fetchPendingAlerts: push before pull ---------------------------------------------------
+
+    @Test
+    fun `fetchPendingAlerts pushes pending acks before pulling`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } throws IOException("offline")
+        repository.acknowledgeAlert("alert-1")
+
+        coEvery { api.acknowledgeAlert("alert-1") } returns ackSuccess()
+        coEvery { api.getPendingAlerts() } returns
+            Response.success(listOf(makeResponse(acknowledged = false)))
+
+        val result = repository.fetchPendingAlerts()
+
+        assertTrue(result.isSuccess)
+        coVerifyOrder {
+            api.acknowledgeAlert("alert-1")
+            api.getPendingAlerts()
+        }
+        // Even though the pull echoed the alert as unacknowledged, the row stays acknowledged.
+        assertTrue(dao.rows.getValue("alert-1").acknowledged)
+    }
+
+    @Test
+    fun `fetchPendingAlerts still pulls when the push cannot land`() = runTest {
+        seedUnackedAlert()
+        coEvery { api.acknowledgeAlert("alert-1") } throws IOException("offline")
+        repository.acknowledgeAlert("alert-1")
+
+        coEvery { api.getPendingAlerts() } returns
+            Response.success(listOf(makeResponse(acknowledged = false)))
+
+        val result = repository.fetchPendingAlerts()
+
+        assertTrue(result.isSuccess)
+        // The pull must not clobber the pending local ack (guard 1).
+        val row = dao.rows.getValue("alert-1")
+        assertTrue(row.acknowledged)
+        assertFalse(row.ackSynced)
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -4,6 +4,7 @@ import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.data.repository.AlertAckHttpException
 import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
@@ -30,6 +31,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AlertsViewModelTest {
@@ -164,7 +166,7 @@ class AlertsViewModelTest {
     @Test
     fun `refreshAlerts offline failure reaches a terminal state with connection copy`() = runTest {
         coEvery { repository.fetchPendingAlerts() } returns
-            Result.failure(java.io.IOException("connect timed out"))
+            Result.failure(IOException("connect timed out"))
 
         val vm = createViewModel()
         advanceUntilIdle()
@@ -205,7 +207,7 @@ class AlertsViewModelTest {
         // The repository marks the row locally regardless of the POST outcome (GLY-130), so the
         // in-memory dedup clear must be unconditional too — the alert is acknowledged either way.
         coEvery { repository.acknowledgeAlert("alert-1") } returns
-            Result.failure(java.io.IOException("backend unreachable"))
+            Result.failure(IOException("backend unreachable"))
 
         val vm = createViewModel()
         advanceUntilIdle()
@@ -217,9 +219,23 @@ class AlertsViewModelTest {
     }
 
     @Test
-    fun `acknowledgeAlert sets user-facing error on terminal failure, never the raw exception message`() = runTest {
+    fun `acknowledgeAlert terminal rejection surfaces a real sync error, never the raw message`() = runTest {
         coEvery { repository.acknowledgeAlert("alert-1") } returns
-            Result.failure(RuntimeException("Acknowledge failed: HTTP 403"))
+            Result.failure(AlertAckHttpException(403, terminal = true))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.acknowledgeAlert("alert-1")
+        advanceUntilIdle()
+
+        assertEquals("Couldn't sync this acknowledgment to the server.", vm.uiState.value.error)
+    }
+
+    @Test
+    fun `acknowledgeAlert unexpected failure shows generic copy, never the raw exception message`() = runTest {
+        coEvery { repository.acknowledgeAlert("alert-1") } returns
+            Result.failure(RuntimeException("java.net.SocketException: raw internals"))
 
         val vm = createViewModel()
         advanceUntilIdle()
@@ -234,7 +250,7 @@ class AlertsViewModelTest {
     fun `acknowledgeAlert offline shows honest deferred-sync copy, not an error`() = runTest {
         networkStatusFlow.value = NetworkStatus.OFFLINE
         coEvery { repository.acknowledgeAlert("alert-1") } returns
-            Result.failure(java.io.IOException("network unreachable"))
+            Result.failure(IOException("network unreachable"))
 
         val vm = createViewModel()
         advanceUntilIdle()
@@ -249,10 +265,11 @@ class AlertsViewModelTest {
     }
 
     @Test
-    fun `acknowledgeAlert backend-unreachable shows honest deferred-sync copy`() = runTest {
-        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+    fun `acknowledgeAlert transient 5xx shows deferred-sync copy - the row auto-reconciles`() = runTest {
+        // The repository classified the failure as transient (row stays pending, will retry),
+        // so the copy must promise the sync, not tell the user to try again.
         coEvery { repository.acknowledgeAlert("alert-1") } returns
-            Result.failure(java.io.IOException("connect refused"))
+            Result.failure(AlertAckHttpException(503, terminal = false))
 
         val vm = createViewModel()
         advanceUntilIdle()
@@ -272,7 +289,7 @@ class AlertsViewModelTest {
         // The ack is still deferred-and-pending, so the copy stays truthful.
         networkStatusFlow.value = NetworkStatus.REACHABLE
         coEvery { repository.acknowledgeAlert("alert-1") } returns
-            Result.failure(java.io.IOException("timeout"))
+            Result.failure(IOException("timeout"))
 
         val vm = createViewModel()
         advanceUntilIdle()
@@ -354,7 +371,7 @@ class AlertsViewModelTest {
     fun `cached alerts still display while alerting is degraded`() = runTest {
         networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
         coEvery { repository.fetchPendingAlerts() } returns
-            Result.failure(java.io.IOException("unreachable"))
+            Result.failure(IOException("unreachable"))
         alertsFlow.value = listOf(makeAlert())
 
         val vm = createViewModel()

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -201,9 +201,11 @@ class AlertsViewModelTest {
     }
 
     @Test
-    fun `acknowledgeAlert does not call markAcknowledged on failure`() = runTest {
+    fun `acknowledgeAlert clears the dedup id even when the server sync fails`() = runTest {
+        // The repository marks the row locally regardless of the POST outcome (GLY-130), so the
+        // in-memory dedup clear must be unconditional too — the alert is acknowledged either way.
         coEvery { repository.acknowledgeAlert("alert-1") } returns
-            Result.failure(RuntimeException("Forbidden"))
+            Result.failure(java.io.IOException("backend unreachable"))
 
         val vm = createViewModel()
         advanceUntilIdle()
@@ -211,11 +213,11 @@ class AlertsViewModelTest {
         vm.acknowledgeAlert("alert-1")
         advanceUntilIdle()
 
-        verify(exactly = 0) { notificationManager.markAcknowledged(any()) }
+        verify { notificationManager.markAcknowledged("alert-1") }
     }
 
     @Test
-    fun `acknowledgeAlert sets user-facing error on failure, never the raw exception message`() = runTest {
+    fun `acknowledgeAlert sets user-facing error on terminal failure, never the raw exception message`() = runTest {
         coEvery { repository.acknowledgeAlert("alert-1") } returns
             Result.failure(RuntimeException("Acknowledge failed: HTTP 403"))
 
@@ -226,6 +228,62 @@ class AlertsViewModelTest {
         advanceUntilIdle()
 
         assertEquals("Couldn't acknowledge the alert. Try again.", vm.uiState.value.error)
+    }
+
+    @Test
+    fun `acknowledgeAlert offline shows honest deferred-sync copy, not an error`() = runTest {
+        networkStatusFlow.value = NetworkStatus.OFFLINE
+        coEvery { repository.acknowledgeAlert("alert-1") } returns
+            Result.failure(java.io.IOException("network unreachable"))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.acknowledgeAlert("alert-1")
+        advanceUntilIdle()
+
+        assertEquals(
+            "Acknowledged locally — will sync when reconnected.",
+            vm.uiState.value.error,
+        )
+    }
+
+    @Test
+    fun `acknowledgeAlert backend-unreachable shows honest deferred-sync copy`() = runTest {
+        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+        coEvery { repository.acknowledgeAlert("alert-1") } returns
+            Result.failure(java.io.IOException("connect refused"))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.acknowledgeAlert("alert-1")
+        advanceUntilIdle()
+
+        assertEquals(
+            "Acknowledged locally — will sync when reconnected.",
+            vm.uiState.value.error,
+        )
+    }
+
+    @Test
+    fun `acknowledgeAlert transport blip while still marked reachable shows deferred-sync copy`() = runTest {
+        // A single IOException can precede the NetworkMonitor flip (threshold = 2 failures).
+        // The ack is still deferred-and-pending, so the copy stays truthful.
+        networkStatusFlow.value = NetworkStatus.REACHABLE
+        coEvery { repository.acknowledgeAlert("alert-1") } returns
+            Result.failure(java.io.IOException("timeout"))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.acknowledgeAlert("alert-1")
+        advanceUntilIdle()
+
+        assertEquals(
+            "Acknowledged locally — will sync when reconnected.",
+            vm.uiState.value.error,
+        )
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertActionReceiverTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertActionReceiverTest.kt
@@ -1,9 +1,132 @@
 package com.glycemicgpt.mobile.service
 
+import com.glycemicgpt.mobile.data.repository.AlertAckHttpException
+import com.glycemicgpt.mobile.data.repository.AlertRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.confirmVerified
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
+import java.io.IOException
 
+/**
+ * Behavioral tests for the "Got It" acknowledge sequence — the GLY-130 live-defect fix.
+ *
+ * The defect: the local silence operations (cancel notification, restore alarm volume, clear
+ * the dedup id) were nested inside the server ack's `.onSuccess`, so with the backend
+ * unreachable a firing safety alarm could not be silenced. These tests pin the fixed contract:
+ * every local operation runs unconditionally and BEFORE the server POST, so a future refactor
+ * that re-gates silence on the network outcome (or reorders the POST ahead of silencing)
+ * fails here instead of shipping.
+ */
 class AlertActionReceiverTest {
+
+    private lateinit var alertRepository: AlertRepository
+    private lateinit var alertNotificationManager: AlertNotificationManager
+    private lateinit var receiver: AlertActionReceiver
+
+    @Before
+    fun setUp() {
+        alertRepository = mockk {
+            coEvery { markAcknowledgedLocally(any()) } just Runs
+        }
+        alertNotificationManager = mockk(relaxUnitFun = true)
+        receiver = AlertActionReceiver().apply {
+            alertRepository = this@AlertActionReceiverTest.alertRepository
+            alertNotificationManager = this@AlertActionReceiverTest.alertNotificationManager
+        }
+    }
+
+    // -- the safety contract: silence never depends on the network -----------------------------
+
+    @Test
+    fun `backend unreachable - every local silence op still runs`() = runTest {
+        coEvery { alertRepository.acknowledgeAlert("srv-1") } returns
+            Result.failure(IOException("backend unreachable"))
+
+        receiver.handleAcknowledge("srv-1", notificationId = 42)
+
+        // The exact live defect being locked: the ack POST failed, yet the alarm is silenced.
+        coVerify(exactly = 1) { alertRepository.markAcknowledgedLocally("srv-1") }
+        verify(exactly = 1) { alertNotificationManager.cancelNotification(42) }
+        verify(exactly = 1) { alertNotificationManager.restoreAlarmVolume() }
+        verify(exactly = 1) { alertNotificationManager.markAcknowledged("srv-1") }
+    }
+
+    @Test
+    fun `silence ops run before the server POST, with the Room mark first`() = runTest {
+        coEvery { alertRepository.acknowledgeAlert("srv-1") } returns
+            Result.failure(IOException("backend unreachable"))
+
+        receiver.handleAcknowledge("srv-1", notificationId = 42)
+
+        // Ordering is the invariant, not an implementation detail: the Room mark must land
+        // before anything else (an SSE re-delivery mid-silence must hit the acknowledged-row
+        // guard), and every silence op must complete before the network attempt begins — a
+        // slow or hung POST may never delay quieting the alarm.
+        coVerifyOrder {
+            alertRepository.markAcknowledgedLocally("srv-1")
+            alertNotificationManager.cancelNotification(42)
+            alertNotificationManager.restoreAlarmVolume()
+            alertNotificationManager.markAcknowledged("srv-1")
+            alertRepository.acknowledgeAlert("srv-1")
+        }
+    }
+
+    @Test
+    fun `server failure produces no further side effects - it is logged and deferred, nothing more`() = runTest {
+        coEvery { alertRepository.acknowledgeAlert("srv-1") } returns
+            Result.failure(AlertAckHttpException(500, terminal = false))
+
+        receiver.handleAcknowledge("srv-1", notificationId = 42)
+
+        // Everything the sequence is allowed to do is verified below; confirmVerified then
+        // proves the failure branch touched nothing else (no un-silencing, no retries here —
+        // the deferred ack belongs to the reconcile pass).
+        coVerify(exactly = 1) { alertRepository.markAcknowledgedLocally("srv-1") }
+        coVerify(exactly = 1) { alertRepository.acknowledgeAlert("srv-1") }
+        verify(exactly = 1) { alertNotificationManager.cancelNotification(42) }
+        verify(exactly = 1) { alertNotificationManager.restoreAlarmVolume() }
+        verify(exactly = 1) { alertNotificationManager.markAcknowledged("srv-1") }
+        confirmVerified(alertRepository, alertNotificationManager)
+    }
+
+    @Test
+    fun `missing notification id - the id-free silence ops still run`() = runTest {
+        coEvery { alertRepository.acknowledgeAlert("srv-1") } returns
+            Result.failure(IOException("backend unreachable"))
+
+        receiver.handleAcknowledge("srv-1", notificationId = -1)
+
+        verify(exactly = 0) { alertNotificationManager.cancelNotification(any()) }
+        verify(exactly = 1) { alertNotificationManager.restoreAlarmVolume() }
+        verify(exactly = 1) { alertNotificationManager.markAcknowledged("srv-1") }
+        coVerify(exactly = 1) { alertRepository.markAcknowledgedLocally("srv-1") }
+    }
+
+    @Test
+    fun `online success runs the identical local sequence - silence is unconditional both ways`() = runTest {
+        coEvery { alertRepository.acknowledgeAlert("srv-1") } returns Result.success(Unit)
+
+        receiver.handleAcknowledge("srv-1", notificationId = 42)
+
+        coVerifyOrder {
+            alertRepository.markAcknowledgedLocally("srv-1")
+            alertNotificationManager.cancelNotification(42)
+            alertNotificationManager.restoreAlarmVolume()
+            alertNotificationManager.markAcknowledged("srv-1")
+            alertRepository.acknowledgeAlert("srv-1")
+        }
+    }
+
+    // -- intent contract ------------------------------------------------------------------------
 
     @Test
     fun `action constants are stable`() {


### PR DESCRIPTION
## Summary

Fixes a live safety defect (Linear GLY-130): with the backend unreachable, a firing glucose alarm could not be silenced. Acknowledging only took effect on HTTP 2xx — the notification's "Got It" silence operations sat inside `.onSuccess`, the Wear dismiss logged success while the Room row stayed unacknowledged (so the alert re-fired), and an SSE re-delivery clobbered any local ack back to unacknowledged.

**Safety invariant now enforced: the local silence path never depends on the network.** Silencing and marking an active alarm always works offline; only the server ack is deferred and reconciled.

## Changes

- **Schema:** `AlertEntity.ack_synced` (Room v12 -> v13, additive migration + committed `13.json`). `acknowledged` is redefined as local/user-intent truth, set unconditionally at ack time; `ack_synced` tracks whether the server POST landed. Pre-migration acknowledged rows are backfilled as synced (they were server-confirmed by definition under the old semantics).
- **Chokepoint (`AlertRepository.acknowledgeAlert`):** marks the local row first, then POSTs. 2xx or terminal 4xx (403/404/422) stamps `ack_synced`; transport/5xx leaves the row pending. Failures are typed (`AlertAckHttpException` with `code` + `terminal`) so callers derive honest copy from the real classification. Never throws past the local mark; `CancellationException` stays cooperative.
- **Reconcile (`reconcilePendingAcks`, mutex-serialized, never throws):** re-POSTs every pending ack to the idempotent `POST /api/v1/alerts/{id}/acknowledge`. Triggers: `NetworkMonitor.status` transition to REACHABLE (including cold start, which drains acks that were pending at process death), every fresh SSE stream connection (covers phones whose only backend traffic is the alert stream), and push-before-pull in `fetchPendingAlerts`.
- **Clobber guards:** `AlertDao.insertPreservingLocalAck` (`@Transaction`) never downgrades a locally-acknowledged row on a stale server echo, and `AlertStreamService.handleAlertEvent` branches on the merged entity — an SSE re-delivery of a locally-acked alert cannot re-alarm.
- **Entry points:** `AlertActionReceiver` marks the row in Room first, then cancels the notification, restores STREAM_ALARM volume, and clears the dedup id unconditionally before the network attempt. `AlertsViewModel` clears the dedup id unconditionally and shows "Acknowledged locally — will sync when reconnected." for deferred syncs (terminal rejections surface as real errors). `WearChatRelayService` no longer logs a false "Acknowledged" on failure; the watch `clearAlert` is backed by a real local mark. No Wear message-contract change.

Backend unchanged.

## Testing

- `./gradlew testDebugUnitTest lintDebug assembleDebug` green.
- New `AlertRepositoryTest` (17 cases: ack state machine incl. typed terminal/transient, reconcile classifier, both clobber guards, push-before-pull ordering, Wear lookup); `AlertsViewModelTest` updated (unconditional dedup clear, deferred-vs-terminal copy); instrumented `Migration12To13Test` run on emulator (rows survive, unacked -> `ack_synced=0`, acked -> backfilled `1`).
- Full emulator E2E with a real firing low alert (backend insert -> SSE -> alarm + volume boost) and `SimulateUnreachableInterceptor` as the offline fault:
  - "Got It" offline -> immediate silence (notification cancelled, volume restored 7 -> 6), row marked locally, backend still unacked; reconnect -> reconcile POST -> backend `acknowledged=true`.
  - `docker compose restart api` during an offline-ack window -> real SSE re-delivery of the still-unacked alert -> "Alert already acknowledged", no re-alarm, no clobber.
  - In-app ack offline -> row flips instantly + honest snackbar.
  - Online regression -> single-pass ack (2xx -> `acknowledged=1, ack_synced=1`), behavior unchanged.
  - Process death with 3 pending acks -> new process reconciled all 3 on reconnect (durability).
  - SSE-open trigger verified in isolation: with no NetworkMonitor transition and no Alerts-screen visit, a stream reconnect alone drained the pending ack.
  - Wear dismiss exercised at unit level (`getLatestUnacknowledgedServerId` no longer resolves a locally-acked row; shares the verified chokepoint). No paired Wear emulator in this run; the relay change is log wording + `Result` handling only.
- Adversarial + senior engineering reviews run; all HIGH/MEDIUM findings fixed (exception hygiene on app-lifetime scopes, deduplicated outcome classification, typed failures, SSE-open reconcile trigger, receiver mark-first ordering, migration backfill). CodeRabbit CLI clean. Security review passed (no PHI in new logs, parameterized queries, receiver not exported); one pre-existing LOW (alerts table survives logout) noted on GLY-134.

## Notes for reviewers

- Caregiver escalation continues while the device is offline until the deferred ack lands — inherent (the phone cannot tell the backend anything offline) and fail-safe (over-notify beats under-notify). The SSE-open trigger minimizes this window.
- Known residual: a POST failing with 5xx while everything else is healthy leaves the ack pending until the next trigger (SSE reconnect, REACHABLE transition, or Alerts-screen refresh); the alert stays silenced locally throughout.
- No Sentry gate: mobile-only change, the backend ack endpoint is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable alert acknowledgement syncing with deferred retries when connectivity returns.
  * Introduced automatic reconciliation of pending acknowledgements when the alert stream becomes available.
* **Bug Fixes**
  * Preserved local acknowledgement state during refreshes and prevented stale updates from downgrading acknowledgements.
  * Improved acknowledgement failure handling, including clearer user messaging for terminal vs retryable issues.
  * Ensured pending acknowledgements reconcile before pulling alert data.
* **Tests**
  * Added coverage for the database migration and the acknowledgement/reconciliation flows, including UI and action-receiver behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->