### PR TITLE
feat(mobile): Wear OS offline tier - freshness-gated alert parity and honest wrist surfaces

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
@@ -135,6 +135,30 @@ class AlertFloor @Inject constructor(
     }
 
     /**
+     * The single data-trust bound shared by every consumer that may alert a human off a local
+     * pump CGM reading (GLY-116 D2): true only when [reading] is safe to alarm on — FRESH by the
+     * active CGM policy against the reading's own sensor timestamp, thresholds synced at least
+     * once, and the wall clock not running behind previously observed time. The floor's firing
+     * path ([onCgmReading]) and the watch relay (`PumpPollingOrchestrator.processCgmReading`)
+     * both call THIS function; a second staleness definition on either path is the silent-floor
+     * bug GLY-115/116 exist to prevent.
+     *
+     * Deliberately NOT part of this bound: degraded-state, notification permission, cooldowns —
+     * those are floor-firing concerns that wrap around the predicate, not data-trust concerns
+     * (a stale reading must not alert the wrist whether the backend is up or down).
+     */
+    fun isReadingAlertable(
+        reading: CgmReading,
+        nowMs: Long = System.currentTimeMillis(),
+    ): Boolean {
+        if (isWallClockRewound(nowMs)) return false
+        noteWallClock(nowMs)
+        if (!alertThresholdStore.isSynced()) return false
+        val thresholds = FreshnessPolicy.cgm(appSettingsStore.debugFastStaleness)
+        return isFreshForAlertFloor(nowMs - reading.timestamp.toEpochMilli(), thresholds)
+    }
+
+    /**
      * The user acknowledged a floor notification of [alertType] ("Got It"). Bounded-snooze
      * episode semantics — an ack means "seen", never "snooze forever" and never "re-alarm the
      * same episode every poll":
@@ -198,22 +222,20 @@ class AlertFloor @Inject constructor(
             return
         }
 
-        // Gate 3: never alarm off hardcoded defaults. A never-synced device shows "monitoring
-        // degraded" instead of guessing thresholds.
-        if (!alertThresholdStore.isSynced()) {
-            Timber.w("Alert floor suppressed: thresholds never synced (type=%s)", alertType)
-            return
-        }
-
-        // Gate 2: FRESH readings only, judged on the CGM's own sensor timestamp — a warmup or
-        // signal-loss poll can succeed every 15s while returning the same old sensor value.
-        val freshnessThresholds = FreshnessPolicy.cgm(appSettingsStore.debugFastStaleness)
+        // Gates 2+3 via the shared data-trust bound (GLY-116 D2): FRESH readings only, judged on
+        // the CGM's own sensor timestamp — a warmup or signal-loss poll can succeed every 15s
+        // while returning the same old sensor value — and never off unsynced defaults. The watch
+        // relay gates on the SAME predicate; only the log detail is computed here.
         val ageMs = nowMs - reading.timestamp.toEpochMilli()
-        if (!isFreshForAlertFloor(ageMs, freshnessThresholds)) {
-            Timber.w(
-                "Alert floor suppressed: reading not FRESH (type=%s, ageMs=%d) — NOT watching",
-                alertType, ageMs,
-            )
+        if (!isReadingAlertable(reading, nowMs)) {
+            if (!alertThresholdStore.isSynced()) {
+                Timber.w("Alert floor suppressed: thresholds never synced (type=%s)", alertType)
+            } else {
+                Timber.w(
+                    "Alert floor suppressed: reading not FRESH (type=%s, ageMs=%d) — NOT watching",
+                    alertType, ageMs,
+                )
+            }
             return
         }
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloor.kt
@@ -146,6 +146,12 @@ class AlertFloor @Inject constructor(
      * Deliberately NOT part of this bound: degraded-state, notification permission, cooldowns —
      * those are floor-firing concerns that wrap around the predicate, not data-trust concerns
      * (a stale reading must not alert the wrist whether the backend is up or down).
+     *
+     * NOT pure: every evaluation also feeds [noteWallClock], so each caller (floor and relay
+     * alike) advances the rewind guard's high-water mark. Deliberate and safe in one direction
+     * only — the mark is a monotonic max, so extra observations can only make rewind detection
+     * MORE aggressive, never mask a rewind — and it means the guard keeps a recent reference
+     * even when only the relay is evaluating readings.
      */
     fun isReadingAlertable(
         reading: CgmReading,
@@ -225,7 +231,9 @@ class AlertFloor @Inject constructor(
         // Gates 2+3 via the shared data-trust bound (GLY-116 D2): FRESH readings only, judged on
         // the CGM's own sensor timestamp — a warmup or signal-loss poll can succeed every 15s
         // while returning the same old sensor value — and never off unsynced defaults. The watch
-        // relay gates on the SAME predicate; only the log detail is computed here.
+        // relay gates on the SAME predicate; only the log detail is computed here. The predicate
+        // re-runs the rewind check (known false here) and noteWallClock (idempotent monotonic
+        // max) — the small overlap is the cost of one bound in one place.
         val ageMs = nowMs - reading.timestamp.toEpochMilli()
         if (!isReadingAlertable(reading, nowMs)) {
             if (!alertThresholdStore.isSynced()) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
@@ -321,6 +321,7 @@ class AlertNotificationManager @Inject constructor(
                 // Lows are life-threatening: re-fire sound on each update.
                 // Highs/IoB: alert once, then silent updates only.
                 .setOnlyAlertOnce(!isLow)
+                .setLocalOnly(isLocalOnlyOnWrist(alert))
                 .addAction(
                     android.R.drawable.ic_menu_close_clear_cancel,
                     "Got It",
@@ -386,6 +387,19 @@ class AlertNotificationManager @Inject constructor(
     private fun buildTitle(alert: AlertEntity): String =
         formatAlertTitle(alert, appSettingsStore.glucoseUnit)
 }
+
+/**
+ * Whether this alert's notification must NOT bridge to a paired watch (GLY-116 D4). True only
+ * for device-computed alert-floor notifications: the floor fires off the same local pump CGM,
+ * behind the same freshness/sync bound, as the watch data-layer relay — so the relay already
+ * covers exactly the floor's fires, and bridging the floor notification too would double-buzz
+ * the wrist. SERVER alerts must keep bridging: they fire off a different (cloud) glucose
+ * source, and while the pump CGM is stale (relay gated silent) the bridged server notification
+ * is the only wrist path left for a real alert. Pure — no Android dependencies — so the
+ * routing rule is unit-testable like [formatAlertTitle].
+ */
+internal fun isLocalOnlyOnWrist(alert: AlertEntity): Boolean =
+    alert.serverId.startsWith(AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX)
 
 /**
  * Builds a notification title (`"EMERGENCY: 320 mg/dL - Alice"`) with the glucose value rendered

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpConnectionService.kt
@@ -18,6 +18,7 @@ import com.glycemicgpt.mobile.R
 import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
+import com.glycemicgpt.mobile.wear.WearMonitoringStatusForwarder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -80,6 +81,9 @@ class PumpConnectionService : Service() {
     @Inject
     lateinit var alertFloorStatusProvider: AlertFloorStatusProvider
 
+    @Inject
+    lateinit var wearMonitoringStatusForwarder: WearMonitoringStatusForwarder
+
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
@@ -97,6 +101,7 @@ class PumpConnectionService : Service() {
     private var connectionWatcherJob: Job? = null
     private var wakeLockRenewalJob: Job? = null
     private var floorStatusWatcherJob: Job? = null
+    private var wearStatusForwarderJob: Job? = null
     @Volatile
     private var started = false
 
@@ -244,6 +249,10 @@ class PumpConnectionService : Service() {
                 }
             }
 
+            // Mirror the same coverage stream to the wrist (GLY-116 axis a): the watch renders
+            // the phone's decision and locally decays it — it never re-derives coverage.
+            wearStatusForwarderJob = wearMonitoringStatusForwarder.start(serviceScope)
+
             ContextCompat.registerReceiver(
                 this,
                 batteryReceiver,
@@ -274,6 +283,8 @@ class PumpConnectionService : Service() {
         connectionWatcherJob = null
         floorStatusWatcherJob?.cancel()
         floorStatusWatcherJob = null
+        wearStatusForwarderJob?.cancel()
+        wearStatusForwarderJob = null
         synchronized(wakeLockSync) {
             stopWakeLockRenewalLocked()
             releaseWakeLockLocked()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -363,7 +363,11 @@ class PumpPollingOrchestrator @Inject constructor(
                             lastAlertSentAtMs = nowMs
                             if (rebuzz) lastAlertBuzzAtMs = nowMs
                         }
-                    } else if (previousAlertType != null) {
+                    } else if (serverAlertType == null && previousAlertType != null) {
+                        // Keyed on the CLASSIFICATION being in-range, not on watchAlertType
+                        // being null: a mapping gap also yields watchAlertType == null, and
+                        // clearing there would retract a possibly-still-true alert — a gap may
+                        // cost the relay a push, never an "All clear".
                         wearDataSender.clearAlert()
                         previousAlertType = null
                     }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -117,6 +117,9 @@ class PumpPollingOrchestrator @Inject constructor(
                         // Any non-CONNECTED state (e.g. SCANNING/CONNECTING/AUTHENTICATING/DISCONNECTED)
                         // pauses polling; log the actual state instead of always saying "disconnected",
                         // which misleads debugging during a pairing attempt (issue #844).
+                        // The latch reset deliberately does NOT clearAlert the wrist: an alert
+                        // shown at disconnect may still be true, and the watch ages it out on
+                        // its own clock (GLY-116 axis b) instead of flipping to "All clear".
                         Timber.d("Pump not ready (current state=%s), pausing polling", state)
                         previousAlertType = null
                         cancelPollingLoops()
@@ -316,29 +319,45 @@ class PumpPollingOrchestrator @Inject constructor(
             SERVER_TO_WATCH_ALERT_TYPE[type]
                 ?: run { Timber.w("No watch mapping for alert type %s", type); null }
         }
+        // GLY-116 AC-A: the relay shares the floor's data-trust bound — a stale, never-synced,
+        // or clock-rewound reading must not alert the wrist any more than it may fire the floor.
+        // A not-alertable reading skips the WHOLE relay alert block: no sendAlert, no clearAlert,
+        // latch untouched. Retracting the shown alert here would flip a possibly-still-true low
+        // into the watch's reassuring "All clear" off data nobody can vouch for; the watch ages
+        // the shown alert out on its own clock instead (axis b). clearAlert stays reserved for a
+        // genuinely FRESH in-range recovery reading below. NOT an early return — the alert-floor
+        // hand-off at the end of this function must still run.
+        val alertable = alertFloor.isReadingAlertable(reading)
         // Serialized: this seam is reachable from the poll loop, the Home manual refresh, and
         // the debug inject concurrently, and the previousAlertType read-check-write must be
         // atomic or an overlap can double-send or drop a needed clearAlert.
-        watchRelayMutex.withLock {
-            try {
-                if (watchAlertType != null && watchAlertType != previousAlertType) {
-                    wearDataSender.sendAlert(
-                        type = watchAlertType,
-                        bgValue = reading.glucoseMgDl,
-                        timestampMs = reading.timestamp.toEpochMilli(),
-                        message = "${alertLabel(watchAlertType)} " +
-                            GlucoseFormat.formatWithLabel(reading.glucoseMgDl, glucoseUnit),
-                    )
-                    previousAlertType = watchAlertType
-                } else if (watchAlertType == null && previousAlertType != null) {
-                    wearDataSender.clearAlert()
-                    previousAlertType = null
+        if (alertable) {
+            watchRelayMutex.withLock {
+                try {
+                    if (watchAlertType != null && watchAlertType != previousAlertType) {
+                        wearDataSender.sendAlert(
+                            type = watchAlertType,
+                            bgValue = reading.glucoseMgDl,
+                            timestampMs = reading.timestamp.toEpochMilli(),
+                            message = "${alertLabel(watchAlertType)} " +
+                                GlucoseFormat.formatWithLabel(reading.glucoseMgDl, glucoseUnit),
+                        )
+                        previousAlertType = watchAlertType
+                    } else if (watchAlertType == null && previousAlertType != null) {
+                        wearDataSender.clearAlert()
+                        previousAlertType = null
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to send alert to watch")
                 }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to send alert to watch")
             }
+        } else if (watchAlertType != null) {
+            Timber.w(
+                "Watch alert relay suppressed: reading not alertable (type=%s)",
+                watchAlertType,
+            )
         }
 
         alertFloor.onCgmReading(reading, serverAlertType)
@@ -414,11 +433,11 @@ class PumpPollingOrchestrator @Inject constructor(
         /**
          * [AlertFloor] classifies in the server's AlertType vocabulary (shared notification slot
          * + channel routing); the watch wire protocol predates it and keeps its own strings.
-         * 57.10 notes: the watch currently receives alerts by THREE paths — this orchestrator
-         * relay, the bridged server notification, and now the bridged floor notification — a
-         * collision left for 57.10 to consolidate. The relay is also freshness-ungated and
-         * classifies off store defaults before the first threshold sync (both pre-existing
-         * behaviors of this path, unlike the floor's gates) — 57.10 should align it.
+         * Wrist alert paths after GLY-116: this relay (gated on
+         * [AlertFloor.isReadingAlertable], same bound as the floor) and the bridged SERVER
+         * notification (different glucose source — it must stay bridged, see
+         * [AlertNotificationManager]); the floor notification is local-only so a single fresh
+         * low is one wrist experience, not three.
          */
         val SERVER_TO_WATCH_ALERT_TYPE = mapOf(
             AlertTypes.LOW_URGENT to "urgent_low",

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -12,6 +12,7 @@ import com.glycemicgpt.mobile.data.repository.PumpDataRepository
 import com.glycemicgpt.mobile.data.repository.SyncQueueEnqueuer
 import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.pump.HistoryLogParser
 import com.glycemicgpt.mobile.domain.pump.PumpDriver
 import com.glycemicgpt.mobile.wear.WearDataSender
@@ -81,6 +82,12 @@ class PumpPollingOrchestrator @Inject constructor(
     /** Serializes the watch alert edge-latch across the poll loop, the Home manual refresh,
      *  and the debug inject. */
     private val watchRelayMutex = Mutex()
+
+    /** Wall-clock ms of the last watch alert push (any kind) and of the last push that was
+     *  allowed to buzz, for the ongoing-episode refresh/re-buzz cadence. Guarded by
+     *  [watchRelayMutex] like the latch they accompany. */
+    private var lastAlertSentAtMs = 0L
+    private var lastAlertBuzzAtMs = 0L
 
     private val lock = Any()
     private var fastJob: Job? = null
@@ -286,7 +293,10 @@ class PumpPollingOrchestrator @Inject constructor(
      * synthetic reading to Room, exercising the exact production path. The only production
      * caller is [pollCgm].
      */
-    suspend fun processCgmReading(reading: CgmReading) {
+    suspend fun processCgmReading(
+        reading: CgmReading,
+        nowMs: Long = System.currentTimeMillis(),
+    ) {
         // We send the raw mg/dL value plus a per-account unit flag so the watch
         // renders glucose in the user's unit. The wire value stays canonical mg/dL;
         // only the watch's displayed/spoken number converts.
@@ -327,7 +337,7 @@ class PumpPollingOrchestrator @Inject constructor(
         // the shown alert out on its own clock instead (axis b). clearAlert stays reserved for a
         // genuinely FRESH in-range recovery reading below. NOT an early return — the alert-floor
         // hand-off at the end of this function must still run.
-        val alertable = alertFloor.isReadingAlertable(reading)
+        val alertable = alertFloor.isReadingAlertable(reading, nowMs)
         // Serialized: this seam is reachable from the poll loop, the Home manual refresh, and
         // the debug inject concurrently, and the previousAlertType read-check-write must be
         // atomic or an overlap can double-send or drop a needed clearAlert.
@@ -335,15 +345,25 @@ class PumpPollingOrchestrator @Inject constructor(
             watchRelayMutex.withLock {
                 try {
                     if (watchAlertType != null && watchAlertType != previousAlertType) {
-                        wearDataSender.sendAlert(
-                            type = watchAlertType,
-                            bgValue = reading.glucoseMgDl,
-                            timestampMs = reading.timestamp.toEpochMilli(),
-                            message = "${alertLabel(watchAlertType)} " +
-                                GlucoseFormat.formatWithLabel(reading.glucoseMgDl, glucoseUnit),
-                        )
+                        sendWatchAlertLocked(watchAlertType, reading, glucoseUnit, rebuzz = true)
                         previousAlertType = watchAlertType
-                    } else if (watchAlertType == null && previousAlertType != null) {
+                        lastAlertSentAtMs = nowMs
+                        lastAlertBuzzAtMs = nowMs
+                    } else if (watchAlertType != null) {
+                        // Ongoing episode, same type: the edge-latch alone would leave the
+                        // wrist's copy frozen at the first crossing — axis (b) would then grey
+                        // a still-live low as "data stale", and the wrist would never re-buzz
+                        // a sustained emergency after the floor notification went local-only
+                        // (D4). So the relay refreshes the shown alert (silent, new timestamp)
+                        // while readings stay alertable, and re-buzzes on the floor's own
+                        // re-alarm cadence — the wrist is never quieter than the phone.
+                        val rebuzz = nowMs - lastAlertBuzzAtMs >= WRIST_ALERT_REBUZZ_MS
+                        if (rebuzz || nowMs - lastAlertSentAtMs >= WRIST_ALERT_REFRESH_MS) {
+                            sendWatchAlertLocked(watchAlertType, reading, glucoseUnit, rebuzz)
+                            lastAlertSentAtMs = nowMs
+                            if (rebuzz) lastAlertBuzzAtMs = nowMs
+                        }
+                    } else if (previousAlertType != null) {
                         wearDataSender.clearAlert()
                         previousAlertType = null
                     }
@@ -360,7 +380,24 @@ class PumpPollingOrchestrator @Inject constructor(
             )
         }
 
-        alertFloor.onCgmReading(reading, serverAlertType)
+        alertFloor.onCgmReading(reading, serverAlertType, nowMs)
+    }
+
+    /** Must be called while holding [watchRelayMutex]. */
+    private suspend fun sendWatchAlertLocked(
+        watchAlertType: String,
+        reading: CgmReading,
+        glucoseUnit: GlucoseUnit,
+        rebuzz: Boolean,
+    ) {
+        wearDataSender.sendAlert(
+            type = watchAlertType,
+            bgValue = reading.glucoseMgDl,
+            timestampMs = reading.timestamp.toEpochMilli(),
+            message = "${alertLabel(watchAlertType)} " +
+                GlucoseFormat.formatWithLabel(reading.glucoseMgDl, glucoseUnit),
+            rebuzz = rebuzz,
+        )
     }
 
     companion object {
@@ -411,6 +448,18 @@ class PumpPollingOrchestrator @Inject constructor(
 
         // When phone battery is low, slow everything down by this factor
         const val LOW_BATTERY_MULTIPLIER = 3
+
+        /** How often the relay re-pushes an ONGOING (unchanged-type) alert while readings stay
+         *  alertable — silent refreshes that keep the wrist copy's timestamp current, so
+         *  axis (b) never greys a still-live alert as "data stale" (the CGM STALE band starts
+         *  at 6 min; 5-min refreshes keep the shown alert inside it). */
+        const val WRIST_ALERT_REFRESH_MS = 5 * 60_000L
+
+        /** Re-buzz cadence for a sustained, never-recovering alert, mirroring
+         *  [AlertFloor.FLOOR_COOLDOWN_MS]: with the floor notification local-only (D4), the
+         *  relay owns the wrist's re-alarm — the wrist must never go permanently silent on an
+         *  ongoing emergency while the phone keeps alarming. */
+        const val WRIST_ALERT_REBUZZ_MS = AlertFloor.FLOOR_COOLDOWN_MS
 
         /** Max history records per type sent to watch. Prevents exceeding DataItem size limit. */
         const val MAX_HISTORY_RECORDS = 500

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
@@ -38,6 +38,34 @@ object WearDataContract {
     const val KEY_ALERT_TIMESTAMP = "alert_ts"
     const val KEY_ALERT_MESSAGE = "alert_msg"
 
+    // Monitoring status path (phone -> watch, GLY-116 axis a): mirrors the phone's
+    // AlertFloorStatus stream so the wrist can honestly say whether ANYTHING (server or the
+    // phone's alert floor) is watching thresholds. The phone computes the coverage decision;
+    // the watch only renders it and locally times it out (a frozen "watching" from a dead
+    // phone must decay, never persist).
+    const val MONITORING_STATUS_PATH = "/glycemicgpt/monitoring_status"
+
+    // Monitoring status keys
+    const val KEY_MONITORING_STATE = "mon_state"
+    const val KEY_MONITORING_REASON = "mon_reason"
+    // Watch-local decay window for this status, ms: one CGM staleness window under the
+    // phone's ACTIVE policy (compressed when the debug fast-staleness toggle is on), so the
+    // watch's timeout tracks the same clock the phone's own "watching" claim decays by.
+    const val KEY_MONITORING_TIMEOUT_MS = "mon_timeout_ms"
+
+    // KEY_MONITORING_STATE values. Vocabulary mirrors the phone's AlertFloorStatus exactly.
+    const val MONITORING_STATE_SERVER_ACTIVE = "server_active"
+    const val MONITORING_STATE_FLOOR_WATCHING = "floor_watching"
+    const val MONITORING_STATE_NOT_WATCHING = "not_watching"
+
+    // KEY_MONITORING_REASON values, present only with MONITORING_STATE_NOT_WATCHING.
+    // MUST match the phone's FloorNotWatchingReason enum names exactly — the watch renders
+    // reason-specific copy and an invented value would fall back to the generic line.
+    const val MONITORING_REASON_NOTIFICATIONS_DENIED = "NOTIFICATIONS_DENIED"
+    const val MONITORING_REASON_THRESHOLDS_NOT_SYNCED = "THRESHOLDS_NOT_SYNCED"
+    const val MONITORING_REASON_PUMP_DISCONNECTED = "PUMP_DISCONNECTED"
+    const val MONITORING_REASON_NO_FRESH_READING = "NO_FRESH_READING"
+
     // MessageClient paths (transient chat relay)
     const val CHAT_REQUEST_PATH = "/glycemicgpt/chat/request"
     const val CHAT_RESPONSE_PATH = "/glycemicgpt/chat/response"

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataContract.kt
@@ -37,6 +37,10 @@ object WearDataContract {
     const val KEY_ALERT_BG_VALUE = "alert_bg"
     const val KEY_ALERT_TIMESTAMP = "alert_ts"
     const val KEY_ALERT_MESSAGE = "alert_msg"
+    // False marks a silent refresh of an ongoing alert (updated value/timestamp, no watch
+    // vibration); true (and absence, for older phone builds that only send on type change) is
+    // a new crossing or the sustained-episode re-alarm.
+    const val KEY_ALERT_REBUZZ = "alert_rebuzz"
 
     // Monitoring status path (phone -> watch, GLY-116 axis a): mirrors the phone's
     // AlertFloorStatus stream so the wrist can honestly say whether ANYTHING (server or the

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataSender.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataSender.kt
@@ -65,13 +65,24 @@ class WearDataSender @Inject constructor(
         }
     }
 
-    suspend fun sendAlert(type: String, bgValue: Int, timestampMs: Long, message: String) {
+    /**
+     * [rebuzz] false marks a silent refresh of an ongoing alert (updated value/timestamp, no
+     * vibration on the watch); true is a new crossing or the sustained-episode re-alarm.
+     */
+    suspend fun sendAlert(
+        type: String,
+        bgValue: Int,
+        timestampMs: Long,
+        message: String,
+        rebuzz: Boolean = true,
+    ) {
         try {
             val request = PutDataMapRequest.create(WearDataContract.ALERT_PATH).apply {
                 dataMap.putString(WearDataContract.KEY_ALERT_TYPE, type)
                 dataMap.putInt(WearDataContract.KEY_ALERT_BG_VALUE, bgValue)
                 dataMap.putLong(WearDataContract.KEY_ALERT_TIMESTAMP, timestampMs)
                 dataMap.putString(WearDataContract.KEY_ALERT_MESSAGE, message)
+                dataMap.putBoolean(WearDataContract.KEY_ALERT_REBUZZ, rebuzz)
             }.asPutDataRequest().setUrgent()
 
             dataClient.putDataItem(request).await()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataSender.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearDataSender.kt
@@ -85,6 +85,34 @@ class WearDataSender @Inject constructor(
         sendAlert(type = "none", bgValue = 0, timestampMs = System.currentTimeMillis(), message = "")
     }
 
+    /**
+     * Mirror the phone's alerting-coverage decision to the wrist (GLY-116 axis a). [state] and
+     * [reason] use the [WearDataContract] monitoring-status vocabulary; [statusTimeoutMs] tells
+     * the watch how long this status may be trusted before it must decay to "no recent data"
+     * (phone-death guard — the watch applies the timeout against its own clock).
+     */
+    suspend fun sendMonitoringStatus(state: String, reason: String?, statusTimeoutMs: Long) {
+        try {
+            val request = PutDataMapRequest.create(WearDataContract.MONITORING_STATUS_PATH).apply {
+                dataMap.putString(WearDataContract.KEY_MONITORING_STATE, state)
+                if (reason != null) {
+                    dataMap.putString(WearDataContract.KEY_MONITORING_REASON, reason)
+                }
+                dataMap.putLong(WearDataContract.KEY_MONITORING_TIMEOUT_MS, statusTimeoutMs)
+                // Force delivery even when the status is unchanged: each re-send is the
+                // heartbeat the watch's local status timeout counts from.
+                dataMap.putLong("_ts", System.currentTimeMillis())
+            }.asPutDataRequest().setUrgent()
+
+            dataClient.putDataItem(request).await()
+            Timber.d("Sent monitoring status to watch: %s (reason=%s)", state, reason)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to send monitoring status to watch")
+        }
+    }
+
     suspend fun sendBasalHistory(data: ByteArray, count: Int) {
         try {
             val request = PutDataMapRequest.create(WearDataContract.BASAL_HISTORY_PATH).apply {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearMonitoringStatusForwarder.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearMonitoringStatusForwarder.kt
@@ -1,0 +1,102 @@
+package com.glycemicgpt.mobile.wear
+
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.service.AlertFloorStatusProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Forwards the phone's alerting-coverage decision to the watch (GLY-116 AC-B, axis a).
+ *
+ * The source is the SAME [AlertFloorStatusProvider] stream that drives the in-app banner and the
+ * foreground-notification text — the wrist claim can never disagree with the phone's. The watch
+ * performs no coverage decision of its own; it renders this status and locally decays it after
+ * the advertised timeout.
+ *
+ * Re-sends on a heartbeat as well as on change: the provider stream deduplicates, so a healthy
+ * steady state would otherwise emit exactly once — and a watch that then loses the phone (process
+ * death, Bluetooth drop) would hold a frozen "watching" forever. Each heartbeat re-send restarts
+ * the watch's local status timeout; silence longer than the advertised window is the watch's
+ * signal that the phone is gone, closing the phone-death honesty hole with the same mechanism
+ * for every cause.
+ */
+@Singleton
+class WearMonitoringStatusForwarder @Inject constructor(
+    private val alertFloorStatusProvider: AlertFloorStatusProvider,
+    private val appSettingsStore: AppSettingsStore,
+    private val wearDataSender: WearDataSender,
+) {
+
+    /** Start forwarding on [scope] (the pump service's lifecycle). */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun start(scope: CoroutineScope): Job = scope.launch {
+        appSettingsStore.debugFastStalenessFlow().flatMapLatest { fast ->
+            // One CGM staleness window under the ACTIVE policy: the same clock the phone's own
+            // "watching" claim decays by, compressed when the debug fast-staleness toggle is on.
+            val timeoutMs = FreshnessPolicy.cgm(fast).staleAfterMs
+            combine(
+                alertFloorStatusProvider.observe(),
+                tickerFlow(heartbeatPeriodMs(timeoutMs)),
+            ) { status, _ -> status to timeoutMs }
+        }.retryWhen { cause, attempt ->
+            // A coverage-status stream must never die silently: the watch would decay to "no
+            // recent data" (honest), but a live phone should keep the wrist current. Resubscribe.
+            Timber.e(cause, "Wear monitoring-status forwarder failed (attempt %d); retrying", attempt)
+            delay(RETRY_DELAY_MS)
+            true
+        }.collect { (status, timeoutMs) ->
+            val (state, reason) = status.toWire()
+            wearDataSender.sendMonitoringStatus(state, reason, timeoutMs)
+        }
+    }
+
+    private fun tickerFlow(periodMs: Long): Flow<Unit> = flow {
+        while (true) {
+            emit(Unit)
+            delay(periodMs)
+        }
+    }
+
+    companion object {
+        /** Pause before resubscribing a failed pipeline, mirroring [AlertFloorStatusProvider]. */
+        const val RETRY_DELAY_MS = 5_000L
+
+        /** Floor for the heartbeat period so the compressed debug policy can't hot-loop sends. */
+        const val MIN_HEARTBEAT_MS = 5_000L
+
+        /**
+         * Re-send cadence: half the advertised timeout, so a single dropped DataItem does not
+         * decay the wrist to "no recent data" while the phone is actually alive and watching.
+         */
+        fun heartbeatPeriodMs(timeoutMs: Long): Long =
+            (timeoutMs / 2).coerceAtLeast(MIN_HEARTBEAT_MS)
+
+        /**
+         * The wire encoding of the phone's coverage decision. Enum-name reasons on purpose:
+         * the contract constants pin the phone's [com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason]
+         * names as the wire vocabulary, so a renamed reason breaks the contract test instead of
+         * silently sending a string the watch renders as generic copy.
+         */
+        fun AlertFloorStatus.toWire(): Pair<String, String?> = when (this) {
+            AlertFloorStatus.ServerActive ->
+                WearDataContract.MONITORING_STATE_SERVER_ACTIVE to null
+            AlertFloorStatus.FloorWatching ->
+                WearDataContract.MONITORING_STATE_FLOOR_WATCHING to null
+            is AlertFloorStatus.FloorNotWatching ->
+                WearDataContract.MONITORING_STATE_NOT_WATCHING to reason.name
+        }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorTest.kt
@@ -5,8 +5,12 @@ import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.local.dao.AlertDao
 import com.glycemicgpt.mobile.data.local.entity.AlertEntity
 import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
 import com.glycemicgpt.mobile.domain.alerting.AlertTypes
+import com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason
+import com.glycemicgpt.mobile.domain.alerting.alertFloorStatus
 import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
 import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
@@ -18,6 +22,7 @@ import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -451,5 +456,82 @@ class AlertFloorTest {
         coEvery { alertDao.getLatestUnacknowledgedTimestampForType(any(), any()) } returns null
         evaluate(mgDl = 54, atMs = nowMs + AlertFloor.FLOOR_COOLDOWN_MS)
         verify(exactly = 1) { alertNotificationManager.showAlertNotification(any(), any()) }
+    }
+
+    // -- isReadingAlertable: the shared data-trust bound the watch relay gates on (GLY-116) ----
+    // Predicate-correctness only: a relay-gate revert does not fail these (the pure function
+    // stays green with no call site) — the behavioral gate lives in PumpPollingOrchestratorTest
+    // and the relay⟺floor agreement in AlertRelayFloorDivergenceTest.
+
+    private fun reading(ageMs: Long, atMs: Long = nowMs) = CgmReading(
+        glucoseMgDl = 54,
+        trendArrow = CgmTrend.FLAT,
+        timestamp = Instant.ofEpochMilli(atMs - ageMs),
+    )
+
+    @Test
+    fun `isReadingAlertable boundary pair at the FRESH-STALE edge`() {
+        // CGM policy: FRESH strictly below 6 min. Edge−1 alertable, edge not.
+        assertTrue(floor.isReadingAlertable(reading(6 * 60_000L - 1), nowMs))
+        assertFalse(floor.isReadingAlertable(reading(6 * 60_000L), nowMs))
+    }
+
+    @Test
+    fun `isReadingAlertable rejects TOO_STALE outright`() {
+        assertFalse(floor.isReadingAlertable(reading(15 * 60_000L), nowMs))
+        assertFalse(floor.isReadingAlertable(reading(8 * 60 * 60_000L), nowMs))
+    }
+
+    @Test
+    fun `isReadingAlertable boundary pair at the future-skew bound`() {
+        // Small forward skew tolerated (pump clocks drift); beyond the bound is not trustable.
+        assertTrue(floor.isReadingAlertable(reading(-60_000L), nowMs))
+        assertFalse(floor.isReadingAlertable(reading(-60_001L), nowMs))
+    }
+
+    @Test
+    fun `isReadingAlertable is false when thresholds never synced even for a fresh reading`() {
+        every { alertThresholdStore.isSynced() } returns false
+        assertFalse(floor.isReadingAlertable(reading(0L), nowMs))
+    }
+
+    @Test
+    fun `isReadingAlertable is false while the wall clock is rewound`() {
+        floor.noteWallClock(nowMs)
+        // Clock jumps back beyond the tolerance: even a reading that looks fresh against the
+        // rewound "now" is untrustworthy (its apparent age is understated).
+        val rewoundNow = nowMs - 5 * 60_000L
+        assertFalse(floor.isReadingAlertable(reading(10_000L, atMs = rewoundNow), rewoundNow))
+        // Clock catches back up: trust resumes.
+        assertTrue(floor.isReadingAlertable(reading(10_000L), nowMs))
+    }
+
+    @Test
+    fun `isReadingAlertable uses the compressed policy under the debug fast-staleness toggle`() {
+        every { appSettingsStore.debugFastStaleness } returns true
+        assertTrue(floor.isReadingAlertable(reading(19_999L), nowMs))
+        assertFalse(floor.isReadingAlertable(reading(20_000L), nowMs))
+    }
+
+    @Test
+    fun `pump clock drift degrades honestly - predicate suppresses and the surface says not watching`() {
+        // AC-F: a pump clock running 20 min slow makes genuinely-new readings look TOO_STALE.
+        // The relay/floor must suppress (indistinguishable from warmup-stale) AND the shared
+        // status decision must land on NO_FRESH_READING — honest-degraded, never silent.
+        val driftedAgeMs = 20 * 60_000L
+        assertFalse(floor.isReadingAlertable(reading(driftedAgeMs), nowMs))
+        val status = alertFloorStatus(
+            networkStatus = NetworkStatus.BACKEND_UNREACHABLE,
+            streamState = AlertStreamState.RECONNECTING,
+            cgmAgeMs = driftedAgeMs,
+            cgmThresholds = FreshnessPolicy.CGM,
+            thresholdsSynced = true,
+            canNotify = true,
+            pumpConnected = true,
+        )
+        assertEquals(
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING),
+            status,
+        )
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertNotificationManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertNotificationManagerTest.kt
@@ -274,6 +274,29 @@ class AlertNotificationManagerTest {
         }
     }
 
+    // --- GLY-116 D4: wrist bridging routing (setLocalOnly decision) ---
+
+    @Test
+    fun `floor alert notifications are local-only - the relay covers their wrist delivery`() {
+        val floorAlert = makeAlert(
+            serverId = AlertNotificationManager.LOCAL_FLOOR_ID_PREFIX + "low_urgent:1750000000000",
+            alertType = "low_urgent",
+            severity = "urgent",
+        )
+        assertTrue(isLocalOnlyOnWrist(floorAlert))
+    }
+
+    @Test
+    fun `server alert notifications keep bridging to the wrist`() {
+        // Server alerts fire off a different (cloud) glucose source: when the pump CGM is
+        // stale and the relay is gated silent, this bridge is the ONLY wrist path for a real
+        // alert. Making it local-only would sever it.
+        assertFalse(isLocalOnlyOnWrist(makeAlert(serverId = "b2f6d9f2-4d3e-4c2a-9c1e-8a7b6c5d4e3f")))
+        assertFalse(isLocalOnlyOnWrist(makeAlert(serverId = "12345")))
+        // A server ID merely CONTAINING the prefix elsewhere does not match.
+        assertFalse(isLocalOnlyOnWrist(makeAlert(serverId = "srv:local-floor:oddball")))
+    }
+
     // --- Helper mirrors for testing without Android context ---
 
     private fun stableNotificationId(alert: AlertEntity): Int {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertRelayFloorDivergenceTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertRelayFloorDivergenceTest.kt
@@ -1,0 +1,134 @@
+package com.glycemicgpt.mobile.service
+
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
+import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
+import com.glycemicgpt.mobile.data.local.dao.AlertDao
+import com.glycemicgpt.mobile.data.local.dao.RawHistoryLogDao
+import com.glycemicgpt.mobile.data.local.entity.AlertEntity
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.data.repository.SyncQueueEnqueuer
+import com.glycemicgpt.mobile.domain.model.CgmReading
+import com.glycemicgpt.mobile.domain.model.CgmTrend
+import com.glycemicgpt.mobile.domain.model.GlucoseUnit
+import com.glycemicgpt.mobile.domain.pump.HistoryLogParser
+import com.glycemicgpt.mobile.domain.pump.PumpDriver
+import com.glycemicgpt.mobile.wear.WearDataSender
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * GLY-116 divergence guard: with every confounder pinned to "the floor would fire" —
+ * server alerting degraded, POST_NOTIFICATIONS granted, no prior fire/ack, no server-episode
+ * row — the watch relay pushes an alert ⟺ the floor fires its notification, across the
+ * freshness+sync grid. Both sides run the REAL code path (real [AlertFloor], real
+ * [PumpPollingOrchestrator.processCgmReading]), so the two consumers cannot drift apart on the
+ * data-trust bound without failing here.
+ *
+ * Explicitly out of scope: the healthy-online case, where the relay pushes but the floor
+ * defers to the server (gate 1) — the paths are MEANT to diverge on the degraded axis, so no
+ * bare `relayPushes ⟺ floorFires` is asserted there.
+ */
+class AlertRelayFloorDivergenceTest {
+
+    private class Fixture(synced: Boolean) {
+        val wearDataSender = mockk<WearDataSender>(relaxed = true)
+        val alertNotificationManager = mockk<AlertNotificationManager>(relaxed = true) {
+            every { canPostAlertNotifications() } returns true
+            every { stableNotificationId(any()) } answers {
+                (firstArg<AlertEntity>().alertType.hashCode() and 0x7FFFFFFF).coerceAtLeast(100)
+            }
+        }
+        private val alertThresholdStore = mockk<AlertThresholdStore>(relaxed = true) {
+            every { urgentLowMgDl } returns 55
+            every { lowWarningMgDl } returns 70
+            every { highWarningMgDl } returns 180
+            every { urgentHighMgDl } returns 250
+            every { isSynced() } returns synced
+        }
+        private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true) {
+            every { debugFastStaleness } returns false
+            every { glucoseUnit } returns GlucoseUnit.MGDL
+        }
+        val floor = AlertFloor(
+            alertThresholdStore,
+            alertNotificationManager,
+            mockk<AlertStreamStateHolder> {
+                every { state } returns MutableStateFlow(AlertStreamState.RECONNECTING)
+            },
+            mockk<NetworkMonitor> {
+                every { status } returns MutableStateFlow(NetworkStatus.BACKEND_UNREACHABLE)
+            },
+            mockk<AlertDao> {
+                coEvery { getLatestUnacknowledgedTimestampForType(any(), any()) } returns null
+            },
+            appSettingsStore,
+        )
+        val orchestrator = PumpPollingOrchestrator(
+            mockk<PumpDriver>(relaxed = true),
+            mockk<PumpDataRepository>(relaxed = true),
+            mockk<SyncQueueEnqueuer>(relaxed = true),
+            mockk<RawHistoryLogDao>(relaxed = true),
+            wearDataSender,
+            mockk<GlucoseRangeStore>(relaxed = true),
+            mockk<SafetyLimitsStore>(relaxed = true),
+            mockk<HistoryLogParser>(relaxed = true),
+            appSettingsStore,
+            floor,
+        )
+    }
+
+    /** Ages chosen well clear of the 6-min FRESH edge: boundary precision belongs to the
+     *  predicate unit tests with an injectable clock; this sweep runs on the real clock. */
+    private fun sweep(ageMs: Long, synced: Boolean, expectBothFire: Boolean) = runTest {
+        val fixture = Fixture(synced)
+        val reading = CgmReading(
+            glucoseMgDl = 54,
+            trendArrow = CgmTrend.FLAT,
+            timestamp = Instant.now().minusMillis(ageMs),
+        )
+        fixture.orchestrator.processCgmReading(reading)
+
+        val expected = if (expectBothFire) 1 else 0
+        coVerify(exactly = expected) {
+            fixture.wearDataSender.sendAlert(any(), any(), any(), any())
+        }
+        verify(exactly = expected) {
+            fixture.alertNotificationManager.showAlertNotification(any(), any())
+        }
+    }
+
+    @Test
+    fun `fresh synced low - relay and floor both fire`() =
+        sweep(ageMs = 0L, synced = true, expectBothFire = true)
+
+    @Test
+    fun `fresh synced low near the FRESH edge - relay and floor both fire`() =
+        sweep(ageMs = 5 * 60_000L, synced = true, expectBothFire = true)
+
+    @Test
+    fun `stale synced low - relay and floor both silent`() =
+        sweep(ageMs = 7 * 60_000L, synced = true, expectBothFire = false)
+
+    @Test
+    fun `too-stale synced low - relay and floor both silent`() =
+        sweep(ageMs = 60 * 60_000L, synced = true, expectBothFire = false)
+
+    @Test
+    fun `fresh never-synced low - relay and floor both silent`() =
+        sweep(ageMs = 0L, synced = false, expectBothFire = false)
+
+    @Test
+    fun `stale never-synced low - relay and floor both silent`() =
+        sweep(ageMs = 7 * 60_000L, synced = false, expectBothFire = false)
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -86,7 +86,9 @@ class PumpPollingOrchestratorTest {
     }
 
     /** AlertFloor's firing gates are covered in AlertFloorTest; here it only classifies (default
-     *  thresholds) so the watch relay mapping and the floor hand-off can be verified. */
+     *  thresholds) so the watch relay mapping and the floor hand-off can be verified. The shared
+     *  data-trust bound defaults to alertable=true so the relay tests exercise the send/clear
+     *  logic; the gate tests below flip it. */
     private val alertFloor = mockk<AlertFloor>(relaxed = true) {
         every { classify(any()) } answers {
             val mgDl = firstArg<Int>()
@@ -98,6 +100,7 @@ class PumpPollingOrchestratorTest {
                 else -> null
             }
         }
+        every { isReadingAlertable(any(), any()) } returns true
     }
 
     /**
@@ -121,6 +124,12 @@ class PumpPollingOrchestratorTest {
 
     /** Alias for tests that only need fast loop data. */
     private val SETTLE_TIME_MS = FAST_SETTLE_MS
+
+    /** Virtual time one further fast-loop cycle costs: the interval plus the two request
+     *  staggers before CGM fires. Advancing bare INTERVAL_FAST_MS accumulates stagger debt and
+     *  silently misses polls from the third cycle on. */
+    private val FAST_CYCLE_MS = PumpPollingOrchestrator.INTERVAL_FAST_MS +
+        PumpPollingOrchestrator.REQUEST_STAGGER_MS * 2
 
     private fun createOrchestrator() = PumpPollingOrchestrator(pumpDriver, repository, syncEnqueuer, rawHistoryLogDao, wearDataSender, glucoseRangeStore, safetyLimitsStore, historyLogParser, appSettingsStore, alertFloor)
 
@@ -429,6 +438,93 @@ class PumpPollingOrchestratorTest {
         advanceTimeBy(PumpPollingOrchestrator.INTERVAL_FAST_MS)
 
         coVerify(exactly = 1) { wearDataSender.clearAlert() }
+        orchestrator.stop()
+    }
+
+    // -- GLY-116 AC-A: the relay gates on the shared data-trust bound ----------
+    // These are the discriminating tests for the relay gate: they drive the REAL
+    // processCgmReading path and flip on a gate revert (the predicate unit tests alone would
+    // stay green with the call site removed).
+
+    @Test
+    fun `not-alertable low reading is not relayed to the watch and nothing is cleared`() = runTest {
+        every { alertFloor.isReadingAlertable(any(), any()) } returns false
+        coEvery { pumpDriver.getCgmStatus() } returns Result.success(
+            CgmReading(glucoseMgDl = 54, trendArrow = CgmTrend.FLAT, timestamp = Instant.now()),
+        )
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(SETTLE_TIME_MS)
+
+        coVerify(exactly = 0) { wearDataSender.sendAlert(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { wearDataSender.clearAlert() }
+        // The CGM display push and the floor hand-off are NOT gated — only the alert relay is.
+        coVerify(atLeast = 1) {
+            wearDataSender.sendCgm(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+        coVerify(atLeast = 1) { alertFloor.onCgmReading(any(), any(), any()) }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `not-alertable reading leaves the shown alert and latch untouched - no false all-clear`() = runTest {
+        // A fresh low latches the watch alert...
+        coEvery { pumpDriver.getCgmStatus() } returns Result.success(
+            CgmReading(glucoseMgDl = 65, trendArrow = CgmTrend.SINGLE_DOWN, timestamp = Instant.now()),
+        )
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(SETTLE_TIME_MS)
+        coVerify(exactly = 1) { wearDataSender.sendAlert("low", 65, any(), any()) }
+
+        // ...then the feed goes stale while the meter drifts in-range: the relay must NOT
+        // retract the shown low into the watch's green "All clear" off data nobody can vouch
+        // for. Axis (b) ages it out on the watch instead. (Each further fast-loop cycle costs
+        // INTERVAL + 2 staggers of virtual time.)
+        every { alertFloor.isReadingAlertable(any(), any()) } returns false
+        coEvery { pumpDriver.getCgmStatus() } returns Result.success(
+            CgmReading(glucoseMgDl = 120, trendArrow = CgmTrend.FLAT, timestamp = Instant.now()),
+        )
+        advanceTimeBy(FAST_CYCLE_MS)
+        coVerify(exactly = 0) { wearDataSender.clearAlert() }
+
+        // The latch survived untouched: a genuinely FRESH in-range recovery still clears once.
+        every { alertFloor.isReadingAlertable(any(), any()) } returns true
+        advanceTimeBy(FAST_CYCLE_MS)
+        coVerify(exactly = 1) { wearDataSender.clearAlert() }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `same low is not re-sent when readings become alertable again - latch not stranded`() = runTest {
+        coEvery { pumpDriver.getCgmStatus() } returns Result.success(
+            CgmReading(glucoseMgDl = 65, trendArrow = CgmTrend.SINGLE_DOWN, timestamp = Instant.now()),
+        )
+        val orchestrator = createOrchestrator()
+        orchestrator.start(this)
+        connectionStateFlow.value = ConnectionState.CONNECTED
+        advanceTimeBy(SETTLE_TIME_MS)
+        coVerify(exactly = 1) { wearDataSender.sendAlert("low", 65, any(), any()) }
+
+        // Stale window passes with the same low...
+        every { alertFloor.isReadingAlertable(any(), any()) } returns false
+        advanceTimeBy(FAST_CYCLE_MS)
+
+        // ...and a fresh reading of the SAME type does not double-send (the latch still holds
+        // "low"), while a fresh reading of a NEW type still fires — the gate skipped the latch,
+        // it did not corrupt it.
+        every { alertFloor.isReadingAlertable(any(), any()) } returns true
+        advanceTimeBy(FAST_CYCLE_MS)
+        coVerify(exactly = 1) { wearDataSender.sendAlert(any(), any(), any(), any()) }
+
+        coEvery { pumpDriver.getCgmStatus() } returns Result.success(
+            CgmReading(glucoseMgDl = 54, trendArrow = CgmTrend.SINGLE_DOWN, timestamp = Instant.now()),
+        )
+        advanceTimeBy(FAST_CYCLE_MS)
+        coVerify(exactly = 1) { wearDataSender.sendAlert("urgent_low", 54, any(), any()) }
         orchestrator.stop()
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -528,6 +528,66 @@ class PumpPollingOrchestratorTest {
         orchestrator.stop()
     }
 
+    // -- GLY-116: ongoing-episode refresh + re-buzz (relay owns the wrist re-alarm, D4) -------
+    // Driven through processCgmReading directly with an injected clock: the refresh/re-buzz
+    // cadence is wall-clock-based, which the virtual-time poll loop cannot advance.
+
+    private val lowReading = { at: Long ->
+        CgmReading(glucoseMgDl = 65, trendArrow = CgmTrend.SINGLE_DOWN, timestamp = Instant.ofEpochMilli(at))
+    }
+
+    @Test
+    fun `ongoing alert is silently refreshed so the wrist copy never ages into data-stale`() = runTest {
+        val orchestrator = createOrchestrator()
+        val t0 = 1_750_000_000_000L
+
+        orchestrator.processCgmReading(lowReading(t0), nowMs = t0)
+        coVerify(exactly = 1) { wearDataSender.sendAlert("low", 65, t0, any(), true) }
+
+        // Within the refresh window: no re-push (DataLayer traffic stays bounded).
+        orchestrator.processCgmReading(lowReading(t0 + 60_000L), nowMs = t0 + 60_000L)
+        coVerify(exactly = 1) { wearDataSender.sendAlert(any(), any(), any(), any(), any()) }
+
+        // Past the refresh window: silent refresh with the new reading's timestamp — axis (b)
+        // on the watch keeps seeing a current alert, not a frozen T0 one.
+        val t1 = t0 + PumpPollingOrchestrator.WRIST_ALERT_REFRESH_MS
+        orchestrator.processCgmReading(lowReading(t1), nowMs = t1)
+        coVerify(exactly = 1) { wearDataSender.sendAlert("low", 65, t1, any(), false) }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `sustained alert re-buzzes on the floor's re-alarm cadence`() = runTest {
+        val orchestrator = createOrchestrator()
+        val t0 = 1_750_000_000_000L
+
+        orchestrator.processCgmReading(lowReading(t0), nowMs = t0)
+        coVerify(exactly = 1) { wearDataSender.sendAlert("low", 65, t0, any(), true) }
+
+        // A sustained, never-recovering low must re-buzz the wrist after the same window the
+        // phone floor re-alarms in — the wrist is never quieter than the phone.
+        val t1 = t0 + PumpPollingOrchestrator.WRIST_ALERT_REBUZZ_MS
+        orchestrator.processCgmReading(lowReading(t1), nowMs = t1)
+        coVerify(exactly = 2) { wearDataSender.sendAlert("low", 65, any(), any(), true) }
+        orchestrator.stop()
+    }
+
+    @Test
+    fun `not-alertable readings do not refresh the wrist alert either`() = runTest {
+        val orchestrator = createOrchestrator()
+        val t0 = 1_750_000_000_000L
+        orchestrator.processCgmReading(lowReading(t0), nowMs = t0)
+        coVerify(exactly = 1) { wearDataSender.sendAlert(any(), any(), any(), any(), any()) }
+
+        // Feed goes stale: no refresh, no re-buzz — the wrist copy ages out honestly instead
+        // of being re-stamped with data nobody can vouch for.
+        every { alertFloor.isReadingAlertable(any(), any()) } returns false
+        val t1 = t0 + PumpPollingOrchestrator.WRIST_ALERT_REBUZZ_MS
+        orchestrator.processCgmReading(lowReading(t0), nowMs = t1)
+        coVerify(exactly = 1) { wearDataSender.sendAlert(any(), any(), any(), any(), any()) }
+        orchestrator.stop()
+    }
+
     // -- Reconnection accelerated polling tests --------------------------------
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/PumpPollingOrchestratorTest.kt
@@ -573,6 +573,29 @@ class PumpPollingOrchestratorTest {
     }
 
     @Test
+    fun `a watch-mapping gap never clears a shown alert - only a genuine in-range recovery does`() = runTest {
+        val orchestrator = createOrchestrator()
+        val t0 = 1_750_000_000_000L
+        orchestrator.processCgmReading(lowReading(t0), nowMs = t0)
+        coVerify(exactly = 1) { wearDataSender.sendAlert(any(), any(), any(), any(), any()) }
+
+        // classify returns a server type with no watch mapping: the relay loses its push
+        // (logged), but it must NOT retract the shown low into the watch's "All clear".
+        every { alertFloor.classify(any()) } returns "some_future_alert_type"
+        orchestrator.processCgmReading(lowReading(t0 + 15_000L), nowMs = t0 + 15_000L)
+        coVerify(exactly = 0) { wearDataSender.clearAlert() }
+
+        // A genuinely in-range classification still clears.
+        every { alertFloor.classify(any()) } returns null
+        orchestrator.processCgmReading(
+            CgmReading(glucoseMgDl = 120, trendArrow = CgmTrend.FLAT, timestamp = Instant.ofEpochMilli(t0 + 30_000L)),
+            nowMs = t0 + 30_000L,
+        )
+        coVerify(exactly = 1) { wearDataSender.clearAlert() }
+        orchestrator.stop()
+    }
+
+    @Test
     fun `not-alertable readings do not refresh the wrist alert either`() = runTest {
         val orchestrator = createOrchestrator()
         val t0 = 1_750_000_000_000L

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearDataContractTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearDataContractTest.kt
@@ -71,6 +71,11 @@ class WearDataContractTest {
     }
 
     @Test
+    fun `alert rebuzz key matches wear-side contract value`() {
+        assertEquals("alert_rebuzz", WearDataContract.KEY_ALERT_REBUZZ)
+    }
+
+    @Test
     fun `monitoring status contract matches wear-side values`() {
         assertEquals("/glycemicgpt/monitoring_status", WearDataContract.MONITORING_STATUS_PATH)
         assertEquals("mon_state", WearDataContract.KEY_MONITORING_STATE)

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearDataContractTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearDataContractTest.kt
@@ -69,4 +69,30 @@ class WearDataContractTest {
         assertEquals("cfg_graph_range_h", WearDataContract.KEY_CONFIG_GRAPH_RANGE_HOURS)
         assertEquals("cfg_theme", WearDataContract.KEY_CONFIG_THEME)
     }
+
+    @Test
+    fun `monitoring status contract matches wear-side values`() {
+        assertEquals("/glycemicgpt/monitoring_status", WearDataContract.MONITORING_STATUS_PATH)
+        assertEquals("mon_state", WearDataContract.KEY_MONITORING_STATE)
+        assertEquals("mon_reason", WearDataContract.KEY_MONITORING_REASON)
+        assertEquals("mon_timeout_ms", WearDataContract.KEY_MONITORING_TIMEOUT_MS)
+        assertEquals("server_active", WearDataContract.MONITORING_STATE_SERVER_ACTIVE)
+        assertEquals("floor_watching", WearDataContract.MONITORING_STATE_FLOOR_WATCHING)
+        assertEquals("not_watching", WearDataContract.MONITORING_STATE_NOT_WATCHING)
+    }
+
+    @Test
+    fun `monitoring reasons are the FloorNotWatchingReason enum names exactly`() {
+        // The wire vocabulary IS the domain enum's names: a reason rename must break here, not
+        // silently degrade the watch's reason copy to the generic line.
+        assertEquals(
+            com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason.entries.map { it.name },
+            listOf(
+                WearDataContract.MONITORING_REASON_NOTIFICATIONS_DENIED,
+                WearDataContract.MONITORING_REASON_THRESHOLDS_NOT_SYNCED,
+                WearDataContract.MONITORING_REASON_PUMP_DISCONNECTED,
+                WearDataContract.MONITORING_REASON_NO_FRESH_READING,
+            ),
+        )
+    }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearMonitoringStatusForwarderTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/wear/WearMonitoringStatusForwarderTest.kt
@@ -1,0 +1,145 @@
+package com.glycemicgpt.mobile.wear
+
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
+import com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason
+import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
+import com.glycemicgpt.mobile.service.AlertFloorStatusProvider
+import com.glycemicgpt.mobile.wear.WearMonitoringStatusForwarder.Companion.heartbeatPeriodMs
+import com.glycemicgpt.mobile.wear.WearMonitoringStatusForwarder.Companion.toWire
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The phone-side forwarding wiring for the wrist coverage mirror (GLY-116 AC-B #7): without
+ * these, the watch-render tests can pass while the phone never sends — a silent I-honesty
+ * failure. Verifies the provider stream reaches [WearDataSender.sendMonitoringStatus] with the
+ * exact wire vocabulary, and that a steady status is re-sent as a heartbeat (the watch's local
+ * timeout counts from the last push, so a single send would decay a healthy wrist to "no
+ * recent data").
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WearMonitoringStatusForwarderTest {
+
+    private val statusFlow = MutableStateFlow<AlertFloorStatus>(AlertFloorStatus.ServerActive)
+    private val provider = mockk<AlertFloorStatusProvider> {
+        every { observe() } returns statusFlow
+    }
+    private val appSettingsStore = mockk<AppSettingsStore>(relaxed = true) {
+        every { debugFastStalenessFlow() } returns flowOf(false)
+    }
+    private val wearDataSender = mockk<WearDataSender>(relaxed = true)
+
+    private val forwarder =
+        WearMonitoringStatusForwarder(provider, appSettingsStore, wearDataSender)
+
+    /** One CGM staleness window under the production policy — the advertised watch timeout. */
+    private val timeoutMs = FreshnessPolicy.CGM.staleAfterMs
+
+    @Test
+    fun `not-watching emission is forwarded with the exact reason vocabulary`() = runTest {
+        statusFlow.value =
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING)
+        val job = forwarder.start(this)
+        advanceTimeBy(1_000L)
+
+        coVerify(atLeast = 1) {
+            wearDataSender.sendMonitoringStatus(
+                WearDataContract.MONITORING_STATE_NOT_WATCHING,
+                WearDataContract.MONITORING_REASON_NO_FRESH_READING,
+                timeoutMs,
+            )
+        }
+        job.cancel()
+    }
+
+    @Test
+    fun `watching emissions forward server-active and floor-watching states`() = runTest {
+        val job = forwarder.start(this)
+        advanceTimeBy(1_000L)
+        coVerify(atLeast = 1) {
+            wearDataSender.sendMonitoringStatus(
+                WearDataContract.MONITORING_STATE_SERVER_ACTIVE,
+                null,
+                timeoutMs,
+            )
+        }
+
+        statusFlow.value = AlertFloorStatus.FloorWatching
+        advanceTimeBy(1_000L)
+        coVerify(atLeast = 1) {
+            wearDataSender.sendMonitoringStatus(
+                WearDataContract.MONITORING_STATE_FLOOR_WATCHING,
+                null,
+                timeoutMs,
+            )
+        }
+        job.cancel()
+    }
+
+    @Test
+    fun `steady status is re-sent as a heartbeat, not just on change`() = runTest {
+        val job = forwarder.start(this)
+        // Three heartbeat periods with NO status change: at least the initial send plus two
+        // re-sends must have gone out, or a dead-phone timeout on the watch would also fire
+        // for a perfectly healthy phone.
+        advanceTimeBy(heartbeatPeriodMs(timeoutMs) * 3 + 1_000L)
+
+        coVerify(atLeast = 3) {
+            wearDataSender.sendMonitoringStatus(
+                WearDataContract.MONITORING_STATE_SERVER_ACTIVE,
+                null,
+                timeoutMs,
+            )
+        }
+        job.cancel()
+    }
+
+    @Test
+    fun `wire mapping mirrors AlertFloorStatus exactly`() {
+        assertEquals(
+            WearDataContract.MONITORING_STATE_SERVER_ACTIVE to null,
+            AlertFloorStatus.ServerActive.toWire(),
+        )
+        assertEquals(
+            WearDataContract.MONITORING_STATE_FLOOR_WATCHING to null,
+            AlertFloorStatus.FloorWatching.toWire(),
+        )
+        // Every reason forwards under its enum name — the contract constants pin the wire
+        // strings, so a reason rename breaks this test instead of silently degrading the
+        // watch's copy to the generic line.
+        assertEquals(
+            WearDataContract.MONITORING_STATE_NOT_WATCHING to "NOTIFICATIONS_DENIED",
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NOTIFICATIONS_DENIED).toWire(),
+        )
+        assertEquals(
+            WearDataContract.MONITORING_STATE_NOT_WATCHING to "THRESHOLDS_NOT_SYNCED",
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.THRESHOLDS_NOT_SYNCED).toWire(),
+        )
+        assertEquals(
+            WearDataContract.MONITORING_STATE_NOT_WATCHING to "PUMP_DISCONNECTED",
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.PUMP_DISCONNECTED).toWire(),
+        )
+        assertEquals(
+            WearDataContract.MONITORING_STATE_NOT_WATCHING to "NO_FRESH_READING",
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING).toWire(),
+        )
+    }
+
+    @Test
+    fun `heartbeat period is half the timeout with a floor`() {
+        assertEquals(3 * 60_000L, heartbeatPeriodMs(6 * 60_000L))
+        // Compressed debug window (20s) halves to 10s — above the anti-hot-loop floor.
+        assertEquals(10_000L, heartbeatPeriodMs(FreshnessPolicy.CGM_DEBUG_FAST.staleAfterMs))
+        // The floor kicks in below 10s windows.
+        assertEquals(WearMonitoringStatusForwarder.MIN_HEARTBEAT_MS, heartbeatPeriodMs(8_000L))
+    }
+}

--- a/apps/mobile/wear-device/build.gradle.kts
+++ b/apps/mobile/wear-device/build.gradle.kts
@@ -168,4 +168,10 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.turbine)
+
+    // Instrumented tests (run on a Wear OS emulator/device)
+    androidTestImplementation(libs.junit.ext)
+    androidTestImplementation(platform(libs.compose.bom))
+    androidTestImplementation(libs.compose.ui.test)
+    debugImplementation(libs.compose.ui.test.manifest)
 }

--- a/apps/mobile/wear-device/src/androidTest/java/com/glycemicgpt/weardevice/presentation/AlertsHonestyUiTest.kt
+++ b/apps/mobile/wear-device/src/androidTest/java/com/glycemicgpt/weardevice/presentation/AlertsHonestyUiTest.kt
@@ -1,0 +1,119 @@
+package com.glycemicgpt.weardevice.presentation
+
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.weardevice.data.WatchDataRepository
+import com.glycemicgpt.weardevice.data.WearDataContract
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * GLY-116 wrist honesty rendering (instrumented on a Wear OS emulator/device):
+ * the green "All clear" is reserved for a current "watching" claim; a not-watching payload,
+ * an aged-out status (dead phone), and a stale shown alert each render their honest state.
+ * State is driven through [WatchDataRepository]'s StateFlows — the same seam the Data Layer
+ * listener writes — so these cover the render half of the mirror; the wire half is covered by
+ * the phone-side forwarder tests + the contract mirror pins.
+ */
+@RunWith(AndroidJUnit4::class)
+class AlertsHonestyUiTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<AlertsActivity>()
+
+    private val timeoutMs = 6 * 60_000L
+
+    @Before
+    fun resetState() {
+        // WatchDataRepository is process-global and the instrumentation runs every test in one
+        // process: without both resets, one test's alert/status leaks into the next's render.
+        WatchDataRepository.clearAlert()
+        WatchDataRepository.clearMonitoringStatus()
+    }
+
+    private fun pushStatus(state: String, reason: String? = null, ageMs: Long = 0L) {
+        WatchDataRepository.updateMonitoringStatus(
+            state = state,
+            reason = reason,
+            timeoutMs = timeoutMs,
+            receivedAtMs = System.currentTimeMillis() - ageMs,
+        )
+    }
+
+    @Test
+    fun watchingStatusRendersAllClear() {
+        pushStatus(WearDataContract.MONITORING_STATE_SERVER_ACTIVE)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("all_clear").assertExists()
+        composeRule.onNodeWithText("No Active Alert").assertExists()
+    }
+
+    @Test
+    fun notWatchingStatusRendersDegradedBannerNotAllClear() {
+        pushStatus(
+            WearDataContract.MONITORING_STATE_NOT_WATCHING,
+            reason = WearDataContract.MONITORING_REASON_PUMP_DISCONNECTED,
+        )
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("not_watching").assertExists()
+        composeRule.onNodeWithText("Monitoring degraded — pump is disconnected.").assertExists()
+        composeRule
+            .onNodeWithText("Caregiver & AI alerts are paused — they need the backend.")
+            .assertExists()
+        composeRule.onNodeWithTag("all_clear").assertDoesNotExist()
+    }
+
+    @Test
+    fun agedOutWatchingStatusDecaysToNoRecentData() {
+        // The last push said "watching", but it is older than its own advertised timeout —
+        // the dead-phone case. A pure mirror would freeze "All clear"; the local decay must
+        // refuse to claim coverage.
+        pushStatus(WearDataContract.MONITORING_STATE_SERVER_ACTIVE, ageMs = timeoutMs + 1_000L)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("no_recent_status").assertExists()
+        composeRule.onNodeWithTag("all_clear").assertDoesNotExist()
+    }
+
+    @Test
+    fun neverReceivedStatusFailsClosed() {
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("no_recent_status").assertExists()
+        composeRule.onNodeWithTag("all_clear").assertDoesNotExist()
+    }
+
+    @Test
+    fun staleAlertRendersAsOfAgeAndNeverAllClear() {
+        pushStatus(WearDataContract.MONITORING_STATE_SERVER_ACTIVE)
+        WatchDataRepository.updateAlert(
+            type = "low",
+            bgValue = 62,
+            timestampMs = System.currentTimeMillis() - 16 * 60_000L,
+            message = "LOW 62 mg/dL",
+        )
+        composeRule.waitForIdle()
+        // Substring match: the exact minute count depends on when the screen sampled its
+        // clock relative to the push; the honesty claim is the "data stale" qualifier.
+        composeRule.onNodeWithTag("alert_age")
+            .assertTextContains("data stale", substring = true)
+        composeRule.onNodeWithTag("all_clear").assertDoesNotExist()
+    }
+
+    @Test
+    fun freshAlertRendersActiveWithAge() {
+        WatchDataRepository.updateAlert(
+            type = "urgent_low",
+            bgValue = 50,
+            timestampMs = System.currentTimeMillis(),
+            message = "URGENT LOW 50 mg/dL",
+        )
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Urgent Low").assertExists()
+        composeRule.onNodeWithTag("alert_age").assertExists()
+        composeRule.onNodeWithText("Dismiss").assertExists()
+    }
+}

--- a/apps/mobile/wear-device/src/androidTest/java/com/glycemicgpt/weardevice/presentation/AlertsHonestyUiTest.kt
+++ b/apps/mobile/wear-device/src/androidTest/java/com/glycemicgpt/weardevice/presentation/AlertsHonestyUiTest.kt
@@ -101,6 +101,23 @@ class AlertsHonestyUiTest {
         composeRule.onNodeWithTag("alert_age")
             .assertTextContains("data stale", substring = true)
         composeRule.onNodeWithTag("all_clear").assertDoesNotExist()
+        // Covered: no coverage warning under the stale body.
+        composeRule.onNodeWithTag("stale_alert_not_watching").assertDoesNotExist()
+    }
+
+    @Test
+    fun staleAlertWithDeadPhoneShowsNotWatchingLine() {
+        // A lingering stale alert occupies the screen the coverage banner would use — the
+        // compact line is the only "not watching" cue left on this surface.
+        WatchDataRepository.updateAlert(
+            type = "low",
+            bgValue = 62,
+            timestampMs = System.currentTimeMillis() - 16 * 60_000L,
+            message = "LOW 62 mg/dL",
+        )
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("stale_alert_not_watching").assertExists()
+        composeRule.onNodeWithTag("all_clear").assertDoesNotExist()
     }
 
     @Test

--- a/apps/mobile/wear-device/src/main/AndroidManifest.xml
+++ b/apps/mobile/wear-device/src/main/AndroidManifest.xml
@@ -68,7 +68,11 @@
             android:exported="false"
             android:theme="@android:style/Theme.DeviceDefault" />
 
-        <!-- IoB Complication Provider -->
+        <!-- IoB Complication Provider.
+             UPDATE_PERIOD_SECONDS 300 (GLY-116): renders are age-bounded on the watch clock,
+             so the glance surface must re-render WITHOUT a phone push — a dead phone stops
+             the data-driven update requests, and a push-only complication would freeze its
+             last (reassuring) state forever. 300s is the platform minimum period. -->
         <service
             android:name=".complications.IoBComplicationDataSource"
             android:exported="true"
@@ -82,7 +86,7 @@
                 android:value="SHORT_TEXT,LONG_TEXT" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0" />
+                android:value="300" />
         </service>
 
         <!-- Permission request activity for Watch Face Push (auto-finishes) -->
@@ -130,7 +134,8 @@
             android:name=".update.UpdateInstallReceiver"
             android:exported="false" />
 
-        <!-- BG Complication Provider -->
+        <!-- BG Complication Provider.
+             UPDATE_PERIOD_SECONDS 300: see the IoB provider note (GLY-116 dead-phone decay). -->
         <service
             android:name=".complications.BgComplicationDataSource"
             android:exported="true"
@@ -144,7 +149,7 @@
                 android:value="SHORT_TEXT,LONG_TEXT" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0" />
+                android:value="300" />
         </service>
 
         <!-- Glucose Graph Complication Provider -->
@@ -164,7 +169,10 @@
                 android:value="0" />
         </service>
 
-        <!-- Alerts Complication Provider -->
+        <!-- Alerts Complication Provider.
+             UPDATE_PERIOD_SECONDS 300: see the IoB provider note (GLY-116 dead-phone decay) —
+             this is the complication that must flip to the "not watching / no recent data"
+             cue when the phone stops pushing. -->
         <service
             android:name=".complications.AlertsComplicationDataSource"
             android:exported="true"
@@ -178,7 +186,7 @@
                 android:value="SMALL_IMAGE" />
             <meta-data
                 android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
-                android:value="0" />
+                android:value="300" />
         </service>
 
         <!-- AI Chat Complication Provider -->

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/AlertsComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/AlertsComplicationDataSource.kt
@@ -35,14 +35,17 @@ class AlertsComplicationDataSource : SuspendingComplicationDataSourceService() {
             return NoDataComplicationData()
         }
 
+        // init: this complication previously read the repository StateFlows without ensuring
+        // the persisted state was restored after a process restart (BG already init-ed).
         WatchDataRepository.init(applicationContext)
+        val now = System.currentTimeMillis()
         val render = render(
             alert = WatchDataRepository.alert.value,
             coverage = WatchDataRepository.coverageFrom(
                 WatchDataRepository.monitoringStatus.value,
-                System.currentTimeMillis(),
+                now,
             ),
-            nowMs = System.currentTimeMillis(),
+            nowMs = now,
         )
 
         val icon = Icon.createWithResource(this, R.drawable.ic_complication_bell)

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/AlertsComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/AlertsComplicationDataSource.kt
@@ -96,17 +96,24 @@ class AlertsComplicationDataSource : SuspendingComplicationDataSourceService() {
             val alertAgeMs = alert?.let { nowMs - it.timestampMs }
             val alertIsStale = alertAgeMs != null &&
                 WatchFreshness.cgmTier(alertAgeMs) == WatchFreshness.Tier.TOO_STALE
+            val covered = coverage is WatchDataRepository.WristCoverage.Watching
 
+            // The stale-alert grey may only render while something is WATCHING: a real alert
+            // whose phone then dies ages past the cap and never auto-clears, and quiet grey
+            // there would be indistinguishable from the healthy all-clear — suppressing the
+            // dead-phone cue in exactly the case it exists for. Uncovered always warns.
             val tint = when {
-                hasActiveAlert && alertIsStale -> COLOR_DEFAULT
+                hasActiveAlert && alertIsStale && covered -> COLOR_DEFAULT
+                hasActiveAlert && alertIsStale -> COLOR_WARNING
                 isUrgent -> COLOR_URGENT
                 hasActiveAlert -> COLOR_WARNING
-                coverage !is WatchDataRepository.WristCoverage.Watching -> COLOR_WARNING
+                !covered -> COLOR_WARNING
                 else -> COLOR_DEFAULT
             }
             val description = when {
                 hasActiveAlert && alertIsStale ->
-                    "Alert as of ${GlucoseDisplayUtils.formatAge(alertAgeMs!!)} — data stale"
+                    "Alert as of ${GlucoseDisplayUtils.formatAge(alertAgeMs!!)} — data stale" +
+                        if (covered) "" else ", not watching"
                 isUrgent -> "Urgent alert active"
                 hasActiveAlert -> "Alert active (${GlucoseDisplayUtils.formatAge(alertAgeMs!!)})"
                 coverage is WatchDataRepository.WristCoverage.NotWatching ->

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/AlertsComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/AlertsComplicationDataSource.kt
@@ -15,6 +15,8 @@ import androidx.wear.watchface.complications.datasource.SuspendingComplicationDa
 import com.glycemicgpt.weardevice.R
 import com.glycemicgpt.weardevice.data.WatchDataRepository
 import com.glycemicgpt.weardevice.presentation.AlertsActivity
+import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
+import com.glycemicgpt.weardevice.util.WatchFreshness
 
 class AlertsComplicationDataSource : SuspendingComplicationDataSourceService() {
 
@@ -33,23 +35,19 @@ class AlertsComplicationDataSource : SuspendingComplicationDataSourceService() {
             return NoDataComplicationData()
         }
 
-        val alert = WatchDataRepository.alert.value
-        val hasActiveAlert = alert != null &&
-            !alert.type.equals("none", ignoreCase = true)
-        val isUrgent = alert?.type?.startsWith("urgent", ignoreCase = true) == true
-        val tintColor = when {
-            isUrgent -> COLOR_URGENT
-            hasActiveAlert -> COLOR_WARNING
-            else -> COLOR_DEFAULT
-        }
-        val description = when {
-            isUrgent -> "Urgent alert active"
-            hasActiveAlert -> "Alert active"
-            else -> "No active alerts"
-        }
+        WatchDataRepository.init(applicationContext)
+        val render = render(
+            alert = WatchDataRepository.alert.value,
+            coverage = WatchDataRepository.coverageFrom(
+                WatchDataRepository.monitoringStatus.value,
+                System.currentTimeMillis(),
+            ),
+            nowMs = System.currentTimeMillis(),
+        )
 
         val icon = Icon.createWithResource(this, R.drawable.ic_complication_bell)
-        icon.setTint(tintColor)
+        icon.setTint(render.tint)
+        val description = render.description
 
         val tapIntent = Intent(this, AlertsActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
@@ -69,10 +67,52 @@ class AlertsComplicationDataSource : SuspendingComplicationDataSourceService() {
             .build()
     }
 
-    private companion object {
+    /** Bell tint + description for a given alert/coverage snapshot. Pure for unit tests. */
+    internal data class AlertsRender(val tint: Int, val description: String)
+
+    internal companion object {
         const val ALERTS_REQUEST_CODE = 2001
         const val COLOR_DEFAULT = 0xFF9CA3AF.toInt()   // Grey
         const val COLOR_WARNING = 0xFFFBBF24.toInt()    // Yellow
         const val COLOR_URGENT = 0xFFEF4444.toInt()     // Red
+
+        /**
+         * GLY-116: a shown alert is aged on the watch clock (axis b) — once its reading is
+         * TOO_STALE it renders as historical ("as of Xm ago"), grey, not active-indefinitely.
+         * With no alert showing, the quiet grey bell is reserved for a current "watching"
+         * claim (axis a); any degraded/unknown coverage turns the bell amber so the glance
+         * says something may not be watching.
+         */
+        fun render(
+            alert: WatchDataRepository.AlertState?,
+            coverage: WatchDataRepository.WristCoverage,
+            nowMs: Long,
+        ): AlertsRender {
+            val hasActiveAlert = alert != null && !alert.type.equals("none", ignoreCase = true)
+            val isUrgent = alert?.type?.startsWith("urgent", ignoreCase = true) == true
+            val alertAgeMs = alert?.let { nowMs - it.timestampMs }
+            val alertIsStale = alertAgeMs != null &&
+                WatchFreshness.cgmTier(alertAgeMs) == WatchFreshness.Tier.TOO_STALE
+
+            val tint = when {
+                hasActiveAlert && alertIsStale -> COLOR_DEFAULT
+                isUrgent -> COLOR_URGENT
+                hasActiveAlert -> COLOR_WARNING
+                coverage !is WatchDataRepository.WristCoverage.Watching -> COLOR_WARNING
+                else -> COLOR_DEFAULT
+            }
+            val description = when {
+                hasActiveAlert && alertIsStale ->
+                    "Alert as of ${GlucoseDisplayUtils.formatAge(alertAgeMs!!)} — data stale"
+                isUrgent -> "Urgent alert active"
+                hasActiveAlert -> "Alert active (${GlucoseDisplayUtils.formatAge(alertAgeMs!!)})"
+                coverage is WatchDataRepository.WristCoverage.NotWatching ->
+                    "Monitoring degraded — not watching"
+                coverage is WatchDataRepository.WristCoverage.NoRecentStatus ->
+                    "No recent data from phone"
+                else -> "No active alerts"
+            }
+            return AlertsRender(tint, description)
+        }
     }
 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/BgComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/BgComplicationDataSource.kt
@@ -14,6 +14,8 @@ import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
 import com.glycemicgpt.weardevice.data.WatchDataRepository
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
+import com.glycemicgpt.weardevice.util.GlucoseUnit
+import com.glycemicgpt.weardevice.util.WatchFreshness
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
@@ -50,30 +52,19 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData {
         WatchDataRepository.init(applicationContext)
         val unit = WatchDataRepository.glucoseUnit.value
-        val now = System.currentTimeMillis()
-        val staleThresholdMs = 15 * 60_000L // 15 minutes
-        // Staleness/validity gates compare the raw mg/dL Int; only the rendered text converts.
-        val cgmState = WatchDataRepository.cgm.value?.takeIf {
-            val ageMs = now - it.timestampMs
-            GlucoseDisplayUtils.isValidGlucose(it.mgDl) &&
-                ageMs in 0 until staleThresholdMs
-        }
-        val bgText = cgmState?.let {
-            "${GlucoseDisplayUtils.formatGlucose(it.mgDl, unit)} ${GlucoseDisplayUtils.trendSymbol(it.trend)}"
-        } ?: "--"
-        val descriptionText = cgmState?.let {
-            "Blood Glucose: ${GlucoseDisplayUtils.formatWithLabel(it.mgDl, unit)}"
-        } ?: "No data"
+        val cgmState = WatchDataRepository.cgm.value
+        val render = render(cgmState, System.currentTimeMillis(), unit)
 
-        val text = PlainComplicationText.Builder(bgText).build()
-        val description = PlainComplicationText.Builder(descriptionText).build()
+        val text = PlainComplicationText.Builder(render.shortText).build()
+        val description = PlainComplicationText.Builder(render.description).build()
 
         // Use TimeDifferenceComplicationText so the system efficiently updates
-        // the "Xm ago" display without waking our service.
-        val title: ComplicationText = if (cgmState != null) {
+        // the "Xm ago" display without waking our service. Kept in every tier that has a
+        // reading at all: for TOO_STALE the age is the only honest thing left to show.
+        val title: ComplicationText = if (render.ageReferenceMs != null) {
             TimeDifferenceComplicationText.Builder(
                 TimeDifferenceStyle.SHORT_SINGLE_UNIT,
-                CountUpTimeReference(Instant.ofEpochMilli(cgmState.timestampMs)),
+                CountUpTimeReference(Instant.ofEpochMilli(render.ageReferenceMs)),
             )
                 .setMinimumTimeUnit(TimeUnit.MINUTES)
                 .build()
@@ -88,10 +79,7 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
                     .build()
             ComplicationType.LONG_TEXT ->
                 LongTextComplicationData.Builder(
-                    text = PlainComplicationText.Builder(
-                        "BG: ${cgmState?.let { GlucoseDisplayUtils.formatWithLabel(it.mgDl, unit) } ?: "--"} " +
-                            (cgmState?.let { GlucoseDisplayUtils.trendSymbol(it.trend) } ?: ""),
-                    ).build(),
+                    text = PlainComplicationText.Builder(render.longText).build(),
                     contentDescription = description,
                 )
                     .setTitle(title)
@@ -100,8 +88,60 @@ class BgComplicationDataSource : SuspendingComplicationDataSourceService() {
         }
     }
 
-    private companion object {
+    /** What the complication shows for a given cached reading + now. Pure so the tier
+     *  boundaries are unit-testable without a service context. */
+    internal data class BgRender(
+        val shortText: String,
+        val longText: String,
+        val description: String,
+        /** Timestamp the "Xm ago" count-up title runs from, or null with no reading at all. */
+        val ageReferenceMs: Long?,
+    )
+
+    internal companion object {
         /** Representative sample value for the complication picker preview. */
         const val PREVIEW_MG_DL = 120
+
+        /**
+         * GLY-116 axis (b): the shown value ages on the shared three-tier policy against the
+         * WATCH's own clock — deliberately no coverage/"watching" input, so a stale feed greys
+         * even while the mirrored status still says ServerActive (the decoupled-source case).
+         * STALE de-emphasises with a "?" marker instead of rendering confident-live until the
+         * 15-min hard cap; TOO_STALE drops the number but keeps the age counting — "--" with
+         * no context was never actionable.
+         */
+        fun render(
+            cgmState: WatchDataRepository.CgmState?,
+            nowMs: Long,
+            unit: GlucoseUnit,
+        ): BgRender {
+            val valid = cgmState?.takeIf { GlucoseDisplayUtils.isValidGlucose(it.mgDl) }
+            val tier = valid?.let { WatchFreshness.cgmTier(nowMs - it.timestampMs) }
+            val showValue =
+                tier == WatchFreshness.Tier.FRESH || tier == WatchFreshness.Tier.STALE
+            val staleMark = if (tier == WatchFreshness.Tier.STALE) "?" else ""
+
+            return if (valid != null && showValue) {
+                val labeled = GlucoseDisplayUtils.formatWithLabel(valid.mgDl, unit)
+                BgRender(
+                    shortText = "${GlucoseDisplayUtils.formatGlucose(valid.mgDl, unit)}$staleMark " +
+                        GlucoseDisplayUtils.trendSymbol(valid.trend),
+                    longText = "BG: $labeled$staleMark ${GlucoseDisplayUtils.trendSymbol(valid.trend)}",
+                    description = if (tier == WatchFreshness.Tier.STALE) {
+                        "Blood Glucose: $labeled (stale)"
+                    } else {
+                        "Blood Glucose: $labeled"
+                    },
+                    ageReferenceMs = valid.timestampMs,
+                )
+            } else {
+                BgRender(
+                    shortText = "--",
+                    longText = "BG: --",
+                    description = "No recent data",
+                    ageReferenceMs = valid?.timestampMs,
+                )
+            }
+        }
     }
 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/IoBComplicationDataSource.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/complications/IoBComplicationDataSource.kt
@@ -9,6 +9,7 @@ import androidx.wear.watchface.complications.data.ShortTextComplicationData
 import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
 import com.glycemicgpt.weardevice.data.WatchDataRepository
+import com.glycemicgpt.weardevice.util.WatchFreshness
 
 class IoBComplicationDataSource : SuspendingComplicationDataSourceService() {
 
@@ -37,9 +38,9 @@ class IoBComplicationDataSource : SuspendingComplicationDataSourceService() {
         if (!WatchDataRepository.watchFaceConfig.value.showIoB) {
             return NoDataComplicationData()
         }
-        val iobState = WatchDataRepository.iob.value
-        val iobText = iobState?.let { "%.2f".format(it.iob) } ?: "--"
-        val descriptionText = iobState?.let { "Insulin on Board: $iobText units" } ?: "No data"
+        val render = render(WatchDataRepository.iob.value, System.currentTimeMillis())
+        val iobText = render.text
+        val descriptionText = render.description
 
         val text = PlainComplicationText.Builder(iobText).build()
         val title = PlainComplicationText.Builder("IoB").build()
@@ -58,6 +59,36 @@ class IoBComplicationDataSource : SuspendingComplicationDataSourceService() {
                     .setTitle(title)
                     .build()
             else -> NoDataComplicationData()
+        }
+    }
+
+    /** What the complication shows for a cached IoB + now. Pure for boundary unit tests. */
+    internal data class IoBRender(val text: String, val description: String)
+
+    internal companion object {
+        /**
+         * GLY-116 axis (b): IoB decays fast enough that an hour-old value presented as current
+         * is dosing-relevant misinformation. Age against the watch clock on the shared PUMP
+         * policy: STALE (>=15 min) keeps the value with a "?" marker, TOO_STALE (>=60 min)
+         * drops it — never an unbounded render.
+         */
+        fun render(iobState: WatchDataRepository.IoBState?, nowMs: Long): IoBRender {
+            val tier = iobState?.let { WatchFreshness.pumpTier(nowMs - it.timestampMs) }
+            val showValue =
+                tier == WatchFreshness.Tier.FRESH || tier == WatchFreshness.Tier.STALE
+            if (iobState == null || !showValue) {
+                return IoBRender(text = "--", description = "No recent data")
+            }
+            val staleMark = if (tier == WatchFreshness.Tier.STALE) "?" else ""
+            val text = "%.2f%s".format(iobState.iob, staleMark)
+            return IoBRender(
+                text = text,
+                description = if (tier == WatchFreshness.Tier.STALE) {
+                    "Insulin on Board: %.2f units (stale)".format(iobState.iob)
+                } else {
+                    "Insulin on Board: $text units"
+                },
+            )
         }
     }
 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/GlycemicDataListenerService.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/GlycemicDataListenerService.kt
@@ -217,6 +217,10 @@ class GlycemicDataListenerService : WearableListenerService() {
                     val alertsEnabled = WatchDataRepository.watchFaceConfig.value.showAlert
                     val rawBg = dataMap.getInt(WearDataContract.KEY_ALERT_BG_VALUE, 0)
                     val bgValue = if (GlucoseDisplayUtils.isValidGlucose(rawBg)) rawBg else 0
+                    // rebuzz=false is a silent refresh of an ongoing alert (GLY-116): the
+                    // display updates but the wrist does not vibrate. Defaults to true so an
+                    // older phone build (which only sends on type change) still buzzes.
+                    val rebuzz = dataMap.getBoolean(WearDataContract.KEY_ALERT_REBUZZ, true)
                     WatchDataRepository.updateAlert(
                         type = alertType,
                         bgValue = bgValue,
@@ -224,10 +228,13 @@ class GlycemicDataListenerService : WearableListenerService() {
                         message = dataMap.getString(WearDataContract.KEY_ALERT_MESSAGE, ""),
                     )
                     alertUpdated = true
-                    if (!alertType.equals("none", ignoreCase = true) && alertsEnabled) {
+                    if (!alertType.equals("none", ignoreCase = true) && alertsEnabled && rebuzz) {
                         vibrateForAlert(alertType)
                     }
-                    Timber.d("Received alert from phone: %s (vibrate=%b)", alertType, alertsEnabled)
+                    Timber.d(
+                        "Received alert from phone: %s (vibrate=%b, rebuzz=%b)",
+                        alertType, alertsEnabled, rebuzz,
+                    )
                 }
             }
         }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/GlycemicDataListenerService.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/GlycemicDataListenerService.kt
@@ -11,6 +11,7 @@ import com.glycemicgpt.weardevice.complications.IoBComplicationDataSource
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils.sanitizeThresholds
 import com.glycemicgpt.weardevice.util.GlucoseUnit
+import com.glycemicgpt.weardevice.util.WatchFreshness
 import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataMapItem
@@ -31,6 +32,7 @@ class GlycemicDataListenerService : WearableListenerService() {
         var configUpdated = false
         var alertUpdated = false
         var categoryLabelsUpdated = false
+        var monitoringStatusUpdated = false
 
         // Two-pass processing: config events first so that data/alert events
         // see the latest showAlert / showIoB state within the same batch.
@@ -188,6 +190,28 @@ class GlycemicDataListenerService : WearableListenerService() {
                     Timber.d("Received CGM update from phone")
                 }
 
+                WearDataContract.MONITORING_STATUS_PATH -> {
+                    val state = dataMap.getString(WearDataContract.KEY_MONITORING_STATE, "")
+                    if (state in VALID_MONITORING_STATES) {
+                        WatchDataRepository.updateMonitoringStatus(
+                            state = state,
+                            reason = dataMap.getString(WearDataContract.KEY_MONITORING_REASON),
+                            // Clamp a nonsense timeout instead of trusting it: too small would
+                            // flap to "no recent data" between heartbeats, absent/huge would
+                            // let a dead phone's last "watching" survive for hours.
+                            timeoutMs = dataMap.getLong(
+                                WearDataContract.KEY_MONITORING_TIMEOUT_MS,
+                                WatchFreshness.DEFAULT_STATUS_TIMEOUT_MS,
+                            ).coerceIn(MIN_STATUS_TIMEOUT_MS, MAX_STATUS_TIMEOUT_MS),
+                            receivedAtMs = System.currentTimeMillis(),
+                        )
+                        monitoringStatusUpdated = true
+                        Timber.d("Received monitoring status from phone: %s", state)
+                    } else {
+                        Timber.w("Rejected unknown monitoring status from phone")
+                    }
+                }
+
                 WearDataContract.ALERT_PATH -> {
                     val alertType = dataMap.getString(WearDataContract.KEY_ALERT_TYPE, "none")
                     val alertsEnabled = WatchDataRepository.watchFaceConfig.value.showAlert
@@ -251,6 +275,25 @@ class GlycemicDataListenerService : WearableListenerService() {
         if (alertUpdated) {
             // Alerts are safety-critical -- always update immediately
             providersToUpdate += AlertsComplicationDataSource::class.java
+        }
+        if (monitoringStatusUpdated) {
+            // Coverage honesty is safety-critical too: the Alerts complication renders the
+            // "not watching" cue. The phone's status heartbeat (>= every timeout/2) doubles as
+            // the periodic re-render tick that lets BG/IoB staleness de-emphasis take effect
+            // without a watch-side alarm clock; the existing BG throttle still applies.
+            providersToUpdate += AlertsComplicationDataSource::class.java
+            if (BgComplicationDataSource::class.java !in providersToUpdate &&
+                now - lastBgUpdateMs >= BG_UPDATE_THROTTLE_MS
+            ) {
+                lastBgUpdateMs = now
+                providersToUpdate += BgComplicationDataSource::class.java
+            }
+            if (IoBComplicationDataSource::class.java !in providersToUpdate &&
+                now - lastIoBUpdateMs >= IOB_UPDATE_THROTTLE_MS
+            ) {
+                lastIoBUpdateMs = now
+                providersToUpdate += IoBComplicationDataSource::class.java
+            }
         }
         if (categoryLabelsUpdated && GraphComplicationDataSource::class.java !in providersToUpdate) {
             val historySize = WatchDataRepository.cgmHistory.value.size
@@ -348,6 +391,15 @@ class GlycemicDataListenerService : WearableListenerService() {
     private companion object {
         const val MAX_ERROR_LENGTH = 200
         const val MAX_HISTORY_RECORDS = 500
+        val VALID_MONITORING_STATES = setOf(
+            WearDataContract.MONITORING_STATE_SERVER_ACTIVE,
+            WearDataContract.MONITORING_STATE_FLOOR_WATCHING,
+            WearDataContract.MONITORING_STATE_NOT_WATCHING,
+        )
+        /** Sanity clamp for the phone-advertised status decay window. The floor covers the
+         *  compressed debug policy (20s), the cap a corrupt/absurd payload. */
+        const val MIN_STATUS_TIMEOUT_MS = 10_000L
+        const val MAX_STATUS_TIMEOUT_MS = 30 * 60_000L
         /** Hard cap per Tandem pump safety limits (max single bolus 25U). */
         const val MAX_BOLUS_UNITS = 25f
         /** Hard cap per Tandem pump safety limits (max basal 15 U/hr). */

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WatchDataRepository.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WatchDataRepository.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.weardevice.data
 import android.content.Context
 import android.content.SharedPreferences
 import com.glycemicgpt.weardevice.util.GlucoseUnit
+import com.glycemicgpt.weardevice.util.WatchFreshness
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -51,6 +52,39 @@ object WatchDataRepository {
         val timestampMs: Long,
         val message: String,
     )
+
+    /**
+     * The phone's mirrored alerting-coverage decision (GLY-116 axis a), plus the watch-clock
+     * receipt time the local decay is judged from. [state]/[reason] use the
+     * [WearDataContract] monitoring-status wire vocabulary verbatim; the watch renders them and
+     * NEVER re-derives coverage. Deliberately not persisted: after a watch process restart the
+     * coverage is genuinely unknown, and the fail-closed render ("no recent data") is the honest
+     * one until the phone's next heartbeat (at most half the timeout away when it is alive).
+     *
+     * @param receivedAtMs watch wall-clock ms at receipt ([System.currentTimeMillis]), the same
+     *   clock the CGM feed is aged by, so both honesty axes decay consistently.
+     */
+    data class MonitoringStatusState(
+        val state: String,
+        val reason: String?,
+        val timeoutMs: Long,
+        val receivedAtMs: Long,
+    )
+
+    /**
+     * What the wrist may claim about alerting coverage right now — the render-side collapse of
+     * [MonitoringStatusState] + its local decay. Pure decision in [coverageFrom].
+     */
+    sealed interface WristCoverage {
+        /** Server or the phone floor is watching, and the claim is current. */
+        data object Watching : WristCoverage
+
+        /** The phone said nothing is watching; [reason] is the wire reason string, if sent. */
+        data class NotWatching(val reason: String?) : WristCoverage
+
+        /** No status ever received, or the last one aged past its timeout (dead/absent phone). */
+        data object NoRecentStatus : WristCoverage
+    }
 
     sealed class ChatState {
         data object Idle : ChatState()
@@ -121,6 +155,9 @@ object WatchDataRepository {
     private val _alert = MutableStateFlow<AlertState?>(null)
     val alert: StateFlow<AlertState?> = _alert.asStateFlow()
 
+    private val _monitoringStatus = MutableStateFlow<MonitoringStatusState?>(null)
+    val monitoringStatus: StateFlow<MonitoringStatusState?> = _monitoringStatus.asStateFlow()
+
     private val _chatState = MutableStateFlow<ChatState>(ChatState.Idle)
     val chatState: StateFlow<ChatState> = _chatState.asStateFlow()
 
@@ -189,6 +226,41 @@ object WatchDataRepository {
 
     fun updateAlert(type: String, bgValue: Int, timestampMs: Long, message: String) {
         _alert.value = if (type == "none") null else AlertState(type, bgValue, timestampMs, message)
+    }
+
+    fun updateMonitoringStatus(state: String, reason: String?, timeoutMs: Long, receivedAtMs: Long) {
+        _monitoringStatus.value = MonitoringStatusState(state, reason, timeoutMs, receivedAtMs)
+    }
+
+    /** Reset seam for the process-global status (tests; a future watch-side sign-out).
+     *  Deliberately fail-closed: a cleared status renders as "no recent data". */
+    fun clearMonitoringStatus() {
+        _monitoringStatus.value = null
+    }
+
+    /**
+     * Collapse the last mirrored status + the watch-local decay into the coverage the wrist may
+     * claim at [nowMs]. Fail-closed on every edge: no status, an aged-out status, or an unknown
+     * state string all land on a non-watching render — the watch never invents coverage the
+     * phone didn't recently vouch for. Small negative ages are tolerated (surfaces sample "now"
+     * on their own cadence, so a status received between ticks reads slightly future-dated);
+     * beyond [WatchFreshness.STATUS_MAX_FUTURE_SKEW_MS] the watch clock has jumped backward and
+     * the decay clock is meaningless, so the claim fails closed.
+     */
+    fun coverageFrom(status: MonitoringStatusState?, nowMs: Long): WristCoverage {
+        if (status == null) return WristCoverage.NoRecentStatus
+        val ageMs = nowMs - status.receivedAtMs
+        if (ageMs < -WatchFreshness.STATUS_MAX_FUTURE_SKEW_MS || ageMs >= status.timeoutMs) {
+            return WristCoverage.NoRecentStatus
+        }
+        return when (status.state) {
+            WearDataContract.MONITORING_STATE_SERVER_ACTIVE,
+            WearDataContract.MONITORING_STATE_FLOOR_WATCHING,
+            -> WristCoverage.Watching
+            WearDataContract.MONITORING_STATE_NOT_WATCHING ->
+                WristCoverage.NotWatching(status.reason)
+            else -> WristCoverage.NoRecentStatus
+        }
     }
 
     fun clearAlert() {

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
@@ -38,6 +38,34 @@ object WearDataContract {
     const val KEY_ALERT_TIMESTAMP = "alert_ts"
     const val KEY_ALERT_MESSAGE = "alert_msg"
 
+    // Monitoring status path (phone -> watch, GLY-116 axis a): mirrors the phone's
+    // AlertFloorStatus stream so the wrist can honestly say whether ANYTHING (server or the
+    // phone's alert floor) is watching thresholds. The phone computes the coverage decision;
+    // the watch only renders it and locally times it out (a frozen "watching" from a dead
+    // phone must decay, never persist).
+    const val MONITORING_STATUS_PATH = "/glycemicgpt/monitoring_status"
+
+    // Monitoring status keys
+    const val KEY_MONITORING_STATE = "mon_state"
+    const val KEY_MONITORING_REASON = "mon_reason"
+    // Watch-local decay window for this status, ms: one CGM staleness window under the
+    // phone's ACTIVE policy (compressed when the debug fast-staleness toggle is on), so the
+    // watch's timeout tracks the same clock the phone's own "watching" claim decays by.
+    const val KEY_MONITORING_TIMEOUT_MS = "mon_timeout_ms"
+
+    // KEY_MONITORING_STATE values. Vocabulary mirrors the phone's AlertFloorStatus exactly.
+    const val MONITORING_STATE_SERVER_ACTIVE = "server_active"
+    const val MONITORING_STATE_FLOOR_WATCHING = "floor_watching"
+    const val MONITORING_STATE_NOT_WATCHING = "not_watching"
+
+    // KEY_MONITORING_REASON values, present only with MONITORING_STATE_NOT_WATCHING.
+    // MUST match the phone's FloorNotWatchingReason enum names exactly — the watch renders
+    // reason-specific copy and an invented value would fall back to the generic line.
+    const val MONITORING_REASON_NOTIFICATIONS_DENIED = "NOTIFICATIONS_DENIED"
+    const val MONITORING_REASON_THRESHOLDS_NOT_SYNCED = "THRESHOLDS_NOT_SYNCED"
+    const val MONITORING_REASON_PUMP_DISCONNECTED = "PUMP_DISCONNECTED"
+    const val MONITORING_REASON_NO_FRESH_READING = "NO_FRESH_READING"
+
     // MessageClient paths (transient chat relay)
     const val CHAT_REQUEST_PATH = "/glycemicgpt/chat/request"
     const val CHAT_RESPONSE_PATH = "/glycemicgpt/chat/response"

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/data/WearDataContract.kt
@@ -37,6 +37,10 @@ object WearDataContract {
     const val KEY_ALERT_BG_VALUE = "alert_bg"
     const val KEY_ALERT_TIMESTAMP = "alert_ts"
     const val KEY_ALERT_MESSAGE = "alert_msg"
+    // False marks a silent refresh of an ongoing alert (updated value/timestamp, no watch
+    // vibration); true (and absence, for older phone builds that only send on type change) is
+    // a new crossing or the sustained-episode re-alarm.
+    const val KEY_ALERT_REBUZZ = "alert_rebuzz"
 
     // Monitoring status path (phone -> watch, GLY-116 axis a): mirrors the phone's
     // AlertFloorStatus stream so the wrist can honestly say whether ANYTHING (server or the

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
@@ -144,6 +144,21 @@ private fun WearAlertScreen(onFinish: () -> Unit) {
                         )
                     }
 
+                    // A lingering stale alert occupies the screen the coverage banner would
+                    // otherwise use — without this line, a dead phone behind a stale alert
+                    // would surface no "not watching" cue on this screen at all.
+                    val coverage = WatchDataRepository.coverageFrom(monitoringStatus, nowMs)
+                    if (isDataStale && coverage !is WristCoverage.Watching) {
+                        Spacer(modifier = Modifier.height(6.dp))
+                        Text(
+                            text = "Not watching — check your phone",
+                            style = MaterialTheme.typography.caption2,
+                            color = COLOR_WARNING,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.testTag("stale_alert_not_watching"),
+                        )
+                    }
+
                     Spacer(modifier = Modifier.height(12.dp))
 
                     Button(

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
@@ -11,8 +11,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -21,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -31,8 +34,12 @@ import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import com.glycemicgpt.weardevice.data.WatchDataRepository
+import com.glycemicgpt.weardevice.data.WatchDataRepository.WristCoverage
+import com.glycemicgpt.weardevice.data.WearDataContract
 import com.glycemicgpt.weardevice.messaging.WearMessageSender
 import com.glycemicgpt.weardevice.util.GlucoseDisplayUtils
+import com.glycemicgpt.weardevice.util.WatchFreshness
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class AlertsActivity : ComponentActivity() {
@@ -44,39 +51,48 @@ class AlertsActivity : ComponentActivity() {
     }
 }
 
+/**
+ * The wrist alert surface, honest on both GLY-116 axes: with no alert showing, the green
+ * "All clear" renders ONLY while the phone recently vouched that something is watching
+ * (axis a, locally decayed); a shown alert is aged against the watch clock and de-emphasised
+ * once its reading is TOO_STALE instead of looking active-indefinitely (axis b). The watch
+ * renders the phone's coverage decision — it never computes its own.
+ */
 @Composable
 private fun WearAlertScreen(onFinish: () -> Unit) {
     val alert by WatchDataRepository.alert.collectAsState()
     val glucoseUnit by WatchDataRepository.glucoseUnit.collectAsState()
+    val monitoringStatus by WatchDataRepository.monitoringStatus.collectAsState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var dismissing by remember { mutableStateOf(false) }
 
+    // Both honesty axes decay with time, not only with new pushes, so the screen re-evaluates
+    // on a ticker: a shown alert must grey out and a "watching" claim must expire even when
+    // nothing new arrives (that silence is exactly the signal).
+    var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(NOW_TICK_MS)
+            nowMs = System.currentTimeMillis()
+        }
+    }
+
     MaterialTheme {
         Scaffold(timeText = { TimeText() }) {
-            if (alert == null) {
-                Column(
-                    modifier = Modifier.fillMaxSize().padding(16.dp),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = "No Active Alert",
-                        style = MaterialTheme.typography.title3,
-                        textAlign = TextAlign.Center,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = "All clear",
-                        style = MaterialTheme.typography.body2,
-                        color = Color(0xFF4ADE80),
-                        textAlign = TextAlign.Center,
-                    )
-                }
+            val currentAlert = alert
+            if (currentAlert == null) {
+                NoAlertContent(WatchDataRepository.coverageFrom(monitoringStatus, nowMs))
             } else {
-                val currentAlert = alert!!
+                val alertAgeMs = nowMs - currentAlert.timestampMs
+                val isDataStale =
+                    WatchFreshness.cgmTier(alertAgeMs) == WatchFreshness.Tier.TOO_STALE
                 val isUrgent = currentAlert.type.startsWith("urgent", ignoreCase = true)
-                val alertColor = if (isUrgent) Color(0xFFEF4444) else Color(0xFFFBBF24)
+                val alertColor = when {
+                    isDataStale -> COLOR_STALE
+                    isUrgent -> COLOR_URGENT
+                    else -> COLOR_WARNING
+                }
 
                 Column(
                     modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp, vertical = 24.dp),
@@ -100,6 +116,23 @@ private fun WearAlertScreen(onFinish: () -> Unit) {
                             textAlign = TextAlign.Center,
                         )
                     }
+
+                    // The alert's age, always visible; once the underlying reading is TOO_STALE
+                    // the line says so explicitly — the alert may still be true, nobody can
+                    // currently vouch either way, and a silent retraction to "All clear" would
+                    // be the opposite lie.
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = if (isDataStale) {
+                            "as of ${GlucoseDisplayUtils.formatAge(alertAgeMs)} — data stale"
+                        } else {
+                            GlucoseDisplayUtils.formatAge(alertAgeMs)
+                        },
+                        style = MaterialTheme.typography.caption2,
+                        color = if (isDataStale) COLOR_STALE else Color(0xFF9CA3AF),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.testTag("alert_age"),
+                    )
 
                     if (currentAlert.message.isNotBlank()) {
                         Spacer(modifier = Modifier.height(6.dp))
@@ -140,6 +173,88 @@ private fun WearAlertScreen(onFinish: () -> Unit) {
     }
 }
 
+/**
+ * The no-active-alert body. The reassuring green "All clear" is reserved for a current
+ * "watching" claim; every other coverage state says plainly that nobody may be watching and
+ * that caregiver + AI alerting need the backend.
+ */
+@Composable
+private fun NoAlertContent(coverage: WristCoverage) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        when (coverage) {
+            is WristCoverage.Watching -> {
+                Text(
+                    text = "No Active Alert",
+                    style = MaterialTheme.typography.title3,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "All clear",
+                    style = MaterialTheme.typography.body2,
+                    color = COLOR_ALL_CLEAR,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.testTag("all_clear"),
+                )
+            }
+            is WristCoverage.NotWatching -> {
+                Text(
+                    text = "Not watching",
+                    style = MaterialTheme.typography.title3,
+                    color = COLOR_WARNING,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.testTag("not_watching"),
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = notWatchingReasonCopy(coverage.reason),
+                    style = MaterialTheme.typography.body2,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = "Caregiver & AI alerts are paused — they need the backend.",
+                    style = MaterialTheme.typography.caption2,
+                    color = Color(0xFF9CA3AF),
+                    textAlign = TextAlign.Center,
+                )
+            }
+            is WristCoverage.NoRecentStatus -> {
+                Text(
+                    text = "No recent data",
+                    style = MaterialTheme.typography.title3,
+                    color = COLOR_STALE,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.testTag("no_recent_status"),
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = "The watch hasn't heard from your phone recently. Alerts may not arrive.",
+                    style = MaterialTheme.typography.body2,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+/** Watch-facing copy per wire reason. Unknown reasons fall back to the generic line. */
+private fun notWatchingReasonCopy(reason: String?): String = when (reason) {
+    WearDataContract.MONITORING_REASON_NOTIFICATIONS_DENIED ->
+        "Monitoring degraded — allow notifications on your phone."
+    WearDataContract.MONITORING_REASON_THRESHOLDS_NOT_SYNCED ->
+        "Monitoring degraded — alert thresholds haven't synced yet."
+    WearDataContract.MONITORING_REASON_PUMP_DISCONNECTED ->
+        "Monitoring degraded — pump is disconnected."
+    WearDataContract.MONITORING_REASON_NO_FRESH_READING ->
+        "Monitoring degraded — no fresh glucose readings."
+    else -> "Monitoring degraded — nothing is watching for lows or highs."
+}
+
 private fun formatAlertType(type: String): String {
     return type.replace("_", " ")
         .split(" ")
@@ -147,3 +262,11 @@ private fun formatAlertType(type: String): String {
             word.replaceFirstChar { it.uppercaseChar() }
         }
 }
+
+private val COLOR_URGENT = Color(0xFFEF4444)
+private val COLOR_WARNING = Color(0xFFFBBF24)
+private val COLOR_STALE = Color(0xFF9CA3AF)
+private val COLOR_ALL_CLEAR = Color(0xFF4ADE80)
+
+/** Re-evaluation cadence for the age/coverage decay while the screen is up. */
+private const val NOW_TICK_MS = 15_000L

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
@@ -89,7 +89,7 @@ private fun WearAlertScreen(onFinish: () -> Unit) {
                     WatchFreshness.cgmTier(alertAgeMs) == WatchFreshness.Tier.TOO_STALE
                 val isUrgent = currentAlert.type.startsWith("urgent", ignoreCase = true)
                 val alertColor = when {
-                    isDataStale -> COLOR_STALE
+                    isDataStale -> COLOR_MUTED
                     isUrgent -> COLOR_URGENT
                     else -> COLOR_WARNING
                 }
@@ -129,7 +129,7 @@ private fun WearAlertScreen(onFinish: () -> Unit) {
                             GlucoseDisplayUtils.formatAge(alertAgeMs)
                         },
                         style = MaterialTheme.typography.caption2,
-                        color = if (isDataStale) COLOR_STALE else Color(0xFF9CA3AF),
+                        color = COLOR_MUTED,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.testTag("alert_age"),
                     )
@@ -219,7 +219,7 @@ private fun NoAlertContent(coverage: WristCoverage) {
                 Text(
                     text = "Caregiver & AI alerts are paused — they need the backend.",
                     style = MaterialTheme.typography.caption2,
-                    color = Color(0xFF9CA3AF),
+                    color = COLOR_MUTED,
                     textAlign = TextAlign.Center,
                 )
             }
@@ -227,7 +227,7 @@ private fun NoAlertContent(coverage: WristCoverage) {
                 Text(
                     text = "No recent data",
                     style = MaterialTheme.typography.title3,
-                    color = COLOR_STALE,
+                    color = COLOR_MUTED,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.testTag("no_recent_status"),
                 )
@@ -265,7 +265,7 @@ private fun formatAlertType(type: String): String {
 
 private val COLOR_URGENT = Color(0xFFEF4444)
 private val COLOR_WARNING = Color(0xFFFBBF24)
-private val COLOR_STALE = Color(0xFF9CA3AF)
+private val COLOR_MUTED = Color(0xFF9CA3AF)
 private val COLOR_ALL_CLEAR = Color(0xFF4ADE80)
 
 /** Re-evaluation cadence for the age/coverage decay while the screen is up. */

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtils.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtils.kt
@@ -86,6 +86,8 @@ object GlucoseDisplayUtils {
         }
     }
 
+    /** Human "how long ago" for the alert/data age lines (GLY-116 axis b). Negative ages
+     *  (clock skew, future-dated push) read as "just now", matching the phone's display rule. */
     fun formatAge(ageMs: Long): String {
         if (ageMs < 0) return "just now"
         val minutes = ageMs / 60_000
@@ -93,15 +95,6 @@ object GlucoseDisplayUtils {
             minutes < 1 -> "just now"
             minutes < 60 -> "${minutes}m ago"
             else -> "${minutes / 60}h ${minutes % 60}m ago"
-        }
-    }
-
-    fun freshnessColor(ageMs: Long): Int {
-        val minutes = ageMs / 60_000
-        return when {
-            minutes < 2 -> 0xFF22C55E.toInt()   // Green
-            minutes < 10 -> 0xFFF97316.toInt()   // Orange
-            else -> 0xFFEF4444.toInt()            // Red
         }
     }
 }

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtils.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtils.kt
@@ -86,9 +86,13 @@ object GlucoseDisplayUtils {
         }
     }
 
-    /** Human "how long ago" for the alert/data age lines (GLY-116 axis b). Negative ages
-     *  (clock skew, future-dated push) read as "just now", matching the phone's display rule. */
+    /** Human "how long ago" for the alert/data age lines (GLY-116 axis b). Small negative ages
+     *  (routine clock skew, future-dated push) read as "just now", matching the phone's display
+     *  rule; beyond the shared skew bound the watch clock has jumped backward and the age is
+     *  meaningless, so the label says so instead of contradicting the TOO_STALE tier
+     *  ("as of just now — data stale" would be incoherent). */
     fun formatAge(ageMs: Long): String {
+        if (ageMs < -WatchFreshness.STATUS_MAX_FUTURE_SKEW_MS) return "unknown time"
         if (ageMs < 0) return "just now"
         val minutes = ageMs / 60_000
         return when {

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/WatchFreshness.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/WatchFreshness.kt
@@ -30,21 +30,27 @@ object WatchFreshness {
     const val DEFAULT_STATUS_TIMEOUT_MS = CGM_STALE_AFTER_MS
 
     /**
-     * Max future-dating (negative age) tolerated on the mirrored status before it is treated
-     * as untrustworthy, mirroring the phone's ALERT_FLOOR_MAX_FUTURE_SKEW_MS. Small negative
-     * ages are ROUTINE — surfaces sample "now" on their own cadence, so a status received
-     * between ticks reads slightly future-dated; failing those closed would flap the wrist to
-     * "no recent data" after every heartbeat. A large negative age means the watch clock
-     * jumped backward and the decay clock is meaningless — that fails closed.
+     * Max future-dating (negative age) tolerated before a timestamp is treated as
+     * untrustworthy, mirroring the phone's ALERT_FLOOR_MAX_FUTURE_SKEW_MS. Small negative
+     * ages are ROUTINE — surfaces sample "now" on their own cadence, so a payload received
+     * between ticks reads slightly future-dated, and pump clocks drift by seconds; failing
+     * those closed would flap the wrist to "no recent data" for healthy feeds. A large
+     * negative age means the watch clock jumped BACKWARD, which understates every age on the
+     * watch — the same hole the phone's stateful rewind guard exists for — so both axes fail
+     * closed on it: coverage decays to "no recent data" and the feed tiers read TOO_STALE.
      */
     const val STATUS_MAX_FUTURE_SKEW_MS = 60_000L
 
     /**
      * Half-open boundaries mirroring the phone's FreshnessThresholds.classify: age <
-     * [staleAfterMs] is FRESH, age < [tooStaleAfterMs] is STALE, else TOO_STALE. Negative ages
-     * (clock skew, future-dated push) read as FRESH — display policy, same as the phone.
+     * [staleAfterMs] is FRESH, age < [tooStaleAfterMs] is STALE, else TOO_STALE. Small
+     * negative ages (routine clock skew) read as FRESH like the phone's display rule, but a
+     * negative age beyond [STATUS_MAX_FUTURE_SKEW_MS] reads TOO_STALE: a rewound watch clock
+     * would otherwise render arbitrarily old values as confident-live for as long as the
+     * rewind lasts, while axis (a) correctly failed closed on the same jump.
      */
     fun classify(ageMs: Long, staleAfterMs: Long, tooStaleAfterMs: Long): Tier = when {
+        ageMs < -STATUS_MAX_FUTURE_SKEW_MS -> Tier.TOO_STALE
         ageMs < staleAfterMs -> Tier.FRESH
         ageMs < tooStaleAfterMs -> Tier.STALE
         else -> Tier.TOO_STALE

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/WatchFreshness.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/util/WatchFreshness.kt
@@ -1,0 +1,56 @@
+package com.glycemicgpt.weardevice.util
+
+// MIRROR: tier bounds must stay in sync with the phone's
+// app/src/main/java/com/glycemicgpt/mobile/domain/freshness/Freshness.kt (FreshnessPolicy.CGM /
+// FreshnessPolicy.PUMP). The wear module deliberately has no dependency on the phone app, so the
+// values are mirrored here the same way WearDataContract is; a drift would make the watch call
+// the same reading fresher or staler than the phone does.
+//
+// GLY-116 axis (b): every wrist surface that shows a pushed value (BG, IoB, the last alert)
+// ages it against the WATCH's own clock with these tiers, independently of the mirrored
+// "watching" status — a dead phone freezes pushes, and only local aging turns that frozen
+// snapshot into an honest "no recent data".
+object WatchFreshness {
+
+    /** Same three-tier vocabulary as the phone's Freshness enum. */
+    enum class Tier { FRESH, STALE, TOO_STALE }
+
+    /** CGM glucose: one missed sensor interval (~6 min) is STALE, three (~15 min) is TOO_STALE. */
+    const val CGM_STALE_AFTER_MS = 6 * 60_000L
+    const val CGM_TOO_STALE_AFTER_MS = 15 * 60_000L
+
+    /** Pump-state values (IoB): polled slower, looser bounds — 15 min STALE, 60 min TOO_STALE. */
+    const val PUMP_STALE_AFTER_MS = 15 * 60_000L
+    const val PUMP_TOO_STALE_AFTER_MS = 60 * 60_000L
+
+    /**
+     * Fallback decay window for the mirrored monitoring status when a (pre-GLY-116) phone build
+     * omits the timeout key: one CGM staleness window, matching what the phone would advertise.
+     */
+    const val DEFAULT_STATUS_TIMEOUT_MS = CGM_STALE_AFTER_MS
+
+    /**
+     * Max future-dating (negative age) tolerated on the mirrored status before it is treated
+     * as untrustworthy, mirroring the phone's ALERT_FLOOR_MAX_FUTURE_SKEW_MS. Small negative
+     * ages are ROUTINE — surfaces sample "now" on their own cadence, so a status received
+     * between ticks reads slightly future-dated; failing those closed would flap the wrist to
+     * "no recent data" after every heartbeat. A large negative age means the watch clock
+     * jumped backward and the decay clock is meaningless — that fails closed.
+     */
+    const val STATUS_MAX_FUTURE_SKEW_MS = 60_000L
+
+    /**
+     * Half-open boundaries mirroring the phone's FreshnessThresholds.classify: age <
+     * [staleAfterMs] is FRESH, age < [tooStaleAfterMs] is STALE, else TOO_STALE. Negative ages
+     * (clock skew, future-dated push) read as FRESH — display policy, same as the phone.
+     */
+    fun classify(ageMs: Long, staleAfterMs: Long, tooStaleAfterMs: Long): Tier = when {
+        ageMs < staleAfterMs -> Tier.FRESH
+        ageMs < tooStaleAfterMs -> Tier.STALE
+        else -> Tier.TOO_STALE
+    }
+
+    fun cgmTier(ageMs: Long): Tier = classify(ageMs, CGM_STALE_AFTER_MS, CGM_TOO_STALE_AFTER_MS)
+
+    fun pumpTier(ageMs: Long): Tier = classify(ageMs, PUMP_STALE_AFTER_MS, PUMP_TOO_STALE_AFTER_MS)
+}

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/complications/ComplicationFreshnessRenderTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/complications/ComplicationFreshnessRenderTest.kt
@@ -1,0 +1,164 @@
+package com.glycemicgpt.weardevice.complications
+
+import com.glycemicgpt.weardevice.data.WatchDataRepository
+import com.glycemicgpt.weardevice.util.GlucoseUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * GLY-116 AC-C: age-bounds for every wrist surface that renders a pushed value, boundary pair
+ * at each tier edge (edge−1 / edge). The render decisions are pure companions, so the same
+ * logic the complication services ship is what these tests drive — and none of them take the
+ * "watching" bit as input, which is the structural proof that axis (b) de-emphasis is
+ * independent of axis (a) coverage (BG greys at STALE age even while the mirrored status says
+ * ServerActive).
+ */
+class ComplicationFreshnessRenderTest {
+
+    private val nowMs = 1_750_000_000_000L
+
+    // -- BG complication: CGM tiers (6-min FRESH boundary, 15-min cap) ------------------------
+
+    private fun cgm(ageMs: Long, mgDl: Int = 120) = WatchDataRepository.CgmState(
+        mgDl = mgDl, trend = "FLAT", timestampMs = nowMs - ageMs,
+        low = 70, high = 180, urgentLow = 55, urgentHigh = 250,
+    )
+
+    @Test
+    fun `BG renders confident-live strictly below the 6-min STALE edge`() {
+        val render = BgComplicationDataSource.render(cgm(6 * 60_000L - 1), nowMs, GlucoseUnit.MGDL)
+        assertEquals("120 →", render.shortText)
+        assertEquals("Blood Glucose: 120 mg/dL", render.description)
+    }
+
+    @Test
+    fun `BG de-emphasises in the STALE band - value kept but marked, not confident-live`() {
+        val render = BgComplicationDataSource.render(cgm(6 * 60_000L), nowMs, GlucoseUnit.MGDL)
+        assertEquals("120? →", render.shortText)
+        assertTrue(render.description.endsWith("(stale)"))
+    }
+
+    @Test
+    fun `BG STALE band boundary pair at the 15-min cap`() {
+        val atEdgeMinus1 = BgComplicationDataSource.render(cgm(15 * 60_000L - 1), nowMs, GlucoseUnit.MGDL)
+        assertEquals("120? →", atEdgeMinus1.shortText)
+
+        val atEdge = BgComplicationDataSource.render(cgm(15 * 60_000L), nowMs, GlucoseUnit.MGDL)
+        assertEquals("--", atEdge.shortText)
+        assertEquals("No recent data", atEdge.description)
+        // The age keeps counting even when the number is dropped — the only honest thing left.
+        assertEquals(nowMs - 15 * 60_000L, atEdge.ageReferenceMs)
+    }
+
+    @Test
+    fun `BG with no cached reading shows placeholder with no age reference`() {
+        val render = BgComplicationDataSource.render(null, nowMs, GlucoseUnit.MGDL)
+        assertEquals("--", render.shortText)
+        assertEquals(null, render.ageReferenceMs)
+    }
+
+    @Test
+    fun `BG future-dated reading renders FRESH - skew is a display concern`() {
+        val render = BgComplicationDataSource.render(cgm(-5_000L), nowMs, GlucoseUnit.MGDL)
+        assertEquals("120 →", render.shortText)
+    }
+
+    @Test
+    fun `BG invalid glucose is rejected regardless of age`() {
+        val render = BgComplicationDataSource.render(cgm(0L, mgDl = 900), nowMs, GlucoseUnit.MGDL)
+        assertEquals("--", render.shortText)
+    }
+
+    // -- IoB complication: PUMP tiers (15-min STALE, 60-min TOO_STALE) ------------------------
+
+    private fun iob(ageMs: Long) =
+        WatchDataRepository.IoBState(iob = 2.45f, timestampMs = nowMs - ageMs)
+
+    @Test
+    fun `IoB boundary pair at the 15-min STALE edge`() {
+        assertEquals("2.45", IoBComplicationDataSource.render(iob(15 * 60_000L - 1), nowMs).text)
+        assertEquals("2.45?", IoBComplicationDataSource.render(iob(15 * 60_000L), nowMs).text)
+    }
+
+    @Test
+    fun `IoB boundary pair at the 60-min TOO_STALE edge - no unbounded render`() {
+        assertEquals("2.45?", IoBComplicationDataSource.render(iob(60 * 60_000L - 1), nowMs).text)
+        val tooStale = IoBComplicationDataSource.render(iob(60 * 60_000L), nowMs)
+        assertEquals("--", tooStale.text)
+        assertEquals("No recent data", tooStale.description)
+    }
+
+    // -- Alerts complication: alert age-bound + coverage cue ----------------------------------
+
+    private fun alert(ageMs: Long, type: String = "low") = WatchDataRepository.AlertState(
+        type = type, bgValue = 62, timestampMs = nowMs - ageMs, message = "LOW 62 mg/dL",
+    )
+
+    @Test
+    fun `active alert below the 15-min cap renders active with its age`() {
+        val render = AlertsComplicationDataSource.render(
+            alert(15 * 60_000L - 1),
+            WatchDataRepository.WristCoverage.Watching,
+            nowMs,
+        )
+        assertEquals(AlertsComplicationDataSource.COLOR_WARNING, render.tint)
+        assertEquals("Alert active (14m ago)", render.description)
+    }
+
+    @Test
+    fun `alert at the 15-min cap de-emphasises to historical - never active-indefinitely`() {
+        val render = AlertsComplicationDataSource.render(
+            alert(15 * 60_000L),
+            WatchDataRepository.WristCoverage.Watching,
+            nowMs,
+        )
+        assertEquals(AlertsComplicationDataSource.COLOR_DEFAULT, render.tint)
+        assertEquals("Alert as of 15m ago — data stale", render.description)
+    }
+
+    @Test
+    fun `urgent alert tints red while its data is current`() {
+        val render = AlertsComplicationDataSource.render(
+            alert(60_000L, type = "urgent_low"),
+            WatchDataRepository.WristCoverage.Watching,
+            nowMs,
+        )
+        assertEquals(AlertsComplicationDataSource.COLOR_URGENT, render.tint)
+    }
+
+    @Test
+    fun `no alert plus watching is the only quiet all-clear`() {
+        val render = AlertsComplicationDataSource.render(
+            null,
+            WatchDataRepository.WristCoverage.Watching,
+            nowMs,
+        )
+        assertEquals(AlertsComplicationDataSource.COLOR_DEFAULT, render.tint)
+        assertEquals("No active alerts", render.description)
+    }
+
+    @Test
+    fun `no alert plus not-watching warns instead of reading all-clear`() {
+        val render = AlertsComplicationDataSource.render(
+            null,
+            WatchDataRepository.WristCoverage.NotWatching("PUMP_DISCONNECTED"),
+            nowMs,
+        )
+        assertEquals(AlertsComplicationDataSource.COLOR_WARNING, render.tint)
+        assertEquals("Monitoring degraded — not watching", render.description)
+        assertFalse(render.description.contains("No active alerts"))
+    }
+
+    @Test
+    fun `no alert plus no recent status warns - dead phone must not look covered`() {
+        val render = AlertsComplicationDataSource.render(
+            null,
+            WatchDataRepository.WristCoverage.NoRecentStatus,
+            nowMs,
+        )
+        assertEquals(AlertsComplicationDataSource.COLOR_WARNING, render.tint)
+        assertEquals("No recent data from phone", render.description)
+    }
+}

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/complications/ComplicationFreshnessRenderTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/complications/ComplicationFreshnessRenderTest.kt
@@ -119,6 +119,28 @@ class ComplicationFreshnessRenderTest {
     }
 
     @Test
+    fun `stale alert with nothing watching warns - quiet grey is reserved for covered`() {
+        // A real alert whose phone then dies ages past the cap and never auto-clears; grey
+        // there would be indistinguishable from the healthy all-clear glance, suppressing the
+        // dead-phone cue in exactly the case it exists for.
+        val notWatching = AlertsComplicationDataSource.render(
+            alert(15 * 60_000L),
+            WatchDataRepository.WristCoverage.NotWatching("PUMP_DISCONNECTED"),
+            nowMs,
+        )
+        assertEquals(AlertsComplicationDataSource.COLOR_WARNING, notWatching.tint)
+        assertEquals("Alert as of 15m ago — data stale, not watching", notWatching.description)
+
+        val noStatus = AlertsComplicationDataSource.render(
+            alert(15 * 60_000L),
+            WatchDataRepository.WristCoverage.NoRecentStatus,
+            nowMs,
+        )
+        assertEquals(AlertsComplicationDataSource.COLOR_WARNING, noStatus.tint)
+        assertEquals("Alert as of 15m ago — data stale, not watching", noStatus.description)
+    }
+
+    @Test
     fun `urgent alert tints red while its data is current`() {
         val render = AlertsComplicationDataSource.render(
             alert(60_000L, type = "urgent_low"),

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WatchDataRepositoryTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WatchDataRepositoryTest.kt
@@ -25,6 +25,7 @@ class WatchDataRepositoryTest {
         )
         WatchDataRepository.updateGlucoseUnit(GlucoseUnit.MGDL)
         WatchDataRepository.clearChat()
+        WatchDataRepository.clearMonitoringStatus()
     }
 
     @Test
@@ -271,5 +272,131 @@ class WatchDataRepositoryTest {
             showSeconds = false, graphRangeHours = 3, theme = "neon_green",
         )
         assertEquals("dark", WatchDataRepository.watchFaceConfig.value.theme)
+    }
+
+    // -- GLY-116 axis (a): mirrored monitoring status + watch-local decay ---------------------
+
+    private val nowMs = 1_750_000_000_000L
+    private val timeoutMs = 6 * 60_000L
+
+    private fun status(
+        state: String = WearDataContract.MONITORING_STATE_SERVER_ACTIVE,
+        reason: String? = null,
+        receivedAtMs: Long = nowMs,
+    ) = WatchDataRepository.MonitoringStatusState(state, reason, timeoutMs, receivedAtMs)
+
+    @Test
+    fun `updateMonitoringStatus publishes the mirrored state`() {
+        WatchDataRepository.updateMonitoringStatus(
+            state = WearDataContract.MONITORING_STATE_NOT_WATCHING,
+            reason = WearDataContract.MONITORING_REASON_PUMP_DISCONNECTED,
+            timeoutMs = timeoutMs,
+            receivedAtMs = nowMs,
+        )
+        val state = WatchDataRepository.monitoringStatus.value
+        assertEquals(WearDataContract.MONITORING_STATE_NOT_WATCHING, state!!.state)
+        assertEquals(WearDataContract.MONITORING_REASON_PUMP_DISCONNECTED, state.reason)
+    }
+
+    @Test
+    fun `coverage is fail-closed with no status ever received`() {
+        assertEquals(
+            WatchDataRepository.WristCoverage.NoRecentStatus,
+            WatchDataRepository.coverageFrom(null, nowMs),
+        )
+    }
+
+    @Test
+    fun `current watching states claim coverage`() {
+        assertEquals(
+            WatchDataRepository.WristCoverage.Watching,
+            WatchDataRepository.coverageFrom(status(), nowMs),
+        )
+        assertEquals(
+            WatchDataRepository.WristCoverage.Watching,
+            WatchDataRepository.coverageFrom(
+                status(state = WearDataContract.MONITORING_STATE_FLOOR_WATCHING),
+                nowMs,
+            ),
+        )
+    }
+
+    @Test
+    fun `not-watching state carries its reason through`() {
+        assertEquals(
+            WatchDataRepository.WristCoverage.NotWatching(
+                WearDataContract.MONITORING_REASON_NO_FRESH_READING,
+            ),
+            WatchDataRepository.coverageFrom(
+                status(
+                    state = WearDataContract.MONITORING_STATE_NOT_WATCHING,
+                    reason = WearDataContract.MONITORING_REASON_NO_FRESH_READING,
+                ),
+                nowMs,
+            ),
+        )
+    }
+
+    @Test
+    fun `stale watching claim decays at the timeout boundary - dead phone cannot look covered`() {
+        // Boundary pair: one ms inside the window still claims, at the window it decays.
+        assertEquals(
+            WatchDataRepository.WristCoverage.Watching,
+            WatchDataRepository.coverageFrom(
+                status(receivedAtMs = nowMs - (timeoutMs - 1)),
+                nowMs,
+            ),
+        )
+        assertEquals(
+            WatchDataRepository.WristCoverage.NoRecentStatus,
+            WatchDataRepository.coverageFrom(
+                status(receivedAtMs = nowMs - timeoutMs),
+                nowMs,
+            ),
+        )
+    }
+
+    @Test
+    fun `small future-dating is tolerated - heartbeats between surface ticks must not flap`() {
+        // Surfaces sample "now" on their own cadence, so a status received between ticks reads
+        // slightly future-dated. That is routine, not a clock jump.
+        assertEquals(
+            WatchDataRepository.WristCoverage.Watching,
+            WatchDataRepository.coverageFrom(status(receivedAtMs = nowMs + 15_000L), nowMs),
+        )
+    }
+
+    @Test
+    fun `a status from beyond the skew tolerance is not trusted - boundary pair`() {
+        // Backward watch-clock jump makes the last status look future-dated / younger; beyond
+        // the tolerance the decay clock is no longer meaningful, so the claim fails closed.
+        assertEquals(
+            WatchDataRepository.WristCoverage.Watching,
+            WatchDataRepository.coverageFrom(status(receivedAtMs = nowMs + 60_000L), nowMs),
+        )
+        assertEquals(
+            WatchDataRepository.WristCoverage.NoRecentStatus,
+            WatchDataRepository.coverageFrom(status(receivedAtMs = nowMs + 60_001L), nowMs),
+        )
+    }
+
+    @Test
+    fun `clearMonitoringStatus fails closed`() {
+        WatchDataRepository.updateMonitoringStatus(
+            state = WearDataContract.MONITORING_STATE_SERVER_ACTIVE,
+            reason = null,
+            timeoutMs = timeoutMs,
+            receivedAtMs = nowMs,
+        )
+        WatchDataRepository.clearMonitoringStatus()
+        assertNull(WatchDataRepository.monitoringStatus.value)
+    }
+
+    @Test
+    fun `unknown state strings fail closed`() {
+        assertEquals(
+            WatchDataRepository.WristCoverage.NoRecentStatus,
+            WatchDataRepository.coverageFrom(status(state = "totally_new_state"), nowMs),
+        )
     }
 }

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WearDataContractTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WearDataContractTest.kt
@@ -74,6 +74,25 @@ class WearDataContractTest {
     }
 
     @Test
+    fun `monitoring status contract matches phone-side values`() {
+        assertEquals("/glycemicgpt/monitoring_status", WearDataContract.MONITORING_STATUS_PATH)
+        assertEquals("mon_state", WearDataContract.KEY_MONITORING_STATE)
+        assertEquals("mon_reason", WearDataContract.KEY_MONITORING_REASON)
+        assertEquals("mon_timeout_ms", WearDataContract.KEY_MONITORING_TIMEOUT_MS)
+        assertEquals("server_active", WearDataContract.MONITORING_STATE_SERVER_ACTIVE)
+        assertEquals("floor_watching", WearDataContract.MONITORING_STATE_FLOOR_WATCHING)
+        assertEquals("not_watching", WearDataContract.MONITORING_STATE_NOT_WATCHING)
+    }
+
+    @Test
+    fun `monitoring reasons mirror the phone FloorNotWatchingReason enum names exactly`() {
+        assertEquals("NOTIFICATIONS_DENIED", WearDataContract.MONITORING_REASON_NOTIFICATIONS_DENIED)
+        assertEquals("THRESHOLDS_NOT_SYNCED", WearDataContract.MONITORING_REASON_THRESHOLDS_NOT_SYNCED)
+        assertEquals("PUMP_DISCONNECTED", WearDataContract.MONITORING_REASON_PUMP_DISCONNECTED)
+        assertEquals("NO_FRESH_READING", WearDataContract.MONITORING_REASON_NO_FRESH_READING)
+    }
+
+    @Test
     fun `config keys are defined`() {
         assertEquals("cfg_show_iob", WearDataContract.KEY_CONFIG_SHOW_IOB)
         assertEquals("cfg_show_graph", WearDataContract.KEY_CONFIG_SHOW_GRAPH)

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WearDataContractTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/data/WearDataContractTest.kt
@@ -74,6 +74,11 @@ class WearDataContractTest {
     }
 
     @Test
+    fun `alert rebuzz key matches phone-side contract value`() {
+        assertEquals("alert_rebuzz", WearDataContract.KEY_ALERT_REBUZZ)
+    }
+
+    @Test
     fun `monitoring status contract matches phone-side values`() {
         assertEquals("/glycemicgpt/monitoring_status", WearDataContract.MONITORING_STATUS_PATH)
         assertEquals("mon_state", WearDataContract.KEY_MONITORING_STATE)
@@ -85,7 +90,9 @@ class WearDataContractTest {
     }
 
     @Test
-    fun `monitoring reasons mirror the phone FloorNotWatchingReason enum names exactly`() {
+    fun `monitoring reason strings are pinned literally - the enforcing half is the phone-side test`() {
+        // This module cannot see the phone's FloorNotWatchingReason enum; the cross-module
+        // guarantee (wire strings == enum names) is asserted in the phone's WearDataContractTest.
         assertEquals("NOTIFICATIONS_DENIED", WearDataContract.MONITORING_REASON_NOTIFICATIONS_DENIED)
         assertEquals("THRESHOLDS_NOT_SYNCED", WearDataContract.MONITORING_REASON_THRESHOLDS_NOT_SYNCED)
         assertEquals("PUMP_DISCONNECTED", WearDataContract.MONITORING_REASON_PUMP_DISCONNECTED)

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtilsTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtilsTest.kt
@@ -124,8 +124,16 @@ class GlucoseDisplayUtilsTest {
     }
 
     @Test
-    fun `formatAge returns just now for negative age (clock skew)`() {
+    fun `formatAge returns just now for small negative age (clock skew)`() {
         assertEquals("just now", GlucoseDisplayUtils.formatAge(-5_000))
+    }
+
+    @Test
+    fun `formatAge boundary pair at the backward-skew bound`() {
+        // Beyond the shared skew bound the tier logic reads TOO_STALE; the label must not
+        // contradict it with "just now" ("as of just now — data stale" is incoherent).
+        assertEquals("just now", GlucoseDisplayUtils.formatAge(-60_000))
+        assertEquals("unknown time", GlucoseDisplayUtils.formatAge(-60_001))
     }
 
     // alertColor tests

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtilsTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/GlucoseDisplayUtilsTest.kt
@@ -128,23 +128,6 @@ class GlucoseDisplayUtilsTest {
         assertEquals("just now", GlucoseDisplayUtils.formatAge(-5_000))
     }
 
-    // freshnessColor tests
-
-    @Test
-    fun `freshnessColor returns green for fresh data`() {
-        assertEquals(0xFF22C55E.toInt(), GlucoseDisplayUtils.freshnessColor(60_000))
-    }
-
-    @Test
-    fun `freshnessColor returns orange for slightly stale data`() {
-        assertEquals(0xFFF97316.toInt(), GlucoseDisplayUtils.freshnessColor(5 * 60_000))
-    }
-
-    @Test
-    fun `freshnessColor returns red for very stale data`() {
-        assertEquals(0xFFEF4444.toInt(), GlucoseDisplayUtils.freshnessColor(15 * 60_000))
-    }
-
     // alertColor tests
 
     @Test

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/WatchFreshnessTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/WatchFreshnessTest.kt
@@ -1,0 +1,48 @@
+package com.glycemicgpt.weardevice.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Boundary pins for the mirrored freshness tiers (GLY-116 axis b). The values MUST match the
+ * phone's FreshnessPolicy (CGM 6/15 min, PUMP 15/60 min) — these tests are the wear-side half
+ * of that mirror contract, boundary pair at each tier edge (edge−1 and edge), half-open like
+ * the phone's FreshnessThresholds.classify.
+ */
+class WatchFreshnessTest {
+
+    @Test
+    fun `cgm tier boundary pair at the FRESH-STALE edge (6 min)`() {
+        assertEquals(WatchFreshness.Tier.FRESH, WatchFreshness.cgmTier(6 * 60_000L - 1))
+        assertEquals(WatchFreshness.Tier.STALE, WatchFreshness.cgmTier(6 * 60_000L))
+    }
+
+    @Test
+    fun `cgm tier boundary pair at the STALE-TOO_STALE edge (15 min)`() {
+        assertEquals(WatchFreshness.Tier.STALE, WatchFreshness.cgmTier(15 * 60_000L - 1))
+        assertEquals(WatchFreshness.Tier.TOO_STALE, WatchFreshness.cgmTier(15 * 60_000L))
+    }
+
+    @Test
+    fun `pump tier boundary pair at the FRESH-STALE edge (15 min)`() {
+        assertEquals(WatchFreshness.Tier.FRESH, WatchFreshness.pumpTier(15 * 60_000L - 1))
+        assertEquals(WatchFreshness.Tier.STALE, WatchFreshness.pumpTier(15 * 60_000L))
+    }
+
+    @Test
+    fun `pump tier boundary pair at the STALE-TOO_STALE edge (60 min)`() {
+        assertEquals(WatchFreshness.Tier.STALE, WatchFreshness.pumpTier(60 * 60_000L - 1))
+        assertEquals(WatchFreshness.Tier.TOO_STALE, WatchFreshness.pumpTier(60 * 60_000L))
+    }
+
+    @Test
+    fun `negative ages read FRESH - clock skew is a display concern, not a staleness one`() {
+        assertEquals(WatchFreshness.Tier.FRESH, WatchFreshness.cgmTier(-5_000L))
+        assertEquals(WatchFreshness.Tier.FRESH, WatchFreshness.pumpTier(-5_000L))
+    }
+
+    @Test
+    fun `default status timeout is one CGM staleness window`() {
+        assertEquals(WatchFreshness.CGM_STALE_AFTER_MS, WatchFreshness.DEFAULT_STATUS_TIMEOUT_MS)
+    }
+}

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/WatchFreshnessTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/util/WatchFreshnessTest.kt
@@ -36,9 +36,19 @@ class WatchFreshnessTest {
     }
 
     @Test
-    fun `negative ages read FRESH - clock skew is a display concern, not a staleness one`() {
+    fun `small negative ages read FRESH - routine clock skew is a display concern`() {
         assertEquals(WatchFreshness.Tier.FRESH, WatchFreshness.cgmTier(-5_000L))
         assertEquals(WatchFreshness.Tier.FRESH, WatchFreshness.pumpTier(-5_000L))
+    }
+
+    @Test
+    fun `negative ages beyond the skew bound read TOO_STALE - boundary pair`() {
+        // A rewound watch clock understates every age; beyond the tolerance the feed fails
+        // closed instead of rendering arbitrarily old values as confident-live.
+        assertEquals(WatchFreshness.Tier.FRESH, WatchFreshness.cgmTier(-60_000L))
+        assertEquals(WatchFreshness.Tier.TOO_STALE, WatchFreshness.cgmTier(-60_001L))
+        assertEquals(WatchFreshness.Tier.FRESH, WatchFreshness.pumpTier(-60_000L))
+        assertEquals(WatchFreshness.Tier.TOO_STALE, WatchFreshness.pumpTier(-60_001L))
     }
 
     @Test


### PR DESCRIPTION
## Summary

The watch alert relay in `PumpPollingOrchestrator.processCgmReading` was freshness-ungated: on the exact stale-sensor scenario the phone's alert floor defends against, the phone stayed correctly silent and said "NOT watching" while the watch buzzed a low/high off that same stale reading. For many users the watch is the primary alerting surface, so this was a live safety-invariant violation in shipped code.

This change carries both alerting invariants onto the wrist:

- **Relay gate (never alert off stale/unknown data).** The relay now gates on `AlertFloor.isReadingAlertable(reading, nowMs)` — the same FRESH + thresholds-synced + wall-clock-rewind bound the floor fires by, factored out of the floor's own gates so there is one staleness definition in one place. A not-alertable reading skips the whole relay alert block: no `sendAlert`, no `clearAlert`, latch untouched. The green "All clear" stays reserved for a genuinely FRESH in-range recovery; a stale in-range drift can no longer retract a possibly-still-true low.
- **Honest wrist surfaces, two independent axes.**
  - *Coverage (axis a):* a new monitoring-status Data Layer payload mirrors the phone's `AlertFloorStatusProvider.observe()` stream — the same stream driving the in-app banner and foreground notification — via `WearMonitoringStatusForwarder`. Reason strings are the `FloorNotWatchingReason` enum names verbatim (pinned by contract tests on both sides). The status is re-sent as a heartbeat (every timeout/2), and the watch decays a silent status to "No recent data" after the advertised window, so a dead phone process can never leave a frozen "watching" on the wrist.
  - *Feed freshness (axis b):* the watch ages its own BG/IoB/alert renders against its local clock on mirrored `FreshnessPolicy` tiers (`WatchFreshness`), independently of the watching bit. BG de-emphasises in the STALE band (>= 6 min) instead of rendering confident-live until the 15-min cap; IoB is bounded by the PUMP policy (60-min hard stop); a shown alert renders its age and flips to "as of Xm ago — data stale" instead of looking active-indefinitely.
- **One wrist buzz per fresh low.** The floor notification is now `setLocalOnly(true)` (the relay covers exactly the floor's fires — same source, same gate). The bridged SERVER notification deliberately keeps bridging: it fires off a different (cloud) glucose source, and while the pump CGM is stale it is the only wrist path left for a real alert.
- Pump-clock drift degrades honestly: a slow pump clock suppresses the relay (indistinguishable from warmup-stale) and surfaces "not watching / no recent data" — never a silent gap.

Scope guardrail (locked decision): the wear module performs no threshold/predictive/coverage decision of its own — `coverageFrom` takes only the mirrored status, and the reduced-coverage copy states that caregiver + AI alerting are paused offline.

## Device repro (Step 0)

On the develop-tip build with `debugFastStaleness` + `simulateBackendUnreachable` on, injecting a stale low (60s-old sensor timestamp under the compressed policy) produced in the same poll tick: `AlertFloor: suppressed: reading not FRESH (type=low_urgent, ageMs=60054) — NOT watching` and a `WearDataSender.sendAlert` push of that same stale low toward the wrist — the invariant violation at the wire boundary. A fresh low additionally posted the floor OS alarm with no `localOnly` flag (bridges to a paired watch), i.e. two wrist buzzes for one event. After the fix, the same stale injection logs `Watch alert relay suppressed: reading not alertable (type=urgent_low)` with no send and no clear, and the floor alarm posts with `flags=AUTO_CANCEL|LOCAL_ONLY`.

Emulator limitation, stated plainly: this host cannot pair the phone and Wear emulators at the GMS layer (no Play companion on the google_apis phone image; `Wearable.API unavailable`), so the phone->watch transport hop itself was not exercised. Phone-side wire behavior was verified by logcat as above; watch-side receipt/render/vibrate paths were verified on the Wear emulator directly (compose instrumented tests + screenshots of all five alert-surface states). A full paired-device pass rides the GLY-119 fault-injection harness / next physical phone+watch session.

## Testing

- `./gradlew testDebugUnitTest lintDebug assembleDebug` green across all modules.
- Behavioral relay-gate tests drive the real `processCgmReading`: `sendAlert` NOT called and `clearAlert` NOT called with the latch intact on a not-alertable reading; called once on a fresh synced low; `clearAlert` on a fresh in-range recovery only. These fail on a relay-gate revert (the predicate unit tests alone would not).
- Divergence guard: real `AlertFloor` + real orchestrator with degraded=true, notifications granted, no cooldown/episode rows pinned; sweeps the freshness x sync grid asserting relay-push <=> floor-fire. The healthy-online divergence (server owns alerting) is deliberately out of scope.
- `isReadingAlertable` boundary pairs (6-min edge, future-skew bound, rewind, never-synced, compressed debug policy, 20-min pump-clock drift -> `NO_FRESH_READING`).
- Forwarder wiring + heartbeat tests; wire-vocabulary mapping pinned to the enum names; contract-mirror pins added on both the app and wear sides.
- Complication tier boundary pairs (BG 6/15 min, IoB 15/60 min, alert age) as pure-render unit tests; the render functions take no "watching" input, which is the structural proof that axis (b) is independent of axis (a).
- Wear instrumented (`:wear-device:connectedDebugAndroidTest`, new androidTest source set, run on the Wear emulator): not-watching banner, All-clear-only-when-watching, dead-phone decay to "No recent data", fail-closed default, stale-alert "as of Xm ago — data stale", fresh urgent low.

The instrumented run caught one real bug pre-merge: a status received between the screen's clock ticks read as slightly future-dated and failed closed, which would have flapped the wrist to "No recent data" after every heartbeat — fixed with a bounded future-skew tolerance (`STATUS_MAX_FUTURE_SKEW_MS`, mirroring the phone's skew guard) plus a boundary-pair test.

## Review rounds (all findings fixed pre-PR)

Adversarial safety review found two HIGH and one MEDIUM, all fixed and pinned by tests:

- A sustained low during an outage would have gone quiet and grey on the wrist: the edge-latched relay sent once per episode, so with the floor notification now local-only the 30-min re-alarm no longer reached the watch, and the frozen first-crossing timestamp let axis (b) grey a live emergency as "data stale". Fix: the relay silently refreshes an ongoing alert every 5 minutes (current timestamp, no vibration, new `alert_rebuzz=false` wire flag that defaults to buzz for older phones) and re-buzzes on the floor's 30-minute cadence — the wrist is never quieter than the phone.
- Complications were push-only (`UPDATE_PERIOD_SECONDS=0`), so a dead phone froze the last reassuring glance state and the new coverage cue could never appear in exactly the case it targets. Fix: BG/IoB/Alerts providers moved to the 300s platform-minimum period so the age-bounded renders decay without a phone push.
- Axis (b) had no backward-watch-clock guard (a rewound clock made stale readings look FRESH while coverage correctly failed closed). Fix: feed tiers read TOO_STALE beyond the 60s future-skew bound, symmetric with the coverage guard.

Senior code-quality review (no HIGH): disclosed the `noteWallClock` side effect in the shared predicate's KDoc, consolidated the muted grey to one named color, clarified which side enforces the contract mirror, single clock sample per complication render.

CodeRabbit CLI (3 rounds, final round clean): caught that a watch-mapping gap would have cleared a still-active wrist alert via the `watchAlertType == null` conflation — the clear is now keyed on the classification itself, with a regression test.

Security review: PASS — new inbound Data Layer payload is allowlist-validated, timeout-clamped, fail-closed on unknown states; receipt time is always watch-local; the attacker-influenceable reason string is mapped to fixed copy, never rendered raw. Residual same-signature spoof surface is inherent to the Data Layer trust model and unchanged by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wear OS now shows clearer alert “honesty,” including monitoring states: watching, not watching (with reason), and no recent data.
  * Alerts support a controlled “rebuzz” behavior for ongoing episodes.
  * Complications (BG/IoB/Alerts) now render using freshness tiers and update more reliably, including improved stale-age wording.
* **Bug Fixes**
  * Improved gating to prevent relaying/clearing wrist alerts when readings aren’t fresh or thresholds aren’t synced.
  * Prevents incorrect wrist clearing during watch/relay divergence and reduces double-buzz for phone-generated floor alerts.
  * Better handling for clock skew/rewind and stale/too-stale transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->