### PR TITLE
feat(mobile): on-device freshness-gated alert floor (GLY-115)

### DIFF
--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/alerts/AlertsDegradedUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/alerts/AlertsDegradedUiTest.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
+import com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
 import com.glycemicgpt.mobile.testutil.indeterminateSpinner
@@ -18,8 +20,12 @@ import org.junit.runner.RunWith
 
 /**
  * On-device rendering of the alerts surface in the degraded (backend unreachable / SSE down)
- * state: the honest banner shows, cached alerts stay visible, and no indeterminate spinner
- * remains (the AC1 no-hang assertion at the composable level).
+ * state: the honest two-state banner (GLY-115) shows, cached alerts stay visible, and no
+ * indeterminate spinner remains (the AC1 no-hang assertion at the composable level).
+ *
+ * 57.9 note: the pre-floor contract ("never imply a device floor exists") is deliberately
+ * flipped — a floor now exists, so the banner must claim it EXACTLY when it can vouch
+ * (watching, with the threshold-only disclaimer) and disclaim it otherwise (NOT watching).
  */
 @RunWith(AndroidJUnit4::class)
 class AlertsDegradedUiTest {
@@ -38,7 +44,7 @@ class AlertsDegradedUiTest {
     )
 
     private fun setContent(
-        degraded: Boolean,
+        status: AlertFloorStatus,
         alerts: List<AlertEntity>,
         isLoading: Boolean = false,
     ) {
@@ -48,7 +54,7 @@ class AlertsDegradedUiTest {
                     uiState = AlertsUiState(isLoading = isLoading),
                     alerts = alerts,
                     glucoseUnit = GlucoseUnit.MGDL,
-                    alertingDegraded = degraded,
+                    alertFloorStatus = status,
                     snackbarHostState = SnackbarHostState(),
                     onRefresh = {},
                     onAcknowledge = {},
@@ -57,9 +63,12 @@ class AlertsDegradedUiTest {
         }
     }
 
+    private val notWatching =
+        AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING)
+
     @Test
     fun degraded_showsBanner_andKeepsCachedAlerts_withNoSpinner() {
-        setContent(degraded = true, alerts = listOf(cachedAlert()))
+        setContent(status = notWatching, alerts = listOf(cachedAlert()))
 
         compose.onNodeWithTag(TAG_ALERTING_DEGRADED_BANNER).assertIsDisplayed()
         compose.onNodeWithText("High glucose warning").assertIsDisplayed()
@@ -67,19 +76,28 @@ class AlertsDegradedUiTest {
     }
 
     @Test
-    fun degraded_bannerIsHonest_serverAlertsPaused_noDeviceFloorClaim() {
-        setContent(degraded = true, alerts = emptyList())
+    fun floorWatching_bannerClaimsCoverage_withThresholdOnlyDisclaimer() {
+        setContent(status = AlertFloorStatus.FloorWatching, alerts = emptyList())
 
-        // Says plainly that server-pushed alerts are paused...
         compose.onNodeWithText("Server alerts paused", substring = true).assertIsDisplayed()
-        // ...and never implies a device/local alert floor is protecting the user (that's 57.9).
-        compose.onNodeWithText("device", substring = true, ignoreCase = true).assertDoesNotExist()
-        compose.onNodeWithText("threshold", substring = true, ignoreCase = true).assertDoesNotExist()
+        compose.onNodeWithText("this phone is watching", substring = true).assertIsDisplayed()
+        compose.onNodeWithText("Threshold-only, no prediction", substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun floorNotWatching_bannerDisclaimsCoverage_neverClaimsWatching() {
+        setContent(status = notWatching, alerts = emptyList())
+
+        // The lethal trap pinned on-device: when the floor cannot vouch, the surface must say
+        // NOT watching and never claim coverage.
+        compose.onNodeWithText("NOT watching", substring = true).assertIsDisplayed()
+        compose.onNodeWithText("is watching your", substring = true).assertDoesNotExist()
     }
 
     @Test
     fun goldenPath_rendersNoBanner() {
-        setContent(degraded = false, alerts = listOf(cachedAlert()))
+        setContent(status = AlertFloorStatus.ServerActive, alerts = listOf(cachedAlert()))
 
         compose.onAllNodesWithTag(TAG_ALERTING_DEGRADED_BANNER).assertCountEquals(0)
         compose.onNodeWithText("High glucose warning").assertIsDisplayed()
@@ -87,7 +105,7 @@ class AlertsDegradedUiTest {
 
     @Test
     fun degraded_withNoCachedAlerts_showsEmptyState_notBlank() {
-        setContent(degraded = true, alerts = emptyList())
+        setContent(status = notWatching, alerts = emptyList())
 
         compose.onNodeWithTag(TAG_ALERTING_DEGRADED_BANNER).assertIsDisplayed()
         compose.onNodeWithText("No alerts").assertIsDisplayed()

--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/meal/MealFullFlowE2ETest.kt
@@ -333,6 +333,7 @@ private class FakeMealApi : GlycemicGptApi {
     override suspend fun patchMealIntelligence(request: MealIntelligenceUpdateRequest) = notUsed()
     override suspend fun getGlucoseRange() = notUsed()
     override suspend fun getSafetyLimits() = notUsed()
+    override suspend fun getAlertThresholds() = notUsed()
     override suspend fun getAnalyticsConfig() = notUsed()
     override suspend fun getPumpProfile() = notUsed()
     override suspend fun putPluginDeclarations(body: PluginDeclarationRequest) = notUsed()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AlertThresholdStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AlertThresholdStore.kt
@@ -52,9 +52,17 @@ class AlertThresholdStore @Inject constructor(
      * Atomically update all four thresholds plus the fetch timestamp in a single
      * SharedPreferences transaction. Only called from backend sync; the caller
      * ([com.glycemicgpt.mobile.data.repository.AuthRepository]) validates range and ordering
-     * before persisting.
+     * before persisting. The guards here are defense-in-depth on the canonical alarm source:
+     * a future caller that bypasses upstream validation must fail loudly (leaving the last
+     * synced values intact), never persist unsafe thresholds.
      */
     fun updateAll(urgentLow: Int, lowWarning: Int, highWarning: Int, urgentHigh: Int) {
+        require(listOf(urgentLow, lowWarning, highWarning, urgentHigh).all { it in 20..500 }) {
+            "Alert thresholds out of the 20-500 mg/dL safety range"
+        }
+        require(urgentLow <= lowWarning && lowWarning < highWarning && highWarning <= urgentHigh) {
+            "Alert thresholds not correctly ordered"
+        }
         prefs.edit()
             .putInt(KEY_URGENT_LOW, urgentLow)
             .putInt(KEY_LOW_WARNING, lowWarning)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AlertThresholdStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AlertThresholdStore.kt
@@ -1,0 +1,92 @@
+package com.glycemicgpt.mobile.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Local cache of the user's server-side alert thresholds (the `alert_thresholds` table the
+ * backend's alert engine fires from), fetched via `GET /api/settings/alert-thresholds`.
+ *
+ * This is what the on-device alert floor fires from, so it must match the server exactly:
+ * sync-only, like [SafetyLimitsStore] -- the mobile app NEVER allows local override; only
+ * [updateAll] from backend sync is permitted. These are deliberately distinct from
+ * [GlucoseRangeStore] (the *display* target range): the two tables are user-editable
+ * independently, and a safety floor firing at display-range values instead of the user's real
+ * alert thresholds would alarm at the wrong glucose levels and desync from the server.
+ *
+ * The defaults mirror the backend's `AlertThreshold` column defaults but exist only for the
+ * watch alert relay -- the alert floor never fires until [isSynced] is true (GLY-115: never
+ * alarm off guessed thresholds).
+ */
+@Singleton
+class AlertThresholdStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("alert_thresholds", Context.MODE_PRIVATE)
+
+    val urgentLowMgDl: Int
+        get() = prefs.getInt(KEY_URGENT_LOW, DEFAULT_URGENT_LOW)
+
+    val lowWarningMgDl: Int
+        get() = prefs.getInt(KEY_LOW_WARNING, DEFAULT_LOW_WARNING)
+
+    val highWarningMgDl: Int
+        get() = prefs.getInt(KEY_HIGH_WARNING, DEFAULT_HIGH_WARNING)
+
+    val urgentHighMgDl: Int
+        get() = prefs.getInt(KEY_URGENT_HIGH, DEFAULT_URGENT_HIGH)
+
+    /** Timestamp of the last successful fetch from the backend, or 0 if never synced. */
+    val lastFetchedMs: Long
+        get() = prefs.getLong(KEY_LAST_FETCHED, 0L)
+
+    /** True once the thresholds have been fetched from the backend at least once. The alert
+     *  floor is gated on this -- it must never fire off the hardcoded defaults. */
+    fun isSynced(): Boolean = lastFetchedMs != 0L
+
+    /**
+     * Atomically update all four thresholds plus the fetch timestamp in a single
+     * SharedPreferences transaction. Only called from backend sync; the caller
+     * ([com.glycemicgpt.mobile.data.repository.AuthRepository]) validates range and ordering
+     * before persisting.
+     */
+    fun updateAll(urgentLow: Int, lowWarning: Int, highWarning: Int, urgentHigh: Int) {
+        prefs.edit()
+            .putInt(KEY_URGENT_LOW, urgentLow)
+            .putInt(KEY_LOW_WARNING, lowWarning)
+            .putInt(KEY_HIGH_WARNING, highWarning)
+            .putInt(KEY_URGENT_HIGH, urgentHigh)
+            .putLong(KEY_LAST_FETCHED, System.currentTimeMillis())
+            .commit()
+    }
+
+    /** Clear all cached thresholds, resetting to defaults and un-syncing. Called on logout so
+     *  the floor can never fire off another account's thresholds. */
+    fun clear() {
+        prefs.edit().clear().commit()
+    }
+
+    /** Returns true if the cached values are older than the given max age (or never synced). */
+    fun isStale(maxAgeMs: Long = STALE_THRESHOLD_MS): Boolean {
+        val age = System.currentTimeMillis() - lastFetchedMs
+        return age > maxAgeMs
+    }
+
+    companion object {
+        const val DEFAULT_URGENT_LOW = 55
+        const val DEFAULT_LOW_WARNING = 70
+        const val DEFAULT_HIGH_WARNING = 180
+        const val DEFAULT_URGENT_HIGH = 250
+        const val STALE_THRESHOLD_MS = 3_600_000L // 1 hour
+
+        private const val KEY_URGENT_LOW = "urgent_low"
+        private const val KEY_LOW_WARNING = "low_warning"
+        private const val KEY_HIGH_WARNING = "high_warning"
+        private const val KEY_URGENT_HIGH = "urgent_high"
+        private const val KEY_LAST_FETCHED = "last_fetched_ms"
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AppSettingsStore.kt
@@ -339,6 +339,22 @@ class AppSettingsStore @Inject constructor(
             prefs.edit().putBoolean(KEY_DEBUG_FAST_STALENESS, value).apply()
         }
 
+    /** Emits [simulateBackendUnreachable] and re-emits on change, so `AlertStreamService` can
+     *  force-drop its SSE stream the moment the fault toggle flips on (the injected transport
+     *  fault only affects NEW requests; a healthy long-lived stream would otherwise stay
+     *  CONNECTED and leave the alerting-degraded arm-condition half-driven). Debug-only, same
+     *  hard gate as the property. Uses the same change-listener mechanism as [glucoseUnitFlow]. */
+    fun simulateBackendUnreachableFlow(): Flow<Boolean> = callbackFlow {
+        trySend(simulateBackendUnreachable)
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_SIMULATE_BACKEND_UNREACHABLE || key == null) {
+                trySend(simulateBackendUnreachable)
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+
     /** Emits [debugFastStaleness] and re-emits on change, so the home screen re-derives freshness
      *  live when the debug toggle flips. Uses the same change-listener mechanism as [glucoseUnitFlow]. */
     fun debugFastStalenessFlow(): Flow<Boolean> = callbackFlow {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/AlertDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/AlertDao.kt
@@ -68,16 +68,18 @@ interface AlertDao {
     suspend fun getLatestUnacknowledgedServerId(): String?
 
     /**
-     * Timestamp of the newest alert of the given type at/after [sinceMs], or null. The alert
-     * floor's episode guard (GLY-115): if the server already alerted for this type just before
-     * the connection dropped, the floor seeds its cooldown from it instead of re-alarming the
-     * same episode across the REACHABLE→UNREACHABLE flip.
+     * Timestamp of the newest UNACKNOWLEDGED alert of the given type at/after [sinceMs], or null.
+     * The alert floor's episode guard (GLY-115): if the server already alerted for this type just
+     * before the connection dropped and the user hasn't acknowledged it, the floor seeds its
+     * cooldown from it instead of re-alarming the same episode across the REACHABLE→UNREACHABLE
+     * flip. Acknowledged alerts are excluded to mirror the server's ack-gated dedup — the user
+     * saw those, so a recurrence is a new emergency the floor must alarm.
      */
     @Query(
         "SELECT MAX(timestamp_ms) FROM alerts " +
-            "WHERE alert_type = :alertType AND timestamp_ms >= :sinceMs",
+            "WHERE alert_type = :alertType AND acknowledged = 0 AND timestamp_ms >= :sinceMs",
     )
-    suspend fun getLatestTimestampForType(alertType: String, sinceMs: Long): Long?
+    suspend fun getLatestUnacknowledgedTimestampForType(alertType: String, sinceMs: Long): Long?
 
     @Query("DELETE FROM alerts WHERE timestamp_ms < :cutoffMs")
     suspend fun deleteOlderThan(cutoffMs: Long)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/AlertDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/AlertDao.kt
@@ -67,6 +67,18 @@ interface AlertDao {
     )
     suspend fun getLatestUnacknowledgedServerId(): String?
 
+    /**
+     * Timestamp of the newest alert of the given type at/after [sinceMs], or null. The alert
+     * floor's episode guard (GLY-115): if the server already alerted for this type just before
+     * the connection dropped, the floor seeds its cooldown from it instead of re-alarming the
+     * same episode across the REACHABLE→UNREACHABLE flip.
+     */
+    @Query(
+        "SELECT MAX(timestamp_ms) FROM alerts " +
+            "WHERE alert_type = :alertType AND timestamp_ms >= :sinceMs",
+    )
+    suspend fun getLatestTimestampForType(alertType: String, sinceMs: Long): Long?
+
     @Query("DELETE FROM alerts WHERE timestamp_ms < :cutoffMs")
     suspend fun deleteOlderThan(cutoffMs: Long)
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/GlycemicGptApi.kt
@@ -2,6 +2,7 @@ package com.glycemicgpt.mobile.data.remote
 
 import com.glycemicgpt.mobile.data.remote.dto.AcknowledgeResponse
 import com.glycemicgpt.mobile.data.remote.dto.AlertResponse
+import com.glycemicgpt.mobile.data.remote.dto.AlertThresholdsResponse
 import com.glycemicgpt.mobile.data.remote.dto.AiProviderStatusResponse
 import com.glycemicgpt.mobile.data.remote.dto.AnalyticsConfigResponse
 import com.glycemicgpt.mobile.data.remote.dto.PumpProfileResponse
@@ -109,6 +110,11 @@ interface GlycemicGptApi {
     // Safety limits settings
     @GET("/api/settings/safety-limits")
     suspend fun getSafetyLimits(): Response<SafetyLimitsResponse>
+
+    // Alert thresholds -- the values the server's alert engine fires from; the
+    // on-device alert floor (GLY-115) must alarm at exactly these levels.
+    @GET("/api/settings/alert-thresholds")
+    suspend fun getAlertThresholds(): Response<AlertThresholdsResponse>
 
     // Analytics configuration
     @GET("/api/settings/analytics-config")

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/remote/dto/ApiModels.kt
@@ -115,6 +115,22 @@ data class GlucoseRangeResponse(
 )
 
 /**
+ * The user's alert thresholds -- the values the backend's alert engine fires from
+ * (`alert_thresholds` table), distinct from the display-oriented [GlucoseRangeResponse].
+ * Fetched so the on-device alert floor alarms at exactly the same glucose levels as the
+ * server. [iobWarning] is returned by the endpoint but unused on-device (the floor is
+ * threshold-only; IoB alerting stays server-side).
+ */
+@JsonClass(generateAdapter = true)
+data class AlertThresholdsResponse(
+    @Json(name = "urgent_low") val urgentLow: Float,
+    @Json(name = "low_warning") val lowWarning: Float,
+    @Json(name = "high_warning") val highWarning: Float,
+    @Json(name = "urgent_high") val urgentHigh: Float,
+    @Json(name = "iob_warning") val iobWarning: Float? = null,
+)
+
+/**
  * Per-account glucose display unit preference. [glucoseUnit] is the backend enum wire value
  * ("mgdl"/"mmol"). [glucoseUnitSource] is the provenance ("seed"/"user"/null) -- "seed" with a
  * non-mgdl unit drives the one-time smart-default confirmation notice. Nullable so an

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.mobile.data.repository
 import android.content.Context
 import com.glycemicgpt.mobile.BuildConfig
 import com.glycemicgpt.mobile.data.auth.AuthManager
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
@@ -40,6 +41,7 @@ class AuthRepository @Inject constructor(
     private val authTokenStore: AuthTokenStore,
     private val glucoseRangeStore: GlucoseRangeStore,
     private val safetyLimitsStore: SafetyLimitsStore,
+    private val alertThresholdStore: AlertThresholdStore,
     private val analyticsSettingsStore: AnalyticsSettingsStore,
     private val pumpProfileStore: PumpProfileStore,
     private val appSettingsStore: AppSettingsStore,
@@ -102,6 +104,7 @@ class AuthRepository @Inject constructor(
                 }
                 scope.launch { fetchGlucoseRange() }
                 scope.launch { fetchSafetyLimits() }
+                scope.launch { fetchAlertThresholds() }
                 scope.launch { fetchGlucoseUnit() }
                 scope.launch { fetchMealIntelligence() }
                 AlertStreamService.start(appContext)
@@ -136,6 +139,9 @@ class AuthRepository @Inject constructor(
         // Server-side cleanup handles orphaned device registrations.
         authTokenStore.clearToken()
         safetyLimitsStore.clear()
+        // The alert floor must never fire off another account's thresholds; clearing also
+        // un-syncs the store, which disarms the floor until the next account's fetch lands.
+        alertThresholdStore.clear()
         analyticsSettingsStore.clear()
         pumpProfileStore.clear()
         // The glucose unit is a per-account preference; reset to the neutral default so a stale
@@ -205,6 +211,11 @@ class AuthRepository @Inject constructor(
 
     suspend fun refreshSafetyLimits() {
         fetchSafetyLimits()
+    }
+
+    /** Reconcile the cached alert thresholds from the backend (the account is the source of truth). */
+    suspend fun refreshAlertThresholds() {
+        fetchAlertThresholds()
     }
 
     /** Reconcile the cached glucose display unit from the backend (the account is the source of truth). */
@@ -371,6 +382,37 @@ class AuthRepository @Inject constructor(
         } catch (e: Exception) {
             // Keep the cached value (ultimately the default ON) on a transient/network failure.
             Timber.w(e, "Failed to fetch meal intelligence preference")
+        }
+    }
+
+    /**
+     * Fetch the alert thresholds the server's alert engine fires from. These feed the on-device
+     * alert floor (GLY-115), which must alarm at exactly the levels the server would -- so a
+     * response that fails validation is dropped, never clamped, leaving the last-known-good
+     * values (or the never-synced state, which keeps the floor disarmed).
+     */
+    private suspend fun fetchAlertThresholds() {
+        try {
+            val response = api.getAlertThresholds()
+            if (response.isSuccessful) {
+                response.body()?.let { thresholds ->
+                    val ul = thresholds.urgentLow.roundToInt()
+                    val lw = thresholds.lowWarning.roundToInt()
+                    val hw = thresholds.highWarning.roundToInt()
+                    val uh = thresholds.urgentHigh.roundToInt()
+                    val allInRange = listOf(ul, lw, hw, uh).all { it in 20..500 }
+                    if (!allInRange || !(ul < lw && lw < hw && hw < uh)) {
+                        Timber.w("Alert thresholds invalid: %d/%d/%d/%d -- ignoring", ul, lw, hw, uh)
+                        return
+                    }
+                    alertThresholdStore.updateAll(ul, lw, hw, uh)
+                    Timber.d("Alert thresholds synced: %d/%d/%d/%d", ul, lw, hw, uh)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to fetch alert thresholds")
         }
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -218,6 +218,18 @@ class AuthRepository @Inject constructor(
         fetchAlertThresholds()
     }
 
+    /**
+     * [refreshAlertThresholds], throttled by the store's staleness window. The background
+     * re-sync hook for a phone acting as a pocket monitor with the UI never opened: called on
+     * every SSE heartbeat/open (~30s cadence), it costs one GET per hour at most, so web edits
+     * to the alert thresholds reach the floor without waiting for a screen load.
+     */
+    suspend fun refreshAlertThresholdsIfStale() {
+        if (alertThresholdStore.isStale()) {
+            fetchAlertThresholds()
+        }
+    }
+
     /** Reconcile the cached glucose display unit from the backend (the account is the source of truth). */
     suspend fun refreshGlucoseUnit() {
         fetchGlucoseUnit()
@@ -396,15 +408,23 @@ class AuthRepository @Inject constructor(
             val response = api.getAlertThresholds()
             if (response.isSuccessful) {
                 response.body()?.let { thresholds ->
+                    // Validate ordering on the raw floats (the server-side truth): rounding two
+                    // server-legal values <1 mg/dL apart can collapse them to equal ints, and
+                    // a config the server accepts must not permanently disarm the floor.
+                    val orderedOnServer = thresholds.urgentLow < thresholds.lowWarning &&
+                        thresholds.lowWarning < thresholds.highWarning &&
+                        thresholds.highWarning < thresholds.urgentHigh
                     val ul = thresholds.urgentLow.roundToInt()
                     val lw = thresholds.lowWarning.roundToInt()
                     val hw = thresholds.highWarning.roundToInt()
                     val uh = thresholds.urgentHigh.roundToInt()
                     val allInRange = listOf(ul, lw, hw, uh).all { it in 20..500 }
-                    if (!allInRange || !(ul < lw && lw < hw && hw < uh)) {
+                    if (!allInRange || !orderedOnServer) {
                         Timber.w("Alert thresholds invalid: %d/%d/%d/%d -- ignoring", ul, lw, hw, uh)
                         return
                     }
+                    // Rounded ties (e.g. 69.8/70.2 -> 70/70) are safe: classify checks the
+                    // urgent band first, so a tie fires the more severe alert.
                     alertThresholdStore.updateAll(ul, lw, hw, uh)
                     Timber.d("Alert thresholds synced: %d/%d/%d/%d", ul, lw, hw, uh)
                 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/alerting/AlertTypes.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/alerting/AlertTypes.kt
@@ -1,0 +1,33 @@
+package com.glycemicgpt.mobile.domain.alerting
+
+/**
+ * The server's alert vocabulary (backend `models/alert.py`), shared by every consumer that keys
+ * behavior off an alert's type or severity: [com.glycemicgpt.mobile.service.AlertFloor] emits
+ * these, `AlertNotificationManager` routes notification channels by them (a low landing off the
+ * DND-bypassing alarm channel is a silent safety downgrade), and the stable notification slot is
+ * derived from them. One home so the sides cannot drift apart without a compile error.
+ *
+ * The watch wire protocol uses different strings (`urgent_low`/`low`/`high`/`urgent_high`) —
+ * map via `PumpPollingOrchestrator.SERVER_TO_WATCH_ALERT_TYPE`, never mix the vocabularies.
+ */
+object AlertTypes {
+    const val LOW_URGENT = "low_urgent"
+    const val LOW_WARNING = "low_warning"
+    const val HIGH_WARNING = "high_warning"
+    const val HIGH_URGENT = "high_urgent"
+    const val IOB_WARNING = "iob_warning"
+
+    /** Alert types that route to the low-glucose channel (IMPORTANCE_HIGH, bypassDnd, alarm). */
+    val LOW_ALERT_TYPES = listOf(LOW_URGENT, LOW_WARNING)
+
+    /** Alert types that route to the high-glucose channel. */
+    val HIGH_ALERT_TYPES = listOf(HIGH_WARNING, HIGH_URGENT)
+}
+
+/** Server severity wire values (backend `AlertSeverity`) used where the mobile side constructs
+ *  or branches on severities. */
+object AlertSeverities {
+    const val WARNING = "warning"
+    const val URGENT = "urgent"
+    const val EMERGENCY = "emergency"
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/alerting/AlertingStatus.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/alerting/AlertingStatus.kt
@@ -1,0 +1,86 @@
+package com.glycemicgpt.mobile.domain.alerting
+
+import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.domain.freshness.FreshnessThresholds
+import com.glycemicgpt.mobile.domain.freshness.isFreshForAlertFloor
+import com.glycemicgpt.mobile.service.AlertStreamState
+
+/**
+ * Whether server-pushed alerting is degraded: the alert SSE stream is not connected, or we can't
+ * reach the backend at all. Either way no new server alerts arrive, and the UI must say so.
+ *
+ * Pure so the visibility rule is unit-testable. Deliberately pessimistic on disagreement between
+ * the two signals — the SSE read timeout is minutes long, so [NetworkStatus] usually notices an
+ * outage first; conversely a stream stuck reconnecting is degraded even while HTTP still works.
+ */
+fun isAlertingDegraded(networkStatus: NetworkStatus, streamState: AlertStreamState): Boolean =
+    networkStatus != NetworkStatus.REACHABLE || streamState != AlertStreamState.CONNECTED
+
+/**
+ * Why the on-device alert floor cannot vouch for coverage, ordered by how actionable the cause
+ * is for the user. When several preconditions fail at once the most actionable one is reported:
+ * a denied notification permission is durable and user-fixable, unsynced thresholds usually
+ * resolve on reconnect, a disconnected pump is a hardware state the user may be able to fix,
+ * and a stale reading is the residual "nothing to act on" case.
+ */
+enum class FloorNotWatchingReason {
+    NOTIFICATIONS_DENIED,
+    THRESHOLDS_NOT_SYNCED,
+    PUMP_DISCONNECTED,
+    NO_FRESH_READING,
+}
+
+/**
+ * Who, if anyone, is watching for glucose alerts right now (GLY-115).
+ *
+ * - [ServerActive] — backend reachable + SSE connected: the server owns alerting, the on-device
+ *   floor stays silent, no degraded surface shows.
+ * - [FloorWatching] — server alerting is degraded, but the on-device alert floor can vouch: the
+ *   pump link is delivering readings, the latest reading is FRESH, the alert thresholds have
+ *   synced at least once, and this device can post alarm notifications.
+ * - [FloorNotWatching] — server alerting is degraded AND the floor cannot vouch. NOTHING is
+ *   watching, and the surface must say so — claiming coverage here is the lethal lie GLY-115's
+ *   AC2/AC7 pin against. Carries the most actionable failed precondition as [FloorNotWatching.reason]
+ *   so the surface can tell the user what would actually restore coverage.
+ */
+sealed interface AlertFloorStatus {
+    data object ServerActive : AlertFloorStatus
+    data object FloorWatching : AlertFloorStatus
+    data class FloorNotWatching(val reason: FloorNotWatchingReason) : AlertFloorStatus
+}
+
+/**
+ * The single truth for the alerting surface: combines the [isAlertingDegraded] arm-condition with
+ * the alert floor's own preconditions. Every input the floor's firing path gates on is mirrored
+ * here — plus [pumpConnected], the floor's implicit fifth gate: evaluation happens only on newly
+ * polled readings, so with the pump link down the floor cannot fire no matter how fresh the
+ * cached reading still looks. The claim ("watching" vs "NOT watching") can never say more than
+ * the floor can deliver. Pure so the selection is unit-testable.
+ *
+ * @param cgmAgeMs age of the latest CGM reading against its own sensor timestamp, or null when no
+ *   reading is cached.
+ * @param cgmThresholds the active CGM freshness policy (the compressed debug policy when the
+ *   fast-staleness fault toggle is on, mirroring the floor's firing gate).
+ * @param thresholdsSynced `AlertThresholdStore.isSynced()` — the floor never fires off unsynced
+ *   defaults, so it must not claim to.
+ * @param canNotify whether POST_NOTIFICATIONS is granted — a floor that cannot post its alarm is
+ *   not watching, whatever the data looks like.
+ * @param pumpConnected whether the BLE pump link is delivering readings — the floor evaluates
+ *   only on each newly polled reading.
+ */
+fun alertFloorStatus(
+    networkStatus: NetworkStatus,
+    streamState: AlertStreamState,
+    cgmAgeMs: Long?,
+    cgmThresholds: FreshnessThresholds,
+    thresholdsSynced: Boolean,
+    canNotify: Boolean,
+    pumpConnected: Boolean,
+): AlertFloorStatus = when {
+    !isAlertingDegraded(networkStatus, streamState) -> AlertFloorStatus.ServerActive
+    !canNotify -> AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NOTIFICATIONS_DENIED)
+    !thresholdsSynced -> AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.THRESHOLDS_NOT_SYNCED)
+    !pumpConnected -> AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.PUMP_DISCONNECTED)
+    cgmAgeMs != null && isFreshForAlertFloor(cgmAgeMs, cgmThresholds) -> AlertFloorStatus.FloorWatching
+    else -> AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING)
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt
@@ -49,6 +49,29 @@ data class FreshnessThresholds(
     }
 }
 
+/**
+ * Max future-dated skew (negative age) the alert floor tolerates before refusing to treat a
+ * reading as fresh. Pump and phone clocks routinely drift by seconds, so a hard `age >= 0`
+ * would silently disable the floor for any user whose pump clock runs slightly ahead — the
+ * exact silent-floor failure GLY-115 exists to prevent, just inverted. One minute comfortably
+ * covers real drift while staying far below the FRESH window a backwards phone-clock jump
+ * would need to resurrect a genuinely old reading.
+ */
+const val ALERT_FLOOR_MAX_FUTURE_SKEW_MS = 60_000L
+
+/**
+ * The alert floor's freshness gate (GLY-115): true only when a reading of the given [ageMs]
+ * (now − the CGM's own sensor timestamp, never poll wall-clock) may drive an on-device alarm
+ * or a "this phone is watching" claim. Strictly [Freshness.FRESH] — STALE/TOO_STALE both fail —
+ * with an explicit clock-skew guard: [FreshnessThresholds.classify] treats negative ages as
+ * FRESH (correct for display), but here a reading future-dated beyond
+ * [ALERT_FLOOR_MAX_FUTURE_SKEW_MS] fails, so a forward-skewed sensor timestamp or a backwards
+ * phone-clock jump cannot resurrect a stale reading into an alarm.
+ */
+fun isFreshForAlertFloor(ageMs: Long, thresholds: FreshnessThresholds): Boolean =
+    ageMs >= -ALERT_FLOOR_MAX_FUTURE_SKEW_MS &&
+        thresholds.classify(ageMs.coerceAtLeast(0L)) == Freshness.FRESH
+
 /** Human "how long ago" for an age in ms. Pure (no Android/Compose) so it is unit-testable and can
  *  be reused by the watch/complication surfaces. Negative ages read as "just now". */
 fun relativeAgeLabel(ageMs: Long): String {
@@ -73,8 +96,9 @@ object FreshnessPolicy {
      * CGM glucose. Sensors (Dexcom G6/G7, Libre) publish a new value roughly every 5 minutes, so a
      * single missed reading (~6 min) is [Freshness.STALE] — worth a badge but still plausibly
      * current. By ~15 min (three missed readings) the trend and value can no longer be trusted as a
-     * live glucose, so it is [Freshness.TOO_STALE] and de-emphasised. The freshness-gated alerting layer reuses
-     * TOO_STALE as the "don't fire a glucose alert off this" floor.
+     * live glucose, so it is [Freshness.TOO_STALE] and de-emphasised. The on-device alert floor
+     * (GLY-115) fires ONLY on [Freshness.FRESH] readings — STALE and TOO_STALE both suppress the
+     * alarm and flip the surface to an honest "not watching"; see [isFreshForAlertFloor].
      */
     val CGM = FreshnessThresholds(staleAfterMs = 6 * MINUTE_MS, tooStaleAfterMs = 15 * MINUTE_MS)
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt
@@ -51,11 +51,10 @@ data class FreshnessThresholds(
 
 /**
  * Max future-dated skew (negative age) the alert floor tolerates before refusing to treat a
- * reading as fresh. Pump and phone clocks routinely drift by seconds, so a hard `age >= 0`
- * would silently disable the floor for any user whose pump clock runs slightly ahead — the
- * exact silent-floor failure GLY-115 exists to prevent, just inverted. One minute comfortably
- * covers real drift while staying far below the FRESH window a backwards phone-clock jump
- * would need to resurrect a genuinely old reading.
+ * reading as fresh, and the rewind tolerance for the stateful wall-clock guard in `AlertFloor`.
+ * Pump and phone clocks routinely drift by seconds, so a hard `age >= 0` would silently disable
+ * the floor for any user whose pump clock runs slightly ahead — the exact silent-floor failure
+ * GLY-115 exists to prevent, just inverted.
  */
 const val ALERT_FLOOR_MAX_FUTURE_SKEW_MS = 60_000L
 
@@ -63,10 +62,19 @@ const val ALERT_FLOOR_MAX_FUTURE_SKEW_MS = 60_000L
  * The alert floor's freshness gate (GLY-115): true only when a reading of the given [ageMs]
  * (now − the CGM's own sensor timestamp, never poll wall-clock) may drive an on-device alarm
  * or a "this phone is watching" claim. Strictly [Freshness.FRESH] — STALE/TOO_STALE both fail —
- * with an explicit clock-skew guard: [FreshnessThresholds.classify] treats negative ages as
- * FRESH (correct for display), but here a reading future-dated beyond
- * [ALERT_FLOOR_MAX_FUTURE_SKEW_MS] fails, so a forward-skewed sensor timestamp or a backwards
- * phone-clock jump cannot resurrect a stale reading into an alarm.
+ * with an explicit skew guard: [FreshnessThresholds.classify] treats negative ages as FRESH
+ * (correct for display), but here a reading future-dated beyond
+ * [ALERT_FLOOR_MAX_FUTURE_SKEW_MS] fails, so a forward-skewed sensor timestamp cannot pass
+ * as fresh.
+ *
+ * WHAT THIS PREDICATE CANNOT SEE: a BACKWARD wall-clock jump shrinks [ageMs] itself, making a
+ * stale reading look fresh to any stateless check. That direction is guarded statefully by
+ * `AlertFloor`'s wall-clock high-water mark (`isWallClockRewound`, mirrored by
+ * `AlertFloorStatusProvider` for the surface claim), which suppresses evaluation while `now`
+ * runs behind previously observed time. Residual, accepted: a rewind larger than the tolerance
+ * occurring while the process is not running leaves no water mark and can under-age a stale
+ * reading — a rare over-alarm edge (fails toward alarming, never toward silence); rewinds
+ * within the tolerance can under-age by at most [ALERT_FLOOR_MAX_FUTURE_SKEW_MS].
  */
 fun isFreshForAlertFloor(ageMs: Long, thresholds: FreshnessThresholds): Boolean =
     ageMs >= -ALERT_FLOOR_MAX_FUTURE_SKEW_MS &&

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt
@@ -118,4 +118,10 @@ object FreshnessPolicy {
      * debug "Fast staleness" fault-injection toggle is on. Seeds the reusable debug harness.
      */
     val CGM_DEBUG_FAST = FreshnessThresholds(staleAfterMs = 20_000L, tooStaleAfterMs = 45_000L)
+
+    /** The active CGM policy for the given debug-fast-staleness toggle state. The one home for
+     *  the swap rule so every consumer (display, alert floor, degraded surface) ages CGM data
+     *  identically. */
+    fun cgm(debugFastStaleness: Boolean): FreshnessThresholds =
+        if (debugFastStaleness) CGM_DEBUG_FAST else CGM
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegraded.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegraded.kt
@@ -19,92 +19,45 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.glycemicgpt.mobile.data.network.NetworkStatus
-import com.glycemicgpt.mobile.domain.freshness.FreshnessThresholds
-import com.glycemicgpt.mobile.domain.freshness.isFreshForAlertFloor
-import com.glycemicgpt.mobile.service.AlertStreamState
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
+import com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason
 
 /** testTag for the honest "server alerts paused" banner. */
 const val TAG_ALERTING_DEGRADED_BANNER = "alerting_degraded_banner"
 
 /**
- * Whether server-pushed alerting is degraded: the alert SSE stream is not connected, or we can't
- * reach the backend at all. Either way no new server alerts arrive, and the UI must say so.
- *
- * Pure so the visibility rule is unit-testable. Deliberately pessimistic on disagreement between
- * the two signals — the SSE read timeout is minutes long, so [NetworkStatus] usually notices an
- * outage first; conversely a stream stuck reconnecting is degraded even while HTTP still works.
- */
-fun isAlertingDegraded(networkStatus: NetworkStatus, streamState: AlertStreamState): Boolean =
-    networkStatus != NetworkStatus.REACHABLE || streamState != AlertStreamState.CONNECTED
-
-/**
- * Who, if anyone, is watching for glucose alerts right now (GLY-115).
- *
- * - [SERVER_ACTIVE] — backend reachable + SSE connected: the server owns alerting, the on-device
- *   floor stays silent, no degraded surface shows.
- * - [FLOOR_WATCHING] — server alerting is degraded, but the on-device alert floor can vouch: the
- *   latest CGM reading is FRESH, the alert thresholds have synced at least once, and this device
- *   can post alarm notifications. The phone will alarm on a threshold crossing.
- * - [FLOOR_NOT_WATCHING] — server alerting is degraded AND the floor cannot vouch (reading
- *   STALE/TOO_STALE or absent, thresholds never synced, or notifications denied). NOTHING is
- *   watching, and the surface must say so — claiming coverage here is the lethal lie GLY-115's
- *   AC2/AC7 pin against.
- */
-enum class AlertFloorStatus { SERVER_ACTIVE, FLOOR_WATCHING, FLOOR_NOT_WATCHING }
-
-/**
- * The single truth for the alerting surface: combines the [isAlertingDegraded] arm-condition with
- * the alert floor's own preconditions. Every input the floor's firing path gates on is mirrored
- * here so the claim ("watching" vs "NOT watching") can never say more than the floor can deliver.
- * Pure so the two-state selection is unit-testable.
- *
- * @param cgmAgeMs age of the latest CGM reading against its own sensor timestamp, or null when no
- *   reading is cached.
- * @param cgmThresholds the active CGM freshness policy (the compressed debug policy when the
- *   fast-staleness fault toggle is on, mirroring the floor's firing gate).
- * @param thresholdsSynced [com.glycemicgpt.mobile.data.local.AlertThresholdStore.isSynced] — the
- *   floor never fires off unsynced defaults, so it must not claim to.
- * @param canNotify whether POST_NOTIFICATIONS is granted — a floor that cannot post its alarm is
- *   not watching, whatever the data looks like.
- */
-fun alertFloorStatus(
-    networkStatus: NetworkStatus,
-    streamState: AlertStreamState,
-    cgmAgeMs: Long?,
-    cgmThresholds: FreshnessThresholds,
-    thresholdsSynced: Boolean,
-    canNotify: Boolean,
-): AlertFloorStatus = when {
-    !isAlertingDegraded(networkStatus, streamState) -> AlertFloorStatus.SERVER_ACTIVE
-    cgmAgeMs != null &&
-        isFreshForAlertFloor(cgmAgeMs, cgmThresholds) &&
-        thresholdsSynced &&
-        canNotify -> AlertFloorStatus.FLOOR_WATCHING
-    else -> AlertFloorStatus.FLOOR_NOT_WATCHING
-}
-
-/**
  * Banner copy for a degraded [AlertFloorStatus]. Pure and exhaustive so the two-state honest-claim
- * selection is pinned by unit test (the lethal trap is showing "watching" while the reading is
- * stale). [AlertFloorStatus.SERVER_ACTIVE] has no banner and returns null.
+ * selection is pinned by unit test (the lethal trap is showing "watching" while the floor cannot
+ * fire). Every NOT-watching variant leads with the non-coverage claim; the tail names the failed
+ * precondition so the one user-fixable cause (notification permission) is not hidden behind a
+ * false "no recent glucose" diagnosis. [AlertFloorStatus.ServerActive] has no banner, returns null.
  */
 fun alertingDegradedBannerText(status: AlertFloorStatus): String? = when (status) {
-    AlertFloorStatus.SERVER_ACTIVE -> null
-    AlertFloorStatus.FLOOR_WATCHING ->
+    AlertFloorStatus.ServerActive -> null
+    AlertFloorStatus.FloorWatching ->
         "Server alerts paused — this phone is watching your latest sensor reading and will " +
             "alarm for lows and highs. Threshold-only, no prediction. Alerts below are from " +
             "before the disconnect."
-    AlertFloorStatus.FLOOR_NOT_WATCHING ->
-        "Monitoring degraded — no recent glucose reading, so this phone is NOT watching for " +
-            "lows or highs. No new alerts will arrive until the connection is restored."
+    is AlertFloorStatus.FloorNotWatching -> "Monitoring degraded — this phone is NOT watching " +
+        "for lows or highs: " + when (status.reason) {
+        FloorNotWatchingReason.NOTIFICATIONS_DENIED ->
+            "notifications are disabled for GlycemicGPT. Enable notifications to restore " +
+                "on-phone alarms."
+        FloorNotWatchingReason.THRESHOLDS_NOT_SYNCED ->
+            "alert thresholds haven't synced from your server yet."
+        FloorNotWatchingReason.PUMP_DISCONNECTED ->
+            "no pump connection, so no new readings are arriving."
+        FloorNotWatchingReason.NO_FRESH_READING ->
+            "no recent glucose reading."
+    } + " No new alerts will arrive until the connection is restored."
 }
 
 /**
  * The honest alerting-degraded banner: server-pushed alerts are paused, and the copy states
  * exactly what the on-device alert floor (GLY-115) can and cannot cover right now — "watching"
- * only when the floor's own preconditions hold, "NOT watching" otherwise. Cached past alerts
- * remain visible below it. Not rendered for [AlertFloorStatus.SERVER_ACTIVE].
+ * only when the floor's own preconditions hold, "NOT watching" (with the failed precondition)
+ * otherwise. Cached past alerts remain visible below it. Renders nothing for
+ * [AlertFloorStatus.ServerActive]; this early-return is the single owner of the visibility rule.
  */
 @Composable
 fun AlertingDegradedBanner(status: AlertFloorStatus, modifier: Modifier = Modifier) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegraded.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegraded.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.domain.freshness.FreshnessThresholds
+import com.glycemicgpt.mobile.domain.freshness.isFreshForAlertFloor
 import com.glycemicgpt.mobile.service.AlertStreamState
 
 /** testTag for the honest "server alerts paused" banner. */
@@ -37,12 +39,76 @@ fun isAlertingDegraded(networkStatus: NetworkStatus, streamState: AlertStreamSta
     networkStatus != NetworkStatus.REACHABLE || streamState != AlertStreamState.CONNECTED
 
 /**
- * The honest alerting-degraded banner: server-pushed alerts are paused and no new alerts will
- * arrive until reconnected. It must NOT claim any device/local alert floor — none exists yet, and
- * implying one would give a false sense of safety. Cached past alerts remain visible below it.
+ * Who, if anyone, is watching for glucose alerts right now (GLY-115).
+ *
+ * - [SERVER_ACTIVE] — backend reachable + SSE connected: the server owns alerting, the on-device
+ *   floor stays silent, no degraded surface shows.
+ * - [FLOOR_WATCHING] — server alerting is degraded, but the on-device alert floor can vouch: the
+ *   latest CGM reading is FRESH, the alert thresholds have synced at least once, and this device
+ *   can post alarm notifications. The phone will alarm on a threshold crossing.
+ * - [FLOOR_NOT_WATCHING] — server alerting is degraded AND the floor cannot vouch (reading
+ *   STALE/TOO_STALE or absent, thresholds never synced, or notifications denied). NOTHING is
+ *   watching, and the surface must say so — claiming coverage here is the lethal lie GLY-115's
+ *   AC2/AC7 pin against.
+ */
+enum class AlertFloorStatus { SERVER_ACTIVE, FLOOR_WATCHING, FLOOR_NOT_WATCHING }
+
+/**
+ * The single truth for the alerting surface: combines the [isAlertingDegraded] arm-condition with
+ * the alert floor's own preconditions. Every input the floor's firing path gates on is mirrored
+ * here so the claim ("watching" vs "NOT watching") can never say more than the floor can deliver.
+ * Pure so the two-state selection is unit-testable.
+ *
+ * @param cgmAgeMs age of the latest CGM reading against its own sensor timestamp, or null when no
+ *   reading is cached.
+ * @param cgmThresholds the active CGM freshness policy (the compressed debug policy when the
+ *   fast-staleness fault toggle is on, mirroring the floor's firing gate).
+ * @param thresholdsSynced [com.glycemicgpt.mobile.data.local.AlertThresholdStore.isSynced] — the
+ *   floor never fires off unsynced defaults, so it must not claim to.
+ * @param canNotify whether POST_NOTIFICATIONS is granted — a floor that cannot post its alarm is
+ *   not watching, whatever the data looks like.
+ */
+fun alertFloorStatus(
+    networkStatus: NetworkStatus,
+    streamState: AlertStreamState,
+    cgmAgeMs: Long?,
+    cgmThresholds: FreshnessThresholds,
+    thresholdsSynced: Boolean,
+    canNotify: Boolean,
+): AlertFloorStatus = when {
+    !isAlertingDegraded(networkStatus, streamState) -> AlertFloorStatus.SERVER_ACTIVE
+    cgmAgeMs != null &&
+        isFreshForAlertFloor(cgmAgeMs, cgmThresholds) &&
+        thresholdsSynced &&
+        canNotify -> AlertFloorStatus.FLOOR_WATCHING
+    else -> AlertFloorStatus.FLOOR_NOT_WATCHING
+}
+
+/**
+ * Banner copy for a degraded [AlertFloorStatus]. Pure and exhaustive so the two-state honest-claim
+ * selection is pinned by unit test (the lethal trap is showing "watching" while the reading is
+ * stale). [AlertFloorStatus.SERVER_ACTIVE] has no banner and returns null.
+ */
+fun alertingDegradedBannerText(status: AlertFloorStatus): String? = when (status) {
+    AlertFloorStatus.SERVER_ACTIVE -> null
+    AlertFloorStatus.FLOOR_WATCHING ->
+        "Server alerts paused — this phone is watching your latest sensor reading and will " +
+            "alarm for lows and highs. Threshold-only, no prediction. Alerts below are from " +
+            "before the disconnect."
+    AlertFloorStatus.FLOOR_NOT_WATCHING ->
+        "Monitoring degraded — no recent glucose reading, so this phone is NOT watching for " +
+            "lows or highs. No new alerts will arrive until the connection is restored."
+}
+
+/**
+ * The honest alerting-degraded banner: server-pushed alerts are paused, and the copy states
+ * exactly what the on-device alert floor (GLY-115) can and cannot cover right now — "watching"
+ * only when the floor's own preconditions hold, "NOT watching" otherwise. Cached past alerts
+ * remain visible below it. Not rendered for [AlertFloorStatus.SERVER_ACTIVE].
  */
 @Composable
-fun AlertingDegradedBanner(modifier: Modifier = Modifier) {
+fun AlertingDegradedBanner(status: AlertFloorStatus, modifier: Modifier = Modifier) {
+    val text = alertingDegradedBannerText(status) ?: return
     Surface(
         modifier = modifier
             .fillMaxWidth()
@@ -62,8 +128,7 @@ fun AlertingDegradedBanner(modifier: Modifier = Modifier) {
             )
             Spacer(Modifier.width(12.dp))
             Text(
-                text = "Server alerts paused — no new alerts will arrive until the connection " +
-                    "is restored. Alerts below are from before the disconnect.",
+                text = text,
                 style = MaterialTheme.typography.bodySmall,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onErrorContainer,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
@@ -57,7 +57,7 @@ fun AlertsScreen(
     val uiState by viewModel.uiState.collectAsState()
     val alerts by viewModel.alerts.collectAsState()
     val glucoseUnit by viewModel.glucoseUnit.collectAsState()
-    val alertingDegraded by viewModel.alertingDegraded.collectAsState()
+    val alertFloorStatus by viewModel.alertFloorStatus.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(uiState.error) {
@@ -71,7 +71,7 @@ fun AlertsScreen(
         uiState = uiState,
         alerts = alerts,
         glucoseUnit = glucoseUnit,
-        alertingDegraded = alertingDegraded,
+        alertFloorStatus = alertFloorStatus,
         snackbarHostState = snackbarHostState,
         onRefresh = viewModel::refreshAlerts,
         onAcknowledge = viewModel::acknowledgeAlert,
@@ -85,15 +85,16 @@ internal fun AlertsContent(
     uiState: AlertsUiState,
     alerts: List<AlertEntity>,
     glucoseUnit: GlucoseUnit,
-    alertingDegraded: Boolean,
+    alertFloorStatus: AlertFloorStatus,
     snackbarHostState: SnackbarHostState,
     onRefresh: () -> Unit,
     onAcknowledge: (serverId: String) -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            if (alertingDegraded) {
+            if (alertFloorStatus != AlertFloorStatus.SERVER_ACTIVE) {
                 AlertingDegradedBanner(
+                    status = alertFloorStatus,
                     modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
                 )
             }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
 import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import java.text.SimpleDateFormat
@@ -92,12 +93,11 @@ internal fun AlertsContent(
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            if (alertFloorStatus != AlertFloorStatus.SERVER_ACTIVE) {
-                AlertingDegradedBanner(
-                    status = alertFloorStatus,
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
-                )
-            }
+            // Visibility is owned by the banner itself (renders nothing for ServerActive).
+            AlertingDegradedBanner(
+                status = alertFloorStatus,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
+            )
             PullToRefreshBox(
                 isRefreshing = uiState.isLoading,
                 onRefresh = onRefresh,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -2,28 +2,19 @@ package com.glycemicgpt.mobile.presentation.alerts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
-import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import com.glycemicgpt.mobile.data.repository.AlertAckHttpException
 import com.glycemicgpt.mobile.data.repository.AlertRepository
-import com.glycemicgpt.mobile.data.repository.PumpDataRepository
-import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import com.glycemicgpt.mobile.service.AlertFloorStatusProvider
 import com.glycemicgpt.mobile.service.AlertNotificationManager
-import com.glycemicgpt.mobile.service.AlertStreamStateHolder
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -42,10 +33,7 @@ class AlertsViewModel @Inject constructor(
     private val alertRepository: AlertRepository,
     private val alertNotificationManager: AlertNotificationManager,
     private val appSettingsStore: AppSettingsStore,
-    private val alertThresholdStore: AlertThresholdStore,
-    pumpDataRepository: PumpDataRepository,
-    networkMonitor: NetworkMonitor,
-    alertStreamStateHolder: AlertStreamStateHolder,
+    alertFloorStatusProvider: AlertFloorStatusProvider,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AlertsUiState())
@@ -60,53 +48,17 @@ class AlertsViewModel @Inject constructor(
 
     /**
      * The alerting surface's single truth (GLY-115 AC7): server-active, or degraded with the
-     * on-device floor watching, or degraded with nothing watching. Drives the two-state
-     * [AlertingDegradedBanner]. Recomputes on every input change plus a ticker, because the
-     * decisive input — the latest CGM reading's age — grows with no new emissions and the
-     * "watching" claim must decay to "NOT watching" on its own when readings stop.
+     * on-device floor watching, or degraded with nothing watching (plus why). Drives the
+     * two-state [AlertingDegradedBanner]. The observation pipeline is shared with the
+     * backgrounded foreground-notification surface via [AlertFloorStatusProvider] so the two
+     * claims can never disagree; the seed is the provider's pessimistic synchronous snapshot.
      */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val alertFloorStatus: StateFlow<AlertFloorStatus> =
-        appSettingsStore.debugFastStalenessFlow().flatMapLatest { fast ->
-            val thresholds = if (fast) FreshnessPolicy.CGM_DEBUG_FAST else FreshnessPolicy.CGM
-            val tickMs = (thresholds.staleAfterMs / 4).coerceIn(MIN_STATUS_TICK_MS, MAX_STATUS_TICK_MS)
-            combine(
-                networkMonitor.status,
-                alertStreamStateHolder.state,
-                pumpDataRepository.observeLatestCgm(),
-                tickerFlow(tickMs),
-            ) { network, stream, cgm, _ ->
-                alertFloorStatus(
-                    networkStatus = network,
-                    streamState = stream,
-                    cgmAgeMs = cgm?.let { System.currentTimeMillis() - it.timestamp.toEpochMilli() },
-                    cgmThresholds = thresholds,
-                    thresholdsSynced = alertThresholdStore.isSynced(),
-                    canNotify = alertNotificationManager.canPostAlertNotifications(),
-                )
-            }
-        }.stateIn(
+    val alertFloorStatus: StateFlow<AlertFloorStatus> = alertFloorStatusProvider.observe()
+        .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),
-            // Seed pessimistically from the live degraded signals with no CGM age yet — a safety
-            // banner may briefly under-claim ("NOT watching") while the flows spin up, but must
-            // never default to a healthy or watching state it can't yet vouch for.
-            alertFloorStatus(
-                networkStatus = networkMonitor.status.value,
-                streamState = alertStreamStateHolder.state.value,
-                cgmAgeMs = null,
-                cgmThresholds = FreshnessPolicy.CGM,
-                thresholdsSynced = alertThresholdStore.isSynced(),
-                canNotify = alertNotificationManager.canPostAlertNotifications(),
-            ),
+            alertFloorStatusProvider.current(),
         )
-
-    private fun tickerFlow(periodMs: Long): Flow<Unit> = flow {
-        while (true) {
-            emit(Unit)
-            delay(periodMs)
-        }
-    }
 
     init {
         viewModelScope.launch { alertRepository.cleanupOldAlerts() }
@@ -165,11 +117,5 @@ class AlertsViewModel @Inject constructor(
             "Acknowledged locally — will sync when reconnected."
         e is AlertAckHttpException -> "Couldn't sync this acknowledgment to the server."
         else -> "Couldn't acknowledge the alert. Try again."
-    }
-
-    private companion object {
-        // Status ticker bounds, mirroring FreshnessUi's cadence discipline.
-        const val MIN_STATUS_TICK_MS = 2_000L
-        const val MAX_STATUS_TICK_MS = 30_000L
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -2,20 +2,28 @@ package com.glycemicgpt.mobile.presentation.alerts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import com.glycemicgpt.mobile.data.repository.AlertAckHttpException
 import com.glycemicgpt.mobile.data.repository.AlertRepository
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
 import com.glycemicgpt.mobile.service.AlertStreamStateHolder
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -34,6 +42,8 @@ class AlertsViewModel @Inject constructor(
     private val alertRepository: AlertRepository,
     private val alertNotificationManager: AlertNotificationManager,
     private val appSettingsStore: AppSettingsStore,
+    private val alertThresholdStore: AlertThresholdStore,
+    pumpDataRepository: PumpDataRepository,
     networkMonitor: NetworkMonitor,
     alertStreamStateHolder: AlertStreamStateHolder,
 ) : ViewModel() {
@@ -49,21 +59,54 @@ class AlertsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), appSettingsStore.glucoseUnit)
 
     /**
-     * Whether server-pushed alerting is degraded (backend unreachable or the alert stream is not
-     * connected). Drives the honest [AlertingDegradedBanner] — cached alerts still display, but no
-     * new alerts arrive until reconnected.
+     * The alerting surface's single truth (GLY-115 AC7): server-active, or degraded with the
+     * on-device floor watching, or degraded with nothing watching. Drives the two-state
+     * [AlertingDegradedBanner]. Recomputes on every input change plus a ticker, because the
+     * decisive input — the latest CGM reading's age — grows with no new emissions and the
+     * "watching" claim must decay to "NOT watching" on its own when readings stop.
      */
-    val alertingDegraded: StateFlow<Boolean> = combine(
-        networkMonitor.status,
-        alertStreamStateHolder.state,
-    ) { network, stream -> isAlertingDegraded(network, stream) }
-        .stateIn(
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val alertFloorStatus: StateFlow<AlertFloorStatus> =
+        appSettingsStore.debugFastStalenessFlow().flatMapLatest { fast ->
+            val thresholds = if (fast) FreshnessPolicy.CGM_DEBUG_FAST else FreshnessPolicy.CGM
+            val tickMs = (thresholds.staleAfterMs / 4).coerceIn(MIN_STATUS_TICK_MS, MAX_STATUS_TICK_MS)
+            combine(
+                networkMonitor.status,
+                alertStreamStateHolder.state,
+                pumpDataRepository.observeLatestCgm(),
+                tickerFlow(tickMs),
+            ) { network, stream, cgm, _ ->
+                alertFloorStatus(
+                    networkStatus = network,
+                    streamState = stream,
+                    cgmAgeMs = cgm?.let { System.currentTimeMillis() - it.timestamp.toEpochMilli() },
+                    cgmThresholds = thresholds,
+                    thresholdsSynced = alertThresholdStore.isSynced(),
+                    canNotify = alertNotificationManager.canPostAlertNotifications(),
+                )
+            }
+        }.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),
-            // Seed from the real current state, not an optimistic false — a safety banner must
-            // never default to "healthy" while the combine spins up.
-            isAlertingDegraded(networkMonitor.status.value, alertStreamStateHolder.state.value),
+            // Seed pessimistically from the live degraded signals with no CGM age yet — a safety
+            // banner may briefly under-claim ("NOT watching") while the flows spin up, but must
+            // never default to a healthy or watching state it can't yet vouch for.
+            alertFloorStatus(
+                networkStatus = networkMonitor.status.value,
+                streamState = alertStreamStateHolder.state.value,
+                cgmAgeMs = null,
+                cgmThresholds = FreshnessPolicy.CGM,
+                thresholdsSynced = alertThresholdStore.isSynced(),
+                canNotify = alertNotificationManager.canPostAlertNotifications(),
+            ),
         )
+
+    private fun tickerFlow(periodMs: Long): Flow<Unit> = flow {
+        while (true) {
+            emit(Unit)
+            delay(periodMs)
+        }
+    }
 
     init {
         viewModelScope.launch { alertRepository.cleanupOldAlerts() }
@@ -122,5 +165,11 @@ class AlertsViewModel @Inject constructor(
             "Acknowledged locally — will sync when reconnected."
         e is AlertAckHttpException -> "Couldn't sync this acknowledgment to the server."
         else -> "Couldn't acknowledge the alert. Try again."
+    }
+
+    private companion object {
+        // Status ticker bounds, mirroring FreshnessUi's cadence discipline.
+        const val MIN_STATUS_TICK_MS = 2_000L
+        const val MAX_STATUS_TICK_MS = 30_000L
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugScreen.kt
@@ -82,6 +82,26 @@ fun BleDebugScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
 
+        // Alert-floor harness (GLY-115): with the backend fault toggles on, a fresh LOW must
+        // fire the floor alarm; a stale LOW must be suppressed with the "NOT watching" surface.
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedButton(
+                onClick = viewModel::injectTestLowCgm,
+                modifier = Modifier.testTag("inject_low_cgm_button"),
+            ) {
+                Text("Inject LOW (fresh)")
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            OutlinedButton(
+                onClick = viewModel::injectTestStaleLowCgm,
+                modifier = Modifier.testTag("inject_stale_low_cgm_button"),
+            ) {
+                Text("Inject LOW (stale)")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         // Connection state indicator
         ConnectionStateBar(connectionState)
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugViewModel.kt
@@ -9,6 +9,7 @@ import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
+import com.glycemicgpt.mobile.service.PumpPollingOrchestrator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -20,6 +21,7 @@ class BleDebugViewModel @Inject constructor(
     private val debugStore: BleDebugStore,
     private val connectionManager: PumpConnectionManager,
     private val pumpDataRepository: PumpDataRepository,
+    private val pollingOrchestrator: PumpPollingOrchestrator,
 ) : ViewModel() {
 
     val entries: StateFlow<List<BleDebugStore.Entry>> = debugStore.entries
@@ -30,27 +32,59 @@ class BleDebugViewModel @Inject constructor(
     }
 
     /**
-     * Debug-only (reusable debug harness): write a fresh synthetic CGM reading to the Room
-     * cache so the emulator — which has no live pump feed — can render the glucose hero and, combined
+     * Debug-only (reusable debug harness): seed a fresh in-range synthetic CGM reading so the
+     * emulator — which has no live pump feed — can render the glucose hero and, combined
      * with the "Fast staleness" toggle, exercise the FRESH → STALE → TOO_STALE de-emphasis path.
      */
     fun injectTestCgm() {
-        // Defense-in-depth: this writes to the same Room cache that drives the real glucose hero, so
-        // hard-gate it to debug the same way the sibling fault-injection settings are, not just via
-        // the debug-only navigation to this screen.
+        injectCgm(TEST_CGM_MG_DL, ageSeconds = 0)
+    }
+
+    /**
+     * Debug-only: inject a LOW reading with a fresh sensor timestamp. With the backend fault
+     * toggles on, this must FIRE the alert floor (GLY-115 AC1/AC10).
+     */
+    fun injectTestLowCgm() {
+        injectCgm(TEST_LOW_CGM_MG_DL, ageSeconds = 0)
+    }
+
+    /**
+     * Debug-only: inject a LOW reading whose sensor timestamp is already aged past the
+     * compressed debug policy's TOO_STALE bound. The alert floor must SUPPRESS and the surface
+     * must say "NOT watching" (GLY-115 AC2 — the safety test).
+     */
+    fun injectTestStaleLowCgm() {
+        injectCgm(TEST_LOW_CGM_MG_DL, ageSeconds = TEST_STALE_AGE_SECONDS)
+    }
+
+    /**
+     * Writes the synthetic reading to the same Room cache the real poll path uses, then drives
+     * [PumpPollingOrchestrator.processCgmReading] — the exact production seam `pollCgm` calls —
+     * so the watch relay and the alert floor see the injected reading exactly as they would a
+     * polled one. The emulator has no BLE pump, so the poll loop never runs there.
+     */
+    private fun injectCgm(mgDl: Int, ageSeconds: Long) {
+        // Defense-in-depth: this writes to the same Room cache that drives the real glucose hero
+        // and can fire a real OS alarm, so hard-gate it to debug the same way the sibling
+        // fault-injection settings are, not just via the debug-only navigation to this screen.
         if (!BuildConfig.DEBUG) return
         viewModelScope.launch {
-            pumpDataRepository.saveCgm(
-                CgmReading(
-                    glucoseMgDl = TEST_CGM_MG_DL,
-                    trendArrow = CgmTrend.FLAT,
-                    timestamp = Instant.now(),
-                ),
+            val reading = CgmReading(
+                glucoseMgDl = mgDl,
+                trendArrow = CgmTrend.FLAT,
+                timestamp = Instant.now().minusSeconds(ageSeconds),
             )
+            pumpDataRepository.saveCgm(reading)
+            pollingOrchestrator.processCgmReading(reading)
         }
     }
 
     private companion object {
         const val TEST_CGM_MG_DL = 120
+        const val TEST_LOW_CGM_MG_DL = 54
+
+        /** Past CGM_DEBUG_FAST's tooStaleAfterMs (45s), so the injected reading lands TOO_STALE
+         *  under the compressed policy the E2E runs with. */
+        const val TEST_STALE_AGE_SECONDS = 60L
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.glycemicgpt.mobile.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
@@ -67,6 +68,7 @@ class HomeViewModel @Inject constructor(
     private val backendSyncManager: BackendSyncManager,
     private val glucoseRangeStore: GlucoseRangeStore,
     private val safetyLimitsStore: SafetyLimitsStore,
+    private val alertThresholdStore: AlertThresholdStore,
     private val analyticsSettingsStore: AnalyticsSettingsStore,
     private val pumpProfileStore: PumpProfileStore,
     private val appSettingsStore: AppSettingsStore,
@@ -201,6 +203,11 @@ class HomeViewModel @Inject constructor(
                 authRepository.refreshSafetyLimits()
                 pluginRegistry.refreshSafetyLimits()
             }
+        }
+        // Refresh alert thresholds if stale (1 hour) -- the alert floor must fire at the same
+        // levels the server does, so edits made on the web propagate on the safety-limits cadence.
+        if (alertThresholdStore.isStale()) {
+            viewModelScope.launch { authRepository.refreshAlertThresholds() }
         }
         // Refresh analytics config from backend if stale (15 min)
         if (analyticsSettingsStore.isStale()) {
@@ -389,6 +396,7 @@ class HomeViewModel @Inject constructor(
                     authRepository.refreshSafetyLimits()
                     pluginRegistry.refreshSafetyLimits()
                 }
+                launch { authRepository.refreshAlertThresholds() }
 
                 pumpDriver.getIoB().onSuccess { repository.saveIoB(it) }
                 delay(PumpPollingOrchestrator.REQUEST_STAGGER_MS)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -76,6 +76,7 @@ class HomeViewModel @Inject constructor(
     private val api: GlycemicGptApi,
     private val pluginRegistry: PluginRegistry,
     private val networkMonitor: NetworkMonitor,
+    private val pollingOrchestrator: PumpPollingOrchestrator,
 ) : ViewModel() {
 
     val connectionState: StateFlow<ConnectionState> = pumpDriver.observeConnectionState()
@@ -406,7 +407,13 @@ class HomeViewModel @Inject constructor(
                 delay(PumpPollingOrchestrator.REQUEST_STAGGER_MS)
                 pumpDriver.getReservoirLevel().onSuccess { repository.saveReservoir(it) }
                 delay(PumpPollingOrchestrator.REQUEST_STAGGER_MS)
-                pumpDriver.getCgmStatus().onSuccess { repository.saveCgm(it) }
+                // Same downstream path as the poll loop: a low fetched by manual refresh during
+                // an outage must reach the alert floor (and the watch relay) immediately, not
+                // wait for the next background poll.
+                pumpDriver.getCgmStatus().onSuccess {
+                    repository.saveCgm(it)
+                    pollingOrchestrator.processCgmReading(it)
+                }
                 // Re-read settings in case the user changed them in Settings
                 _dataRetentionDays.value = appSettingsStore.dataRetentionDays
                 _showPumpLabels.value = appSettingsStore.showPumpLabels

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import com.glycemicgpt.mobile.data.auth.AuthManager
 import com.glycemicgpt.mobile.data.auth.AuthState
 import com.glycemicgpt.mobile.data.local.AlertSoundCategory
 import com.glycemicgpt.mobile.data.local.AlertSoundStore
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
@@ -234,6 +235,7 @@ class SettingsViewModel @Inject constructor(
     private val appSettingsStore: AppSettingsStore,
     private val glucoseRangeStore: GlucoseRangeStore,
     private val safetyLimitsStore: SafetyLimitsStore,
+    private val alertThresholdStore: AlertThresholdStore,
     private val authRepository: AuthRepository,
     private val appUpdateChecker: AppUpdateChecker,
     private val authManager: AuthManager,
@@ -358,6 +360,9 @@ class SettingsViewModel @Inject constructor(
             }
             if (safetyLimitsStore.isStale()) {
                 viewModelScope.launch { authRepository.refreshSafetyLimits() }
+            }
+            if (alertThresholdStore.isStale()) {
+                viewModelScope.launch { authRepository.refreshAlertThresholds() }
             }
             // Reconcile the per-account glucose unit so the seed-confirmation notice
             // reflects the latest account provenance when Settings opens.

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
@@ -31,10 +31,18 @@ class AlertActionReceiver : BroadcastReceiver() {
         const val ACTION_ACKNOWLEDGE = "com.glycemicgpt.mobile.ACTION_ACKNOWLEDGE_ALERT"
         const val EXTRA_SERVER_ID = "extra_server_id"
         const val EXTRA_NOTIFICATION_ID = "extra_notification_id"
+
+        /** Extract the alert type from a floor serverId (`local-floor:<type>:<timestampMs>`),
+         *  or null if the id is malformed. */
+        internal fun floorAlertTypeFromServerId(serverId: String): String? = serverId
+            .removePrefix(AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX)
+            .substringBeforeLast(':', missingDelimiterValue = "")
+            .ifEmpty { null }
     }
 
     @Inject lateinit var alertRepository: AlertRepository
     @Inject lateinit var alertNotificationManager: AlertNotificationManager
+    @Inject lateinit var alertFloor: AlertFloor
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun onReceive(context: Context, intent: Intent) {
@@ -76,7 +84,10 @@ class AlertActionReceiver : BroadcastReceiver() {
 
         // A device-computed floor alert (GLY-115) has no server record: nothing to POST, and a
         // synthetic id must never reach the acknowledge endpoint. Silencing above is complete.
+        // Clearing the floor's cooldown mirrors the server's ack-gated dedup — an ack means
+        // "seen", so a NEW crossing minutes later must alarm again, not sit out the window.
         if (serverId.startsWith(AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX)) {
+            floorAlertTypeFromServerId(serverId)?.let { alertFloor.onFloorAlertAcknowledged(it) }
             Timber.d("Floor alert %s acknowledged locally; no server record to sync", serverId)
             return
         }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertActionReceiver.kt
@@ -74,6 +74,13 @@ class AlertActionReceiver : BroadcastReceiver() {
         alertNotificationManager.restoreAlarmVolume()
         alertNotificationManager.markAcknowledged(serverId)
 
+        // A device-computed floor alert (GLY-115) has no server record: nothing to POST, and a
+        // synthetic id must never reach the acknowledge endpoint. Silencing above is complete.
+        if (serverId.startsWith(AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX)) {
+            Timber.d("Floor alert %s acknowledged locally; no server record to sync", serverId)
+            return
+        }
+
         alertRepository.acknowledgeAlert(serverId)
             .onSuccess {
                 Timber.d("Alert acknowledged via notification: %s", serverId)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
@@ -5,11 +5,13 @@ import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.dao.AlertDao
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.domain.alerting.AlertSeverities
+import com.glycemicgpt.mobile.domain.alerting.AlertTypes
+import com.glycemicgpt.mobile.domain.alerting.isAlertingDegraded
 import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
 import com.glycemicgpt.mobile.domain.freshness.isFreshForAlertFloor
 import com.glycemicgpt.mobile.domain.model.CgmReading
-import com.glycemicgpt.mobile.presentation.alerts.isAlertingDegraded
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -48,7 +50,14 @@ import javax.inject.Singleton
  * every poll; and the episode guard seeds that cooldown from Room's server-alert history so the
  * floor does not re-alarm a low the server already announced just before the connection dropped.
  *
- * Fires in the server's AlertType vocabulary ([TYPE_LOW_URGENT] etc., matching the backend's
+ * Like the server's dedup, the suppression window is ACK-GATED: the backend only dedups against
+ * unacknowledged alerts (an acked alert means the user saw it — a recurrence is a new emergency
+ * and re-alerts immediately). The floor mirrors that: the episode guard ignores acknowledged
+ * server alerts, and [onFloorAlertAcknowledged] clears the type's cooldown, so an ack can never
+ * silence a NEW distinct low that develops minutes later — exactly the window where the floor is
+ * the only guard.
+ *
+ * Fires in the server's AlertType vocabulary ([AlertTypes], matching the backend's
  * `models/alert.py`), NOT the watch relay's strings — the notification slot and channel routing
  * key off the server vocabulary, and mixing them would break both.
  */
@@ -76,11 +85,23 @@ class AlertFloor @Inject constructor(
      * from ever alarming off those defaults.
      */
     fun classify(mgDl: Int): String? = when {
-        mgDl <= alertThresholdStore.urgentLowMgDl -> TYPE_LOW_URGENT
-        mgDl >= alertThresholdStore.urgentHighMgDl -> TYPE_HIGH_URGENT
-        mgDl <= alertThresholdStore.lowWarningMgDl -> TYPE_LOW_WARNING
-        mgDl >= alertThresholdStore.highWarningMgDl -> TYPE_HIGH_WARNING
+        mgDl <= alertThresholdStore.urgentLowMgDl -> AlertTypes.LOW_URGENT
+        mgDl >= alertThresholdStore.urgentHighMgDl -> AlertTypes.HIGH_URGENT
+        mgDl <= alertThresholdStore.lowWarningMgDl -> AlertTypes.LOW_WARNING
+        mgDl >= alertThresholdStore.highWarningMgDl -> AlertTypes.HIGH_WARNING
         else -> null
+    }
+
+    /**
+     * The user acknowledged a floor notification of [alertType] ("Got It"). Clears the type's
+     * cooldown so a NEW crossing minutes later alarms again — mirroring the server, whose dedup
+     * only counts unacknowledged alerts. An ack means "seen", never "snooze for the rest of the
+     * window": suppressing a fresh distinct low after an ack is exactly the silent-floor failure
+     * this class exists to prevent. A sustained, un-recovered low re-firing right after an ack is
+     * the accepted cost, and matches what the server does online.
+     */
+    suspend fun onFloorAlertAcknowledged(alertType: String) {
+        fireMutex.withLock { lastFiredAtMsByType.remove(alertType) }
     }
 
     /**
@@ -110,8 +131,7 @@ class AlertFloor @Inject constructor(
 
         // Gate 2: FRESH readings only, judged on the CGM's own sensor timestamp — a warmup or
         // signal-loss poll can succeed every 15s while returning the same old sensor value.
-        val freshnessThresholds =
-            if (appSettingsStore.debugFastStaleness) FreshnessPolicy.CGM_DEBUG_FAST else FreshnessPolicy.CGM
+        val freshnessThresholds = FreshnessPolicy.cgm(appSettingsStore.debugFastStaleness)
         val ageMs = nowMs - reading.timestamp.toEpochMilli()
         if (!isFreshForAlertFloor(ageMs, freshnessThresholds)) {
             Timber.w(
@@ -134,12 +154,13 @@ class AlertFloor @Inject constructor(
                 return
             }
 
-            // Episode guard: if the server announced this same alert type within the window
-            // (Room keeps the server alert history), the low predates the outage and was already
-            // alarmed — seed the cooldown from it instead of re-alarming across the
-            // REACHABLE→UNREACHABLE flip.
+            // Episode guard: if the server announced this same alert type within the window and
+            // the user has NOT acknowledged it (Room keeps the server alert history), the low
+            // predates the outage and is still actively alarmed — seed the cooldown from it
+            // instead of re-alarming across the REACHABLE→UNREACHABLE flip. Acked alerts are
+            // excluded in the query, mirroring the server's ack-gated dedup.
             val recentServerAlertMs = try {
-                alertDao.getLatestTimestampForType(alertType, nowMs - FLOOR_COOLDOWN_MS)
+                alertDao.getLatestUnacknowledgedTimestampForType(alertType, nowMs - FLOOR_COOLDOWN_MS)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -149,7 +170,9 @@ class AlertFloor @Inject constructor(
                 null
             }
             if (recentServerAlertMs != null) {
-                lastFiredAtMsByType[alertType] = recentServerAlertMs
+                // Clamp the seed: a server timestamp ahead of this phone's clock would otherwise
+                // stretch the suppression window past 30 minutes by the skew amount.
+                lastFiredAtMsByType[alertType] = minOf(recentServerAlertMs, nowMs)
                 Timber.d(
                     "Alert floor suppressed: server already alerted %s at %d (episode guard)",
                     alertType, recentServerAlertMs,
@@ -184,10 +207,10 @@ class AlertFloor @Inject constructor(
             serverId = AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX +
                 "$alertType:${reading.timestamp.toEpochMilli()}",
             alertType = alertType,
-            severity = if (alertType == TYPE_LOW_URGENT || alertType == TYPE_HIGH_URGENT) {
-                "urgent"
+            severity = if (alertType == AlertTypes.LOW_URGENT || alertType == AlertTypes.HIGH_URGENT) {
+                AlertSeverities.URGENT
             } else {
-                "warning"
+                AlertSeverities.WARNING
             },
             message = "${floorHeadline(alertType)} $glucoseLabel — computed on your phone from " +
                 "your last sensor reading. Threshold-only, no prediction. Not a replacement " +
@@ -198,22 +221,16 @@ class AlertFloor @Inject constructor(
     }
 
     companion object {
-        // Server AlertType vocabulary (backend models/alert.py). The watch relay uses different
-        // strings — map via PumpPollingOrchestrator.SERVER_TO_WATCH_ALERT_TYPE, never mix.
-        const val TYPE_LOW_URGENT = "low_urgent"
-        const val TYPE_LOW_WARNING = "low_warning"
-        const val TYPE_HIGH_WARNING = "high_warning"
-        const val TYPE_HIGH_URGENT = "high_urgent"
-
-        /** Re-alarm suppression window per alert type, mirroring the server's
-         *  `DEDUP_WINDOW_MINUTES = 30` so floor and server agree on what "the same episode" is. */
+        /** Re-alarm suppression window per unacknowledged alert type, mirroring the server's
+         *  `DEDUP_WINDOW_MINUTES = 30` so floor and server agree on what "the same episode" is.
+         *  Ack-gated like the server's — see the class KDoc and [onFloorAlertAcknowledged]. */
         const val FLOOR_COOLDOWN_MS = 30 * 60_000L
 
-        internal fun floorHeadline(alertType: String): String = when (alertType) {
-            TYPE_LOW_URGENT -> "Urgent low glucose"
-            TYPE_LOW_WARNING -> "Low glucose"
-            TYPE_HIGH_WARNING -> "High glucose"
-            TYPE_HIGH_URGENT -> "Urgent high glucose"
+        private fun floorHeadline(alertType: String): String = when (alertType) {
+            AlertTypes.LOW_URGENT -> "Urgent low glucose"
+            AlertTypes.LOW_WARNING -> "Low glucose"
+            AlertTypes.HIGH_WARNING -> "High glucose"
+            AlertTypes.HIGH_URGENT -> "Urgent high glucose"
             else -> "Glucose alert"
         }
     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
@@ -1,0 +1,220 @@
+package com.glycemicgpt.mobile.service
+
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.dao.AlertDao
+import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.domain.freshness.isFreshForAlertFloor
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.presentation.alerts.isAlertingDegraded
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The on-device, freshness-gated alert floor (GLY-115): when the backend cannot deliver alerts,
+ * the phone itself fires a low/high OS alarm off the just-polled CGM reading — but ONLY on a
+ * genuinely FRESH reading. Threshold-only by design: no trajectory projection, no prediction
+ * horizons, no IoB escalation — those stay server-side.
+ *
+ * THE SAFETY INVARIANT: never fire on a non-FRESH reading. Alerting on stale cached CGM would be
+ * a silent floor — the user hears an alarm engine that is actually reasoning about old data, or
+ * worse, hears nothing and believes they are covered. When this class cannot vouch for the data,
+ * it stays silent and the degraded surface says "NOT watching"
+ * ([com.glycemicgpt.mobile.presentation.alerts.alertFloorStatus] mirrors these gates exactly).
+ *
+ * Four preconditions, ALL required before firing:
+ *  1. Server alerting degraded — [isAlertingDegraded]; while REACHABLE+CONNECTED the server owns
+ *     alerting and the floor is silent (primary dedup layer).
+ *  2. Reading FRESH — [isFreshForAlertFloor] against the CGM's own sensor timestamp (never poll
+ *     wall-clock), with the clock-skew guard, using the debug-swapped policy when the
+ *     fast-staleness fault toggle is on.
+ *  3. Thresholds synced at least once — [AlertThresholdStore.isSynced]; never alarm off
+ *     hardcoded defaults.
+ *  4. POST_NOTIFICATIONS granted — checked here (and again inside
+ *     [AlertNotificationManager.showAlertNotification]).
+ *
+ * Dedup against the server (no shared UUIDs — the phone cannot predict server alert IDs):
+ * gate 1 kills the double-fire at the source; the shared
+ * [AlertNotificationManager.stableNotificationId] slot (`alertType|patientName`) makes a server
+ * re-delivery on reconnect REPLACE the floor notification instead of stacking; a per-type
+ * cooldown mirroring the server's 30-minute dedup window stops a sustained low from re-alarming
+ * every poll; and the episode guard seeds that cooldown from Room's server-alert history so the
+ * floor does not re-alarm a low the server already announced just before the connection dropped.
+ *
+ * Fires in the server's AlertType vocabulary ([TYPE_LOW_URGENT] etc., matching the backend's
+ * `models/alert.py`), NOT the watch relay's strings — the notification slot and channel routing
+ * key off the server vocabulary, and mixing them would break both.
+ */
+@Singleton
+class AlertFloor @Inject constructor(
+    private val alertThresholdStore: AlertThresholdStore,
+    private val alertNotificationManager: AlertNotificationManager,
+    private val alertStreamStateHolder: AlertStreamStateHolder,
+    private val networkMonitor: NetworkMonitor,
+    private val alertDao: AlertDao,
+    private val appSettingsStore: AppSettingsStore,
+) {
+
+    /** Wall-clock ms of the floor's last fire per alert type. Guarded by [fireMutex]. */
+    private val lastFiredAtMsByType = mutableMapOf<String, Long>()
+    private val fireMutex = Mutex()
+
+    /**
+     * Classify a CGM value against the synced server alert thresholds, in the server's AlertType
+     * vocabulary. Urgent bands win over warning bands, mirroring both the server's evaluation
+     * order and the previous display-range classifier. Returns null in range.
+     *
+     * Uses the store's defaults before the first sync — acceptable for the watch relay that also
+     * consumes this classification, but [onCgmReading]'s synced-once gate keeps the floor itself
+     * from ever alarming off those defaults.
+     */
+    fun classify(mgDl: Int): String? = when {
+        mgDl <= alertThresholdStore.urgentLowMgDl -> TYPE_LOW_URGENT
+        mgDl >= alertThresholdStore.urgentHighMgDl -> TYPE_HIGH_URGENT
+        mgDl <= alertThresholdStore.lowWarningMgDl -> TYPE_LOW_WARNING
+        mgDl >= alertThresholdStore.highWarningMgDl -> TYPE_HIGH_WARNING
+        else -> null
+    }
+
+    /**
+     * Evaluate the floor for a just-polled (or debug-injected) CGM reading. [alertType] is the
+     * [classify] result for the reading, in server vocabulary; null means in range and is a no-op.
+     * [nowMs] is injectable for tests only.
+     */
+    suspend fun onCgmReading(
+        reading: CgmReading,
+        alertType: String?,
+        nowMs: Long = System.currentTimeMillis(),
+    ) {
+        if (alertType == null) return
+
+        // Gate 1: arm only while the server cannot alert. While the stream is healthy the server
+        // is the sole alerting source and the floor must stay silent.
+        if (!isAlertingDegraded(networkMonitor.status.value, alertStreamStateHolder.state.value)) {
+            return
+        }
+
+        // Gate 3: never alarm off hardcoded defaults. A never-synced device shows "monitoring
+        // degraded" instead of guessing thresholds.
+        if (!alertThresholdStore.isSynced()) {
+            Timber.w("Alert floor suppressed: thresholds never synced (type=%s)", alertType)
+            return
+        }
+
+        // Gate 2: FRESH readings only, judged on the CGM's own sensor timestamp — a warmup or
+        // signal-loss poll can succeed every 15s while returning the same old sensor value.
+        val freshnessThresholds =
+            if (appSettingsStore.debugFastStaleness) FreshnessPolicy.CGM_DEBUG_FAST else FreshnessPolicy.CGM
+        val ageMs = nowMs - reading.timestamp.toEpochMilli()
+        if (!isFreshForAlertFloor(ageMs, freshnessThresholds)) {
+            Timber.w(
+                "Alert floor suppressed: reading not FRESH (type=%s, ageMs=%d) — NOT watching",
+                alertType, ageMs,
+            )
+            return
+        }
+
+        // Gate 4: a floor that cannot post is not a floor. Checked before the cooldown is
+        // stamped so a permission granted a minute later doesn't find the alarm already "spent".
+        if (!alertNotificationManager.canPostAlertNotifications()) {
+            Timber.w("Alert floor suppressed: POST_NOTIFICATIONS not granted (type=%s)", alertType)
+            return
+        }
+
+        fireMutex.withLock {
+            val lastFiredAtMs = lastFiredAtMsByType[alertType]
+            if (lastFiredAtMs != null && nowMs - lastFiredAtMs < FLOOR_COOLDOWN_MS) {
+                return
+            }
+
+            // Episode guard: if the server announced this same alert type within the window
+            // (Room keeps the server alert history), the low predates the outage and was already
+            // alarmed — seed the cooldown from it instead of re-alarming across the
+            // REACHABLE→UNREACHABLE flip.
+            val recentServerAlertMs = try {
+                alertDao.getLatestTimestampForType(alertType, nowMs - FLOOR_COOLDOWN_MS)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Fail toward alerting: a broken episode lookup may cost one duplicate alarm,
+                // never a missed one.
+                Timber.w(e, "Alert floor episode lookup failed; proceeding to fire")
+                null
+            }
+            if (recentServerAlertMs != null) {
+                lastFiredAtMsByType[alertType] = recentServerAlertMs
+                Timber.d(
+                    "Alert floor suppressed: server already alerted %s at %d (episode guard)",
+                    alertType, recentServerAlertMs,
+                )
+                return
+            }
+
+            val entity = buildFloorAlertEntity(alertType, reading)
+            alertNotificationManager.showAlertNotification(
+                entity,
+                alertNotificationManager.stableNotificationId(entity),
+            )
+            lastFiredAtMsByType[alertType] = nowMs
+            Timber.i(
+                "Alert floor fired: %s at %d mg/dL (reading ageMs=%d)",
+                alertType, reading.glucoseMgDl, ageMs,
+            )
+        }
+    }
+
+    /**
+     * A floor alert as an [AlertEntity] — the shape [AlertNotificationManager] renders. Never
+     * persisted to Room (the alerts table is server history); the `local-floor:` serverId prefix
+     * tells [AlertActionReceiver] there is no server record to acknowledge. The message carries
+     * the device-computed provenance and its limits; the title stays the glanceable
+     * severity + value line the manager already builds.
+     */
+    private fun buildFloorAlertEntity(alertType: String, reading: CgmReading): AlertEntity {
+        val glucoseLabel =
+            GlucoseFormat.formatWithLabel(reading.glucoseMgDl, appSettingsStore.glucoseUnit)
+        return AlertEntity(
+            serverId = AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX +
+                "$alertType:${reading.timestamp.toEpochMilli()}",
+            alertType = alertType,
+            severity = if (alertType == TYPE_LOW_URGENT || alertType == TYPE_HIGH_URGENT) {
+                "urgent"
+            } else {
+                "warning"
+            },
+            message = "${floorHeadline(alertType)} $glucoseLabel — computed on your phone from " +
+                "your last sensor reading. Threshold-only, no prediction. Not a replacement " +
+                "for your CGM app.",
+            currentValue = reading.glucoseMgDl.toDouble(),
+            timestampMs = reading.timestamp.toEpochMilli(),
+        )
+    }
+
+    companion object {
+        // Server AlertType vocabulary (backend models/alert.py). The watch relay uses different
+        // strings — map via PumpPollingOrchestrator.SERVER_TO_WATCH_ALERT_TYPE, never mix.
+        const val TYPE_LOW_URGENT = "low_urgent"
+        const val TYPE_LOW_WARNING = "low_warning"
+        const val TYPE_HIGH_WARNING = "high_warning"
+        const val TYPE_HIGH_URGENT = "high_urgent"
+
+        /** Re-alarm suppression window per alert type, mirroring the server's
+         *  `DEDUP_WINDOW_MINUTES = 30` so floor and server agree on what "the same episode" is. */
+        const val FLOOR_COOLDOWN_MS = 30 * 60_000L
+
+        internal fun floorHeadline(alertType: String): String = when (alertType) {
+            TYPE_LOW_URGENT -> "Urgent low glucose"
+            TYPE_LOW_WARNING -> "Low glucose"
+            TYPE_HIGH_WARNING -> "High glucose"
+            TYPE_HIGH_URGENT -> "Urgent high glucose"
+            else -> "Glucose alert"
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
@@ -9,6 +9,7 @@ import com.glycemicgpt.mobile.domain.alerting.AlertSeverities
 import com.glycemicgpt.mobile.domain.alerting.AlertTypes
 import com.glycemicgpt.mobile.domain.alerting.isAlertingDegraded
 import com.glycemicgpt.mobile.domain.format.GlucoseFormat
+import com.glycemicgpt.mobile.domain.freshness.ALERT_FLOOR_MAX_FUTURE_SKEW_MS
 import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
 import com.glycemicgpt.mobile.domain.freshness.isFreshForAlertFloor
 import com.glycemicgpt.mobile.domain.model.CgmReading
@@ -51,11 +52,25 @@ import javax.inject.Singleton
  * floor does not re-alarm a low the server already announced just before the connection dropped.
  *
  * Like the server's dedup, the suppression window is ACK-GATED: the backend only dedups against
- * unacknowledged alerts (an acked alert means the user saw it — a recurrence is a new emergency
- * and re-alerts immediately). The floor mirrors that: the episode guard ignores acknowledged
- * server alerts, and [onFloorAlertAcknowledged] clears the type's cooldown, so an ack can never
- * silence a NEW distinct low that develops minutes later — exactly the window where the floor is
- * the only guard.
+ * unacknowledged alerts, so the episode guard ignores acknowledged server alerts. A "Got It" on
+ * a floor alert ([onFloorAlertAcknowledged]) means "seen", with bounded-snooze episode
+ * semantics: the ongoing episode is silenced and the cooldown restarts from the ack; any
+ * evaluated reading that no longer classifies as the acked type fully re-arms it (a re-cross is
+ * a distinct episode and alarms immediately); and a sustained, never-recovering low re-alarms
+ * [FLOOR_COOLDOWN_MS] after the ack — the floor never goes permanently silent on an ongoing
+ * emergency. (Deliberate divergence from the server, which re-alerts an acked sustained low on
+ * its own evaluation cadence: re-alarming every 15s poll would be alarm-spam that trains users
+ * to disable notifications.)
+ *
+ * Wall-clock rewind guard: [isFreshForAlertFloor] can only defend forward skew statelessly. A
+ * BACKWARD wall-clock jump (NTP correction, manual change) shrinks a stale reading's apparent
+ * age, so this class keeps a high-water mark of every wall-clock time it has observed
+ * ([noteWallClock], also fed by [AlertFloorStatusProvider]'s tick) and refuses to evaluate — and
+ * the surface refuses to claim watching — while `now` runs more than the skew tolerance behind
+ * it ([isWallClockRewound]). Fails closed with the honest "NOT watching" surface until the wall
+ * clock catches back up. Residual: a rewind while the process is not running leaves no water
+ * mark, so a stale reading can under-age by the rewind amount — a rare over-alarm edge that
+ * fails toward alarming, never toward silence.
  *
  * Fires in the server's AlertType vocabulary ([AlertTypes], matching the backend's
  * `models/alert.py`), NOT the watch relay's strings — the notification slot and channel routing
@@ -71,9 +86,36 @@ class AlertFloor @Inject constructor(
     private val appSettingsStore: AppSettingsStore,
 ) {
 
-    /** Wall-clock ms of the floor's last fire per alert type. Guarded by [fireMutex]. */
+    /** Wall-clock ms of the floor's last fire (or last ack) per alert type. Guarded by [fireMutex]. */
     private val lastFiredAtMsByType = mutableMapOf<String, Long>()
+
+    /** Types acknowledged mid-episode: suppressed until recovery or the cooldown elapses, then
+     *  fully re-armed. Guarded by [fireMutex]. */
+    private val ackedTypes = mutableSetOf<String>()
     private val fireMutex = Mutex()
+
+    /** Highest wall-clock ms ever observed by the floor (evaluations + status ticks). Monotonic
+     *  max; a plain @Volatile is enough — a lost racing update can only lower the mark slightly,
+     *  never raise it wrongly. */
+    @Volatile
+    private var wallClockHighWaterMs = 0L
+
+    /** Record an observed wall-clock time. Called on every evaluation and every status tick so
+     *  the rewind guard has a recent reference even when no CGM is flowing. */
+    fun noteWallClock(nowMs: Long) {
+        if (nowMs > wallClockHighWaterMs) {
+            wallClockHighWaterMs = nowMs
+        }
+    }
+
+    /**
+     * True when [nowMs] runs more than the skew tolerance behind the highest wall-clock time
+     * ever observed — i.e. the wall clock jumped backward. While true, sensor ages computed
+     * from the wall clock are understated and must not be trusted: the floor suppresses and
+     * the surface says NOT watching until the clock catches back up.
+     */
+    fun isWallClockRewound(nowMs: Long): Boolean =
+        nowMs + ALERT_FLOOR_MAX_FUTURE_SKEW_MS < wallClockHighWaterMs
 
     /**
      * Classify a CGM value against the synced server alert thresholds, in the server's AlertType
@@ -93,15 +135,24 @@ class AlertFloor @Inject constructor(
     }
 
     /**
-     * The user acknowledged a floor notification of [alertType] ("Got It"). Clears the type's
-     * cooldown so a NEW crossing minutes later alarms again — mirroring the server, whose dedup
-     * only counts unacknowledged alerts. An ack means "seen", never "snooze for the rest of the
-     * window": suppressing a fresh distinct low after an ack is exactly the silent-floor failure
-     * this class exists to prevent. A sustained, un-recovered low re-firing right after an ack is
-     * the accepted cost, and matches what the server does online.
+     * The user acknowledged a floor notification of [alertType] ("Got It"). Bounded-snooze
+     * episode semantics — an ack means "seen", never "snooze forever" and never "re-alarm the
+     * same episode every poll":
+     *  - the ongoing episode is silenced and the cooldown restarts from the ack;
+     *  - any evaluated reading that no longer classifies as this type re-arms it fully (see
+     *    [onCgmReading]'s recovery handling) — a re-cross is a distinct episode and alarms
+     *    immediately;
+     *  - a sustained low that never recovers re-alarms [FLOOR_COOLDOWN_MS] after the ack, so
+     *    the floor cannot go permanently silent on an ongoing emergency.
      */
-    suspend fun onFloorAlertAcknowledged(alertType: String) {
-        fireMutex.withLock { lastFiredAtMsByType.remove(alertType) }
+    suspend fun onFloorAlertAcknowledged(
+        alertType: String,
+        nowMs: Long = System.currentTimeMillis(),
+    ) {
+        fireMutex.withLock {
+            lastFiredAtMsByType[alertType] = nowMs
+            ackedTypes.add(alertType)
+        }
     }
 
     /**
@@ -114,6 +165,31 @@ class AlertFloor @Inject constructor(
         alertType: String?,
         nowMs: Long = System.currentTimeMillis(),
     ) {
+        // Wall-clock rewind guard, BEFORE anything trusts a wall-clock age: while the clock runs
+        // behind the high-water mark, sensor ages are understated and nothing may fire. Recovery
+        // handling is also skipped — an understated age could fake a recovery reading too.
+        if (isWallClockRewound(nowMs)) {
+            Timber.w(
+                "Alert floor suppressed: wall clock rewound (now=%d, highWater=%d) — NOT watching",
+                nowMs, wallClockHighWaterMs,
+            )
+            return
+        }
+        noteWallClock(nowMs)
+
+        // Episode recovery: every evaluated reading that no longer classifies as an acked type
+        // proves that episode ended — fully re-arm the type so the next crossing alarms
+        // immediately as a distinct episode. Only acked types re-arm this way: unacknowledged
+        // cooldowns deliberately survive boundary flapping (the notification is still up, and
+        // re-alarming every crossing of a hovering glucose is the spam the window exists to stop).
+        fireMutex.withLock {
+            val recovered = ackedTypes.filter { it != alertType }
+            recovered.forEach {
+                ackedTypes.remove(it)
+                lastFiredAtMsByType.remove(it)
+            }
+        }
+
         if (alertType == null) return
 
         // Gate 1: arm only while the server cannot alert. While the stream is healthy the server
@@ -186,6 +262,9 @@ class AlertFloor @Inject constructor(
                 alertNotificationManager.stableNotificationId(entity),
             )
             lastFiredAtMsByType[alertType] = nowMs
+            // A fresh fire is a new, unacknowledged notification: the acked flag from a
+            // previous episode must not carry over.
+            ackedTypes.remove(alertType)
             Timber.i(
                 "Alert floor fired: %s at %d mg/dL (reading ageMs=%d)",
                 alertType, reading.glucoseMgDl, ageMs,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloorStatusProvider.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloorStatusProvider.kt
@@ -1,0 +1,100 @@
+package com.glycemicgpt.mobile.service
+
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
+import com.glycemicgpt.mobile.domain.alerting.alertFloorStatus
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The one observation pipeline behind the honest alerting surface (GLY-115 AC7). The pure
+ * decision lives in [alertFloorStatus]; this class owns WHICH inputs feed it and on WHAT
+ * cadence — exactly the parts the in-app banner ([com.glycemicgpt.mobile.presentation.alerts.AlertsViewModel])
+ * and the backgrounded foreground-notification text ([PumpConnectionService]) must never
+ * disagree on, which is why there is a single shared provider instead of two pipelines.
+ *
+ * Recomputes on every input change plus a ticker, because the decisive input — the latest CGM
+ * reading's age — grows with no new emissions: the "watching" claim must decay to "NOT watching"
+ * on its own when readings stop. Tick cadence derives from the active freshness policy the same
+ * way FreshnessUi's does, so the compressed debug policy flips within seconds during E2E.
+ */
+@Singleton
+class AlertFloorStatusProvider @Inject constructor(
+    private val networkMonitor: NetworkMonitor,
+    private val alertStreamStateHolder: AlertStreamStateHolder,
+    private val pumpDataRepository: PumpDataRepository,
+    private val pumpConnectionManager: PumpConnectionManager,
+    private val alertThresholdStore: AlertThresholdStore,
+    private val appSettingsStore: AppSettingsStore,
+    private val alertNotificationManager: AlertNotificationManager,
+) {
+
+    /** Live status stream. Cold; each collector gets its own ticker, deduplicated via
+     *  [distinctUntilChanged]. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observe(): Flow<AlertFloorStatus> =
+        appSettingsStore.debugFastStalenessFlow().flatMapLatest { fast ->
+            val thresholds = FreshnessPolicy.cgm(fast)
+            val tickMs = (thresholds.staleAfterMs / 4).coerceIn(MIN_TICK_MS, MAX_TICK_MS)
+            combine(
+                networkMonitor.status,
+                alertStreamStateHolder.state,
+                pumpDataRepository.observeLatestCgm(),
+                pumpConnectionManager.connectionState,
+                tickerFlow(tickMs),
+            ) { network, stream, cgm, pumpState, _ ->
+                alertFloorStatus(
+                    networkStatus = network,
+                    streamState = stream,
+                    cgmAgeMs = cgm?.let { System.currentTimeMillis() - it.timestamp.toEpochMilli() },
+                    cgmThresholds = thresholds,
+                    thresholdsSynced = alertThresholdStore.isSynced(),
+                    canNotify = alertNotificationManager.canPostAlertNotifications(),
+                    pumpConnected = pumpState == ConnectionState.CONNECTED,
+                )
+            }
+        }.distinctUntilChanged()
+
+    /**
+     * Synchronous snapshot from the current values, for seeding a StateFlow before [observe]'s
+     * first emission. Uses no CGM age (the Room read is async) — deliberately pessimistic: a
+     * safety surface may briefly under-claim ("NOT watching") while the flows spin up, but must
+     * never default to a healthy or watching state it can't yet vouch for.
+     */
+    fun current(): AlertFloorStatus = alertFloorStatus(
+        networkStatus = networkMonitor.status.value,
+        streamState = alertStreamStateHolder.state.value,
+        cgmAgeMs = null,
+        cgmThresholds = FreshnessPolicy.cgm(appSettingsStore.debugFastStaleness),
+        thresholdsSynced = alertThresholdStore.isSynced(),
+        canNotify = alertNotificationManager.canPostAlertNotifications(),
+        pumpConnected = pumpConnectionManager.connectionState.value == ConnectionState.CONNECTED,
+    )
+
+    private fun tickerFlow(periodMs: Long): Flow<Unit> = flow {
+        while (true) {
+            emit(Unit)
+            delay(periodMs)
+        }
+    }
+
+    private companion object {
+        // Ticker bounds, mirroring FreshnessUi's cadence discipline: fast enough that the
+        // compressed debug policy decays near its marks, never hot-looping.
+        const val MIN_TICK_MS = 2_000L
+        const val MAX_TICK_MS = 30_000L
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloorStatusProvider.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloorStatusProvider.kt
@@ -42,6 +42,7 @@ class AlertFloorStatusProvider @Inject constructor(
     private val alertThresholdStore: AlertThresholdStore,
     private val appSettingsStore: AppSettingsStore,
     private val alertNotificationManager: AlertNotificationManager,
+    private val alertFloor: AlertFloor,
 ) {
 
     /** Live status stream. Cold; each collector gets its own ticker, deduplicated via
@@ -58,10 +59,22 @@ class AlertFloorStatusProvider @Inject constructor(
                 pumpConnectionManager.connectionState,
                 tickerFlow(tickMs),
             ) { network, stream, cgm, pumpState, _ ->
+                // Feed the floor's wall-clock rewind guard on every tick (so it has a recent
+                // reference even with no CGM flowing) and mirror it: while the clock runs
+                // behind the high-water mark, sensor ages are understated, so the reading is
+                // treated as absent — the claim degrades to NOT watching, exactly like the
+                // floor's own suppression.
+                val nowMs = System.currentTimeMillis()
+                alertFloor.noteWallClock(nowMs)
+                val cgmAgeMs = if (alertFloor.isWallClockRewound(nowMs)) {
+                    null
+                } else {
+                    cgm?.let { nowMs - it.timestamp.toEpochMilli() }
+                }
                 alertFloorStatus(
                     networkStatus = network,
                     streamState = stream,
-                    cgmAgeMs = cgm?.let { System.currentTimeMillis() - it.timestamp.toEpochMilli() },
+                    cgmAgeMs = cgmAgeMs,
                     cgmThresholds = thresholds,
                     thresholdsSynced = alertThresholdStore.isSynced(),
                     canNotify = alertNotificationManager.canPostAlertNotifications(),

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloorStatusProvider.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloorStatusProvider.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.retryWhen
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -66,6 +68,14 @@ class AlertFloorStatusProvider @Inject constructor(
                     pumpConnected = pumpState == ConnectionState.CONNECTED,
                 )
             }
+        }.retryWhen { cause, attempt ->
+            // A safety-status stream must never die silently: a frozen StateFlow downstream
+            // would keep claiming whatever was last emitted. Fail closed (pessimistic
+            // snapshot) and resubscribe — the claim degrades, it never lies or stops.
+            Timber.e(cause, "Alert floor status pipeline failed (attempt %d); retrying", attempt)
+            emit(current())
+            delay(RETRY_DELAY_MS)
+            true
         }.distinctUntilChanged()
 
     /**
@@ -96,5 +106,9 @@ class AlertFloorStatusProvider @Inject constructor(
         // compressed debug policy decays near its marks, never hot-looping.
         const val MIN_TICK_MS = 2_000L
         const val MAX_TICK_MS = 30_000L
+
+        /** Pause before resubscribing a failed pipeline — long enough not to hot-loop on a
+         *  persistent fault, short next to the freshness bounds the status is judged by. */
+        const val RETRY_DELAY_MS = 5_000L
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
@@ -1,19 +1,16 @@
 package com.glycemicgpt.mobile.service
 
-import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.RingtoneManager
 import android.net.Uri
-import android.os.Build
 import androidx.core.app.NotificationCompat
-import androidx.core.content.ContextCompat
+import androidx.core.app.NotificationManagerCompat
 import com.glycemicgpt.mobile.data.local.AlertSoundCategory
 import com.glycemicgpt.mobile.data.local.AlertSoundStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
@@ -254,20 +251,18 @@ class AlertNotificationManager @Inject constructor(
     }
 
     /**
-     * Whether this device can post alert notifications at all (POST_NOTIFICATIONS granted, or a
-     * pre-Tiramisu OS where the permission does not exist). The alert floor's honest degraded
+     * Whether this device can post alert notifications at all. The alert floor's honest degraded
      * surface uses this: a floor that cannot post its alarm must not claim to be watching.
+     * [NotificationManagerCompat.areNotificationsEnabled] covers both regimes — the runtime
+     * POST_NOTIFICATIONS permission on Tiramisu+ AND the app-level notifications toggle in
+     * system settings on older OSes (minSdk 30), which a raw permission check would miss.
      */
     fun canPostAlertNotifications(): Boolean =
-        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.POST_NOTIFICATIONS,
-            ) == PackageManager.PERMISSION_GRANTED
+        NotificationManagerCompat.from(context).areNotificationsEnabled()
 
     fun showAlertNotification(alert: AlertEntity, notificationId: Int) {
         if (!canPostAlertNotifications()) {
-            Timber.w("POST_NOTIFICATIONS permission not granted, skipping alert notification")
+            Timber.w("Notifications disabled for the app, skipping alert notification")
             return
         }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
@@ -52,6 +52,13 @@ class AlertNotificationManager @Inject constructor(
         fun lowChannelId(version: Int) = "low_alerts_v$version"
         fun highChannelId(version: Int) = "high_alerts_v$version"
         fun aiChannelId(version: Int) = "ai_notifications_v$version"
+
+        /**
+         * `serverId` prefix marking a device-computed alert-floor notification (GLY-115). Floor
+         * alerts have no server record: [AlertActionReceiver] must not POST their acknowledgement
+         * to the backend, and they are never persisted to the alerts table.
+         */
+        const val LOCAL_FLOOR_ID_PREFIX = "local-floor:"
     }
 
     private val manager = context.getSystemService(NotificationManager::class.java)
@@ -243,16 +250,22 @@ class AlertNotificationManager @Inject constructor(
         notifiedServerIds.remove(serverId)
     }
 
+    /**
+     * Whether this device can post alert notifications at all (POST_NOTIFICATIONS granted, or a
+     * pre-Tiramisu OS where the permission does not exist). The alert floor's honest degraded
+     * surface uses this: a floor that cannot post its alarm must not claim to be watching.
+     */
+    fun canPostAlertNotifications(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+
     fun showAlertNotification(alert: AlertEntity, notificationId: Int) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.POST_NOTIFICATIONS,
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
-                Timber.w("POST_NOTIFICATIONS permission not granted, skipping alert notification")
-                return
-            }
+        if (!canPostAlertNotifications()) {
+            Timber.w("POST_NOTIFICATIONS permission not granted, skipping alert notification")
+            return
         }
 
         val isLow = alert.alertType in LOW_ALERT_TYPES

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
@@ -18,6 +18,7 @@ import com.glycemicgpt.mobile.data.local.AlertSoundCategory
 import com.glycemicgpt.mobile.data.local.AlertSoundStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.domain.alerting.AlertTypes
 import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.presentation.MainActivity
@@ -36,8 +37,10 @@ class AlertNotificationManager @Inject constructor(
         private const val GROUP_KEY = "com.glycemicgpt.ALERTS"
         private const val MAX_NOTIFIED_IDS = 200
 
-        private val LOW_ALERT_TYPES = listOf("low_urgent", "low_warning")
-        private val HIGH_ALERT_TYPES = listOf("high_warning", "high_urgent")
+        // Channel routing keys off the shared server vocabulary — a drifted string here would
+        // silently route a life-threatening low off the DND-bypassing alarm channel.
+        private val LOW_ALERT_TYPES = AlertTypes.LOW_ALERT_TYPES
+        private val HIGH_ALERT_TYPES = AlertTypes.HIGH_ALERT_TYPES
 
         // Legacy channel IDs to clean up on migration
         private val LEGACY_CHANNEL_IDS = listOf(

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
@@ -14,6 +14,7 @@ import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.remote.SimulateUnreachableInterceptor
 import com.glycemicgpt.mobile.data.remote.dto.AlertResponse
 import com.glycemicgpt.mobile.data.repository.AlertRepository
+import com.glycemicgpt.mobile.data.repository.AuthRepository
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -57,6 +58,7 @@ class AlertStreamService : Service() {
     }
 
     @Inject lateinit var authTokenStore: AuthTokenStore
+    @Inject lateinit var authRepository: AuthRepository
     @Inject lateinit var alertRepository: AlertRepository
     @Inject lateinit var alertNotificationManager: AlertNotificationManager
     @Inject lateinit var alertStreamStateHolder: AlertStreamStateHolder
@@ -251,7 +253,15 @@ class AlertStreamService : Service() {
                     resetBackoffIfStable()
                     when (type) {
                         "alert" -> handleAlertEvent(data, adapter)
-                        "heartbeat" -> Timber.v("Alert SSE heartbeat")
+                        "heartbeat" -> {
+                            Timber.v("Alert SSE heartbeat")
+                            // Background re-sync for the alert floor's thresholds (GLY-115): a
+                            // phone acting as a pocket monitor may never open the UI, and this
+                            // heartbeat (~30s) is its only recurring backend touchpoint. The
+                            // staleness window throttles it to at most one GET per hour, so web
+                            // edits to the alert thresholds reach the floor within the hour.
+                            serviceScope.launch { authRepository.refreshAlertThresholdsIfStale() }
+                        }
                     }
                 }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamService.kt
@@ -8,7 +8,10 @@ import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
+import com.glycemicgpt.mobile.BuildConfig
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.glycemicgpt.mobile.data.remote.SimulateUnreachableInterceptor
 import com.glycemicgpt.mobile.data.remote.dto.AlertResponse
 import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.squareup.moshi.Moshi
@@ -57,6 +60,8 @@ class AlertStreamService : Service() {
     @Inject lateinit var alertRepository: AlertRepository
     @Inject lateinit var alertNotificationManager: AlertNotificationManager
     @Inject lateinit var alertStreamStateHolder: AlertStreamStateHolder
+    @Inject lateinit var simulateUnreachableInterceptor: SimulateUnreachableInterceptor
+    @Inject lateinit var appSettingsStore: AppSettingsStore
     @Inject lateinit var moshi: Moshi
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -88,12 +93,32 @@ class AlertStreamService : Service() {
             // CONNECTED — this is the worst-case delay before the alerting-degraded banner
             // appears when the backend dies without closing the socket.
             .readTimeout(75, TimeUnit.SECONDS)
+            // Debug fault injection must cover the SSE client too (no-op in release): without
+            // it, "simulate backend unreachable" flips NetworkMonitor but reconnect attempts
+            // here would still succeed, so the stream could never be held in RECONNECTING and
+            // the alert-floor arm-condition would only be half-drivable in E2E.
+            .addInterceptor(simulateUnreachableInterceptor)
             .build()
     }
 
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
+        if (BuildConfig.DEBUG) {
+            // The injected transport fault only fails NEW requests; an already-open stream keeps
+            // receiving heartbeats and would sit CONNECTED for up to the read timeout. Force-drop
+            // it when the toggle flips on so the fault takes effect immediately: the cancel
+            // surfaces as onFailure → RECONNECTING, and every reconnect then fails through the
+            // interceptor until the toggle is turned off.
+            serviceScope.launch {
+                appSettingsStore.simulateBackendUnreachableFlow().collect { simulate ->
+                    if (simulate) {
+                        Timber.d("Debug fault injection on; force-dropping alert SSE stream")
+                        eventSource?.cancel()
+                    }
+                }
+            }
+        }
         Timber.d("AlertStreamService created")
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamStateHolder.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertStreamStateHolder.kt
@@ -16,7 +16,10 @@ import javax.inject.Singleton
  *   connection has been established yet this process.
  *
  * Anything other than [CONNECTED] means **no new server alerts arrive** — the UI must say so
- * honestly. There is no device/local alert floor yet, so the degraded surface must never imply one.
+ * honestly. A non-CONNECTED state is also half of the arm-condition for the on-device alert
+ * floor ([AlertFloor], GLY-115): the phone alarms on threshold crossings itself, but ONLY off a
+ * FRESH sensor reading — so the degraded surface may claim "watching" only when the floor's own
+ * preconditions hold (see `alertFloorStatus`), and must say "NOT watching" otherwise.
  */
 enum class AlertStreamState { CONNECTED, DISCONNECTED, RECONNECTING }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
@@ -15,28 +15,16 @@ import android.os.PowerManager
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.glycemicgpt.mobile.R
-import com.glycemicgpt.mobile.data.local.AlertThresholdStore
-import com.glycemicgpt.mobile.data.local.AppSettingsStore
-import com.glycemicgpt.mobile.data.network.NetworkMonitor
-import com.glycemicgpt.mobile.data.repository.PumpDataRepository
-import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
-import com.glycemicgpt.mobile.presentation.alerts.AlertFloorStatus
-import com.glycemicgpt.mobile.presentation.alerts.alertFloorStatus
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -69,10 +57,6 @@ class PumpConnectionService : Service() {
         private const val WAKE_LOCK_RENEW_MS = 15L * 60 * 1000 // renew every 15 minutes
         // Shorter wake lock for reconnection: covers max 32s backoff + GATT + JPAKE auth
         private const val RECONNECT_WAKE_LOCK_TIMEOUT_MS = 2L * 60 * 1000 // 2 minutes
-        // Floor-status ticker bounds, mirroring FreshnessUi's cadence discipline: fast enough
-        // that the compressed debug policy decays near its marks, never hot-looping.
-        private const val MIN_FLOOR_STATUS_TICK_MS = 2_000L
-        private const val MAX_FLOOR_STATUS_TICK_MS = 30_000L
 
         fun start(context: Context) {
             context.startForegroundService(Intent(context, PumpConnectionService::class.java))
@@ -93,24 +77,18 @@ class PumpConnectionService : Service() {
     lateinit var connectionManager: PumpConnectionManager
 
     @Inject
-    lateinit var networkMonitor: NetworkMonitor
-
-    @Inject
-    lateinit var alertStreamStateHolder: AlertStreamStateHolder
-
-    @Inject
-    lateinit var pumpDataRepository: PumpDataRepository
-
-    @Inject
-    lateinit var alertThresholdStore: AlertThresholdStore
-
-    @Inject
-    lateinit var appSettingsStore: AppSettingsStore
-
-    @Inject
-    lateinit var alertNotificationManager: AlertNotificationManager
+    lateinit var alertFloorStatusProvider: AlertFloorStatusProvider
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Last floor status emitted by the shared provider. Read by [onStartCommand]'s rebuild of
+     * the foreground notification: redundant service starts (every Settings open while paired)
+     * must not clobber an honest "NOT watching" text with the default copy — the provider's
+     * distinctUntilChanged stream would not re-emit an unchanged status to repair it.
+     */
+    @Volatile
+    private var lastFloorStatus: AlertFloorStatus = AlertFloorStatus.ServerActive
     private var batteryReceiverRegistered = false
     private var bluetoothReceiverRegistered = false
     private val wakeLockSync = Any()
@@ -198,7 +176,9 @@ class PumpConnectionService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val notification = buildNotification()
+        // Rebuild from the cached status, never the default: a redundant start during an outage
+        // must not replace the honest "NOT watching" text with all-is-well copy.
+        val notification = buildNotification(lastFloorStatus)
         startForeground(NOTIFICATION_ID, notification)
 
         // Guard: only start orchestrators and watchers once per service lifecycle.
@@ -240,9 +220,11 @@ class PumpConnectionService : Service() {
             // is not open, this foreground notification is the only place that can say whether
             // anything is watching for lows/highs. Mutate it to "watching"/"NOT watching" while
             // server alerting is degraded and revert when the server reconnects. Status text
-            // only — always the silent low-importance channel, never an alarm.
+            // only — always the silent low-importance channel, never an alarm. The pipeline is
+            // the same shared provider the in-app banner uses, so the two claims cannot disagree.
             floorStatusWatcherJob = serviceScope.launch {
-                observeAlertFloorStatus().collect { status ->
+                alertFloorStatusProvider.observe().collect { status ->
+                    lastFloorStatus = status
                     getSystemService(NotificationManager::class.java)
                         .notify(NOTIFICATION_ID, buildNotification(status))
                 }
@@ -390,51 +372,11 @@ class PumpConnectionService : Service() {
         manager.createNotificationChannel(channel)
     }
 
-    /**
-     * Live [AlertFloorStatus] for the backgrounded degraded surface. Recomputes on every input
-     * change plus a ticker, because the decisive input — the latest CGM reading's age — grows
-     * with no new emissions: if BLE also drops (no fresh readings), the claim must decay from
-     * "watching" to "NOT watching" on its own. Tick cadence derives from the active freshness
-     * policy the same way FreshnessUi's does, so the compressed debug policy flips within
-     * seconds during E2E.
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private fun observeAlertFloorStatus(): Flow<AlertFloorStatus> =
-        appSettingsStore.debugFastStalenessFlow().flatMapLatest { fast ->
-            val thresholds = if (fast) FreshnessPolicy.CGM_DEBUG_FAST else FreshnessPolicy.CGM
-            val tickMs = (thresholds.staleAfterMs / 4)
-                .coerceIn(MIN_FLOOR_STATUS_TICK_MS, MAX_FLOOR_STATUS_TICK_MS)
-            combine(
-                networkMonitor.status,
-                alertStreamStateHolder.state,
-                pumpDataRepository.observeLatestCgm(),
-                tickerFlow(tickMs),
-            ) { network, stream, cgm, _ ->
-                alertFloorStatus(
-                    networkStatus = network,
-                    streamState = stream,
-                    cgmAgeMs = cgm?.let { System.currentTimeMillis() - it.timestamp.toEpochMilli() },
-                    cgmThresholds = thresholds,
-                    thresholdsSynced = alertThresholdStore.isSynced(),
-                    canNotify = alertNotificationManager.canPostAlertNotifications(),
-                )
-            }
-        }.distinctUntilChanged()
-
-    private fun tickerFlow(periodMs: Long): Flow<Unit> = flow {
-        while (true) {
-            emit(Unit)
-            delay(periodMs)
-        }
-    }
-
-    private fun buildNotification(
-        floorStatus: AlertFloorStatus = AlertFloorStatus.SERVER_ACTIVE,
-    ): Notification {
+    private fun buildNotification(floorStatus: AlertFloorStatus): Notification {
         val contentText = when (floorStatus) {
-            AlertFloorStatus.SERVER_ACTIVE -> getString(R.string.pump_service_notification_text)
-            AlertFloorStatus.FLOOR_WATCHING -> getString(R.string.pump_service_floor_watching_text)
-            AlertFloorStatus.FLOOR_NOT_WATCHING ->
+            AlertFloorStatus.ServerActive -> getString(R.string.pump_service_notification_text)
+            AlertFloorStatus.FloorWatching -> getString(R.string.pump_service_floor_watching_text)
+            is AlertFloorStatus.FloorNotWatching ->
                 getString(R.string.pump_service_floor_not_watching_text)
         }
         return NotificationCompat.Builder(this, CHANNEL_ID)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
@@ -172,6 +172,10 @@ class PumpConnectionService : Service() {
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
+        // Seed from the provider's pessimistic snapshot: a cold start into an existing outage
+        // (post-reboot) must not render the optimistic default while the watcher's first async
+        // emission is still in flight.
+        lastFloorStatus = alertFloorStatusProvider.current()
         Timber.d("PumpConnectionService created")
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
@@ -15,15 +15,28 @@ import android.os.PowerManager
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.glycemicgpt.mobile.R
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
+import com.glycemicgpt.mobile.presentation.alerts.AlertFloorStatus
+import com.glycemicgpt.mobile.presentation.alerts.alertFloorStatus
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -56,6 +69,10 @@ class PumpConnectionService : Service() {
         private const val WAKE_LOCK_RENEW_MS = 15L * 60 * 1000 // renew every 15 minutes
         // Shorter wake lock for reconnection: covers max 32s backoff + GATT + JPAKE auth
         private const val RECONNECT_WAKE_LOCK_TIMEOUT_MS = 2L * 60 * 1000 // 2 minutes
+        // Floor-status ticker bounds, mirroring FreshnessUi's cadence discipline: fast enough
+        // that the compressed debug policy decays near its marks, never hot-looping.
+        private const val MIN_FLOOR_STATUS_TICK_MS = 2_000L
+        private const val MAX_FLOOR_STATUS_TICK_MS = 30_000L
 
         fun start(context: Context) {
             context.startForegroundService(Intent(context, PumpConnectionService::class.java))
@@ -75,6 +92,24 @@ class PumpConnectionService : Service() {
     @Inject
     lateinit var connectionManager: PumpConnectionManager
 
+    @Inject
+    lateinit var networkMonitor: NetworkMonitor
+
+    @Inject
+    lateinit var alertStreamStateHolder: AlertStreamStateHolder
+
+    @Inject
+    lateinit var pumpDataRepository: PumpDataRepository
+
+    @Inject
+    lateinit var alertThresholdStore: AlertThresholdStore
+
+    @Inject
+    lateinit var appSettingsStore: AppSettingsStore
+
+    @Inject
+    lateinit var alertNotificationManager: AlertNotificationManager
+
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var batteryReceiverRegistered = false
     private var bluetoothReceiverRegistered = false
@@ -82,6 +117,7 @@ class PumpConnectionService : Service() {
     private var wakeLock: PowerManager.WakeLock? = null
     private var connectionWatcherJob: Job? = null
     private var wakeLockRenewalJob: Job? = null
+    private var floorStatusWatcherJob: Job? = null
     @Volatile
     private var started = false
 
@@ -200,6 +236,18 @@ class PumpConnectionService : Service() {
                 }
             }
 
+            // The backgrounded half of the honest alerting surface (GLY-115 AC7): while the app
+            // is not open, this foreground notification is the only place that can say whether
+            // anything is watching for lows/highs. Mutate it to "watching"/"NOT watching" while
+            // server alerting is degraded and revert when the server reconnects. Status text
+            // only — always the silent low-importance channel, never an alarm.
+            floorStatusWatcherJob = serviceScope.launch {
+                observeAlertFloorStatus().collect { status ->
+                    getSystemService(NotificationManager::class.java)
+                        .notify(NOTIFICATION_ID, buildNotification(status))
+                }
+            }
+
             ContextCompat.registerReceiver(
                 this,
                 batteryReceiver,
@@ -228,6 +276,8 @@ class PumpConnectionService : Service() {
         backendSyncManager.stop()
         connectionWatcherJob?.cancel()
         connectionWatcherJob = null
+        floorStatusWatcherJob?.cancel()
+        floorStatusWatcherJob = null
         synchronized(wakeLockSync) {
             stopWakeLockRenewalLocked()
             releaseWakeLockLocked()
@@ -340,10 +390,56 @@ class PumpConnectionService : Service() {
         manager.createNotificationChannel(channel)
     }
 
-    private fun buildNotification(): Notification {
+    /**
+     * Live [AlertFloorStatus] for the backgrounded degraded surface. Recomputes on every input
+     * change plus a ticker, because the decisive input — the latest CGM reading's age — grows
+     * with no new emissions: if BLE also drops (no fresh readings), the claim must decay from
+     * "watching" to "NOT watching" on its own. Tick cadence derives from the active freshness
+     * policy the same way FreshnessUi's does, so the compressed debug policy flips within
+     * seconds during E2E.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observeAlertFloorStatus(): Flow<AlertFloorStatus> =
+        appSettingsStore.debugFastStalenessFlow().flatMapLatest { fast ->
+            val thresholds = if (fast) FreshnessPolicy.CGM_DEBUG_FAST else FreshnessPolicy.CGM
+            val tickMs = (thresholds.staleAfterMs / 4)
+                .coerceIn(MIN_FLOOR_STATUS_TICK_MS, MAX_FLOOR_STATUS_TICK_MS)
+            combine(
+                networkMonitor.status,
+                alertStreamStateHolder.state,
+                pumpDataRepository.observeLatestCgm(),
+                tickerFlow(tickMs),
+            ) { network, stream, cgm, _ ->
+                alertFloorStatus(
+                    networkStatus = network,
+                    streamState = stream,
+                    cgmAgeMs = cgm?.let { System.currentTimeMillis() - it.timestamp.toEpochMilli() },
+                    cgmThresholds = thresholds,
+                    thresholdsSynced = alertThresholdStore.isSynced(),
+                    canNotify = alertNotificationManager.canPostAlertNotifications(),
+                )
+            }
+        }.distinctUntilChanged()
+
+    private fun tickerFlow(periodMs: Long): Flow<Unit> = flow {
+        while (true) {
+            emit(Unit)
+            delay(periodMs)
+        }
+    }
+
+    private fun buildNotification(
+        floorStatus: AlertFloorStatus = AlertFloorStatus.SERVER_ACTIVE,
+    ): Notification {
+        val contentText = when (floorStatus) {
+            AlertFloorStatus.SERVER_ACTIVE -> getString(R.string.pump_service_notification_text)
+            AlertFloorStatus.FLOOR_WATCHING -> getString(R.string.pump_service_floor_watching_text)
+            AlertFloorStatus.FLOOR_NOT_WATCHING ->
+                getString(R.string.pump_service_floor_not_watching_text)
+        }
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.pump_service_notification_title))
-            .setContentText(getString(R.string.pump_service_notification_text))
+            .setContentText(contentText)
             .setSmallIcon(android.R.drawable.stat_sys_data_bluetooth)
             .setOngoing(true)
             .setSilent(true)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
@@ -19,6 +19,7 @@ import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -227,10 +228,19 @@ class PumpConnectionService : Service() {
             // only — always the silent low-importance channel, never an alarm. The pipeline is
             // the same shared provider the in-app banner uses, so the two claims cannot disagree.
             floorStatusWatcherJob = serviceScope.launch {
-                alertFloorStatusProvider.observe().collect { status ->
-                    lastFloorStatus = status
-                    getSystemService(NotificationManager::class.java)
-                        .notify(NOTIFICATION_ID, buildNotification(status))
+                try {
+                    alertFloorStatusProvider.observe().collect { status ->
+                        lastFloorStatus = status
+                        getSystemService(NotificationManager::class.java)
+                            .notify(NOTIFICATION_ID, buildNotification(status))
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // A status-only surface must never take down the pump service (the BLE
+                    // link and polling matter more than the notification text). The provider
+                    // already retries upstream faults internally; this guards the notify path.
+                    Timber.e(e, "Floor status watcher failed; foreground text frozen at last value")
                 }
             }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -9,6 +9,7 @@ import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.data.local.entity.RawHistoryLogEntity
 import com.glycemicgpt.mobile.data.repository.PumpDataRepository
 import com.glycemicgpt.mobile.data.repository.SyncQueueEnqueuer
+import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.pump.HistoryLogParser
 import com.glycemicgpt.mobile.domain.pump.PumpDriver
@@ -48,6 +49,7 @@ class PumpPollingOrchestrator @Inject constructor(
     private val safetyLimitsStore: SafetyLimitsStore,
     private val historyLogParser: HistoryLogParser,
     private val appSettingsStore: AppSettingsStore,
+    private val alertFloor: AlertFloor,
 ) {
 
     /** Set by PumpConnectionService to trigger immediate sync after enqueue. */
@@ -257,49 +259,66 @@ class PumpPollingOrchestrator @Inject constructor(
             pumpDriver.getCgmStatus()
                 .onSuccess {
                     repository.saveCgm(it)
-                    // We send the raw mg/dL value plus a per-account unit flag so the watch
-                    // renders glucose in the user's unit. The wire value stays canonical mg/dL;
-                    // only the watch's displayed/spoken number converts.
-                    val glucoseUnit = appSettingsStore.glucoseUnit
-                    try {
-                        wearDataSender.sendCgm(
-                            mgDl = it.glucoseMgDl,
-                            trend = it.trendArrow.name,
-                            timestampMs = it.timestamp.toEpochMilli(),
-                            low = glucoseRangeStore.low,
-                            high = glucoseRangeStore.high,
-                            urgentLow = glucoseRangeStore.urgentLow,
-                            urgentHigh = glucoseRangeStore.urgentHigh,
-                            unit = glucoseUnit,
-                        )
-                    } catch (e: Exception) {
-                        Timber.w(e, "Failed to send CGM to watch")
-                    }
-
-                    // Alert threshold detection for watch (uses dynamic thresholds, stays mg/dL)
-                    val alertType = detectAlertForCgm(it.glucoseMgDl)
-                    try {
-                        if (alertType != null && alertType != previousAlertType) {
-                            wearDataSender.sendAlert(
-                                type = alertType,
-                                bgValue = it.glucoseMgDl,
-                                timestampMs = it.timestamp.toEpochMilli(),
-                                message = "${alertLabel(alertType)} " +
-                                    GlucoseFormat.formatWithLabel(it.glucoseMgDl, glucoseUnit),
-                            )
-                            previousAlertType = alertType
-                        } else if (alertType == null && previousAlertType != null) {
-                            wearDataSender.clearAlert()
-                            previousAlertType = null
-                        }
-                    } catch (e: Exception) {
-                        Timber.w(e, "Failed to send alert to watch")
-                    }
+                    processCgmReading(it)
                 }
                 .onFailure { Timber.w(it, "Failed to poll CGM status") }
         } catch (e: Exception) {
             Timber.w(e, "CGM poll exception")
         }
+    }
+
+    /**
+     * Everything downstream of a persisted CGM reading: the watch relay and the on-device alert
+     * floor. Public ONLY as the debug-harness seam — `BleDebugViewModel.injectTestCgm` drives it
+     * on an emulator (which has no BLE pump, so [pollCgm] never runs there) after writing the
+     * synthetic reading to Room, exercising the exact production path. The only production
+     * caller is [pollCgm].
+     */
+    suspend fun processCgmReading(reading: CgmReading) {
+        // We send the raw mg/dL value plus a per-account unit flag so the watch
+        // renders glucose in the user's unit. The wire value stays canonical mg/dL;
+        // only the watch's displayed/spoken number converts.
+        val glucoseUnit = appSettingsStore.glucoseUnit
+        try {
+            wearDataSender.sendCgm(
+                mgDl = reading.glucoseMgDl,
+                trend = reading.trendArrow.name,
+                timestampMs = reading.timestamp.toEpochMilli(),
+                low = glucoseRangeStore.low,
+                high = glucoseRangeStore.high,
+                urgentLow = glucoseRangeStore.urgentLow,
+                urgentHigh = glucoseRangeStore.urgentHigh,
+                unit = glucoseUnit,
+            )
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to send CGM to watch")
+        }
+
+        // One classification feeds both consumers, off the synced server alert thresholds
+        // (GLY-115) rather than the display range: the values the server's alert engine fires
+        // from are the ones worth waking anyone for. AlertFloor speaks the server AlertType
+        // vocabulary; the watch wire protocol keeps its own strings, so map before sending.
+        val serverAlertType = alertFloor.classify(reading.glucoseMgDl)
+        val watchAlertType = serverAlertType?.let { SERVER_TO_WATCH_ALERT_TYPE.getValue(it) }
+        try {
+            if (watchAlertType != null && watchAlertType != previousAlertType) {
+                wearDataSender.sendAlert(
+                    type = watchAlertType,
+                    bgValue = reading.glucoseMgDl,
+                    timestampMs = reading.timestamp.toEpochMilli(),
+                    message = "${alertLabel(watchAlertType)} " +
+                        GlucoseFormat.formatWithLabel(reading.glucoseMgDl, glucoseUnit),
+                )
+                previousAlertType = watchAlertType
+            } else if (watchAlertType == null && previousAlertType != null) {
+                wearDataSender.clearAlert()
+                previousAlertType = null
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to send alert to watch")
+        }
+
+        alertFloor.onCgmReading(reading, serverAlertType)
     }
 
     companion object {
@@ -368,15 +387,20 @@ class PumpPollingOrchestrator @Inject constructor(
             "high" -> "HIGH"
             else -> ""
         }
-    }
 
-    /** Detect alert type using dynamically configured glucose thresholds. */
-    private fun detectAlertForCgm(mgDl: Int): String? = when {
-        mgDl <= glucoseRangeStore.urgentLow -> "urgent_low"
-        mgDl >= glucoseRangeStore.urgentHigh -> "urgent_high"
-        mgDl <= glucoseRangeStore.low -> "low"
-        mgDl >= glucoseRangeStore.high -> "high"
-        else -> null
+        /**
+         * [AlertFloor] classifies in the server's AlertType vocabulary (shared notification slot
+         * + channel routing); the watch wire protocol predates it and keeps its own strings.
+         * 57.10 note: the watch currently receives alerts by THREE paths — this orchestrator
+         * relay, the bridged server notification, and now the bridged floor notification — a
+         * collision left for 57.10 to consolidate.
+         */
+        val SERVER_TO_WATCH_ALERT_TYPE = mapOf(
+            AlertFloor.TYPE_LOW_URGENT to "urgent_low",
+            AlertFloor.TYPE_LOW_WARNING to "low",
+            AlertFloor.TYPE_HIGH_WARNING to "high",
+            AlertFloor.TYPE_HIGH_URGENT to "urgent_high",
+        )
     }
 
     private suspend fun pollBattery() {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.mobile.service
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
+import com.glycemicgpt.mobile.domain.alerting.AlertTypes
 import com.glycemicgpt.mobile.data.local.dao.RawHistoryLogDao
 import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.PumpActivityMode
@@ -391,15 +392,17 @@ class PumpPollingOrchestrator @Inject constructor(
         /**
          * [AlertFloor] classifies in the server's AlertType vocabulary (shared notification slot
          * + channel routing); the watch wire protocol predates it and keeps its own strings.
-         * 57.10 note: the watch currently receives alerts by THREE paths — this orchestrator
+         * 57.10 notes: the watch currently receives alerts by THREE paths — this orchestrator
          * relay, the bridged server notification, and now the bridged floor notification — a
-         * collision left for 57.10 to consolidate.
+         * collision left for 57.10 to consolidate. The relay is also freshness-ungated and
+         * classifies off store defaults before the first threshold sync (both pre-existing
+         * behaviors of this path, unlike the floor's gates) — 57.10 should align it.
          */
         val SERVER_TO_WATCH_ALERT_TYPE = mapOf(
-            AlertFloor.TYPE_LOW_URGENT to "urgent_low",
-            AlertFloor.TYPE_LOW_WARNING to "low",
-            AlertFloor.TYPE_HIGH_WARNING to "high",
-            AlertFloor.TYPE_HIGH_URGENT to "urgent_high",
+            AlertTypes.LOW_URGENT to "urgent_low",
+            AlertTypes.LOW_WARNING to "low",
+            AlertTypes.HIGH_WARNING to "high",
+            AlertTypes.HIGH_URGENT to "urgent_high",
         )
     }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -291,6 +291,8 @@ class PumpPollingOrchestrator @Inject constructor(
                 urgentHigh = glucoseRangeStore.urgentHigh,
                 unit = glucoseUnit,
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Timber.w(e, "Failed to send CGM to watch")
         }
@@ -299,8 +301,13 @@ class PumpPollingOrchestrator @Inject constructor(
         // (GLY-115) rather than the display range: the values the server's alert engine fires
         // from are the ones worth waking anyone for. AlertFloor speaks the server AlertType
         // vocabulary; the watch wire protocol keeps its own strings, so map before sending.
+        // The lookup must be non-throwing: a mapping gap may cost the watch relay, never the
+        // alert-floor hand-off below.
         val serverAlertType = alertFloor.classify(reading.glucoseMgDl)
-        val watchAlertType = serverAlertType?.let { SERVER_TO_WATCH_ALERT_TYPE.getValue(it) }
+        val watchAlertType = serverAlertType?.let { type ->
+            SERVER_TO_WATCH_ALERT_TYPE[type]
+                ?: run { Timber.w("No watch mapping for alert type %s", type); null }
+        }
         try {
             if (watchAlertType != null && watchAlertType != previousAlertType) {
                 wearDataSender.sendAlert(
@@ -315,6 +322,8 @@ class PumpPollingOrchestrator @Inject constructor(
                 wearDataSender.clearAlert()
                 previousAlertType = null
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Timber.w(e, "Failed to send alert to watch")
         }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -70,9 +72,15 @@ class PumpPollingOrchestrator @Inject constructor(
     @Volatile
     private var hasBeenConnectedBefore: Boolean = false
 
-    /** Track the last alert type sent to watch to avoid re-sending the same alert. */
+    /** Track the last alert type sent to watch to avoid re-sending the same alert.
+     *  Guarded by [watchRelayMutex] in [processCgmReading]; the disconnect reset in [start]
+     *  is safe unsynchronized (polling is already cancelled there). */
     @Volatile
     private var previousAlertType: String? = null
+
+    /** Serializes the watch alert edge-latch across the poll loop, the Home manual refresh,
+     *  and the debug inject. */
+    private val watchRelayMutex = Mutex()
 
     private val lock = Any()
     private var fastJob: Job? = null
@@ -308,24 +316,29 @@ class PumpPollingOrchestrator @Inject constructor(
             SERVER_TO_WATCH_ALERT_TYPE[type]
                 ?: run { Timber.w("No watch mapping for alert type %s", type); null }
         }
-        try {
-            if (watchAlertType != null && watchAlertType != previousAlertType) {
-                wearDataSender.sendAlert(
-                    type = watchAlertType,
-                    bgValue = reading.glucoseMgDl,
-                    timestampMs = reading.timestamp.toEpochMilli(),
-                    message = "${alertLabel(watchAlertType)} " +
-                        GlucoseFormat.formatWithLabel(reading.glucoseMgDl, glucoseUnit),
-                )
-                previousAlertType = watchAlertType
-            } else if (watchAlertType == null && previousAlertType != null) {
-                wearDataSender.clearAlert()
-                previousAlertType = null
+        // Serialized: this seam is reachable from the poll loop, the Home manual refresh, and
+        // the debug inject concurrently, and the previousAlertType read-check-write must be
+        // atomic or an overlap can double-send or drop a needed clearAlert.
+        watchRelayMutex.withLock {
+            try {
+                if (watchAlertType != null && watchAlertType != previousAlertType) {
+                    wearDataSender.sendAlert(
+                        type = watchAlertType,
+                        bgValue = reading.glucoseMgDl,
+                        timestampMs = reading.timestamp.toEpochMilli(),
+                        message = "${alertLabel(watchAlertType)} " +
+                            GlucoseFormat.formatWithLabel(reading.glucoseMgDl, glucoseUnit),
+                    )
+                    previousAlertType = watchAlertType
+                } else if (watchAlertType == null && previousAlertType != null) {
+                    wearDataSender.clearAlert()
+                    previousAlertType = null
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to send alert to watch")
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Timber.w(e, "Failed to send alert to watch")
         }
 
         alertFloor.onCgmReading(reading, serverAlertType)

--- a/apps/mobile/app/src/main/res/values/strings.xml
+++ b/apps/mobile/app/src/main/res/values/strings.xml
@@ -4,5 +4,5 @@
     <string name="pump_service_notification_title">Connected to pump</string>
     <string name="pump_service_notification_text">Reading pump data in background</string>
     <string name="pump_service_floor_watching_text">Server alerts paused — this phone is watching for lows and highs</string>
-    <string name="pump_service_floor_not_watching_text">Alerts degraded — NOT watching (no recent glucose reading)</string>
+    <string name="pump_service_floor_not_watching_text">Alerts degraded — this phone is NOT watching for lows or highs</string>
 </resources>

--- a/apps/mobile/app/src/main/res/values/strings.xml
+++ b/apps/mobile/app/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="app_name">GlycemicGPT</string>
     <string name="pump_service_notification_title">Connected to pump</string>
     <string name="pump_service_notification_text">Reading pump data in background</string>
+    <string name="pump_service_floor_watching_text">Server alerts paused — this phone is watching for lows and highs</string>
+    <string name="pump_service_floor_not_watching_text">Alerts degraded — NOT watching (no recent glucose reading)</string>
 </resources>

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/AlertThresholdStoreTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/AlertThresholdStoreTest.kt
@@ -2,6 +2,7 @@ package com.glycemicgpt.mobile.data.local
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -67,6 +68,29 @@ class AlertThresholdStoreTest {
         assertTrue(store.isStale())
     }
 
+    @Test
+    fun `updateAll rejects values outside the 20-500 safety range and persists nothing`() {
+        val store = InMemoryAlertThresholdStore()
+        assertThrows(IllegalArgumentException::class.java) {
+            store.updateAll(10, 75, 170, 260)
+        }
+        assertFalse(store.isSynced())
+    }
+
+    @Test
+    fun `updateAll rejects disordered thresholds but allows rounded ties at urgent boundaries`() {
+        val store = InMemoryAlertThresholdStore()
+        // A low band overlapping the high band can never persist...
+        assertThrows(IllegalArgumentException::class.java) {
+            store.updateAll(80, 70, 170, 260)
+        }
+        assertFalse(store.isSynced())
+        // ...but urgent/warning ties from float rounding (69.8/70.2 -> 70/70) are legal; the
+        // classifier checks the urgent band first, so a tie fires the more severe alert.
+        store.updateAll(70, 70, 170, 170)
+        assertTrue(store.isSynced())
+    }
+
     /**
      * In-memory mirror of [AlertThresholdStore] for testing without Android SharedPreferences.
      * Mirrors the same storage/retrieval logic.
@@ -91,6 +115,12 @@ class AlertThresholdStoreTest {
         fun isSynced(): Boolean = lastFetchedMs != 0L
 
         fun updateAll(urgentLow: Int, lowWarning: Int, highWarning: Int, urgentHigh: Int) {
+            require(listOf(urgentLow, lowWarning, highWarning, urgentHigh).all { it in 20..500 }) {
+                "Alert thresholds out of the 20-500 mg/dL safety range"
+            }
+            require(urgentLow <= lowWarning && lowWarning < highWarning && highWarning <= urgentHigh) {
+                "Alert thresholds not correctly ordered"
+            }
             _urgentLow = urgentLow
             _lowWarning = lowWarning
             _highWarning = highWarning

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/AlertThresholdStoreTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/AlertThresholdStoreTest.kt
@@ -1,0 +1,114 @@
+package com.glycemicgpt.mobile.data.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [AlertThresholdStore] semantics (GLY-115). Uses an in-memory mirror to avoid the
+ * Android SharedPreferences dependency, mirroring [SafetyLimitsStoreTest]'s pattern. The
+ * contract that matters most: [AlertThresholdStore.isSynced] is false until the first
+ * backend fetch and false again after [AlertThresholdStore.clear] — the alert floor's
+ * never-fire-off-defaults gate keys off it.
+ */
+class AlertThresholdStoreTest {
+
+    @Test
+    fun `defaults mirror the backend column defaults`() {
+        val store = InMemoryAlertThresholdStore()
+        assertEquals(AlertThresholdStore.DEFAULT_URGENT_LOW, store.urgentLowMgDl)
+        assertEquals(AlertThresholdStore.DEFAULT_LOW_WARNING, store.lowWarningMgDl)
+        assertEquals(AlertThresholdStore.DEFAULT_HIGH_WARNING, store.highWarningMgDl)
+        assertEquals(AlertThresholdStore.DEFAULT_URGENT_HIGH, store.urgentHighMgDl)
+    }
+
+    @Test
+    fun `never synced until the first update`() {
+        val store = InMemoryAlertThresholdStore()
+        assertFalse(store.isSynced())
+        store.updateAll(50, 75, 170, 260)
+        assertTrue(store.isSynced())
+    }
+
+    @Test
+    fun `updateAll persists all four thresholds`() {
+        val store = InMemoryAlertThresholdStore()
+        store.updateAll(50, 75, 170, 260)
+        assertEquals(50, store.urgentLowMgDl)
+        assertEquals(75, store.lowWarningMgDl)
+        assertEquals(170, store.highWarningMgDl)
+        assertEquals(260, store.urgentHighMgDl)
+    }
+
+    @Test
+    fun `clear resets to defaults and un-syncs - disarming the floor`() {
+        val store = InMemoryAlertThresholdStore()
+        store.updateAll(50, 75, 170, 260)
+        store.clear()
+        assertFalse(store.isSynced())
+        assertEquals(AlertThresholdStore.DEFAULT_URGENT_LOW, store.urgentLowMgDl)
+        assertEquals(AlertThresholdStore.DEFAULT_LOW_WARNING, store.lowWarningMgDl)
+    }
+
+    @Test
+    fun `isStale is true when never fetched and false right after update`() {
+        val store = InMemoryAlertThresholdStore()
+        assertTrue(store.isStale())
+        store.updateAll(50, 75, 170, 260)
+        assertFalse(store.isStale())
+    }
+
+    @Test
+    fun `isStale is true when max age exceeded`() {
+        val store = InMemoryAlertThresholdStore()
+        store.updateAll(50, 75, 170, 260)
+        store.forceLastFetched(System.currentTimeMillis() - AlertThresholdStore.STALE_THRESHOLD_MS - 1)
+        assertTrue(store.isStale())
+    }
+
+    /**
+     * In-memory mirror of [AlertThresholdStore] for testing without Android SharedPreferences.
+     * Mirrors the same storage/retrieval logic.
+     */
+    private class InMemoryAlertThresholdStore {
+        private var _urgentLow: Int = AlertThresholdStore.DEFAULT_URGENT_LOW
+        private var _lowWarning: Int = AlertThresholdStore.DEFAULT_LOW_WARNING
+        private var _highWarning: Int = AlertThresholdStore.DEFAULT_HIGH_WARNING
+        private var _urgentHigh: Int = AlertThresholdStore.DEFAULT_URGENT_HIGH
+        var lastFetchedMs: Long = 0L
+            private set
+
+        fun forceLastFetched(ms: Long) {
+            lastFetchedMs = ms
+        }
+
+        val urgentLowMgDl: Int get() = _urgentLow
+        val lowWarningMgDl: Int get() = _lowWarning
+        val highWarningMgDl: Int get() = _highWarning
+        val urgentHighMgDl: Int get() = _urgentHigh
+
+        fun isSynced(): Boolean = lastFetchedMs != 0L
+
+        fun updateAll(urgentLow: Int, lowWarning: Int, highWarning: Int, urgentHigh: Int) {
+            _urgentLow = urgentLow
+            _lowWarning = lowWarning
+            _highWarning = highWarning
+            _urgentHigh = urgentHigh
+            lastFetchedMs = System.currentTimeMillis()
+        }
+
+        fun clear() {
+            _urgentLow = AlertThresholdStore.DEFAULT_URGENT_LOW
+            _lowWarning = AlertThresholdStore.DEFAULT_LOW_WARNING
+            _highWarning = AlertThresholdStore.DEFAULT_HIGH_WARNING
+            _urgentHigh = AlertThresholdStore.DEFAULT_URGENT_HIGH
+            lastFetchedMs = 0L
+        }
+
+        fun isStale(maxAgeMs: Long = AlertThresholdStore.STALE_THRESHOLD_MS): Boolean {
+            val age = System.currentTimeMillis() - lastFetchedMs
+            return age > maxAgeMs
+        }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
@@ -71,6 +71,10 @@ class AlertRepositoryTest {
                 .maxWithOrNull(compareBy({ it.timestampMs }, { it.id }))
                 ?.serverId
 
+        override suspend fun getLatestTimestampForType(alertType: String, sinceMs: Long): Long? =
+            rows.values.filter { it.alertType == alertType && it.timestampMs >= sinceMs }
+                .maxOfOrNull { it.timestampMs }
+
         override suspend fun deleteOlderThan(cutoffMs: Long) {
             rows.values.removeAll { it.timestampMs < cutoffMs }
         }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AlertRepositoryTest.kt
@@ -71,8 +71,8 @@ class AlertRepositoryTest {
                 .maxWithOrNull(compareBy({ it.timestampMs }, { it.id }))
                 ?.serverId
 
-        override suspend fun getLatestTimestampForType(alertType: String, sinceMs: Long): Long? =
-            rows.values.filter { it.alertType == alertType && it.timestampMs >= sinceMs }
+        override suspend fun getLatestUnacknowledgedTimestampForType(alertType: String, sinceMs: Long): Long? =
+            rows.values.filter { it.alertType == alertType && !it.acknowledged && it.timestampMs >= sinceMs }
                 .maxOfOrNull { it.timestampMs }
 
         override suspend fun deleteOlderThan(cutoffMs: Long) {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/AuthRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.glycemicgpt.mobile.data.repository
 
 import android.content.Context
 import com.glycemicgpt.mobile.data.auth.AuthManager
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
@@ -9,6 +10,7 @@ import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.PumpProfileStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
+import com.glycemicgpt.mobile.data.remote.dto.AlertThresholdsResponse
 import com.glycemicgpt.mobile.data.remote.dto.GlucoseRangeResponse
 import com.glycemicgpt.mobile.data.remote.dto.GlucoseUnitResponse
 import com.glycemicgpt.mobile.data.remote.dto.HealthResponse
@@ -45,6 +47,7 @@ class AuthRepositoryTest {
     }
     private val glucoseRangeStore = mockk<GlucoseRangeStore>(relaxed = true)
     private val safetyLimitsStore = mockk<SafetyLimitsStore>(relaxed = true)
+    private val alertThresholdStore = mockk<AlertThresholdStore>(relaxed = true)
     private val analyticsSettingsStore = mockk<AnalyticsSettingsStore>(relaxed = true)
     private val pumpProfileStore = mockk<PumpProfileStore>(relaxed = true)
     private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true)
@@ -53,7 +56,7 @@ class AuthRepositoryTest {
     private val authManager = mockk<AuthManager>(relaxed = true)
 
     private val repository = AuthRepository(
-        appContext, authTokenStore, glucoseRangeStore, safetyLimitsStore,
+        appContext, authTokenStore, glucoseRangeStore, safetyLimitsStore, alertThresholdStore,
         analyticsSettingsStore, pumpProfileStore, appSettingsStore, api, deviceRepository, authManager,
     )
 
@@ -203,6 +206,9 @@ class AuthRepositoryTest {
 
         verify { authTokenStore.clearToken() }
         verify { safetyLimitsStore.clear() }
+        // The alert floor must never fire off another account's thresholds; the clear also
+        // un-syncs the store, disarming the floor until the next account's fetch lands.
+        verify { alertThresholdStore.clear() }
         verify { analyticsSettingsStore.clear() }
         verify { pumpProfileStore.clear() }
         verify { appSettingsStore.glucoseUnit = GlucoseUnit.MGDL }
@@ -438,5 +444,72 @@ class AuthRepositoryTest {
 
         verify(exactly = 1) { authTokenStore.clearToken() }
         verify(exactly = 0) { authTokenStore.clearAccessToken() }
+    }
+
+    // -- alert thresholds: the values the on-device alert floor fires from (GLY-115) -----------
+
+    @Test
+    fun `login fetches alert thresholds alongside the other settings`() = runTest {
+        coEvery { api.login(any()) } returns Response.success(
+            LoginResponse(
+                accessToken = "jwt123",
+                refreshToken = "refresh123",
+                tokenType = "bearer",
+                expiresIn = 3600,
+                user = UserDto(id = "1", email = "user@test.com", role = "user"),
+            ),
+        )
+        coEvery { api.getAlertThresholds() } returns Response.success(
+            AlertThresholdsResponse(urgentLow = 55f, lowWarning = 70f, highWarning = 180f, urgentHigh = 250f),
+        )
+
+        repository.login("https://test.example.com", "user@test.com", "pass", testScope)
+
+        coVerify { api.getAlertThresholds() }
+        verify { alertThresholdStore.updateAll(55, 70, 180, 250) }
+    }
+
+    @Test
+    fun `refreshAlertThresholds rounds and persists valid server values`() = runTest {
+        coEvery { api.getAlertThresholds() } returns Response.success(
+            AlertThresholdsResponse(urgentLow = 54.4f, lowWarning = 72.6f, highWarning = 179.5f, urgentHigh = 260f),
+        )
+
+        repository.refreshAlertThresholds()
+
+        verify { alertThresholdStore.updateAll(54, 73, 180, 260) }
+    }
+
+    @Test
+    fun `refreshAlertThresholds drops a response with broken ordering`() = runTest {
+        // urgent_low above low_warning: dropped, never clamped -- the floor must fire at the
+        // server's real levels or not at all.
+        coEvery { api.getAlertThresholds() } returns Response.success(
+            AlertThresholdsResponse(urgentLow = 80f, lowWarning = 70f, highWarning = 180f, urgentHigh = 250f),
+        )
+
+        repository.refreshAlertThresholds()
+
+        verify(exactly = 0) { alertThresholdStore.updateAll(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `refreshAlertThresholds drops out-of-range values`() = runTest {
+        coEvery { api.getAlertThresholds() } returns Response.success(
+            AlertThresholdsResponse(urgentLow = 10f, lowWarning = 70f, highWarning = 180f, urgentHigh = 250f),
+        )
+
+        repository.refreshAlertThresholds()
+
+        verify(exactly = 0) { alertThresholdStore.updateAll(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `refreshAlertThresholds leaves the store untouched when the backend call fails`() = runTest {
+        coEvery { api.getAlertThresholds() } throws java.io.IOException("offline")
+
+        repository.refreshAlertThresholds()
+
+        verify(exactly = 0) { alertThresholdStore.updateAll(any(), any(), any(), any()) }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/freshness/FreshnessTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/domain/freshness/FreshnessTest.kt
@@ -87,4 +87,36 @@ class FreshnessTest {
         assertEquals("23h ago", relativeAgeLabel(23 * 60 * 60_000L))
         assertEquals("1d ago", relativeAgeLabel(24 * 60 * 60_000L))
     }
+
+    // -- isFreshForAlertFloor (GLY-115) — the floor's FRESH-only gate ------------
+
+    @Test
+    fun `alert floor gate accepts only FRESH ages`() {
+        val cgm = FreshnessPolicy.CGM
+        assertEquals(true, isFreshForAlertFloor(0L, cgm))
+        assertEquals(true, isFreshForAlertFloor(6 * 60_000L - 1, cgm))
+        // STALE and TOO_STALE both fail — the floor never fires on either.
+        assertEquals(false, isFreshForAlertFloor(6 * 60_000L, cgm))
+        assertEquals(false, isFreshForAlertFloor(15 * 60_000L, cgm))
+    }
+
+    @Test
+    fun `alert floor gate tolerates small future skew but refuses beyond the bound`() {
+        val cgm = FreshnessPolicy.CGM
+        // Routine pump/phone clock drift must not silently disable the floor...
+        assertEquals(true, isFreshForAlertFloor(-1L, cgm))
+        assertEquals(true, isFreshForAlertFloor(-ALERT_FLOOR_MAX_FUTURE_SKEW_MS, cgm))
+        // ...but a reading future-dated beyond the bound (backwards phone-clock jump) must not
+        // be resurrected as FRESH, even though the display classifier would call it FRESH.
+        assertEquals(false, isFreshForAlertFloor(-ALERT_FLOOR_MAX_FUTURE_SKEW_MS - 1, cgm))
+        assertEquals(Freshness.FRESH, cgm.classify(-ALERT_FLOOR_MAX_FUTURE_SKEW_MS - 1))
+    }
+
+    @Test
+    fun `alert floor gate honors the compressed debug policy`() {
+        val fast = FreshnessPolicy.CGM_DEBUG_FAST
+        assertEquals(true, isFreshForAlertFloor(10_000L, fast))
+        assertEquals(false, isFreshForAlertFloor(20_000L, fast))
+        assertEquals(false, isFreshForAlertFloor(60_000L, fast))
+    }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegradedTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegradedTest.kt
@@ -1,6 +1,10 @@
 package com.glycemicgpt.mobile.presentation.alerts
 
 import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
+import com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason
+import com.glycemicgpt.mobile.domain.alerting.alertFloorStatus
+import com.glycemicgpt.mobile.domain.alerting.isAlertingDegraded
 import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
 import com.glycemicgpt.mobile.service.AlertStreamState
 import org.junit.Assert.assertEquals
@@ -49,79 +53,129 @@ class AlertingDegradedTest {
         cgmAgeMs: Long? = 0L,
         thresholdsSynced: Boolean = true,
         canNotify: Boolean = true,
-    ) = alertFloorStatus(network, stream, cgmAgeMs, FreshnessPolicy.CGM, thresholdsSynced, canNotify)
+        pumpConnected: Boolean = true,
+    ) = alertFloorStatus(
+        network, stream, cgmAgeMs, FreshnessPolicy.CGM, thresholdsSynced, canNotify, pumpConnected,
+    )
+
+    private fun reasonOf(status: AlertFloorStatus): FloorNotWatchingReason =
+        (status as AlertFloorStatus.FloorNotWatching).reason
 
     @Test
     fun `healthy server wins regardless of floor inputs`() {
         assertEquals(
-            AlertFloorStatus.SERVER_ACTIVE,
+            AlertFloorStatus.ServerActive,
             status(
                 network = NetworkStatus.REACHABLE,
                 stream = AlertStreamState.CONNECTED,
                 cgmAgeMs = null,
                 thresholdsSynced = false,
                 canNotify = false,
+                pumpConnected = false,
             ),
         )
     }
 
     @Test
-    fun `degraded with a fresh reading and synced thresholds claims watching`() {
-        assertEquals(AlertFloorStatus.FLOOR_WATCHING, status(cgmAgeMs = 30_000L))
+    fun `degraded with fresh reading, synced thresholds and a live pump claims watching`() {
+        assertEquals(AlertFloorStatus.FloorWatching, status(cgmAgeMs = 30_000L))
     }
 
     @Test
     fun `degraded with a stale reading claims NOT watching - the lethal trap pinned`() {
         // Exactly the claim GLY-115 exists to keep honest: STALE and TOO_STALE readings mean
         // the floor cannot fire, so the surface must never say "watching".
-        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, status(cgmAgeMs = 6 * 60_000L))
-        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, status(cgmAgeMs = 20 * 60_000L))
+        assertEquals(
+            FloorNotWatchingReason.NO_FRESH_READING,
+            reasonOf(status(cgmAgeMs = 6 * 60_000L)),
+        )
+        assertEquals(
+            FloorNotWatchingReason.NO_FRESH_READING,
+            reasonOf(status(cgmAgeMs = 20 * 60_000L)),
+        )
     }
 
     @Test
     fun `degraded with no reading at all claims NOT watching`() {
-        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, status(cgmAgeMs = null))
+        assertEquals(FloorNotWatchingReason.NO_FRESH_READING, reasonOf(status(cgmAgeMs = null)))
     }
 
     @Test
     fun `degraded with unsynced thresholds claims NOT watching even on a fresh reading`() {
         assertEquals(
-            AlertFloorStatus.FLOOR_NOT_WATCHING,
-            status(cgmAgeMs = 0L, thresholdsSynced = false),
+            FloorNotWatchingReason.THRESHOLDS_NOT_SYNCED,
+            reasonOf(status(cgmAgeMs = 0L, thresholdsSynced = false)),
         )
     }
 
     @Test
     fun `degraded without notification permission claims NOT watching`() {
         assertEquals(
-            AlertFloorStatus.FLOOR_NOT_WATCHING,
-            status(cgmAgeMs = 0L, canNotify = false),
+            FloorNotWatchingReason.NOTIFICATIONS_DENIED,
+            reasonOf(status(cgmAgeMs = 0L, canNotify = false)),
+        )
+    }
+
+    @Test
+    fun `degraded with the pump disconnected claims NOT watching even on a fresh cached reading`() {
+        // The floor evaluates only on newly polled readings: with BLE down it cannot fire no
+        // matter how fresh the cached reading still looks. Claiming "watching" here would be a
+        // multi-minute false-coverage window bounded only by freshness decay.
+        assertEquals(
+            FloorNotWatchingReason.PUMP_DISCONNECTED,
+            reasonOf(status(cgmAgeMs = 0L, pumpConnected = false)),
         )
     }
 
     @Test
     fun `a reading future-dated beyond the skew bound claims NOT watching`() {
-        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, status(cgmAgeMs = -10 * 60_000L))
+        assertEquals(
+            FloorNotWatchingReason.NO_FRESH_READING,
+            reasonOf(status(cgmAgeMs = -10 * 60_000L)),
+        )
+    }
+
+    @Test
+    fun `the most actionable failed precondition wins when several fail at once`() {
+        // Denied notifications are durable and user-fixable; they must not be hidden behind a
+        // "no recent glucose" diagnosis the user can't act on.
+        assertEquals(
+            FloorNotWatchingReason.NOTIFICATIONS_DENIED,
+            reasonOf(
+                status(cgmAgeMs = null, thresholdsSynced = false, canNotify = false, pumpConnected = false),
+            ),
+        )
     }
 
     // -- banner copy selection ------------------------------------------------------------------
 
     @Test
     fun `watching copy says the phone is watching and carries the threshold-only disclaimer`() {
-        val text = alertingDegradedBannerText(AlertFloorStatus.FLOOR_WATCHING)!!
+        val text = alertingDegradedBannerText(AlertFloorStatus.FloorWatching)!!
         assertTrue(text.contains("this phone is watching"))
         assertTrue(text.contains("Threshold-only, no prediction"))
     }
 
     @Test
-    fun `not-watching copy says NOT watching and never claims coverage`() {
-        val text = alertingDegradedBannerText(AlertFloorStatus.FLOOR_NOT_WATCHING)!!
-        assertTrue(text.contains("NOT watching"))
-        assertFalse(text.contains("is watching your"))
+    fun `every not-watching variant says NOT watching and never claims coverage`() {
+        for (reason in FloorNotWatchingReason.entries) {
+            val text = alertingDegradedBannerText(AlertFloorStatus.FloorNotWatching(reason))!!
+            assertTrue("$reason copy must claim non-coverage", text.contains("NOT watching"))
+            assertFalse("$reason copy must not claim coverage", text.contains("is watching your"))
+        }
+    }
+
+    @Test
+    fun `notifications-denied copy names the user-fixable remediation`() {
+        val text = alertingDegradedBannerText(
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NOTIFICATIONS_DENIED),
+        )!!
+        assertTrue(text.contains("Enable notifications"))
+        assertFalse(text.contains("no recent glucose"))
     }
 
     @Test
     fun `server-active has no banner copy`() {
-        assertNull(alertingDegradedBannerText(AlertFloorStatus.SERVER_ACTIVE))
+        assertNull(alertingDegradedBannerText(AlertFloorStatus.ServerActive))
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegradedTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertingDegradedTest.kt
@@ -1,8 +1,11 @@
 package com.glycemicgpt.mobile.presentation.alerts
 
 import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
 import com.glycemicgpt.mobile.service.AlertStreamState
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -36,5 +39,89 @@ class AlertingDegradedTest {
         for (stream in AlertStreamState.entries) {
             assertTrue(isAlertingDegraded(NetworkStatus.OFFLINE, stream))
         }
+    }
+
+    // -- alertFloorStatus (GLY-115 AC7): the two-state honest claim ----------------------------
+
+    private fun status(
+        network: NetworkStatus = NetworkStatus.BACKEND_UNREACHABLE,
+        stream: AlertStreamState = AlertStreamState.RECONNECTING,
+        cgmAgeMs: Long? = 0L,
+        thresholdsSynced: Boolean = true,
+        canNotify: Boolean = true,
+    ) = alertFloorStatus(network, stream, cgmAgeMs, FreshnessPolicy.CGM, thresholdsSynced, canNotify)
+
+    @Test
+    fun `healthy server wins regardless of floor inputs`() {
+        assertEquals(
+            AlertFloorStatus.SERVER_ACTIVE,
+            status(
+                network = NetworkStatus.REACHABLE,
+                stream = AlertStreamState.CONNECTED,
+                cgmAgeMs = null,
+                thresholdsSynced = false,
+                canNotify = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `degraded with a fresh reading and synced thresholds claims watching`() {
+        assertEquals(AlertFloorStatus.FLOOR_WATCHING, status(cgmAgeMs = 30_000L))
+    }
+
+    @Test
+    fun `degraded with a stale reading claims NOT watching - the lethal trap pinned`() {
+        // Exactly the claim GLY-115 exists to keep honest: STALE and TOO_STALE readings mean
+        // the floor cannot fire, so the surface must never say "watching".
+        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, status(cgmAgeMs = 6 * 60_000L))
+        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, status(cgmAgeMs = 20 * 60_000L))
+    }
+
+    @Test
+    fun `degraded with no reading at all claims NOT watching`() {
+        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, status(cgmAgeMs = null))
+    }
+
+    @Test
+    fun `degraded with unsynced thresholds claims NOT watching even on a fresh reading`() {
+        assertEquals(
+            AlertFloorStatus.FLOOR_NOT_WATCHING,
+            status(cgmAgeMs = 0L, thresholdsSynced = false),
+        )
+    }
+
+    @Test
+    fun `degraded without notification permission claims NOT watching`() {
+        assertEquals(
+            AlertFloorStatus.FLOOR_NOT_WATCHING,
+            status(cgmAgeMs = 0L, canNotify = false),
+        )
+    }
+
+    @Test
+    fun `a reading future-dated beyond the skew bound claims NOT watching`() {
+        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, status(cgmAgeMs = -10 * 60_000L))
+    }
+
+    // -- banner copy selection ------------------------------------------------------------------
+
+    @Test
+    fun `watching copy says the phone is watching and carries the threshold-only disclaimer`() {
+        val text = alertingDegradedBannerText(AlertFloorStatus.FLOOR_WATCHING)!!
+        assertTrue(text.contains("this phone is watching"))
+        assertTrue(text.contains("Threshold-only, no prediction"))
+    }
+
+    @Test
+    fun `not-watching copy says NOT watching and never claims coverage`() {
+        val text = alertingDegradedBannerText(AlertFloorStatus.FLOOR_NOT_WATCHING)!!
+        assertTrue(text.contains("NOT watching"))
+        assertFalse(text.contains("is watching your"))
+    }
+
+    @Test
+    fun `server-active has no banner copy`() {
+        assertNull(alertingDegradedBannerText(AlertFloorStatus.SERVER_ACTIVE))
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -1,11 +1,15 @@
 package com.glycemicgpt.mobile.presentation.alerts
 
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import com.glycemicgpt.mobile.data.network.NetworkStatus
 import com.glycemicgpt.mobile.data.repository.AlertAckHttpException
 import com.glycemicgpt.mobile.data.repository.AlertRepository
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertNotificationManager
 import com.glycemicgpt.mobile.service.AlertStreamStateHolder
@@ -22,6 +26,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -32,6 +37,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AlertsViewModelTest {
@@ -39,9 +45,12 @@ class AlertsViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private val alertsFlow = MutableStateFlow<List<AlertEntity>>(emptyList())
     private val networkStatusFlow = MutableStateFlow(NetworkStatus.REACHABLE)
+    private val latestCgmFlow = MutableStateFlow<CgmReading?>(null)
     private lateinit var repository: AlertRepository
     private lateinit var notificationManager: AlertNotificationManager
     private lateinit var appSettingsStore: AppSettingsStore
+    private lateinit var alertThresholdStore: AlertThresholdStore
+    private lateinit var pumpDataRepository: PumpDataRepository
     private lateinit var networkMonitor: NetworkMonitor
     private lateinit var alertStreamStateHolder: AlertStreamStateHolder
 
@@ -52,10 +61,19 @@ class AlertsViewModelTest {
             every { observeRecentAlerts() } returns alertsFlow
             coEvery { fetchPendingAlerts() } returns Result.success(emptyList())
         }
-        notificationManager = mockk(relaxed = true)
+        notificationManager = mockk(relaxed = true) {
+            every { canPostAlertNotifications() } returns true
+        }
         appSettingsStore = mockk(relaxed = true) {
             every { glucoseUnit } returns GlucoseUnit.MGDL
             every { glucoseUnitFlow() } returns flowOf(GlucoseUnit.MGDL)
+            every { debugFastStalenessFlow() } returns flowOf(false)
+        }
+        alertThresholdStore = mockk(relaxed = true) {
+            every { isSynced() } returns true
+        }
+        pumpDataRepository = mockk(relaxed = true) {
+            every { observeLatestCgm() } returns latestCgmFlow
         }
         networkMonitor = mockk(relaxed = true) {
             every { status } returns networkStatusFlow
@@ -72,8 +90,16 @@ class AlertsViewModelTest {
         repository,
         notificationManager,
         appSettingsStore,
+        alertThresholdStore,
+        pumpDataRepository,
         networkMonitor,
         alertStreamStateHolder,
+    )
+
+    private fun cgmReading(ageMs: Long) = CgmReading(
+        glucoseMgDl = 120,
+        trendArrow = CgmTrend.FLAT,
+        timestamp = Instant.now().minusMillis(ageMs),
     )
 
     private fun makeAlert(
@@ -317,52 +343,85 @@ class AlertsViewModelTest {
         assertNull(vm.uiState.value.error)
     }
 
-    // -- alertingDegraded (AC4 banner input) -----------------------------------
+    // -- alertFloorStatus (GLY-115 AC7 banner input) -----------------------------
+    // These use runCurrent() (not advanceUntilIdle) while the status flow is subscribed:
+    // the flow embeds an infinite freshness ticker, so draining the scheduler never idles.
 
     @Test
-    fun `alerting is not degraded when backend reachable and stream connected`() = runTest {
+    fun `status is SERVER_ACTIVE when backend reachable and stream connected`() = runTest {
         alertStreamStateHolder.onStreamOpened()
         val vm = createViewModel()
 
-        val job = backgroundScope.launch(testDispatcher) { vm.alertingDegraded.collect { } }
-        advanceUntilIdle()
+        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
+        runCurrent()
 
-        assertFalse(vm.alertingDegraded.value)
+        assertEquals(AlertFloorStatus.SERVER_ACTIVE, vm.alertFloorStatus.value)
         job.cancel()
     }
 
     @Test
-    fun `alerting degrades when the backend becomes unreachable`() = runTest {
+    fun `backend unreachable with a fresh reading flips to FLOOR_WATCHING`() = runTest {
         alertStreamStateHolder.onStreamOpened()
+        latestCgmFlow.value = cgmReading(ageMs = 30_000L)
         val vm = createViewModel()
 
-        val job = backgroundScope.launch(testDispatcher) { vm.alertingDegraded.collect { } }
-        advanceUntilIdle()
-        assertFalse(vm.alertingDegraded.value)
+        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
+        runCurrent()
+        assertEquals(AlertFloorStatus.SERVER_ACTIVE, vm.alertFloorStatus.value)
 
         networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
-        advanceUntilIdle()
+        runCurrent()
 
-        assertTrue(vm.alertingDegraded.value)
+        assertEquals(AlertFloorStatus.FLOOR_WATCHING, vm.alertFloorStatus.value)
         job.cancel()
     }
 
     @Test
-    fun `alerting degrades when the stream drops and recovers on reconnect`() = runTest {
+    fun `backend unreachable with a stale reading is FLOOR_NOT_WATCHING - the honest claim`() = runTest {
         alertStreamStateHolder.onStreamOpened()
+        latestCgmFlow.value = cgmReading(ageMs = 20 * 60_000L)
+        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
         val vm = createViewModel()
 
-        val job = backgroundScope.launch(testDispatcher) { vm.alertingDegraded.collect { } }
-        advanceUntilIdle()
-        assertFalse(vm.alertingDegraded.value)
+        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
+        runCurrent()
+
+        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, vm.alertFloorStatus.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `unsynced thresholds keep the degraded surface at FLOOR_NOT_WATCHING`() = runTest {
+        every { alertThresholdStore.isSynced() } returns false
+        alertStreamStateHolder.onStreamOpened()
+        latestCgmFlow.value = cgmReading(ageMs = 0L)
+        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+        val vm = createViewModel()
+
+        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
+        runCurrent()
+
+        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, vm.alertFloorStatus.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `stream drop degrades and reconnect restores SERVER_ACTIVE`() = runTest {
+        alertStreamStateHolder.onStreamOpened()
+        latestCgmFlow.value = cgmReading(ageMs = 0L)
+        val vm = createViewModel()
+
+        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
+        runCurrent()
+        assertEquals(AlertFloorStatus.SERVER_ACTIVE, vm.alertFloorStatus.value)
 
         alertStreamStateHolder.onStreamRetrying()
-        advanceUntilIdle()
-        assertTrue(vm.alertingDegraded.value)
+        runCurrent()
+        assertEquals(AlertFloorStatus.FLOOR_WATCHING, vm.alertFloorStatus.value)
 
         alertStreamStateHolder.onStreamOpened()
-        advanceUntilIdle()
-        assertFalse(vm.alertingDegraded.value)
+        runCurrent()
+        assertEquals(AlertFloorStatus.SERVER_ACTIVE, vm.alertFloorStatus.value)
 
         job.cancel()
     }
@@ -375,11 +434,11 @@ class AlertsViewModelTest {
         alertsFlow.value = listOf(makeAlert())
 
         val vm = createViewModel()
-        val degradedJob = backgroundScope.launch(testDispatcher) { vm.alertingDegraded.collect { } }
+        val degradedJob = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
         val alertsJob = backgroundScope.launch(testDispatcher) { vm.alerts.collect { } }
-        advanceUntilIdle()
+        runCurrent()
 
-        assertTrue(vm.alertingDegraded.value)
+        assertTrue(vm.alertFloorStatus.value != AlertFloorStatus.SERVER_ACTIVE)
         assertEquals(1, vm.alerts.value.size)
         assertFalse(vm.uiState.value.isLoading)
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -1,18 +1,15 @@
 package com.glycemicgpt.mobile.presentation.alerts
 
-import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
-import com.glycemicgpt.mobile.data.network.NetworkMonitor
 import com.glycemicgpt.mobile.data.network.NetworkStatus
 import com.glycemicgpt.mobile.data.repository.AlertAckHttpException
 import com.glycemicgpt.mobile.data.repository.AlertRepository
-import com.glycemicgpt.mobile.data.repository.PumpDataRepository
-import com.glycemicgpt.mobile.domain.model.CgmReading
-import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
+import com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import com.glycemicgpt.mobile.service.AlertFloorStatusProvider
 import com.glycemicgpt.mobile.service.AlertNotificationManager
-import com.glycemicgpt.mobile.service.AlertStreamStateHolder
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -45,14 +42,11 @@ class AlertsViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private val alertsFlow = MutableStateFlow<List<AlertEntity>>(emptyList())
     private val networkStatusFlow = MutableStateFlow(NetworkStatus.REACHABLE)
-    private val latestCgmFlow = MutableStateFlow<CgmReading?>(null)
+    private val floorStatusFlow = MutableStateFlow<AlertFloorStatus>(AlertFloorStatus.ServerActive)
     private lateinit var repository: AlertRepository
     private lateinit var notificationManager: AlertNotificationManager
     private lateinit var appSettingsStore: AppSettingsStore
-    private lateinit var alertThresholdStore: AlertThresholdStore
-    private lateinit var pumpDataRepository: PumpDataRepository
-    private lateinit var networkMonitor: NetworkMonitor
-    private lateinit var alertStreamStateHolder: AlertStreamStateHolder
+    private lateinit var alertFloorStatusProvider: AlertFloorStatusProvider
 
     @Before
     fun setUp() {
@@ -61,24 +55,17 @@ class AlertsViewModelTest {
             every { observeRecentAlerts() } returns alertsFlow
             coEvery { fetchPendingAlerts() } returns Result.success(emptyList())
         }
-        notificationManager = mockk(relaxed = true) {
-            every { canPostAlertNotifications() } returns true
-        }
+        notificationManager = mockk(relaxed = true)
         appSettingsStore = mockk(relaxed = true) {
             every { glucoseUnit } returns GlucoseUnit.MGDL
             every { glucoseUnitFlow() } returns flowOf(GlucoseUnit.MGDL)
-            every { debugFastStalenessFlow() } returns flowOf(false)
         }
-        alertThresholdStore = mockk(relaxed = true) {
-            every { isSynced() } returns true
+        // The status pipeline itself is AlertFloorStatusProvider's (and alertFloorStatus's)
+        // responsibility, covered by their own tests; here the VM just relays it.
+        alertFloorStatusProvider = mockk {
+            every { observe() } returns floorStatusFlow
+            every { current() } answers { floorStatusFlow.value }
         }
-        pumpDataRepository = mockk(relaxed = true) {
-            every { observeLatestCgm() } returns latestCgmFlow
-        }
-        networkMonitor = mockk(relaxed = true) {
-            every { status } returns networkStatusFlow
-        }
-        alertStreamStateHolder = AlertStreamStateHolder()
     }
 
     @After
@@ -90,16 +77,7 @@ class AlertsViewModelTest {
         repository,
         notificationManager,
         appSettingsStore,
-        alertThresholdStore,
-        pumpDataRepository,
-        networkMonitor,
-        alertStreamStateHolder,
-    )
-
-    private fun cgmReading(ageMs: Long) = CgmReading(
-        glucoseMgDl = 120,
-        trendArrow = CgmTrend.FLAT,
-        timestamp = Instant.now().minusMillis(ageMs),
+        alertFloorStatusProvider,
     )
 
     private fun makeAlert(
@@ -344,91 +322,37 @@ class AlertsViewModelTest {
     }
 
     // -- alertFloorStatus (GLY-115 AC7 banner input) -----------------------------
-    // These use runCurrent() (not advanceUntilIdle) while the status flow is subscribed:
-    // the flow embeds an infinite freshness ticker, so draining the scheduler never idles.
+    // The pipeline (which inputs, what cadence) belongs to AlertFloorStatusProvider and the
+    // pure alertFloorStatus(); these tests pin only the VM's relay-and-seed contract.
 
     @Test
-    fun `status is SERVER_ACTIVE when backend reachable and stream connected`() = runTest {
-        alertStreamStateHolder.onStreamOpened()
+    fun `status seeds from the provider snapshot and relays live emissions`() = runTest {
+        floorStatusFlow.value = AlertFloorStatus.ServerActive
         val vm = createViewModel()
 
         val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
         runCurrent()
+        assertEquals(AlertFloorStatus.ServerActive, vm.alertFloorStatus.value)
 
-        assertEquals(AlertFloorStatus.SERVER_ACTIVE, vm.alertFloorStatus.value)
-        job.cancel()
-    }
-
-    @Test
-    fun `backend unreachable with a fresh reading flips to FLOOR_WATCHING`() = runTest {
-        alertStreamStateHolder.onStreamOpened()
-        latestCgmFlow.value = cgmReading(ageMs = 30_000L)
-        val vm = createViewModel()
-
-        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
+        floorStatusFlow.value = AlertFloorStatus.FloorWatching
         runCurrent()
-        assertEquals(AlertFloorStatus.SERVER_ACTIVE, vm.alertFloorStatus.value)
+        assertEquals(AlertFloorStatus.FloorWatching, vm.alertFloorStatus.value)
 
-        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+        floorStatusFlow.value =
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING)
         runCurrent()
-
-        assertEquals(AlertFloorStatus.FLOOR_WATCHING, vm.alertFloorStatus.value)
-        job.cancel()
-    }
-
-    @Test
-    fun `backend unreachable with a stale reading is FLOOR_NOT_WATCHING - the honest claim`() = runTest {
-        alertStreamStateHolder.onStreamOpened()
-        latestCgmFlow.value = cgmReading(ageMs = 20 * 60_000L)
-        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
-        val vm = createViewModel()
-
-        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
-        runCurrent()
-
-        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, vm.alertFloorStatus.value)
-        job.cancel()
-    }
-
-    @Test
-    fun `unsynced thresholds keep the degraded surface at FLOOR_NOT_WATCHING`() = runTest {
-        every { alertThresholdStore.isSynced() } returns false
-        alertStreamStateHolder.onStreamOpened()
-        latestCgmFlow.value = cgmReading(ageMs = 0L)
-        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
-        val vm = createViewModel()
-
-        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
-        runCurrent()
-
-        assertEquals(AlertFloorStatus.FLOOR_NOT_WATCHING, vm.alertFloorStatus.value)
-        job.cancel()
-    }
-
-    @Test
-    fun `stream drop degrades and reconnect restores SERVER_ACTIVE`() = runTest {
-        alertStreamStateHolder.onStreamOpened()
-        latestCgmFlow.value = cgmReading(ageMs = 0L)
-        val vm = createViewModel()
-
-        val job = backgroundScope.launch(testDispatcher) { vm.alertFloorStatus.collect { } }
-        runCurrent()
-        assertEquals(AlertFloorStatus.SERVER_ACTIVE, vm.alertFloorStatus.value)
-
-        alertStreamStateHolder.onStreamRetrying()
-        runCurrent()
-        assertEquals(AlertFloorStatus.FLOOR_WATCHING, vm.alertFloorStatus.value)
-
-        alertStreamStateHolder.onStreamOpened()
-        runCurrent()
-        assertEquals(AlertFloorStatus.SERVER_ACTIVE, vm.alertFloorStatus.value)
-
+        assertEquals(
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING),
+            vm.alertFloorStatus.value,
+        )
         job.cancel()
     }
 
     @Test
     fun `cached alerts still display while alerting is degraded`() = runTest {
         networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+        floorStatusFlow.value =
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING)
         coEvery { repository.fetchPendingAlerts() } returns
             Result.failure(IOException("unreachable"))
         alertsFlow.value = listOf(makeAlert())
@@ -438,7 +362,7 @@ class AlertsViewModelTest {
         val alertsJob = backgroundScope.launch(testDispatcher) { vm.alerts.collect { } }
         runCurrent()
 
-        assertTrue(vm.alertFloorStatus.value != AlertFloorStatus.SERVER_ACTIVE)
+        assertTrue(vm.alertFloorStatus.value != AlertFloorStatus.ServerActive)
         assertEquals(1, vm.alerts.value.size)
         assertFalse(vm.uiState.value.isLoading)
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.glycemicgpt.mobile.presentation.home
 
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
@@ -121,6 +122,10 @@ class HomeViewModelTest {
         every { isStale(any()) } returns false
     }
 
+    private val alertThresholdStore = mockk<AlertThresholdStore>(relaxed = true) {
+        every { isStale(any()) } returns false
+    }
+
     private val analyticsSettingsStore = mockk<AnalyticsSettingsStore>(relaxed = true) {
         every { dayBoundaryHour } returns 0
         every { categoryLabels } returns emptyMap()
@@ -162,7 +167,7 @@ class HomeViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, api, pluginRegistry, networkMonitor)
+    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, alertThresholdStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, api, pluginRegistry, networkMonitor)
 
     @Test
     fun `initial state has null readings and not refreshing`() = runTest {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -33,6 +33,7 @@ import com.glycemicgpt.mobile.domain.plugin.ui.DashboardCardDescriptor
 import com.glycemicgpt.mobile.domain.pump.PumpDriver
 import com.glycemicgpt.mobile.plugin.PluginRegistry
 import com.glycemicgpt.mobile.service.BackendSyncManager
+import com.glycemicgpt.mobile.service.PumpPollingOrchestrator
 import com.glycemicgpt.mobile.service.SyncStatus
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -157,6 +158,8 @@ class HomeViewModelTest {
         every { status } returns networkStatusFlow
     }
 
+    private val pollingOrchestrator = mockk<PumpPollingOrchestrator>(relaxed = true)
+
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
@@ -167,7 +170,7 @@ class HomeViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, alertThresholdStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, api, pluginRegistry, networkMonitor)
+    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, alertThresholdStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, api, pluginRegistry, networkMonitor, pollingOrchestrator)
 
     @Test
     fun `initial state has null readings and not refreshing`() = runTest {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -5,6 +5,7 @@ import android.os.PowerManager
 import com.glycemicgpt.mobile.data.auth.AuthManager
 import com.glycemicgpt.mobile.data.auth.AuthState
 import com.glycemicgpt.mobile.data.local.AlertSoundStore
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
@@ -95,6 +96,9 @@ class SettingsViewModelTest {
     private val safetyLimitsStore = mockk<SafetyLimitsStore>(relaxed = true) {
         every { isStale(any()) } returns false
     }
+    private val alertThresholdStore = mockk<AlertThresholdStore>(relaxed = true) {
+        every { isStale(any()) } returns false
+    }
     private val appUpdateChecker = mockk<AppUpdateChecker>()
     private val authManager = mockk<AuthManager>(relaxed = true) {
         every { authState } returns MutableStateFlow(AuthState.Unauthenticated)
@@ -131,7 +135,7 @@ class SettingsViewModelTest {
     }
 
     private fun createViewModel() =
-        SettingsViewModel(appContext, pumpCredentialStore, appSettingsStore, glucoseRangeStore, safetyLimitsStore, authRepository, appUpdateChecker, authManager, alertSoundStore, alertNotificationManager, pluginRegistry, watchFacePusher, wearDataSender, wearAppUpdateChecker, wearApkPusher, analyticsSettingsStore)
+        SettingsViewModel(appContext, pumpCredentialStore, appSettingsStore, glucoseRangeStore, safetyLimitsStore, alertThresholdStore, authRepository, appUpdateChecker, authManager, alertSoundStore, alertNotificationManager, pluginRegistry, watchFacePusher, wearDataSender, wearAppUpdateChecker, wearApkPusher, analyticsSettingsStore)
 
     @Test
     fun `loadState initializes from stores`() {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertActionReceiverTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertActionReceiverTest.kt
@@ -40,7 +40,7 @@ class AlertActionReceiverTest {
         }
         alertNotificationManager = mockk(relaxUnitFun = true)
         alertFloor = mockk {
-            coEvery { onFloorAlertAcknowledged(any()) } just Runs
+            coEvery { onFloorAlertAcknowledged(any(), any()) } just Runs
         }
         receiver = AlertActionReceiver().apply {
             alertRepository = this@AlertActionReceiverTest.alertRepository
@@ -147,7 +147,7 @@ class AlertActionReceiverTest {
         verify(exactly = 1) { alertNotificationManager.markAcknowledged(floorId) }
         // ...the floor's cooldown for the type is cleared (ack-gated dedup, mirroring the
         // server: a NEW crossing minutes later must alarm again)...
-        coVerify(exactly = 1) { alertFloor.onFloorAlertAcknowledged("low_urgent") }
+        coVerify(exactly = 1) { alertFloor.onFloorAlertAcknowledged("low_urgent", any()) }
         // ...but there is no server record: the synthetic id must never reach the ack endpoint.
         coVerify(exactly = 0) { alertRepository.acknowledgeAlert(any()) }
         confirmVerified(alertRepository, alertNotificationManager, alertFloor)
@@ -159,7 +159,7 @@ class AlertActionReceiverTest {
 
         receiver.handleAcknowledge("srv-1", notificationId = 42)
 
-        coVerify(exactly = 0) { alertFloor.onFloorAlertAcknowledged(any()) }
+        coVerify(exactly = 0) { alertFloor.onFloorAlertAcknowledged(any(), any()) }
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertActionReceiverTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertActionReceiverTest.kt
@@ -30,6 +30,7 @@ class AlertActionReceiverTest {
 
     private lateinit var alertRepository: AlertRepository
     private lateinit var alertNotificationManager: AlertNotificationManager
+    private lateinit var alertFloor: AlertFloor
     private lateinit var receiver: AlertActionReceiver
 
     @Before
@@ -38,9 +39,13 @@ class AlertActionReceiverTest {
             coEvery { markAcknowledgedLocally(any()) } just Runs
         }
         alertNotificationManager = mockk(relaxUnitFun = true)
+        alertFloor = mockk {
+            coEvery { onFloorAlertAcknowledged(any()) } just Runs
+        }
         receiver = AlertActionReceiver().apply {
             alertRepository = this@AlertActionReceiverTest.alertRepository
             alertNotificationManager = this@AlertActionReceiverTest.alertNotificationManager
+            alertFloor = this@AlertActionReceiverTest.alertFloor
         }
     }
 
@@ -140,9 +145,35 @@ class AlertActionReceiverTest {
         verify(exactly = 1) { alertNotificationManager.cancelNotification(42) }
         verify(exactly = 1) { alertNotificationManager.restoreAlarmVolume() }
         verify(exactly = 1) { alertNotificationManager.markAcknowledged(floorId) }
+        // ...the floor's cooldown for the type is cleared (ack-gated dedup, mirroring the
+        // server: a NEW crossing minutes later must alarm again)...
+        coVerify(exactly = 1) { alertFloor.onFloorAlertAcknowledged("low_urgent") }
         // ...but there is no server record: the synthetic id must never reach the ack endpoint.
         coVerify(exactly = 0) { alertRepository.acknowledgeAlert(any()) }
-        confirmVerified(alertRepository, alertNotificationManager)
+        confirmVerified(alertRepository, alertNotificationManager, alertFloor)
+    }
+
+    @Test
+    fun `server alert ack never touches the floor cooldown`() = runTest {
+        coEvery { alertRepository.acknowledgeAlert("srv-1") } returns Result.success(Unit)
+
+        receiver.handleAcknowledge("srv-1", notificationId = 42)
+
+        coVerify(exactly = 0) { alertFloor.onFloorAlertAcknowledged(any()) }
+    }
+
+    @Test
+    fun `floor serverId parsing extracts the alert type and rejects malformed ids`() {
+        assertEquals(
+            "low_urgent",
+            AlertActionReceiver.floorAlertTypeFromServerId("local-floor:low_urgent:175000"),
+        )
+        assertEquals(
+            "high_warning",
+            AlertActionReceiver.floorAlertTypeFromServerId("local-floor:high_warning:1"),
+        )
+        assertEquals(null, AlertActionReceiver.floorAlertTypeFromServerId("local-floor:"))
+        assertEquals(null, AlertActionReceiver.floorAlertTypeFromServerId("local-floor:oops"))
     }
 
     // -- intent contract ------------------------------------------------------------------------

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertActionReceiverTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertActionReceiverTest.kt
@@ -126,6 +126,25 @@ class AlertActionReceiverTest {
         }
     }
 
+    // -- floor alerts (GLY-115): local-only acknowledgement -------------------------------------
+
+    @Test
+    fun `floor alert ack silences locally and never POSTs the synthetic id to the server`() = runTest {
+        val floorId = AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX + "low_urgent:1750000000000"
+
+        receiver.handleAcknowledge(floorId, notificationId = 42)
+
+        // The full local silence sequence still runs (a floor alarm must be silenceable exactly
+        // like a server one)...
+        coVerify(exactly = 1) { alertRepository.markAcknowledgedLocally(floorId) }
+        verify(exactly = 1) { alertNotificationManager.cancelNotification(42) }
+        verify(exactly = 1) { alertNotificationManager.restoreAlarmVolume() }
+        verify(exactly = 1) { alertNotificationManager.markAcknowledged(floorId) }
+        // ...but there is no server record: the synthetic id must never reach the ack endpoint.
+        coVerify(exactly = 0) { alertRepository.acknowledgeAlert(any()) }
+        confirmVerified(alertRepository, alertNotificationManager)
+    }
+
     // -- intent contract ------------------------------------------------------------------------
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorTest.kt
@@ -1,0 +1,325 @@
+package com.glycemicgpt.mobile.service
+
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.dao.AlertDao
+import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Behavioral tests for the on-device freshness-gated alert floor (GLY-115).
+ *
+ * The lethal invariant pinned here: the floor NEVER fires on a non-FRESH reading (AC2), and each
+ * of the four preconditions independently blocks firing (AC1/AC3/AC4). Plus the dedup layers:
+ * per-type cooldown mirroring the server's 30-minute window, the episode guard across the
+ * REACHABLE→UNREACHABLE flip, and the server-vocabulary classification (AC5/AC6).
+ */
+class AlertFloorTest {
+
+    private val networkStatusFlow = MutableStateFlow(NetworkStatus.BACKEND_UNREACHABLE)
+    private val streamStateFlow = MutableStateFlow(AlertStreamState.RECONNECTING)
+
+    private lateinit var alertThresholdStore: AlertThresholdStore
+    private lateinit var alertNotificationManager: AlertNotificationManager
+    private lateinit var alertStreamStateHolder: AlertStreamStateHolder
+    private lateinit var networkMonitor: NetworkMonitor
+    private lateinit var alertDao: AlertDao
+    private lateinit var appSettingsStore: AppSettingsStore
+    private lateinit var floor: AlertFloor
+
+    /** Fixed "now" so freshness and cooldown math is deterministic. */
+    private val nowMs = 1_750_000_000_000L
+
+    @Before
+    fun setUp() {
+        alertThresholdStore = mockk(relaxed = true) {
+            every { urgentLowMgDl } returns 55
+            every { lowWarningMgDl } returns 70
+            every { highWarningMgDl } returns 180
+            every { urgentHighMgDl } returns 250
+            every { isSynced() } returns true
+        }
+        alertNotificationManager = mockk(relaxed = true) {
+            every { canPostAlertNotifications() } returns true
+            every { stableNotificationId(any()) } answers {
+                (firstArg<AlertEntity>().alertType.hashCode() and 0x7FFFFFFF).coerceAtLeast(100)
+            }
+        }
+        alertStreamStateHolder = mockk {
+            every { state } returns streamStateFlow
+        }
+        networkMonitor = mockk {
+            every { status } returns networkStatusFlow
+        }
+        alertDao = mockk {
+            coEvery { getLatestTimestampForType(any(), any()) } returns null
+        }
+        appSettingsStore = mockk(relaxed = true) {
+            every { debugFastStaleness } returns false
+            every { glucoseUnit } returns GlucoseUnit.MGDL
+        }
+        floor = AlertFloor(
+            alertThresholdStore,
+            alertNotificationManager,
+            alertStreamStateHolder,
+            networkMonitor,
+            alertDao,
+            appSettingsStore,
+        )
+    }
+
+    /** Run the floor for a reading whose sensor timestamp is [ageMs] before [atMs]. */
+    private suspend fun evaluate(mgDl: Int, ageMs: Long = 0L, atMs: Long = nowMs) {
+        floor.onCgmReading(
+            CgmReading(
+                glucoseMgDl = mgDl,
+                trendArrow = CgmTrend.FLAT,
+                timestamp = Instant.ofEpochMilli(atMs - ageMs),
+            ),
+            floor.classify(mgDl),
+            nowMs = atMs,
+        )
+    }
+
+    // -- classification: server AlertType vocabulary off the synced alert thresholds -----------
+
+    @Test
+    fun `classify maps bands to the server vocabulary with urgent precedence`() {
+        assertEquals(AlertFloor.TYPE_LOW_URGENT, floor.classify(55))
+        assertEquals(AlertFloor.TYPE_LOW_URGENT, floor.classify(40))
+        assertEquals(AlertFloor.TYPE_LOW_WARNING, floor.classify(56))
+        assertEquals(AlertFloor.TYPE_LOW_WARNING, floor.classify(70))
+        assertNull(floor.classify(71))
+        assertNull(floor.classify(120))
+        assertNull(floor.classify(179))
+        assertEquals(AlertFloor.TYPE_HIGH_WARNING, floor.classify(180))
+        assertEquals(AlertFloor.TYPE_HIGH_WARNING, floor.classify(249))
+        assertEquals(AlertFloor.TYPE_HIGH_URGENT, floor.classify(250))
+        assertEquals(AlertFloor.TYPE_HIGH_URGENT, floor.classify(400))
+    }
+
+    @Test
+    fun `classify never emits the watch vocabulary`() {
+        for (mgDl in intArrayOf(40, 60, 200, 300)) {
+            val type = floor.classify(mgDl)
+            assertTrue(
+                "watch string leaked into floor classification: $type",
+                type !in setOf("urgent_low", "low", "high", "urgent_high"),
+            )
+        }
+    }
+
+    // -- AC1: all gates pass, floor fires ------------------------------------------------------
+
+    @Test
+    fun `fresh low while degraded fires the alarm with disclaimer and stable slot`() = runTest {
+        evaluate(mgDl = 54, ageMs = 30_000L)
+
+        val entity = slot<AlertEntity>()
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(capture(entity), any()) }
+        with(entity.captured) {
+            assertEquals(AlertFloor.TYPE_LOW_URGENT, alertType)
+            assertEquals("urgent", severity)
+            assertEquals(54.0, currentValue, 0.0)
+            assertTrue(serverId.startsWith(AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX))
+            assertTrue(message.contains("computed on your phone"))
+            assertTrue(message.contains("Threshold-only, no prediction"))
+            assertTrue(message.contains("Not a replacement for your CGM app"))
+        }
+    }
+
+    @Test
+    fun `fresh high fires with warning severity`() = runTest {
+        evaluate(mgDl = 200)
+
+        val entity = slot<AlertEntity>()
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(capture(entity), any()) }
+        assertEquals(AlertFloor.TYPE_HIGH_WARNING, entity.captured.alertType)
+        assertEquals("warning", entity.captured.severity)
+    }
+
+    @Test
+    fun `in-range reading is a no-op`() = runTest {
+        evaluate(mgDl = 120)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- AC2: THE safety invariant — never fire on a non-FRESH reading -------------------------
+
+    @Test
+    fun `STALE reading never fires`() = runTest {
+        // 6 min is the FRESH/STALE boundary (half-open: exactly 6 min is STALE)
+        evaluate(mgDl = 54, ageMs = 6 * 60_000L)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `TOO_STALE reading never fires`() = runTest {
+        evaluate(mgDl = 54, ageMs = 20 * 60_000L)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `reading just inside the FRESH bound fires`() = runTest {
+        evaluate(mgDl = 54, ageMs = 6 * 60_000L - 1)
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `clock skew - small future-dated reading still fires`() = runTest {
+        // Pump clocks routinely run seconds ahead; a hard age>=0 gate would silently disable
+        // the floor — the inverted version of the same lethal failure.
+        evaluate(mgDl = 54, ageMs = -30_000L)
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `clock skew - reading future-dated beyond tolerance never fires`() = runTest {
+        // A backwards phone-clock jump makes a genuinely old reading look future-dated; the
+        // display classifier calls any negative age FRESH, the floor must not.
+        evaluate(mgDl = 54, ageMs = -10 * 60_000L)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `debug fast staleness policy governs the gate when enabled`() = runTest {
+        every { appSettingsStore.debugFastStaleness } returns true
+        // 30s old: FRESH under the real 6-min policy, STALE under CGM_DEBUG_FAST (20s) — the
+        // floor must read the swapped policy or the E2E harness would test nothing.
+        evaluate(mgDl = 54, ageMs = 30_000L)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+
+        evaluate(mgDl = 54, ageMs = 10_000L)
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- AC4: armed only when the server can't alert -------------------------------------------
+
+    @Test
+    fun `reachable and connected - floor stays silent on a fresh low`() = runTest {
+        networkStatusFlow.value = NetworkStatus.REACHABLE
+        streamStateFlow.value = AlertStreamState.CONNECTED
+
+        evaluate(mgDl = 54)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `stream down alone arms the floor even while HTTP works`() = runTest {
+        networkStatusFlow.value = NetworkStatus.REACHABLE
+        streamStateFlow.value = AlertStreamState.DISCONNECTED
+
+        evaluate(mgDl = 54)
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `device offline arms the floor`() = runTest {
+        networkStatusFlow.value = NetworkStatus.OFFLINE
+        streamStateFlow.value = AlertStreamState.CONNECTED
+
+        evaluate(mgDl = 54)
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- AC3: never fire off unsynced (default) thresholds -------------------------------------
+
+    @Test
+    fun `never-synced thresholds - floor never fires`() = runTest {
+        every { alertThresholdStore.isSynced() } returns false
+
+        evaluate(mgDl = 54)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- gate 4: notifications permission ------------------------------------------------------
+
+    @Test
+    fun `notifications denied - floor does not fire and does not spend the cooldown`() = runTest {
+        every { alertNotificationManager.canPostAlertNotifications() } returns false
+        evaluate(mgDl = 54)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+
+        // Permission granted moments later: the alarm must not have been "spent" silently.
+        every { alertNotificationManager.canPostAlertNotifications() } returns true
+        evaluate(mgDl = 54, atMs = nowMs + 15_000L)
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- AC6: cooldown + type transitions ------------------------------------------------------
+
+    @Test
+    fun `sustained low does not re-alarm within the 30-minute window`() = runTest {
+        evaluate(mgDl = 54)
+        evaluate(mgDl = 53, atMs = nowMs + 15_000L)
+        evaluate(mgDl = 52, atMs = nowMs + 29 * 60_000L)
+
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `still low after the window elapses re-alarms`() = runTest {
+        evaluate(mgDl = 54)
+        evaluate(mgDl = 54, atMs = nowMs + AlertFloor.FLOOR_COOLDOWN_MS)
+
+        verify(exactly = 2) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `escalation to a different type fires immediately`() = runTest {
+        evaluate(mgDl = 65) // low_warning
+        evaluate(mgDl = 54, atMs = nowMs + 15_000L) // low_urgent — different type, no cooldown
+
+        verify(exactly = 2) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- AC5 episode guard: no double-alarm across the degraded flip ---------------------------
+
+    @Test
+    fun `server alerted the same type just before the outage - floor suppresses and seeds cooldown`() = runTest {
+        coEvery {
+            alertDao.getLatestTimestampForType(AlertFloor.TYPE_LOW_URGENT, any())
+        } returns nowMs - 5 * 60_000L
+
+        evaluate(mgDl = 54)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+
+        // Still inside the window measured from the SERVER alert: stays suppressed.
+        evaluate(mgDl = 54, atMs = nowMs + 10 * 60_000L)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `old server alert outside the window does not suppress`() = runTest {
+        coEvery { alertDao.getLatestTimestampForType(any(), any()) } returns null
+
+        evaluate(mgDl = 54)
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `episode lookup failure fails toward alerting`() = runTest {
+        coEvery { alertDao.getLatestTimestampForType(any(), any()) } throws RuntimeException("db closed")
+
+        evaluate(mgDl = 54)
+        // A broken lookup may cost a duplicate alarm, never a missed one.
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorTest.kt
@@ -5,6 +5,7 @@ import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.dao.AlertDao
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.domain.alerting.AlertTypes
 import com.glycemicgpt.mobile.data.network.NetworkStatus
 import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
@@ -69,7 +70,7 @@ class AlertFloorTest {
             every { status } returns networkStatusFlow
         }
         alertDao = mockk {
-            coEvery { getLatestTimestampForType(any(), any()) } returns null
+            coEvery { getLatestUnacknowledgedTimestampForType(any(), any()) } returns null
         }
         appSettingsStore = mockk(relaxed = true) {
             every { debugFastStaleness } returns false
@@ -102,17 +103,17 @@ class AlertFloorTest {
 
     @Test
     fun `classify maps bands to the server vocabulary with urgent precedence`() {
-        assertEquals(AlertFloor.TYPE_LOW_URGENT, floor.classify(55))
-        assertEquals(AlertFloor.TYPE_LOW_URGENT, floor.classify(40))
-        assertEquals(AlertFloor.TYPE_LOW_WARNING, floor.classify(56))
-        assertEquals(AlertFloor.TYPE_LOW_WARNING, floor.classify(70))
+        assertEquals(AlertTypes.LOW_URGENT, floor.classify(55))
+        assertEquals(AlertTypes.LOW_URGENT, floor.classify(40))
+        assertEquals(AlertTypes.LOW_WARNING, floor.classify(56))
+        assertEquals(AlertTypes.LOW_WARNING, floor.classify(70))
         assertNull(floor.classify(71))
         assertNull(floor.classify(120))
         assertNull(floor.classify(179))
-        assertEquals(AlertFloor.TYPE_HIGH_WARNING, floor.classify(180))
-        assertEquals(AlertFloor.TYPE_HIGH_WARNING, floor.classify(249))
-        assertEquals(AlertFloor.TYPE_HIGH_URGENT, floor.classify(250))
-        assertEquals(AlertFloor.TYPE_HIGH_URGENT, floor.classify(400))
+        assertEquals(AlertTypes.HIGH_WARNING, floor.classify(180))
+        assertEquals(AlertTypes.HIGH_WARNING, floor.classify(249))
+        assertEquals(AlertTypes.HIGH_URGENT, floor.classify(250))
+        assertEquals(AlertTypes.HIGH_URGENT, floor.classify(400))
     }
 
     @Test
@@ -135,7 +136,7 @@ class AlertFloorTest {
         val entity = slot<AlertEntity>()
         verify(exactly = 1) { alertNotificationManager.showAlertNotification(capture(entity), any()) }
         with(entity.captured) {
-            assertEquals(AlertFloor.TYPE_LOW_URGENT, alertType)
+            assertEquals(AlertTypes.LOW_URGENT, alertType)
             assertEquals("urgent", severity)
             assertEquals(54.0, currentValue, 0.0)
             assertTrue(serverId.startsWith(AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX))
@@ -151,7 +152,7 @@ class AlertFloorTest {
 
         val entity = slot<AlertEntity>()
         verify(exactly = 1) { alertNotificationManager.showAlertNotification(capture(entity), any()) }
-        assertEquals(AlertFloor.TYPE_HIGH_WARNING, entity.captured.alertType)
+        assertEquals(AlertTypes.HIGH_WARNING, entity.captured.alertType)
         assertEquals("warning", entity.captured.severity)
     }
 
@@ -295,7 +296,7 @@ class AlertFloorTest {
     @Test
     fun `server alerted the same type just before the outage - floor suppresses and seeds cooldown`() = runTest {
         coEvery {
-            alertDao.getLatestTimestampForType(AlertFloor.TYPE_LOW_URGENT, any())
+            alertDao.getLatestUnacknowledgedTimestampForType(AlertTypes.LOW_URGENT, any())
         } returns nowMs - 5 * 60_000L
 
         evaluate(mgDl = 54)
@@ -308,7 +309,7 @@ class AlertFloorTest {
 
     @Test
     fun `old server alert outside the window does not suppress`() = runTest {
-        coEvery { alertDao.getLatestTimestampForType(any(), any()) } returns null
+        coEvery { alertDao.getLatestUnacknowledgedTimestampForType(any(), any()) } returns null
 
         evaluate(mgDl = 54)
         verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
@@ -316,10 +317,52 @@ class AlertFloorTest {
 
     @Test
     fun `episode lookup failure fails toward alerting`() = runTest {
-        coEvery { alertDao.getLatestTimestampForType(any(), any()) } throws RuntimeException("db closed")
+        coEvery { alertDao.getLatestUnacknowledgedTimestampForType(any(), any()) } throws RuntimeException("db closed")
 
         evaluate(mgDl = 54)
         // A broken lookup may cost a duplicate alarm, never a missed one.
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- ack-gated dedup: an ack must never silence a NEW distinct emergency -------------------
+
+    @Test
+    fun `Got It ack clears the cooldown - a new crossing minutes later alarms again`() = runTest {
+        evaluate(mgDl = 54)
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+
+        // User acknowledges (aware, treats); glucose recovers, then crashes again 20 minutes
+        // later — well inside the raw 30-min window. The server would re-alert (its dedup only
+        // counts unacknowledged alerts); the floor must too.
+        floor.onFloorAlertAcknowledged(AlertTypes.LOW_URGENT)
+        evaluate(mgDl = 50, atMs = nowMs + 20 * 60_000L)
+
+        verify(exactly = 2) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `ack of one type does not clear another type's cooldown`() = runTest {
+        evaluate(mgDl = 54) // low_urgent fires
+        floor.onFloorAlertAcknowledged(AlertTypes.HIGH_WARNING)
+        evaluate(mgDl = 54, atMs = nowMs + 15_000L)
+
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `future-dated server alert seed is clamped - skew cannot stretch the silence window`() = runTest {
+        // Phone clock behind the server: the persisted server alert timestamp is "in the future".
+        // Unclamped, the suppression window would be 30 min + skew.
+        coEvery {
+            alertDao.getLatestUnacknowledgedTimestampForType(AlertTypes.LOW_URGENT, any())
+        } returns nowMs + 10 * 60_000L
+
+        evaluate(mgDl = 54)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+
+        // Exactly one full window after "now" (the clamped seed) the floor may fire again.
+        coEvery { alertDao.getLatestUnacknowledgedTimestampForType(any(), any()) } returns null
+        evaluate(mgDl = 54, atMs = nowMs + AlertFloor.FLOOR_COOLDOWN_MS)
         verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorTest.kt
@@ -324,28 +324,115 @@ class AlertFloorTest {
         verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
     }
 
-    // -- ack-gated dedup: an ack must never silence a NEW distinct emergency -------------------
+    // -- ack semantics: bounded snooze, distinct-episode re-arm, never permanent silence -------
 
     @Test
-    fun `Got It ack clears the cooldown - a new crossing minutes later alarms again`() = runTest {
+    fun `acked then recovered then re-crossed - alarms again immediately as a distinct episode`() = runTest {
         evaluate(mgDl = 54)
         verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
 
-        // User acknowledges (aware, treats); glucose recovers, then crashes again 20 minutes
-        // later — well inside the raw 30-min window. The server would re-alert (its dedup only
-        // counts unacknowledged alerts); the floor must too.
-        floor.onFloorAlertAcknowledged(AlertTypes.LOW_URGENT)
+        // User acknowledges (aware, treats); glucose recovers into range, then crashes again
+        // 20 minutes after the first fire — a NEW distinct low well inside the raw 30-min
+        // window. Recovery re-armed the type, so it must alarm immediately.
+        floor.onFloorAlertAcknowledged(AlertTypes.LOW_URGENT, nowMs = nowMs + 60_000L)
+        evaluate(mgDl = 120, atMs = nowMs + 10 * 60_000L) // recovery reading
         evaluate(mgDl = 50, atMs = nowMs + 20 * 60_000L)
 
         verify(exactly = 2) { alertNotificationManager.showAlertNotification(any(), any()) }
     }
 
     @Test
+    fun `acked sustained low does not re-alarm on the next polls - ack is not a 15s snooze loop`() = runTest {
+        evaluate(mgDl = 54)
+        floor.onFloorAlertAcknowledged(AlertTypes.LOW_URGENT, nowMs = nowMs + 60_000L)
+
+        // Same un-recovered low on subsequent polls: silenced (the user just said "seen").
+        evaluate(mgDl = 54, atMs = nowMs + 75_000L)
+        evaluate(mgDl = 53, atMs = nowMs + 10 * 60_000L)
+
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `acked sustained low re-alarms one cooldown after the ack - never permanently silent`() = runTest {
+        evaluate(mgDl = 54)
+        floor.onFloorAlertAcknowledged(AlertTypes.LOW_URGENT, nowMs = nowMs + 60_000L)
+
+        // Still low, never recovered, 30 minutes after the ack: the safety backstop fires.
+        evaluate(mgDl = 52, atMs = nowMs + 60_000L + AlertFloor.FLOOR_COOLDOWN_MS)
+
+        verify(exactly = 2) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `unacked boundary flapping stays inside the cooldown - recovery only re-arms acked types`() = runTest {
+        evaluate(mgDl = 65) // low_warning fires, NOT acknowledged
+        evaluate(mgDl = 75, atMs = nowMs + 15_000L) // hovers back in range
+        evaluate(mgDl = 68, atMs = nowMs + 30_000L) // crosses again
+
+        // The unacked notification is still up; re-alarming every boundary crossing of a
+        // hovering glucose is the spam the dedup window exists to stop.
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
     fun `ack of one type does not clear another type's cooldown`() = runTest {
         evaluate(mgDl = 54) // low_urgent fires
-        floor.onFloorAlertAcknowledged(AlertTypes.HIGH_WARNING)
+        floor.onFloorAlertAcknowledged(AlertTypes.HIGH_WARNING, nowMs = nowMs)
         evaluate(mgDl = 54, atMs = nowMs + 15_000L)
 
+        verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- wall-clock rewind guard: a backward jump must never resurrect a stale reading ---------
+
+    @Test
+    fun `backward clock jump cannot resurrect a stale reading - the false-guarantee fix`() = runTest {
+        // A sensor stuck in warmup keeps returning a 12-min-old value: correctly suppressed.
+        val staleReading = CgmReading(
+            glucoseMgDl = 54,
+            trendArrow = CgmTrend.FLAT,
+            timestamp = Instant.ofEpochMilli(nowMs - 12 * 60_000L),
+        )
+        floor.onCgmReading(staleReading, floor.classify(54), nowMs = nowMs)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+
+        // The wall clock jumps back ~7 minutes: the same reading now LOOKS 5 minutes old
+        // (inside the FRESH window). The high-water mark from the first evaluation must
+        // suppress it — firing here would be alerting on stale data.
+        floor.onCgmReading(staleReading, floor.classify(54), nowMs = nowMs - 7 * 60_000L + 15_000L)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+
+        // Once the wall clock catches back up past the high-water mark, the reading honestly
+        // classifies TOO_STALE again: still suppressed, by the ordinary freshness gate.
+        floor.onCgmReading(staleReading, floor.classify(54), nowMs = nowMs + 15_000L)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `while rewound even an apparently fresh reading is suppressed - fail closed`() = runTest {
+        // Establish the high-water mark with an in-range evaluation.
+        evaluate(mgDl = 120, atMs = nowMs)
+
+        // Clock rewinds 5 minutes; a reading timestamped just before the rewound "now" looks
+        // 10s fresh, but no wall-clock-derived age is trustworthy until the clock catches up.
+        val rewoundNow = nowMs - 5 * 60_000L
+        val reading = CgmReading(
+            glucoseMgDl = 54,
+            trendArrow = CgmTrend.FLAT,
+            timestamp = Instant.ofEpochMilli(rewoundNow - 10_000L),
+        )
+        floor.onCgmReading(reading, floor.classify(54), nowMs = rewoundNow)
+        verify(exactly = 0) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    @Test
+    fun `rewind within the skew tolerance is not treated as a jump`() = runTest {
+        evaluate(mgDl = 120, atMs = nowMs)
+        // 30s backward (NTP nudge, within ALERT_FLOOR_MAX_FUTURE_SKEW_MS): a genuinely fresh
+        // low must still fire — over-suppressing on routine drift would silently disable the
+        // floor, the same lethal failure inverted.
+        evaluate(mgDl = 54, ageMs = 10_000L, atMs = nowMs - 30_000L)
         verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -6,6 +6,7 @@ import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
 import com.glycemicgpt.mobile.data.local.dao.RawHistoryLogDao
 import com.glycemicgpt.mobile.data.repository.PumpDataRepository
 import com.glycemicgpt.mobile.data.repository.SyncQueueEnqueuer
+import com.glycemicgpt.mobile.domain.alerting.AlertTypes
 import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.CgmReading
@@ -90,10 +91,10 @@ class PumpPollingOrchestratorTest {
         every { classify(any()) } answers {
             val mgDl = firstArg<Int>()
             when {
-                mgDl <= 55 -> AlertFloor.TYPE_LOW_URGENT
-                mgDl >= 250 -> AlertFloor.TYPE_HIGH_URGENT
-                mgDl <= 70 -> AlertFloor.TYPE_LOW_WARNING
-                mgDl >= 180 -> AlertFloor.TYPE_HIGH_WARNING
+                mgDl <= 55 -> AlertTypes.LOW_URGENT
+                mgDl >= 250 -> AlertTypes.HIGH_URGENT
+                mgDl <= 70 -> AlertTypes.LOW_WARNING
+                mgDl >= 180 -> AlertTypes.HIGH_WARNING
                 else -> null
             }
         }
@@ -397,12 +398,12 @@ class PumpPollingOrchestratorTest {
         // The floor is evaluated on EVERY poll (not edge-latched like the watch relay) — a low
         // that persists across an offline window must keep meeting the floor's own gates.
         coVerify(exactly = 1) {
-            alertFloor.onCgmReading(match { it.glucoseMgDl == 65 }, AlertFloor.TYPE_LOW_WARNING, any())
+            alertFloor.onCgmReading(match { it.glucoseMgDl == 65 }, AlertTypes.LOW_WARNING, any())
         }
 
         advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
         coVerify(exactly = 2) {
-            alertFloor.onCgmReading(match { it.glucoseMgDl == 65 }, AlertFloor.TYPE_LOW_WARNING, any())
+            alertFloor.onCgmReading(match { it.glucoseMgDl == 65 }, AlertTypes.LOW_WARNING, any())
         }
         orchestrator.stop()
     }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -84,6 +84,21 @@ class PumpPollingOrchestratorTest {
         every { glucoseUnit } returns GlucoseUnit.MGDL
     }
 
+    /** AlertFloor's firing gates are covered in AlertFloorTest; here it only classifies (default
+     *  thresholds) so the watch relay mapping and the floor hand-off can be verified. */
+    private val alertFloor = mockk<AlertFloor>(relaxed = true) {
+        every { classify(any()) } answers {
+            val mgDl = firstArg<Int>()
+            when {
+                mgDl <= 55 -> AlertFloor.TYPE_LOW_URGENT
+                mgDl >= 250 -> AlertFloor.TYPE_HIGH_URGENT
+                mgDl <= 70 -> AlertFloor.TYPE_LOW_WARNING
+                mgDl >= 180 -> AlertFloor.TYPE_HIGH_WARNING
+                else -> null
+            }
+        }
+    }
+
     /**
      * Time to advance past the fast loop's initial delay + stagger + margin.
      * Fast loop fires at: INITIAL_DELAY + 0 + STAGGER + 0 + STAGGER (= 1500ms for CGM).
@@ -106,7 +121,7 @@ class PumpPollingOrchestratorTest {
     /** Alias for tests that only need fast loop data. */
     private val SETTLE_TIME_MS = FAST_SETTLE_MS
 
-    private fun createOrchestrator() = PumpPollingOrchestrator(pumpDriver, repository, syncEnqueuer, rawHistoryLogDao, wearDataSender, glucoseRangeStore, safetyLimitsStore, historyLogParser, appSettingsStore)
+    private fun createOrchestrator() = PumpPollingOrchestrator(pumpDriver, repository, syncEnqueuer, rawHistoryLogDao, wearDataSender, glucoseRangeStore, safetyLimitsStore, historyLogParser, appSettingsStore, alertFloor)
 
     @Test
     fun `does not poll when disconnected`() = runTest {
@@ -311,8 +326,8 @@ class PumpPollingOrchestratorTest {
         orchestrator.stop()
     }
 
-    // Alert threshold detection is now an instance method using GlucoseRangeStore.
-    // We test it indirectly through watch alert sends (see below).
+    // Alert classification lives in AlertFloor (server alert thresholds, server vocabulary);
+    // the orchestrator maps to the watch wire strings. Tested through watch alert sends below.
 
     @Test
     fun `alertLabel returns correct labels`() {
@@ -365,6 +380,30 @@ class PumpPollingOrchestratorTest {
         advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
 
         coVerify(exactly = 1) { wearDataSender.sendAlert("low", 65, any(), "LOW 3.6 mmol/L") }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `every polled CGM reading is handed to the alert floor with its server-vocab type`() = runTest {
+        coEvery { pumpDriver.getCgmStatus() } returns Result.success(
+            CgmReading(glucoseMgDl = 65, trendArrow = CgmTrend.SINGLE_DOWN, timestamp = Instant.now()),
+        )
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(SETTLE_TIME_MS)
+
+        // The floor is evaluated on EVERY poll (not edge-latched like the watch relay) — a low
+        // that persists across an offline window must keep meeting the floor's own gates.
+        coVerify(exactly = 1) {
+            alertFloor.onCgmReading(match { it.glucoseMgDl == 65 }, AlertFloor.TYPE_LOW_WARNING, any())
+        }
+
+        advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
+        coVerify(exactly = 2) {
+            alertFloor.onCgmReading(match { it.glucoseMgDl == 65 }, AlertFloor.TYPE_LOW_WARNING, any())
+        }
         orchestrator.stop()
     }
 


### PR DESCRIPTION
## Summary

When the backend cannot deliver glucose alerts (unreachable, offline, or the alert SSE stream down), the phone itself now fires low/high OS alarms off the just-polled CGM reading — but only when it can genuinely vouch for the data. When it can't, it says so honestly instead of pretending coverage.

**The safety invariant:** the floor never fires — and the UI never claims "watching" — on a non-FRESH reading. Alerting on stale cached CGM would be a silent floor; every gate below exists to prevent that, and each one is pinned by a unit test.

### Firing gates (all required)
1. **Server alerting degraded** — `isAlertingDegraded` (network unreachable/offline or stream not CONNECTED). While the server is healthy it owns alerting and the floor is silent.
2. **Reading FRESH** — judged against the CGM's own sensor timestamp (never poll wall-clock), with a clock-skew guard: small future-dated drift (<=60s) is tolerated so routine pump/phone clock skew can't silently disable the floor, but anything beyond fails closed.
3. **Alert thresholds synced at least once** — a new sync-only `AlertThresholdStore` fed by `GET /api/settings/alert-thresholds`, so the floor fires at exactly the values the server's alert engine uses (the `alert_thresholds` table, not the display range). Never fires off hardcoded defaults; cleared on logout; re-synced hourly in the background off the SSE heartbeat.
4. **POST_NOTIFICATIONS granted.**

### Delivery and dedup
- Reuses `AlertNotificationManager` and the existing DND-bypassing `USAGE_ALARM` low channel; the notification title stays glanceable and the message carries the device-computed disclaimer (threshold-only, no prediction, not a CGM replacement).
- Fires in the server AlertType vocabulary, now centralized in `AlertTypes` and shared with the channel routing so the strings cannot drift apart.
- Three dedup layers with **ack-gated parity to the server's 30-minute window**: the degraded arm-gate, the shared `stableNotificationId` slot (a server re-delivery on reconnect replaces the floor card instead of stacking), and a per-type cooldown seeded from Room's unacknowledged server-alert history across the reachable->unreachable flip. A "Got It" ack clears the type's cooldown — like the server, an ack means seen, never snooze, so a new distinct low minutes later alarms again.
- Floor alerts are notification-only (`local-floor:` id prefix); acks silence locally and never POST the synthetic id.

### Honest degraded surface (in-app + backgrounded)
- One shared `AlertFloorStatusProvider` pipeline drives both the Alerts-tab banner and the `PumpConnectionService` foreground text, so the two claims cannot disagree. It mirrors every firing gate — including a fifth: with the pump link down the floor cannot evaluate, so a still-fresh cached reading no longer produces a false "watching" window.
- "NOT watching" copy names the actual failed precondition (notifications denied / thresholds unsynced / pump disconnected / no fresh reading) so the one user-fixable cause is never hidden.
- The claim decays on its own as the reading ages (freshness-derived ticker), and redundant service starts can no longer clobber the honest foreground text.

### Debug harness
- `SimulateUnreachableInterceptor` now also covers the SSE client, with a debug-only force-drop when the toggle flips so the stream actually falls to RECONNECTING.
- `injectTestCgm` gains fresh-LOW and stale-LOW variants that drive the exact production `processCgmReading` seam.
- All debug seams hard-gated on `BuildConfig.DEBUG` end to end.

Out of scope by design: prediction/trajectory/IoB logic stays server-side; Wear consolidation is 57.10 (the floor's OS notification auto-bridges to the watch).

## Testing

- `./gradlew testDebugUnitTest lintDebug assembleDebug` green (new suites: `AlertFloorTest`, `AlertThresholdStoreTest`, extended `AlertingDegradedTest`/`FreshnessTest`/`AlertActionReceiverTest`/`AuthRepositoryTest`).
- Full emulator E2E with fault injection and compressed freshness (20s/45s), thresholds seeded to values distinct from the display range to prove the source:
  - online + fresh low -> floor silent (server owns alerting)
  - degraded + fresh low -> real alarm on the low channel with the disclaimer; a low developing while offline fires on the next reading
  - degraded + stale low -> suppressed, surface flips to NOT watching (and decays there on its own as data ages)
  - never-synced thresholds -> suppressed with honest surface
  - sustained low -> one alarm per window; ack -> local-only silence, and a new crossing after ack re-alarms
  - reconnect -> server re-delivery replaces the floor notification in place (same slot, no stacking, no re-alarm)
- Adversarial, senior-engineer, dedicated safety, and security reviews completed; all HIGH/MEDIUM findings fixed and re-verified (ack-parity dedup, pump-connected surface gate, cooldown clock-skew clamp, foreground-text clobber, background threshold re-sync, cause-specific copy). CodeRabbit CLI findings addressed.
- Not coverable on emulator: physical Doze-wake (unchanged, previously verified channel) and the foreground text with a live pump link (status logic unit-tested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an on-device “alert floor” for when server alerting is degraded, including freshness-gated low/high notifications, improved degraded banner/status messaging, and per-type re-alert cooldown.
  * Alert thresholds are now fetched and reconciled after login/refresh, kept up to date when stale, and used for the alert floor.
  * Pump foreground notification now reflects “watching” vs “not watching” states.
  * Added debug tools to inject fresh or stale CGM readings to test alert-floor behavior.
* **Bug Fixes**
  * Local “floor” acknowledgements no longer interfere with server alert acknowledgements.
  * Alert notification posting is more consistently gated when notifications are disabled.
* **Tests**
  * Expanded unit/UI coverage for alert-floor states, banners, threshold sync, and cooldown/ack handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->