### PR TITLE
fix(mobile): offline refresh-token expiry no longer locks out local reads

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -89,10 +89,12 @@ class AuthManager @Inject constructor(
         /** Refresh preconditions failed locally (refresh token missing or
          *  expired, no base URL) before any network call. The session is
          *  dead for network purposes, but nothing was sent or rotated, so
-         *  the store is preserved: wiping the refresh token + user email on
-         *  a local expiry would turn an offline TTL crossing into a
-         *  permanent re-onboarding lockout instead of a reconnect-time
-         *  re-auth. */
+         *  the store is preserved. An expired refresh token can never be
+         *  refreshed -- recovery is always a manual re-sign-in via the
+         *  session banner -- but wiping here would erase the user email and
+         *  flip the state to Unauthenticated, turning an offline TTL
+         *  crossing into a re-onboarding lockout instead of an honest
+         *  "session expired, sign in again". */
         object Expired : RefreshOutcome()
 
         /** Server definitively rejected the refresh token (401/403) -- the
@@ -226,7 +228,7 @@ class AuthManager @Inject constructor(
                 }
                 is RefreshOutcome.Expired -> {
                     // Local expiry: preserve the store (refresh token + user
-                    // email) so the post-reconnect re-auth has its context.
+                    // email) so the manual re-sign-in keeps its context.
                     onRefreshFailedLocked()
                 }
                 is RefreshOutcome.Rejected -> {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -51,7 +51,10 @@ class AuthManager @Inject constructor(
     /** Dispatcher for blocking IO operations. Overridable for testing. */
     var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 
-    private val _authState = MutableStateFlow<AuthState>(AuthState.Unauthenticated)
+    // Starts Initializing (not Unauthenticated): the value before
+    // validateOnStartup runs is unresolved, and session-prompt UI keys off
+    // the distinction -- see AuthState.Initializing.
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Initializing)
     val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
     // Volatile because refreshJob is mutated from mixed lock contexts:

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthManager.kt
@@ -86,8 +86,19 @@ class AuthManager @Inject constructor(
         /** Token was rotated. */
         data class Success(val accessToken: String) : RefreshOutcome()
 
-        /** Server rejected the refresh token (401/403) -- session is dead. */
+        /** Refresh preconditions failed locally (refresh token missing or
+         *  expired, no base URL) before any network call. The session is
+         *  dead for network purposes, but nothing was sent or rotated, so
+         *  the store is preserved: wiping the refresh token + user email on
+         *  a local expiry would turn an offline TTL crossing into a
+         *  permanent re-onboarding lockout instead of a reconnect-time
+         *  re-auth. */
         object Expired : RefreshOutcome()
+
+        /** Server definitively rejected the refresh token (401/403) -- the
+         *  session is dead server-side (revoked/invalid) and the stored
+         *  token is useless; the store is wiped. */
+        object Rejected : RefreshOutcome()
 
         /** A logout landed while the refresh was in flight -- the result
          *  belongs to the previous session and was dropped. The store and
@@ -214,6 +225,11 @@ class AuthManager @Inject constructor(
                     scheduleProactiveRefresh(scope)
                 }
                 is RefreshOutcome.Expired -> {
+                    // Local expiry: preserve the store (refresh token + user
+                    // email) so the post-reconnect re-auth has its context.
+                    onRefreshFailedLocked()
+                }
+                is RefreshOutcome.Rejected -> {
                     authTokenStore.clearToken()
                     onRefreshFailedLocked()
                 }
@@ -309,6 +325,11 @@ class AuthManager @Inject constructor(
                     outcome.accessToken
                 }
                 is RefreshOutcome.Expired -> {
+                    // Local expiry: preserve the store (see performRefresh).
+                    onRefreshFailedLocked()
+                    null
+                }
+                is RefreshOutcome.Rejected -> {
                     authTokenStore.clearToken()
                     onRefreshFailedLocked()
                     null
@@ -402,7 +423,7 @@ class AuthManager @Inject constructor(
                     resp.code == 401 || resp.code == 403 -> {
                         // Definitive auth rejection -- refresh token is invalid/revoked
                         Timber.w("Token refresh rejected with HTTP ${resp.code}, clearing session")
-                        RefreshOutcome.Expired
+                        RefreshOutcome.Rejected
                     }
                     else -> {
                         // 5xx server error -- preserve tokens for retry

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthState.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/auth/AuthState.kt
@@ -5,6 +5,12 @@ package com.glycemicgpt.mobile.data.auth
  * Observable via StateFlow from [AuthManager].
  */
 sealed class AuthState {
+    /** Session status not yet resolved (pre-startup-validation default).
+     *  UI must not treat this as signed-out: rendering session prompts off
+     *  this unresolved state would flash them at every cold start before
+     *  [AuthManager.validateOnStartup] resolves the real state. */
+    data object Initializing : AuthState()
+
     /** User has a valid access token. */
     data object Authenticated : AuthState()
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
@@ -97,10 +97,13 @@ class AuthTokenStore @Inject constructor(
      * Returns true if the user has an active session (valid refresh token exists),
      * regardless of whether the current access token has expired.
      *
-     * Use this for navigation decisions (start destination, service keep-alive)
-     * where an expired access token should trigger a background refresh, NOT a
-     * logout. Use [isLoggedIn] only for checking whether an API call can be made
-     * right now without refreshing first.
+     * Use this for service keep-alive decisions where an expired access token
+     * should trigger a background refresh, NOT a logout. Do NOT gate the app's
+     * start destination on it: a refresh token that expires while the device is
+     * offline would route to Onboarding and lock the local pump/CGM reads behind
+     * a login that cannot succeed offline -- start routing keys on onboarding
+     * completion alone. Use [isLoggedIn] only for checking whether an API call
+     * can be made right now without refreshing first.
      */
     fun hasActiveSession(): Boolean = !isRefreshTokenExpired()
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptor.kt
@@ -59,11 +59,16 @@ class TokenRefreshInterceptor @Inject constructor(
         // cheap, but we're in the request hot path so avoid repeating it.
         val authManager = authManagerProvider.get()
 
-        // If the refresh token itself is expired, the session is dead. Clear
-        // and notify -- no point hitting the server.
+        // If the refresh token itself is expired, the session is dead for
+        // network purposes -- no point hitting the server. Notify (sets
+        // AuthState.Expired, surfacing the session banner) but do NOT clear
+        // the store: nothing was rotated, and wiping the refresh token +
+        // user email here would turn an offline expiry into a permanent
+        // re-onboarding lockout of the local pump/CGM reads. Only deliberate
+        // logout (AuthRepository.logout) and a server-side rejection wipe an
+        // intact store.
         if (authTokenStore.isRefreshTokenExpired()) {
             Timber.w("Refresh token expired, cannot auto-refresh")
-            authTokenStore.clearToken()
             authManager.onRefreshFailed()
             return response
         }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -93,6 +93,18 @@ sealed class Screen(val route: String, val label: String, val icon: ImageVector)
 
 private val bottomNavItems = listOf(Screen.Home, Screen.AiChat, Screen.Alerts, Screen.Settings)
 
+/**
+ * Start-destination policy: keyed on onboarding completion ALONE, deliberately
+ * independent of session validity. Routing an expired session to Onboarding
+ * would lock the local Room-served pump/CGM reads behind a login that cannot
+ * succeed offline (a refresh token that expires mid-offline-stretch would
+ * otherwise re-onboard the user). A session-less Home surfaces the tappable
+ * session banner instead, and every network surface keeps its own session
+ * guard.
+ */
+internal fun startDestinationRoute(onboardingComplete: Boolean): String =
+    if (onboardingComplete) Screen.Home.route else Screen.Onboarding.route
+
 // Routes that show their own TopAppBar + back button; bottom nav is hidden on these.
 private val spokeRoutes = setOf(
     Screen.ChartDetail.route,
@@ -116,15 +128,8 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
     val settingsViewModel: SettingsViewModel = hiltViewModel()
     val authState by settingsViewModel.authState.collectAsState()
 
-    // Use hasActiveSession() (checks refresh token) instead of isLoggedIn() (checks access token).
-    // This prevents routing to onboarding when the access token is expired but a valid
-    // refresh token exists -- the AuthManager will refresh it asynchronously.
     val startDestination = remember {
-        if (appSettingsStore.onboardingComplete && authTokenStore.hasActiveSession()) {
-            Screen.Home.route
-        } else {
-            Screen.Onboarding.route
-        }
+        startDestinationRoute(appSettingsStore.onboardingComplete)
     }
 
     val isOnboarding = currentDestination?.route == Screen.Onboarding.route
@@ -196,11 +201,19 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                 InsecureHttpBanner()
             }
 
-            // Session expired banner (not shown during onboarding)
+            // Session banner (not shown during onboarding). Covers both
+            // session-less states so a Home rendered without a session --
+            // now reachable at cold start by design -- always surfaces a
+            // tappable path to the Settings sign-in.
             if (!isOnboarding) {
-                (authState as? AuthState.Expired)?.let { expired ->
+                val sessionBannerMessage = when (val state = authState) {
+                    is AuthState.Expired -> state.message
+                    is AuthState.Unauthenticated -> "Not signed in, tap to sign in"
+                    else -> null
+                }
+                sessionBannerMessage?.let { message ->
                     SessionExpiredBanner(
-                        message = expired.message,
+                        message = message,
                         onClick = {
                             navController.navigate(Screen.Settings.route) {
                                 popUpTo(navController.graph.findStartDestination().id) {
@@ -356,7 +369,8 @@ private fun SessionExpiredBanner(message: String, onClick: () -> Unit) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
                 imageVector = Icons.Default.Warning,
-                contentDescription = "Session expired",
+                // Decorative: the adjacent Text carries the state-specific message.
+                contentDescription = null,
                 tint = MaterialTheme.colorScheme.onErrorContainer,
             )
             Spacer(modifier = Modifier.width(8.dp))

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -105,6 +105,19 @@ private val bottomNavItems = listOf(Screen.Home, Screen.AiChat, Screen.Alerts, S
 internal fun startDestinationRoute(onboardingComplete: Boolean): String =
     if (onboardingComplete) Screen.Home.route else Screen.Onboarding.route
 
+/**
+ * Session-banner policy: a message only for RESOLVED session-less states.
+ * Initializing is the pre-validation default -- rendering the banner off it
+ * would flash "not signed in" at cold start before
+ * [com.glycemicgpt.mobile.data.auth.AuthManager.validateOnStartup] resolves
+ * the real state. Refreshing and Authenticated are live sessions.
+ */
+internal fun sessionBannerMessage(state: AuthState): String? = when (state) {
+    is AuthState.Expired -> state.message
+    is AuthState.Unauthenticated -> "Not signed in, tap to sign in"
+    is AuthState.Initializing, is AuthState.Refreshing, is AuthState.Authenticated -> null
+}
+
 // Routes that show their own TopAppBar + back button; bottom nav is hidden on these.
 private val spokeRoutes = setOf(
     Screen.ChartDetail.route,
@@ -202,16 +215,13 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
             }
 
             // Session banner (not shown during onboarding). Covers both
-            // session-less states so a Home rendered without a session --
-            // now reachable at cold start by design -- always surfaces a
-            // tappable path to the Settings sign-in.
+            // RESOLVED session-less states so a Home rendered without a
+            // session -- now reachable at cold start by design -- always
+            // surfaces a tappable path to the Settings sign-in. The policy
+            // (incl. staying silent while Initializing) lives in
+            // sessionBannerMessage().
             if (!isOnboarding) {
-                val sessionBannerMessage = when (val state = authState) {
-                    is AuthState.Expired -> state.message
-                    is AuthState.Unauthenticated -> "Not signed in, tap to sign in"
-                    else -> null
-                }
-                sessionBannerMessage?.let { message ->
+                sessionBannerMessage(authState)?.let { message ->
                     SessionExpiredBanner(
                         message = message,
                         onClick = {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -223,7 +223,7 @@ class AuthManagerTest {
     }
 
     @Test
-    fun `performRefresh sets Expired when refresh token is expired`() = runTest {
+    fun `performRefresh sets Expired and preserves the store when refresh token expired locally`() = runTest {
         every { authTokenStore.getRefreshToken() } returns "expired-refresh"
         every { authTokenStore.isRefreshTokenExpired() } returns true
 
@@ -231,6 +231,30 @@ class AuthManagerTest {
         manager.performRefresh(testScope)
 
         assertTrue(manager.authState.value is AuthState.Expired)
+        // GLY-133: crossing the refresh-token TTL while running must not wipe
+        // the store -- nothing was sent or rotated, and the preserved refresh
+        // token + user email are the reconnect-time re-auth context. Wiping
+        // here made an offline expiry a permanent re-onboarding lockout.
+        verify(exactly = 0) { authTokenStore.clearToken() }
+        verify(exactly = 0) { authTokenStore.clearCredentials() }
+    }
+
+    @Test
+    fun `refreshForInterceptor sets Expired and preserves the store when refresh token expired locally`() = runTest {
+        every { authTokenStore.getToken() } returns null
+        every { authTokenStore.getRefreshToken() } returns "expired-refresh"
+        every { authTokenStore.isRefreshTokenExpired() } returns true
+
+        val manager = createManager()
+        // A live session must exist for the expiry to be observable; from
+        // Unauthenticated the logout-wins guard keeps the state put.
+        manager.onLoginSuccess(testScope)
+        val result = manager.refreshForInterceptor(null)
+
+        assertNull(result)
+        assertTrue(manager.authState.value is AuthState.Expired)
+        verify(exactly = 0) { authTokenStore.clearToken() }
+        verify(exactly = 0) { authTokenStore.clearCredentials() }
     }
 
     @Test
@@ -255,6 +279,9 @@ class AuthManagerTest {
         manager.performRefresh(testScope)
 
         assertTrue(manager.authState.value is AuthState.Expired)
+        // Unlike a local expiry (store preserved), a definitive server-side
+        // rejection means the stored refresh token is revoked/useless -- it
+        // must still be wiped.
         verify { authTokenStore.clearToken() }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -90,6 +90,17 @@ class AuthManagerTest {
     // --- validateOnStartup ---
 
     @Test
+    fun `auth state starts Initializing until startup validation resolves it`() {
+        // The pre-validation default must be distinguishable from a resolved
+        // signed-out state: session-prompt UI stays silent on Initializing,
+        // so an authenticated user never sees a "not signed in" flash while
+        // the app boots.
+        val manager = createManager()
+
+        assertEquals(AuthState.Initializing, manager.authState.value)
+    }
+
+    @Test
     fun `validateOnStartup sets Unauthenticated when no refresh token`() {
         every { authTokenStore.getRefreshToken() } returns null
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthManagerTest.kt
@@ -233,8 +233,9 @@ class AuthManagerTest {
         assertTrue(manager.authState.value is AuthState.Expired)
         // GLY-133: crossing the refresh-token TTL while running must not wipe
         // the store -- nothing was sent or rotated, and the preserved refresh
-        // token + user email are the reconnect-time re-auth context. Wiping
-        // here made an offline expiry a permanent re-onboarding lockout.
+        // token + user email keep the manual re-sign-in honest ("session
+        // expired", not re-onboarding). Wiping here made an offline expiry a
+        // permanent lockout.
         verify(exactly = 0) { authTokenStore.clearToken() }
         verify(exactly = 0) { authTokenStore.clearCredentials() }
     }
@@ -244,6 +245,7 @@ class AuthManagerTest {
         every { authTokenStore.getToken() } returns null
         every { authTokenStore.getRefreshToken() } returns "expired-refresh"
         every { authTokenStore.isRefreshTokenExpired() } returns true
+        every { authTokenStore.getTokenExpiresAtMs() } returns System.currentTimeMillis() + 3_600_000
 
         val manager = createManager()
         // A live session must exist for the expiry to be observable; from
@@ -255,6 +257,9 @@ class AuthManagerTest {
         assertTrue(manager.authState.value is AuthState.Expired)
         verify(exactly = 0) { authTokenStore.clearToken() }
         verify(exactly = 0) { authTokenStore.clearCredentials() }
+        // onLoginSuccess armed the proactive-refresh timer; cancel it so
+        // runTest's final advance can't re-enter the refresh machinery.
+        testScope.coroutineContext.cancelChildren()
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/remote/TokenRefreshInterceptorTest.kt
@@ -97,7 +97,7 @@ class TokenRefreshInterceptorTest {
     }
 
     @Test
-    fun `401 with expired refresh token notifies AuthManager and clears tokens`() {
+    fun `401 with expired refresh token notifies AuthManager and preserves the store`() {
         every { authTokenStore.getRefreshToken() } returns "expired-refresh"
         every { authTokenStore.isRefreshTokenExpired() } returns true
 
@@ -114,9 +114,14 @@ class TokenRefreshInterceptorTest {
         val response = interceptor.intercept(chain)
 
         assertEquals(401, response.code)
-        verify { authTokenStore.clearToken() }
         verify { authManager.onRefreshFailed() }
         coVerify(exactly = 0) { authManager.refreshForInterceptor(any()) }
+        // GLY-133: a locally-expired refresh token must NOT wipe the store.
+        // Nothing was rotated; clearing here erased the refresh token + user
+        // email and turned an offline expiry into a permanent re-onboarding
+        // lockout. Deliberate logout remains the only intact-store wipe.
+        verify(exactly = 0) { authTokenStore.clearToken() }
+        verify(exactly = 0) { authTokenStore.clearCredentials() }
     }
 
     // --- delegation to AuthManager.refreshForInterceptor ---

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -428,4 +428,20 @@ class AuthRepositoryTest {
             assertTrue(result.isFailure)
             verify(exactly = 0) { appSettingsStore.glucoseUnitSeedPending = any() }
         }
+
+    // -- GLY-133 wipe/preserve boundary ---------------------------------------
+
+    @Test
+    fun `logout performs the full-store wipe -- the boundary the expiry paths must not cross`() {
+        // The token-expiry paths (AuthManager's local Expired outcome and
+        // TokenRefreshInterceptor's expired-refresh pre-check) deliberately
+        // preserve the token store so an offline TTL crossing can re-auth on
+        // reconnect. Deliberate sign-out is the load-bearing counterpart:
+        // it must keep wiping the FULL store (refresh token + user email via
+        // clearToken, not just the access token) exactly as before.
+        repository.logout(testScope)
+
+        verify(exactly = 1) { authTokenStore.clearToken() }
+        verify(exactly = 0) { authTokenStore.clearAccessToken() }
+    }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -429,16 +429,11 @@ class AuthRepositoryTest {
             verify(exactly = 0) { appSettingsStore.glucoseUnitSeedPending = any() }
         }
 
-    // -- GLY-133 wipe/preserve boundary ---------------------------------------
-
     @Test
-    fun `logout performs the full-store wipe -- the boundary the expiry paths must not cross`() {
-        // The token-expiry paths (AuthManager's local Expired outcome and
-        // TokenRefreshInterceptor's expired-refresh pre-check) deliberately
-        // preserve the token store so an offline TTL crossing can re-auth on
-        // reconnect. Deliberate sign-out is the load-bearing counterpart:
-        // it must keep wiping the FULL store (refresh token + user email via
-        // clearToken, not just the access token) exactly as before.
+    fun `logout wipes the full store, never the access-token-only partial clear`() {
+        // The token-expiry paths (GLY-133) preserve the store; deliberate
+        // sign-out is the counterpart boundary and must keep wiping the FULL
+        // store -- clearToken, not the partial clearAccessToken.
         repository.logout(testScope)
 
         verify(exactly = 1) { authTokenStore.clearToken() }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/SessionBannerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/SessionBannerTest.kt
@@ -1,0 +1,47 @@
+package com.glycemicgpt.mobile.presentation.navigation
+
+import com.glycemicgpt.mobile.data.auth.AuthState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the session-banner policy: a banner only for RESOLVED session-less
+ * states. The pre-validation [AuthState.Initializing] default must render
+ * nothing -- keying the banner off it would flash "not signed in" at cold
+ * start for every authenticated user before startup validation resolves
+ * the real state.
+ */
+class SessionBannerTest {
+
+    @Test
+    fun `initializing shows no banner`() {
+        assertNull(sessionBannerMessage(AuthState.Initializing))
+    }
+
+    @Test
+    fun `refreshing shows no banner`() {
+        assertNull(sessionBannerMessage(AuthState.Refreshing))
+    }
+
+    @Test
+    fun `authenticated shows no banner`() {
+        assertNull(sessionBannerMessage(AuthState.Authenticated))
+    }
+
+    @Test
+    fun `expired shows its message`() {
+        assertEquals(
+            "Session expired, please sign in again",
+            sessionBannerMessage(AuthState.Expired()),
+        )
+    }
+
+    @Test
+    fun `unauthenticated shows the sign-in prompt`() {
+        assertEquals(
+            "Not signed in, tap to sign in",
+            sessionBannerMessage(AuthState.Unauthenticated),
+        )
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/StartDestinationTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/StartDestinationTest.kt
@@ -1,0 +1,25 @@
+package com.glycemicgpt.mobile.presentation.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the GLY-133 start-destination policy: routing is keyed on onboarding
+ * completion ALONE. The predicate deliberately takes no session/token input --
+ * the previous `onboardingComplete && hasActiveSession()` form sent a device
+ * whose refresh token expired offline to Onboarding, locking its intact local
+ * pump/CGM reads behind a login that cannot succeed offline. If a session
+ * parameter ever reappears here, that lockout is back.
+ */
+class StartDestinationTest {
+
+    @Test
+    fun `onboarding complete starts at Home`() {
+        assertEquals(Screen.Home.route, startDestinationRoute(onboardingComplete = true))
+    }
+
+    @Test
+    fun `first-ever user starts at Onboarding`() {
+        assertEquals(Screen.Onboarding.route, startDestinationRoute(onboardingComplete = false))
+    }
+}


### PR DESCRIPTION
## Problem

A device that stays offline past the 30-day refresh-token TTL cold-starts into Onboarding, locking the user's intact local BLE-direct pump/CGM reads (Room-served) behind a login that cannot succeed offline. Two compounding defects:

- **Routing lockout:** the NavHost start destination required `hasActiveSession()` (refresh-token validity), so an expired token re-onboarded the device even though the local data was fine.
- **Token wipe at expiry:** crossing the TTL while the app was running called `clearToken()` from three sites (the 401 interceptor's expired-refresh pre-check and both `AuthManager` refresh entry points), erasing the refresh token and user email and making the lockout permanent.

## Fix (mobile-only, no data-layer or backend change)

- **NavHost start destination keys on onboarding completion alone** (`startDestinationRoute()`, unit-tested). A session-less Home renders cached Room data with the honest staleness treatment and a tappable session banner; every network surface keeps its own session guard.
- **Local (pre-network) refresh-token expiry preserves the token store.** The interceptor pre-check no longer wipes; `AuthManager`'s `RefreshOutcome.Expired` now covers only local precondition failures and preserves the store.
- **Server-side rejection still wipes.** `RefreshOutcome.Expired` was split: a definitive 401/403 from the refresh endpoint maps to a new `Rejected` outcome that clears the store exactly as before. (The story assumed all `Expired` outcomes were pre-network; the code also returned it for server rejections, so the split preserves the revocation semantics that GLY-131's tests pin.)
- **Session banner widened to `Expired || Unauthenticated`** with distinct copy for each, so any session-less Home always surfaces a reachable re-auth path (banner taps through to the Settings sign-in).
- **Genuine logout is untouched and test-pinned:** `AuthRepository.logout` still performs the full-store wipe and `SettingsViewModel.logout` resets `onboardingComplete`, so a deliberately signed-out device still cold-starts to Onboarding.

## Tests

- `AuthManagerTest`: local expiry via both `performRefresh` and `refreshForInterceptor` sets `Expired` and leaves the store intact; server 401/403 still wipes; all fail on a reverted implementation.
- `TokenRefreshInterceptorTest`: a 401 with an expired refresh token returns the 401, notifies `onRefreshFailed`, and does not touch the store.
- `AuthRepositoryTest`: logout performs the full-store `clearToken` (never the partial `clearAccessToken`) — the wipe/preserve boundary.
- `StartDestinationTest`: pins the onboarding-only start policy and locks the predicate signature.
- `./gradlew testDebugUnitTest lintDebug assembleDebug` green.

## E2E verification (emulator, debug build, dedicated API instance with short-TTL tokens)

| Scenario | Result |
|---|---|
| Offline + expired refresh token, cold start | Home with cached CGM card + "Session expired" banner (previously: Onboarding lockout) |
| Refresh token expires while app is running | Banner appears, store preserved (logcat shows the expired pre-check, no wipe) |
| Reconnect, banner -> Settings -> sign in | Session restored, banner clears, Room data identical before/after re-login |
| Genuine logout | Routes to Onboarding, full-store wipe, still Onboarding after cold restart |
| Fresh install | Onboarding, unaffected |
| Session-less navigation sweep | AI Chat offline state, Alerts honest degrade, chart detail spoke — no crash |
| Onboarded device with wiped session, cold start | Home with distinct "Not signed in, tap to sign in" banner; cached reading honestly de-emphasized as too old |

## Review notes and accepted lows

- Adversarial + senior reviews: no HIGH/MEDIUM after fixes; retry behavior at expiry is fail-closed and bounded (pre-check short-circuits, proactive timer cancelled).
- Security review: PASS. Retaining an already-expired refresh token in EncryptedSharedPreferences has no attacker value — it is never transmitted after expiry (every send path gates on `isRefreshTokenExpired()`), the server would reject it anyway (and that path wipes), and a valid token was always retained during normal sessions, so post-expiry retention strictly lowers the value of what is extractable. Genuine logout still wipes everything.
- Conscious tradeoff: a fully-expired (or server-revoked) session now cold-starts to Home showing cached read-only data instead of hiding it behind Onboarding. That data was already visible mid-session at expiry, lives in encrypted storage, and the OS lock screen is the real gate; deliberate sign-out still hides it by resetting onboarding. Defense-in-depth for shared devices would be an app-level biometric lock (separate story).
- Accepted cosmetic low: during an in-session logout there is a sub-frame window where the widened banner could flash before navigation lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Locally expired refresh tokens no longer clear saved sign-in data.
  * Server-side refresh rejections now trigger the full session wipe, while local expiry follows the preserve-store flow.
  * Startup routing now depends only on onboarding completion (Home vs Onboarding).
  * Refreshed session-expired banner behavior and message mapping, with the banner hidden during onboarding/startup.

* **Tests**
  * Added/updated tests covering local refresh expiry handling, interceptor behavior, logout full wipe, and onboarding-based start destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->