### PR TITLE
feat(api): caregiver lost-contact data-gap alert (GLY-137)

### DIFF
--- a/apps/api/migrations/versions/080_add_no_data_alert_type.py
+++ b/apps/api/migrations/versions/080_add_no_data_alert_type.py
@@ -1,0 +1,35 @@
+"""Add no_data alert type (GLY-137).
+
+Adds the 'no_data' value to the alerttype enum for the caregiver
+"lost contact" / data-gap alert.
+
+DELIBERATE divergence from the older enum-add migrations (028/036/052/
+068/079): those run ``op.execute("COMMIT")`` before ALTER TYPE because
+pre-PG12 forbade ADD VALUE inside a transaction block. On PG12+ (this
+project's floor) ADD VALUE is transactional as long as the new value is
+not USED in the same transaction -- and 'no_data' is only referenced at
+runtime by the data-gap detector, never by a migration. The COMMIT hack
+breaks alembic's transactional bookkeeping for everything after it in
+the run, so per the GLY-137 review it is not repeated here; new enum-add
+migrations should follow this form.
+
+Revision ID: 080_add_no_data_alert_type
+Revises: 079_add_copilot_subscription
+"""
+
+from alembic import op
+
+revision = "080_add_no_data_alert_type"
+down_revision = "079_add_copilot_subscription"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE alerttype ADD VALUE IF NOT EXISTS 'no_data'")
+
+
+def downgrade() -> None:
+    # PostgreSQL cannot remove enum values. Delete rows referencing
+    # 'no_data' so earlier revisions never encounter the unknown value.
+    op.execute("DELETE FROM alerts WHERE alert_type = 'no_data'")

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -130,6 +130,15 @@ class Settings(BaseSettings):
     escalation_check_interval_minutes: int = 1  # Check every 1 minute
     escalation_check_enabled: bool = True  # Enable/disable automatic escalation
 
+    # Caregiver data-gap ("lost contact") alerts (GLY-137)
+    # The detector keys off backend data-ARRIVAL age (GlucoseReading.received_at),
+    # never phone liveness -- cloud-sync users' data flows regardless of their
+    # phone. Bounded like the sync ticks (feeds APScheduler's IntervalTrigger);
+    # the open-alert TTL is derived as 2x this interval so a dead detector
+    # self-clears quickly.
+    data_gap_alert_enabled: bool = True
+    data_gap_check_interval_minutes: int = Field(default=5, ge=1, le=60)
+
     # Daily brief auto-generation (issue #741)
     # Bounded like the sync-tick intervals: the value feeds IntervalTrigger, which
     # starves/crashes on zero/negative/absurd values.

--- a/apps/api/src/models/alert.py
+++ b/apps/api/src/models/alert.py
@@ -23,6 +23,10 @@ class AlertType(str, enum.Enum):
     HIGH_WARNING = "high_warning"
     HIGH_URGENT = "high_urgent"
     IOB_WARNING = "iob_warning"
+    # GLY-137: glucose data stopped arriving at the backend for a
+    # caregiver-monitored patient ("lost contact"). Caregiver-only delivery;
+    # the patient sees staleness on their own dashboard instead.
+    NO_DATA = "no_data"
 
 
 class AlertSeverity(str, enum.Enum):
@@ -112,7 +116,7 @@ class Alert(Base):
         nullable=True,
     )
 
-    # Source of alert: "predictive", "current", "iob"
+    # Source of alert: "predictive", "current", "iob", "data_gap"
     source: Mapped[str] = mapped_column(
         String(50),
         nullable=False,

--- a/apps/api/src/services/alert_notifier.py
+++ b/apps/api/src/services/alert_notifier.py
@@ -37,6 +37,7 @@ ALERT_HEADLINE: dict[AlertType, str] = {
     AlertType.HIGH_WARNING: "High Glucose Warning",
     AlertType.HIGH_URGENT: "Urgent High Glucose",
     AlertType.IOB_WARNING: "High Insulin on Board",
+    AlertType.NO_DATA: "No CGM Data",
 }
 
 # Alert type -> recommended action
@@ -46,6 +47,7 @@ ALERT_ACTION: dict[AlertType, str] = {
     AlertType.HIGH_WARNING: "Check insulin dosing and hydration",
     AlertType.HIGH_URGENT: "Check for missed bolus or pump issue",
     AlertType.IOB_WARNING: "Monitor glucose closely for dropping trend",
+    AlertType.NO_DATA: "Check on them and their CGM connection",
 }
 
 

--- a/apps/api/src/services/data_gap_alerts.py
+++ b/apps/api/src/services/data_gap_alerts.py
@@ -44,7 +44,7 @@ from src.models.alert import Alert, AlertSeverity, AlertType
 from src.models.glooko_sync_state import GlookoSyncState
 from src.models.glucose import GlucoseReading
 from src.models.medtronic_connect_state import MedtronicConnectState
-from src.models.nightscout_connection import NightscoutConnection
+from src.models.nightscout_connection import NightscoutConnection, NightscoutSyncStatus
 from src.services.cgm_source import glucose_readings_query
 from src.services.glucose_unit import resolve_glucose_unit
 
@@ -132,6 +132,11 @@ async def resolve_no_data_threshold_minutes(
                 select(NightscoutConnection.sync_interval_minutes).where(
                     NightscoutConnection.user_id == user_id,
                     NightscoutConnection.is_active.is_(True),
+                    # Same rule as Glooko/Medtronic above: only a connection
+                    # whose last sync SUCCEEDED is currently delivering.
+                    # Errored/auth-failed/never-synced rows are the outage to
+                    # surface and must not extend the deadline.
+                    NightscoutConnection.last_sync_status == NightscoutSyncStatus.OK,
                 )
             )
         )

--- a/apps/api/src/services/data_gap_alerts.py
+++ b/apps/api/src/services/data_gap_alerts.py
@@ -1,0 +1,365 @@
+"""GLY-137: Caregiver "lost contact" / data-gap alert detector.
+
+Fires a WARNING ``NO_DATA`` alert when a caregiver-monitored patient's
+glucose data stops ARRIVING at the backend, so the caregiver sees an
+explicit "No CGM data for Nm" instead of a silently frozen tile. The
+predictive alert engine deliberately suppresses on stale data
+(``evaluate_alerts_for_user``), which is correct for threshold alerts but
+leaves the caregiver blind during exactly the blackout that can mask a low.
+
+Load-bearing invariants (adversarial history in the GLY-137 story; the
+per-decision rationale lives on the functions below):
+
+- Age keys off backend data-ARRIVAL (``received_at``), never phone liveness
+  or device clocks -- cloud-sync users' data flows regardless of their phone.
+- Armed on caregiver link + recent-baseline (or an existing episode), never
+  a source list -- Glooko/Medtronic/CareLink write readings without a
+  ``cgm_role`` and must still arm.
+- One alert per gap episode, held open while blind, auto-resolved on resume:
+  in the normal path "cleared" means "data resumed". The only silent clear
+  is detector death -> short-TTL expiry, an accepted operational fail-safe.
+- No dedicated patient alarm: ``notify_user_of_alerts`` (patient Telegram)
+  is never called; delivery rides the existing caregiver SSE/poll fan-out
+  unchanged. Like any ``Alert`` row keyed on the patient, it DOES also
+  appear on the patient's own generic alert surfaces (poll/SSE/notification)
+  -- honest, non-escalating, and consistent with the staleness banner the
+  patient already sees.
+- Sensor warmup (~2h) fires by design in v1 -- the caregiver genuinely has
+  no data, and the WARNING tile auto-resolves; session-aware suppression is
+  deferred to v2.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config import settings
+from src.core.units import format_glucose
+from src.logging_config import get_logger
+from src.models import glooko_sync_state, medtronic_connect_state
+from src.models.alert import Alert, AlertSeverity, AlertType
+from src.models.glooko_sync_state import GlookoSyncState
+from src.models.glucose import GlucoseReading
+from src.models.medtronic_connect_state import MedtronicConnectState
+from src.models.nightscout_connection import NightscoutConnection
+from src.services.cgm_source import glucose_readings_query
+from src.services.glucose_unit import resolve_glucose_unit
+
+logger = get_logger(__name__)
+
+# Base threshold: fire when no reading has arrived for this long. Above the
+# 5-min check tick and GLUCOSE_STALE_MINUTES=10 (a routine CGM hiccup), below
+# anything that would leave a caregiver blind through a real emergency. For
+# patients on slow PULL sources (Glooko / Medtronic Connect default to 30-min
+# sync intervals, and received_at is stamped at sync time) the effective
+# threshold widens to 2x their slowest active source interval -- otherwise a
+# perfectly healthy 30-min-pull patient would false-alarm on every cycle.
+# See resolve_no_data_threshold_minutes.
+NO_DATA_THRESHOLD_MINUTES = 30
+
+# Arming baseline: only patients whose data actually flowed recently are
+# watched, so never-configured / just-onboarded users don't false-alarm. An
+# open NO_DATA episode keeps a >24h blackout armed past this window.
+ARMING_BASELINE_HOURS = 24
+
+# Alert.source value for data-gap alerts (existing values: "predictive",
+# "current", "iob").
+NO_DATA_ALERT_SOURCE = "data_gap"
+
+
+class DataGapAction(str, Enum):
+    """What a detector tick did for one patient (for job-level logging)."""
+
+    CREATED = "created"
+    RENEWED = "renewed"
+    RESOLVED = "resolved"
+    NONE = "none"
+
+
+async def resolve_no_data_threshold_minutes(
+    db: AsyncSession, user_id: uuid.UUID
+) -> int:
+    """Effective gap threshold: ``max(base, 2x slowest active pull interval)``.
+
+    ``received_at`` is stamped at SYNC time for pull sources, so a healthy
+    patient's arrival age is bounded by their sync interval, not the CGM's
+    5-min cadence -- Glooko and Medtronic Connect default to 30-min pulls,
+    which would sit exactly on the base threshold and false-alarm every
+    cycle. 2x the interval means roughly two consecutive missed pulls before
+    the caregiver is alerted (the classic heartbeat rule).
+
+    Only sources that could currently be DELIVERING readings widen the
+    threshold: a disconnected/errored source is exactly the outage this
+    detector exists to surface, so it must not buy itself a longer deadline.
+    With several sources the slowest wins -- conservative against false
+    alarms; a real blackout means ALL of them stopped, and the slowest one's
+    cadence bounds how long "no new rows" is still normal.
+    """
+    intervals: list[int] = []
+
+    glooko = (
+        await db.execute(
+            select(GlookoSyncState.sync_interval_minutes).where(
+                GlookoSyncState.user_id == user_id,
+                GlookoSyncState.enabled.is_(True),
+                GlookoSyncState.cgm_sync_enabled.is_(True),
+                GlookoSyncState.status == glooko_sync_state.STATUS_CONNECTED,
+            )
+        )
+    ).scalar_one_or_none()
+    if glooko is not None:
+        intervals.append(glooko)
+
+    medtronic = (
+        await db.execute(
+            select(MedtronicConnectState.sync_interval_minutes).where(
+                MedtronicConnectState.user_id == user_id,
+                MedtronicConnectState.enabled.is_(True),
+                MedtronicConnectState.status
+                == medtronic_connect_state.STATUS_CONNECTED,
+            )
+        )
+    ).scalar_one_or_none()
+    if medtronic is not None:
+        intervals.append(medtronic)
+
+    ns_intervals = (
+        (
+            await db.execute(
+                select(NightscoutConnection.sync_interval_minutes).where(
+                    NightscoutConnection.user_id == user_id,
+                    NightscoutConnection.is_active.is_(True),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # sync_interval_minutes is non-null by schema on all three tables; the
+    # None-filter is belt-and-braces so a future nullable column can't turn
+    # max() into a tick-aborting TypeError.
+    intervals.extend(i for i in ns_intervals if i is not None)
+
+    # Dexcom Share syncs on the global interval (default 5 min) -- always well
+    # under the base threshold, so it never widens and needs no lookup here.
+
+    return max(NO_DATA_THRESHOLD_MINUTES, 2 * max(intervals, default=0))
+
+
+def no_data_alert_ttl_minutes() -> int:
+    """Open-alert TTL: 2x the check interval.
+
+    Long enough that a healthy detector always renews before expiry, short
+    enough that a dead detector's alert self-clears in ~2 ticks instead of
+    lingering as a stale "no data" claim.
+    """
+    return 2 * settings.data_gap_check_interval_minutes
+
+
+def format_gap_message(
+    age_minutes: float,
+    last_value_display: str,
+    last_received: datetime,
+) -> str:
+    """Human message for the caregiver tile.
+
+    The timestamp is the backend ingestion time (UTC) -- "when we last heard"
+    -- matching the detection semantic, not the device-reported reading time.
+    """
+    minutes = int(age_minutes)
+    age_str = f"{minutes}m" if minutes < 60 else f"{minutes // 60}h {minutes % 60}m"
+    return (
+        f"No CGM data for {age_str} "
+        f"(last: {last_value_display} at {last_received.strftime('%H:%M')} UTC)"
+    )
+
+
+async def _render_gap_message(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    age_minutes: float,
+    latest: GlucoseReading,
+    last_received: datetime,
+) -> str:
+    """Resolve the patient's display unit and render the gap message."""
+    unit = await resolve_glucose_unit(db, user_id)
+    return format_gap_message(
+        age_minutes, format_glucose(float(latest.value), unit), last_received
+    )
+
+
+async def _latest_reading_by_arrival(
+    db: AsyncSession, user_id: uuid.UUID
+) -> GlucoseReading | None:
+    """Most recently ARRIVED reading via the GLY-123 primary funnel.
+
+    Ordered by ``received_at`` (ingestion clock), not ``reading_timestamp``:
+    the detector's semantic is "data stopped arriving", and a skewed device
+    clock must not mask or fake a blackout. The funnel decides which sources
+    count (fail-safe: no primary => exclude nothing).
+    """
+    stmt = (
+        (await glucose_readings_query(db, user_id))
+        .order_by(desc(GlucoseReading.received_at))
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def _episode_alert(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    last_received: datetime | None,
+) -> Alert | None:
+    """Newest NO_DATA alert belonging to the CURRENT gap episode.
+
+    An alert belongs to the current episode iff it was created after the
+    last received reading -- i.e. no data has flowed since it fired. When
+    the user has no readings at all (``last_received is None``), any
+    NO_DATA alert is episode-relevant.
+    """
+    stmt = select(Alert).where(
+        Alert.user_id == user_id,
+        Alert.alert_type == AlertType.NO_DATA,
+    )
+    if last_received is not None:
+        stmt = stmt.where(Alert.created_at > last_received)
+    stmt = stmt.order_by(desc(Alert.created_at)).limit(1)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def _resolve_open_alerts(
+    db: AsyncSession, user_id: uuid.UUID, now: datetime
+) -> bool:
+    """Ack every unacknowledged NO_DATA alert for the user (data resumed)."""
+    result = await db.execute(
+        select(Alert).where(
+            Alert.user_id == user_id,
+            Alert.alert_type == AlertType.NO_DATA,
+            Alert.acknowledged.is_(False),
+        )
+    )
+    alerts = list(result.scalars().all())
+    for alert in alerts:
+        alert.acknowledged = True
+        alert.acknowledged_at = now
+    return bool(alerts)
+
+
+async def evaluate_data_gap_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> DataGapAction:
+    """Run one data-gap detector tick for a caregiver-monitored patient.
+
+    The caller has already established that the patient has at least one
+    caregiver link with ``can_receive_alerts``; this function applies the
+    recent-baseline arming gate and the episode lifecycle, and commits.
+    """
+    now = datetime.now(UTC)
+
+    latest = await _latest_reading_by_arrival(db, user_id)
+
+    last_received: datetime | None = None
+    if latest is not None:
+        last_received = latest.received_at
+        if last_received.tzinfo is None:
+            last_received = last_received.replace(tzinfo=UTC)
+
+    episode = await _episode_alert(db, user_id, last_received)
+
+    if latest is None:
+        # No readings via the funnel at all. Armed only if an episode alert
+        # already exists (e.g. readings aged out of retention mid-blackout);
+        # hold it open, never fire fresh (no baseline, no last-known value).
+        if episode is not None and not episode.acknowledged:
+            episode.expires_at = now + timedelta(minutes=no_data_alert_ttl_minutes())
+            await db.commit()
+            return DataGapAction.RENEWED
+        return DataGapAction.NONE
+
+    age_minutes = (now - last_received).total_seconds() / 60
+
+    # Only pay the per-source lookups once the base threshold is exceeded --
+    # under it, data is fresh for every source type.
+    threshold_minutes = NO_DATA_THRESHOLD_MINUTES
+    if age_minutes > NO_DATA_THRESHOLD_MINUTES:
+        threshold_minutes = await resolve_no_data_threshold_minutes(db, user_id)
+
+    if age_minutes <= threshold_minutes:
+        # Data is flowing (within the patient's normal arrival cadence) --
+        # the episode (if any) is over.
+        if await _resolve_open_alerts(db, user_id, now):
+            await db.commit()
+            logger.info(
+                "Data-gap alert auto-resolved (data resumed)",
+                user_id=str(user_id),
+                age_minutes=round(age_minutes, 1),
+            )
+            return DataGapAction.RESOLVED
+        return DataGapAction.NONE
+
+    # In a gap.
+    if episode is not None:
+        if episode.acknowledged:
+            # Someone acked this ongoing episode; no data has flowed since it
+            # fired, so do NOT re-fire every tick. Known v1 limitation of the
+            # shared per-patient row (as for every alert type): one
+            # caregiver's ack clears it for all caregivers -- per-caregiver
+            # ack state / re-fire-after-N-hours is deferred with escalation
+            # to v2.
+            return DataGapAction.NONE
+        # Hold the alert open while blind (also revives an expired-unacked
+        # episode row after a detector outage, instead of creating a
+        # duplicate). Refresh the message so the reported age stays honest.
+        episode.expires_at = now + timedelta(minutes=no_data_alert_ttl_minutes())
+        episode.message = await _render_gap_message(
+            db, user_id, age_minutes, latest, last_received
+        )
+        await db.commit()
+        return DataGapAction.RENEWED
+
+    if age_minutes > ARMING_BASELINE_HOURS * 60:
+        # No readings in the baseline window and no open episode: not armed.
+        # (A blackout that FIRED before crossing 24h stays armed above via
+        # the episode branch.) Accepted blind spot: a caregiver who links to
+        # a patient ALREADY dark for >24h gets no retroactive alert -- the
+        # baseline gate exists to stop alarm storms on long-dormant accounts,
+        # and the caregiver dashboard still shows no data for them.
+        return DataGapAction.NONE
+
+    # Onset: data flowed since the last NO_DATA episode (or there never was
+    # one) and has now been absent past the threshold -- fire one alert.
+    # (A reading landing between the queries above and this insert produces a
+    # one-tick spurious alert; the next tick's resume branch auto-resolves
+    # it, so the blast radius is one check interval.)
+    alert = Alert(
+        user_id=user_id,
+        alert_type=AlertType.NO_DATA,
+        severity=AlertSeverity.WARNING,
+        # current_value is non-null by schema; carry the LAST-KNOWN value
+        # (never 0 / a fake low). Clients branch on alert_type == "no_data"
+        # and render the message, not this number, as the headline.
+        current_value=float(latest.value),
+        predicted_value=None,
+        prediction_minutes=None,
+        iob_value=None,
+        message=await _render_gap_message(
+            db, user_id, age_minutes, latest, last_received
+        ),
+        trend_rate=None,
+        source=NO_DATA_ALERT_SOURCE,
+        created_at=now,
+        expires_at=now + timedelta(minutes=no_data_alert_ttl_minutes()),
+    )
+    db.add(alert)
+    await db.commit()
+    logger.info(
+        "Data-gap alert created",
+        user_id=str(user_id),
+        age_minutes=round(age_minutes, 1),
+    )
+    return DataGapAction.CREATED

--- a/apps/api/src/services/predictive_alerts.py
+++ b/apps/api/src/services/predictive_alerts.py
@@ -119,16 +119,20 @@ def determine_severity(
     Returns:
         Appropriate AlertSeverity level.
     """
-    # Base severity by alert type
+    # Base severity by alert type. NO_DATA is included for totality even
+    # though the data-gap detector (GLY-137) sets WARNING directly; the
+    # .get fallback keeps a future AlertType addition from raising KeyError
+    # on a live alerting path.
     base_severity = {
         AlertType.LOW_URGENT: AlertSeverity.URGENT,
         AlertType.LOW_WARNING: AlertSeverity.WARNING,
         AlertType.HIGH_WARNING: AlertSeverity.WARNING,
         AlertType.HIGH_URGENT: AlertSeverity.URGENT,
         AlertType.IOB_WARNING: AlertSeverity.WARNING,
+        AlertType.NO_DATA: AlertSeverity.WARNING,
     }
 
-    severity = base_severity[alert_type]
+    severity = base_severity.get(alert_type, AlertSeverity.WARNING)
 
     # IoB-based escalation for low glucose alerts
     if iob_value is not None and alert_type in (

--- a/apps/api/src/services/predictive_alerts.py
+++ b/apps/api/src/services/predictive_alerts.py
@@ -132,6 +132,13 @@ def determine_severity(
         AlertType.NO_DATA: AlertSeverity.WARNING,
     }
 
+    if alert_type not in base_severity:
+        # Observable, not silent: a future alert type missing here would
+        # otherwise be quietly under-triaged to WARNING.
+        logger.warning(
+            "Unmapped alert_type in determine_severity; defaulting to WARNING",
+            alert_type=str(alert_type),
+        )
     severity = base_severity.get(alert_type, AlertSeverity.WARNING)
 
     # IoB-based escalation for low glucose alerts

--- a/apps/api/src/services/scheduler.py
+++ b/apps/api/src/services/scheduler.py
@@ -17,6 +17,7 @@ from src.config import settings
 from src.database import get_session_maker
 from src.logging_config import get_logger
 from src.models import glooko_sync_state as glooko_state
+from src.models.caregiver_link import CaregiverLink
 from src.models.glooko_sync_state import GlookoSyncState
 from src.models.integration import (
     IntegrationCredential,
@@ -31,6 +32,7 @@ from src.models.medtronic_connect_state import (
 )
 from src.models.tandem_sync_state import TandemSyncState
 from src.services.daily_brief import generate_briefs_all_users
+from src.services.data_gap_alerts import DataGapAction, evaluate_data_gap_for_user
 from src.services.dexcom_sync import DexcomSyncError, sync_dexcom_for_user
 from src.services.integrations.glooko.sync import (
     GlookoSyncRunError,
@@ -567,6 +569,76 @@ async def check_alerts_all_users() -> None:
     )
 
 
+async def check_data_gaps_all_users() -> None:
+    """Run the caregiver data-gap detector for all monitored patients (GLY-137).
+
+    Candidates are patients with at least one alert-receiving caregiver link
+    -- deliberately NOT the DEXCOM/TANDEM credential loop above (which misses
+    Nightscout/Glooko/Medtronic writers and includes pump-only Tandem) and NOT
+    ``list_cgm_sources`` (which only enumerates Dexcom + Nightscout). The
+    recent-baseline arming gate lives inside ``evaluate_data_gap_for_user``.
+    """
+    from sqlalchemy import distinct
+
+    logger.info("Starting scheduled data-gap check for monitored patients")
+
+    async with get_session_maker()() as db:
+        result = await db.execute(
+            select(distinct(CaregiverLink.patient_id)).where(
+                CaregiverLink.can_receive_alerts.is_(True)
+            )
+        )
+        patient_ids = [row[0] for row in result.all()]
+
+    if not patient_ids:
+        logger.info("No caregiver-monitored patients for data-gap check")
+        return
+
+    action_counts = dict.fromkeys(DataGapAction, 0)
+    error_count = 0
+    tick_started = datetime.now(UTC)
+
+    for patient_id in patient_ids:
+        try:
+            async with get_session_maker()() as user_db:
+                action = await evaluate_data_gap_for_user(user_db, patient_id)
+                action_counts[action] += 1
+        except Exception as e:
+            logger.error(
+                "Data-gap check failed for patient",
+                user_id=str(patient_id),
+                error=str(e),
+            )
+            error_count += 1
+
+        # 0.1s like the escalation loop (not the sync jobs' rate-limit 0.5s --
+        # this loop only hits our own DB). The open-alert TTL is 2x the check
+        # interval, so a tick must finish within one interval or held-open
+        # alerts flicker out before their renewal; the warning below trips
+        # long before patient count makes that possible.
+        await asyncio.sleep(0.1)
+
+    tick_minutes = (datetime.now(UTC) - tick_started).total_seconds() / 60
+    if tick_minutes > settings.data_gap_check_interval_minutes:
+        logger.warning(
+            "Data-gap tick outlasted its interval; held-open alerts may "
+            "expire between renewals -- reduce monitored-patient latency "
+            "or raise the interval",
+            tick_minutes=round(tick_minutes, 1),
+            interval_minutes=settings.data_gap_check_interval_minutes,
+            patients_checked=len(patient_ids),
+        )
+
+    logger.info(
+        "Scheduled data-gap check completed",
+        patients_checked=len(patient_ids),
+        alerts_created=action_counts[DataGapAction.CREATED],
+        alerts_renewed=action_counts[DataGapAction.RENEWED],
+        alerts_resolved=action_counts[DataGapAction.RESOLVED],
+        errors=error_count,
+    )
+
+
 async def check_escalations_all_users() -> None:
     """Run escalation checks for users with unacknowledged critical alerts.
 
@@ -885,6 +957,24 @@ def start_scheduler() -> AsyncIOScheduler:
         logger.info(
             "Scheduled alert check job",
             interval_minutes=settings.alert_check_interval_minutes,
+        )
+
+    # Add caregiver data-gap alert check job if enabled (GLY-137)
+    if settings.data_gap_alert_enabled:
+        scheduler.add_job(
+            check_data_gaps_all_users,
+            trigger=IntervalTrigger(minutes=settings.data_gap_check_interval_minutes),
+            id="data_gap_check",
+            name="Caregiver Data-Gap Alert Check",
+            replace_existing=True,
+            # A slow tick (many monitored patients) must not stack with the
+            # next one -- stacked ticks could double-create episode alerts.
+            max_instances=1,
+            coalesce=True,
+        )
+        logger.info(
+            "Scheduled caregiver data-gap check job",
+            interval_minutes=settings.data_gap_check_interval_minutes,
         )
 
     # Add escalation check job if enabled (Story 6.7)

--- a/apps/api/tests/test_data_gap_alerts.py
+++ b/apps/api/tests/test_data_gap_alerts.py
@@ -504,8 +504,10 @@ class TestSourceCoverage:
             await _cleanup(db_session, patient.id, caregiver.id)
 
     async def test_threshold_resolution(self, db_session):
-        """No pull sources => base 30; a slow active Nightscout connection
-        widens to 2x its interval."""
+        """No pull sources => base 30; a slow HEALTHY Nightscout connection
+        widens to 2x its interval; an erroring one must not (same rule as the
+        Glooko/Medtronic connected-only filters -- a broken sync is the outage
+        to surface, not a reason to extend the deadline)."""
         patient, caregiver = await _make_monitored_patient(db_session)
         try:
             assert (
@@ -513,22 +515,29 @@ class TestSourceCoverage:
                 == NO_DATA_THRESHOLD_MINUTES
             )
 
-            db_session.add(
-                NightscoutConnection(
-                    user_id=patient.id,
-                    name="slow NS",
-                    base_url="https://ns.example.com",
-                    auth_type=NightscoutAuthType.TOKEN,
-                    encrypted_credential="enc",
-                    api_version=NightscoutApiVersion.V1,
-                    last_sync_status=NightscoutSyncStatus.NEVER,
-                    sync_interval_minutes=60,
-                )
+            conn = NightscoutConnection(
+                user_id=patient.id,
+                name="slow NS",
+                base_url="https://ns.example.com",
+                auth_type=NightscoutAuthType.TOKEN,
+                encrypted_credential="enc",
+                api_version=NightscoutApiVersion.V1,
+                last_sync_status=NightscoutSyncStatus.OK,
+                sync_interval_minutes=60,
             )
+            db_session.add(conn)
             await db_session.commit()
 
             assert (
                 await resolve_no_data_threshold_minutes(db_session, patient.id) == 120
+            )
+
+            conn.last_sync_status = NightscoutSyncStatus.AUTH_FAILED
+            await db_session.commit()
+
+            assert (
+                await resolve_no_data_threshold_minutes(db_session, patient.id)
+                == NO_DATA_THRESHOLD_MINUTES
             )
         finally:
             await _cleanup(db_session, patient.id, caregiver.id)

--- a/apps/api/tests/test_data_gap_alerts.py
+++ b/apps/api/tests/test_data_gap_alerts.py
@@ -1,0 +1,685 @@
+"""GLY-137: Tests for the caregiver "lost contact" / data-gap alert detector.
+
+These are real-DB tests (the detector is query-shaped: funnel ordering,
+episode dedup, and lifecycle transitions all live in SQL). Each test creates
+its own users and cleans up after itself because the detector commits.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import delete, select
+
+from src.core.auth import get_current_user
+from src.main import app
+from src.models import glooko_sync_state
+from src.models.alert import Alert, AlertSeverity, AlertType
+from src.models.caregiver_link import CaregiverLink
+from src.models.device_registration import DeviceRegistration
+from src.models.glooko_sync_state import GlookoSyncState
+from src.models.glucose import GlucoseReading, TrendDirection
+from src.models.medtronic_connect_state import MedtronicConnectState
+from src.models.nightscout_connection import (
+    NightscoutApiVersion,
+    NightscoutAuthType,
+    NightscoutConnection,
+    NightscoutSyncStatus,
+)
+from src.models.user import User, UserRole
+from src.routers.alert_api import AlertResponse, alert_to_dict
+from src.services import data_gap_alerts
+from src.services.data_gap_alerts import (
+    ARMING_BASELINE_HOURS,
+    NO_DATA_ALERT_SOURCE,
+    NO_DATA_THRESHOLD_MINUTES,
+    DataGapAction,
+    evaluate_data_gap_for_user,
+    format_gap_message,
+    no_data_alert_ttl_minutes,
+    resolve_no_data_threshold_minutes,
+)
+from src.services.escalation_engine import get_unacknowledged_critical_alerts
+
+# ── Fixture helpers ──
+
+
+async def _make_user(db, role: UserRole) -> User:
+    user = User(
+        email=f"gly137-{uuid.uuid4().hex}@integration.test",
+        hashed_password="x" * 60,  # noqa: S106 -- not a real hash, test-only
+        role=role,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _make_monitored_patient(
+    db, can_receive_alerts: bool = True
+) -> tuple[User, User]:
+    patient = await _make_user(db, UserRole.DIABETIC)
+    caregiver = await _make_user(db, UserRole.CAREGIVER)
+    db.add(
+        CaregiverLink(
+            caregiver_id=caregiver.id,
+            patient_id=patient.id,
+            can_receive_alerts=can_receive_alerts,
+        )
+    )
+    await db.commit()
+    return patient, caregiver
+
+
+async def _add_reading(
+    db,
+    user_id: uuid.UUID,
+    received_minutes_ago: float,
+    value: int = 112,
+    source: str = "dexcom",
+    reading_timestamp: datetime | None = None,
+) -> GlucoseReading:
+    received_at = datetime.now(UTC) - timedelta(minutes=received_minutes_ago)
+    reading = GlucoseReading(
+        user_id=user_id,
+        value=value,
+        reading_timestamp=reading_timestamp or received_at,
+        trend=TrendDirection.FLAT,
+        trend_rate=0.0,
+        received_at=received_at,
+        source=source,
+    )
+    db.add(reading)
+    await db.commit()
+    return reading
+
+
+async def _add_pull_source_state(
+    db,
+    user_id: uuid.UUID,
+    source: str,
+    status: str = glooko_sync_state.STATUS_CONNECTED,
+    sync_interval_minutes: int = 30,
+) -> None:
+    """Attach a Glooko / Medtronic Connect sync-state row (default: healthy
+    30-min pull), so the per-source threshold widening has something real to
+    key off."""
+    if source == "glooko":
+        db.add(
+            GlookoSyncState(
+                user_id=user_id,
+                encrypted_email="enc-email",
+                encrypted_password="enc-password",  # noqa: S106 -- test-only ciphertext stand-in
+                status=status,
+                sync_interval_minutes=sync_interval_minutes,
+            )
+        )
+    elif source == "medtronic":
+        db.add(
+            MedtronicConnectState(
+                user_id=user_id,
+                encrypted_username="enc-user",
+                encrypted_refresh_token="enc-token",  # noqa: S106 -- test-only ciphertext stand-in
+                status=status,
+                sync_interval_minutes=sync_interval_minutes,
+            )
+        )
+    else:
+        raise ValueError(f"unknown pull source {source}")
+    await db.commit()
+
+
+async def _no_data_alerts(db, user_id: uuid.UUID) -> list[Alert]:
+    result = await db.execute(
+        select(Alert)
+        .where(Alert.user_id == user_id, Alert.alert_type == AlertType.NO_DATA)
+        .order_by(Alert.created_at)
+    )
+    return list(result.scalars().all())
+
+
+async def _cleanup(db, *user_ids: uuid.UUID) -> None:
+    await db.rollback()
+    for table, col in (
+        (Alert, Alert.user_id),
+        (GlucoseReading, GlucoseReading.user_id),
+        (DeviceRegistration, DeviceRegistration.user_id),
+        (GlookoSyncState, GlookoSyncState.user_id),
+        (MedtronicConnectState, MedtronicConnectState.user_id),
+        (NightscoutConnection, NightscoutConnection.user_id),
+    ):
+        await db.execute(delete(table).where(col.in_(user_ids)))
+    await db.execute(
+        delete(CaregiverLink).where(
+            CaregiverLink.patient_id.in_(user_ids)
+            | CaregiverLink.caregiver_id.in_(user_ids)
+        )
+    )
+    await db.execute(delete(User).where(User.id.in_(user_ids)))
+    await db.commit()
+
+
+# ── Discriminating false-alarm guard ──
+
+
+@pytest.mark.asyncio
+class TestNoFalseAlarms:
+    async def test_fresh_readings_with_stale_device_heartbeat_no_alert(
+        self, db_session
+    ):
+        """Fresh data arrival + a 60-min-stale DeviceRegistration => NO alert.
+
+        The stale-device fixture is what makes this test discriminate: an
+        implementation keyed off phone liveness (last_seen_at) instead of
+        data-arrival age would fire here and fail.
+        """
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(db_session, patient.id, received_minutes_ago=5)
+            db_session.add(
+                DeviceRegistration(
+                    user_id=patient.id,
+                    device_token=f"tok-{uuid.uuid4().hex}",
+                    device_name="stale phone",
+                    last_seen_at=datetime.now(UTC) - timedelta(minutes=90),
+                )
+            )
+            await db_session.commit()
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.NONE
+            assert await _no_data_alerts(db_session, patient.id) == []
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_never_had_data_not_armed(self, db_session):
+        """A monitored patient with zero readings (e.g. pump-only Tandem or
+        just-onboarded) never arms and never fires."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.NONE
+            assert await _no_data_alerts(db_session, patient.id) == []
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_gap_older_than_baseline_without_episode_not_armed(self, db_session):
+        """A >24h-old last reading with no open episode does not fire; the
+        baseline window bounds retroactive alarms on stale accounts."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(
+                db_session,
+                patient.id,
+                received_minutes_ago=ARMING_BASELINE_HOURS * 60 + 60,
+            )
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.NONE
+            assert await _no_data_alerts(db_session, patient.id) == []
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+
+# ── Lifecycle ──
+
+
+@pytest.mark.asyncio
+class TestLifecycle:
+    async def test_gap_fires_exactly_one_warning_alert(self, db_session):
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(
+                db_session, patient.id, received_minutes_ago=35, value=112
+            )
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.CREATED
+            alerts = await _no_data_alerts(db_session, patient.id)
+            assert len(alerts) == 1
+            alert = alerts[0]
+            assert alert.severity == AlertSeverity.WARNING
+            assert alert.acknowledged is False
+            assert alert.source == NO_DATA_ALERT_SOURCE
+            # current_value carries the LAST-KNOWN reading, never 0/fake.
+            assert alert.current_value == 112.0
+            assert "No CGM data for 35m" in alert.message
+            assert "last:" in alert.message
+            # Short TTL: held open by renewal, not a long hardcoded expiry.
+            ttl = timedelta(minutes=no_data_alert_ttl_minutes())
+            assert alert.expires_at <= datetime.now(UTC) + ttl
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_sustained_gap_renews_single_row(self, db_session):
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(db_session, patient.id, received_minutes_ago=35)
+            assert (
+                await evaluate_data_gap_for_user(db_session, patient.id)
+                == DataGapAction.CREATED
+            )
+            (alert,) = await _no_data_alerts(db_session, patient.id)
+            first_expiry = alert.expires_at
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.RENEWED
+            alerts = await _no_data_alerts(db_session, patient.id)
+            assert len(alerts) == 1  # still exactly one row for the episode
+            assert alerts[0].expires_at >= first_expiry
+            assert alerts[0].acknowledged is False
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_manual_ack_during_gap_does_not_refire(self, db_session):
+        """The HIGH-fix: a caregiver acking a persistent "no data" alert while
+        the gap is STILL ongoing must not spawn a new alert every tick --
+        onset is gated on data-having-flowed, not on open-ness."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(db_session, patient.id, received_minutes_ago=35)
+            await evaluate_data_gap_for_user(db_session, patient.id)
+            (alert,) = await _no_data_alerts(db_session, patient.id)
+
+            # Caregiver manually acknowledges mid-gap.
+            alert.acknowledged = True
+            alert.acknowledged_at = datetime.now(UTC)
+            await db_session.commit()
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.NONE
+            assert len(await _no_data_alerts(db_session, patient.id)) == 1
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_resume_auto_resolves_and_drops_from_pending(self, db_session):
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(db_session, patient.id, received_minutes_ago=35)
+            await evaluate_data_gap_for_user(db_session, patient.id)
+
+            # Caregiver /pending sees the alert while the gap is open.
+            app.dependency_overrides[get_current_user] = lambda: caregiver
+            try:
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    pending = await client.get("/api/v1/alerts/pending")
+                    assert pending.status_code == 200
+                    types = [a["alert_type"] for a in pending.json()]
+                    assert "no_data" in types
+
+                    # Data resumes.
+                    await _add_reading(db_session, patient.id, received_minutes_ago=1)
+                    action = await evaluate_data_gap_for_user(db_session, patient.id)
+                    assert action == DataGapAction.RESOLVED
+
+                    (alert,) = await _no_data_alerts(db_session, patient.id)
+                    assert alert.acknowledged is True
+                    assert alert.acknowledged_at is not None
+
+                    pending = await client.get("/api/v1/alerts/pending")
+                    types = [a["alert_type"] for a in pending.json()]
+                    assert "no_data" not in types
+            finally:
+                app.dependency_overrides.pop(get_current_user, None)
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_resume_then_regap_fires_fresh_episode(self, db_session):
+        """Data flowing after a resolved episode re-arms onset."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            now = datetime.now(UTC)
+            # A previous episode, already resolved 90 minutes ago.
+            db_session.add(
+                Alert(
+                    user_id=patient.id,
+                    alert_type=AlertType.NO_DATA,
+                    severity=AlertSeverity.WARNING,
+                    current_value=110.0,
+                    message="No CGM data for 31m (last: 110 mg/dL at 00:00 UTC)",
+                    source=NO_DATA_ALERT_SOURCE,
+                    acknowledged=True,
+                    acknowledged_at=now - timedelta(minutes=60),
+                    created_at=now - timedelta(minutes=90),
+                    expires_at=now - timedelta(minutes=80),
+                )
+            )
+            await db_session.commit()
+            # Data flowed AFTER that episode... then stopped again 40 min ago.
+            await _add_reading(db_session, patient.id, received_minutes_ago=40)
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.CREATED
+            alerts = await _no_data_alerts(db_session, patient.id)
+            assert len(alerts) == 2
+            assert alerts[-1].acknowledged is False
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_blackout_past_baseline_stays_armed_via_open_episode(
+        self, db_session
+    ):
+        """A >24h blackout with an open episode alert keeps renewing -- the
+        patient must not silently de-arm mid-emergency."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            now = datetime.now(UTC)
+            await _add_reading(
+                db_session,
+                patient.id,
+                received_minutes_ago=ARMING_BASELINE_HOURS * 60 + 60,
+            )
+            db_session.add(
+                Alert(
+                    user_id=patient.id,
+                    alert_type=AlertType.NO_DATA,
+                    severity=AlertSeverity.WARNING,
+                    current_value=110.0,
+                    message="No CGM data for 24h 30m (last: 110 mg/dL at 00:00 UTC)",
+                    source=NO_DATA_ALERT_SOURCE,
+                    created_at=now - timedelta(hours=24, minutes=30),
+                    expires_at=now + timedelta(minutes=5),
+                )
+            )
+            await db_session.commit()
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.RENEWED
+            (alert,) = await _no_data_alerts(db_session, patient.id)
+            assert alert.acknowledged is False
+            assert alert.expires_at > now
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_warmup_gap_fires_once_holds_and_resolves(self, db_session):
+        """Pins the v1 D6 decision: a ~2h sensor-warmup gap IS surfaced (the
+        caregiver genuinely has no data), held open as a single WARNING, and
+        auto-resolves when session data resumes."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(db_session, patient.id, received_minutes_ago=120)
+
+            assert (
+                await evaluate_data_gap_for_user(db_session, patient.id)
+                == DataGapAction.CREATED
+            )
+            assert (
+                await evaluate_data_gap_for_user(db_session, patient.id)
+                == DataGapAction.RENEWED
+            )
+            alerts = await _no_data_alerts(db_session, patient.id)
+            assert len(alerts) == 1
+            assert alerts[0].severity == AlertSeverity.WARNING
+            assert "2h 0m" in alerts[0].message
+
+            # Warmup ends, data resumes.
+            await _add_reading(db_session, patient.id, received_minutes_ago=1)
+            assert (
+                await evaluate_data_gap_for_user(db_session, patient.id)
+                == DataGapAction.RESOLVED
+            )
+            (alert,) = await _no_data_alerts(db_session, patient.id)
+            assert alert.acknowledged is True
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+
+# ── Scope / coverage across source types ──
+
+
+@pytest.mark.asyncio
+class TestSourceCoverage:
+    @pytest.mark.parametrize("source", ["glooko", "medtronic"])
+    async def test_non_role_managed_sources_fire(self, db_session, source):
+        """The HIGH-fix: Glooko / Medtronic-CareLink users write real readings
+        but have no cgm_role, so a list_cgm_sources arming gate would silently
+        exclude them. They must arm and fire off reading existence alone --
+        here past 2x their 30-min pull interval (two missed pulls)."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_pull_source_state(db_session, patient.id, source)
+            await _add_reading(
+                db_session, patient.id, received_minutes_ago=90, source=source
+            )
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.CREATED
+            (alert,) = await _no_data_alerts(db_session, patient.id)
+            assert alert.severity == AlertSeverity.WARNING
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    @pytest.mark.parametrize("source", ["glooko", "medtronic"])
+    async def test_healthy_pull_cadence_does_not_false_alarm(self, db_session, source):
+        """A CONNECTED 30-min-pull patient whose newest arrival is 45 min old
+        is inside normal cadence (threshold widens to 2x interval = 60m) --
+        NO alert. A flat 30-min threshold would fire here on every healthy
+        sync cycle and train caregivers to ignore the alert."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_pull_source_state(db_session, patient.id, source)
+            await _add_reading(
+                db_session, patient.id, received_minutes_ago=45, source=source
+            )
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.NONE
+            assert await _no_data_alerts(db_session, patient.id) == []
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_errored_pull_source_does_not_widen_threshold(self, db_session):
+        """A broken sync is exactly the outage to surface: an ERROR-status
+        Glooko state must not buy itself the widened deadline, so the base
+        30-min threshold applies and a 45-min gap fires."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_pull_source_state(
+                db_session, patient.id, "glooko", status=glooko_sync_state.STATUS_ERROR
+            )
+            await _add_reading(
+                db_session, patient.id, received_minutes_ago=45, source="glooko"
+            )
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.CREATED
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_threshold_resolution(self, db_session):
+        """No pull sources => base 30; a slow active Nightscout connection
+        widens to 2x its interval."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            assert (
+                await resolve_no_data_threshold_minutes(db_session, patient.id)
+                == NO_DATA_THRESHOLD_MINUTES
+            )
+
+            db_session.add(
+                NightscoutConnection(
+                    user_id=patient.id,
+                    name="slow NS",
+                    base_url="https://ns.example.com",
+                    auth_type=NightscoutAuthType.TOKEN,
+                    encrypted_credential="enc",
+                    api_version=NightscoutApiVersion.V1,
+                    last_sync_status=NightscoutSyncStatus.NEVER,
+                    sync_interval_minutes=60,
+                )
+            )
+            await db_session.commit()
+
+            assert (
+                await resolve_no_data_threshold_minutes(db_session, patient.id) == 120
+            )
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_job_discovery_skips_unlinked_and_muted_patients(self, db_session):
+        """check_data_gaps_all_users only evaluates patients with an
+        alert-receiving caregiver link."""
+        from src.services.scheduler import check_data_gaps_all_users
+
+        linked, caregiver = await _make_monitored_patient(db_session)
+        muted, muted_cg = await _make_monitored_patient(
+            db_session, can_receive_alerts=False
+        )
+        unlinked = await _make_user(db_session, UserRole.DIABETIC)
+        try:
+            for uid in (linked.id, muted.id, unlinked.id):
+                await _add_reading(db_session, uid, received_minutes_ago=45)
+
+            await check_data_gaps_all_users()
+
+            assert len(await _no_data_alerts(db_session, linked.id)) == 1
+            assert await _no_data_alerts(db_session, muted.id) == []
+            assert await _no_data_alerts(db_session, unlinked.id) == []
+        finally:
+            await _cleanup(
+                db_session, linked.id, caregiver.id, muted.id, muted_cg.id, unlinked.id
+            )
+
+
+# ── Correctness ──
+
+
+@pytest.mark.asyncio
+class TestCorrectness:
+    async def test_age_measured_off_received_at_not_reading_timestamp(self, db_session):
+        """A future-skewed device clock (reading_timestamp ahead of now) must
+        not mask a blackout: the reading ARRIVED 45 min ago, so it fires. A
+        reading_timestamp-based implementation would compute a negative age
+        and stay silent."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(
+                db_session,
+                patient.id,
+                received_minutes_ago=45,
+                reading_timestamp=datetime.now(UTC) + timedelta(minutes=10),
+            )
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.CREATED
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_tz_naive_received_at_normalized(self, db_session, monkeypatch):
+        """A tz-naive received_at (non-PG backends return naive datetimes) is
+        treated as UTC, not a crash or a skewed age."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            naive_received = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+                minutes=45
+            )
+            fake_reading = SimpleNamespace(value=112, received_at=naive_received)
+            monkeypatch.setattr(
+                data_gap_alerts,
+                "_latest_reading_by_arrival",
+                AsyncMock(return_value=fake_reading),
+            )
+
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.CREATED
+            (alert,) = await _no_data_alerts(db_session, patient.id)
+            assert "45m" in alert.message
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_warning_severity_not_selected_by_escalation(self, db_session):
+        """NO_DATA stays WARNING => the escalation engine's URGENT/EMERGENCY
+        selection never picks it up (v1 has no emergency-contact paging)."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(db_session, patient.id, received_minutes_ago=35)
+            await evaluate_data_gap_for_user(db_session, patient.id)
+
+            critical = await get_unacknowledged_critical_alerts(db_session, patient.id)
+            assert critical == []
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_detector_never_notifies_the_patient(self, db_session, monkeypatch):
+        """No dedicated patient alarm path: the detector must not call the
+        patient Telegram notifier. (The row still appears on the patient's
+        own generic alert surfaces like any Alert -- that is accepted and
+        honest; what is pinned here is that no Telegram push fires.)"""
+        from src.services import alert_notifier
+
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            spy = AsyncMock(
+                side_effect=AssertionError(
+                    "notify_user_of_alerts must not run for NO_DATA"
+                )
+            )
+            monkeypatch.setattr(alert_notifier, "notify_user_of_alerts", spy)
+
+            await _add_reading(db_session, patient.id, received_minutes_ago=35)
+            action = await evaluate_data_gap_for_user(db_session, patient.id)
+
+            assert action == DataGapAction.CREATED
+            spy.assert_not_called()
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+    async def test_alert_response_round_trip(self, db_session):
+        """A NO_DATA row serializes through the mobile/SSE payload path
+        (nullable predicted/iob/trend fields) without a 500."""
+        patient, caregiver = await _make_monitored_patient(db_session)
+        try:
+            await _add_reading(db_session, patient.id, received_minutes_ago=35)
+            await evaluate_data_gap_for_user(db_session, patient.id)
+            (alert,) = await _no_data_alerts(db_session, patient.id)
+
+            response = AlertResponse(**alert_to_dict(alert, patient_name="Alice"))
+
+            assert response.alert_type == "no_data"
+            assert response.severity == "warning"
+            assert response.patient_name == "Alice"
+            assert response.predicted_value is None
+            assert response.iob_value is None
+        finally:
+            await _cleanup(db_session, patient.id, caregiver.id)
+
+
+# ── Message formatting ──
+
+
+class TestFormatGapMessage:
+    def test_minutes(self):
+        msg = format_gap_message(
+            42.7, "112 mg/dL", datetime(2026, 7, 4, 13, 5, tzinfo=UTC)
+        )
+        assert msg == "No CGM data for 42m (last: 112 mg/dL at 13:05 UTC)"
+
+    def test_hours(self):
+        msg = format_gap_message(
+            150.0, "6.2 mmol/L", datetime(2026, 7, 4, 3, 15, tzinfo=UTC)
+        )
+        assert msg == "No CGM data for 2h 30m (last: 6.2 mmol/L at 03:15 UTC)"
+
+    def test_threshold_constant_sane(self):
+        # Above the 5-min tick and the 10-min staleness window, well below
+        # anything that would hide a real emergency.
+        assert 10 < NO_DATA_THRESHOLD_MINUTES <= 60

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "glycemicgpt-api"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertNotificationManager.kt
@@ -405,6 +405,11 @@ internal fun isLocalOnlyOnWrist(alert: AlertEntity): Boolean =
  * Builds a notification title (`"EMERGENCY: 320 mg/dL - Alice"`) with the glucose value rendered
  * in [unit]. Pure -- no Android dependencies -- so it can be exercised directly in unit tests.
  * Alert detection and the stored [AlertEntity.currentValue] stay canonical mg/dL.
+ *
+ * NO_DATA (caregiver data-gap, GLY-137) alerts carry only a LAST-KNOWN value in
+ * [AlertEntity.currentValue] -- rendering it in the title would fake a live reading during
+ * exactly the blackout the alert reports, so the title states the gap instead; the notification
+ * body (the server message) carries the gap age and last-known value.
  */
 internal fun formatAlertTitle(alert: AlertEntity, unit: GlucoseUnit): String {
     val prefix = when (alert.severity) {
@@ -414,5 +419,8 @@ internal fun formatAlertTitle(alert: AlertEntity, unit: GlucoseUnit): String {
         else -> "Info"
     }
     val patientSuffix = alert.patientName?.let { " - $it" } ?: ""
+    if (alert.alertType == "no_data") {
+        return "$prefix: No CGM data$patientSuffix"
+    }
     return "$prefix: ${GlucoseFormat.formatWithLabel(alert.currentValue.toInt(), unit)}$patientSuffix"
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertNotificationManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertNotificationManagerTest.kt
@@ -134,6 +134,25 @@ class AlertNotificationManagerTest {
         assertEquals("URGENT: 3.1 mmol/L - Alice", formatAlertTitle(alert, GlucoseUnit.MMOL))
     }
 
+    @Test
+    fun `no_data title states the gap instead of faking a live glucose value`() {
+        // GLY-137: currentValue on a data-gap alert is the LAST-KNOWN reading,
+        // not a live one -- it must never appear in the title as if current.
+        val alert = makeAlert(
+            alertType = "no_data",
+            severity = "warning",
+            currentValue = 112.0,
+            patientName = "Alice",
+        )
+        assertEquals("Warning: No CGM data - Alice", formatAlertTitle(alert, GlucoseUnit.MGDL))
+    }
+
+    @Test
+    fun `no_data title omits glucose in mmol mode too`() {
+        val alert = makeAlert(alertType = "no_data", severity = "warning", currentValue = 112.0)
+        assertEquals("Warning: No CGM data", formatAlertTitle(alert, GlucoseUnit.MMOL))
+    }
+
     // --- Stable notification ID tests ---
 
     @Test

--- a/apps/web/__tests__/components/dashboard/alert-card.test.tsx
+++ b/apps/web/__tests__/components/dashboard/alert-card.test.tsx
@@ -84,4 +84,26 @@ describe("AlertCard message body", () => {
     );
     expect(screen.getByText(message)).toBeInTheDocument();
   });
+
+  it("shows a no_data alert's message, never its last-known value as a live number (GLY-137)", () => {
+    const message = "No CGM data for 42m (last: 112 mg/dL at 13:05 UTC)";
+    const { container } = render(
+      <AlertCard
+        alert={makeAlert({
+          alert_type: "no_data",
+          current_value: 112,
+          predicted_value: null,
+          prediction_minutes: null,
+          trend_rate: null,
+          message,
+        })}
+        onAcknowledge={jest.fn()}
+      />
+    );
+    // The message (gap age + explicitly-labeled last value) is the body...
+    expect(screen.getByText(message)).toBeInTheDocument();
+    // ...and the headline glucose block is suppressed: current_value is a
+    // LAST-KNOWN reading, so no standalone "112" number may render as if live.
+    expect(screen.queryByText("112")).toBeNull();
+  });
 });

--- a/apps/web/__tests__/lib/alert-utils.test.ts
+++ b/apps/web/__tests__/lib/alert-utils.test.ts
@@ -68,4 +68,15 @@ describe("formatAlertSummary", () => {
     expect(formatAlertSummary(alert, "mgdl")).toBe(message);
     expect(formatAlertSummary(alert, "mmol")).toBe(message);
   });
+
+  it("returns the no_data message verbatim, never the last-known value as live glucose (GLY-137)", () => {
+    const message = "No CGM data for 42m (last: 112 mg/dL at 13:05 UTC)";
+    const alert = makeAlert({
+      alert_type: "no_data",
+      current_value: 112,
+      message,
+    });
+    expect(formatAlertSummary(alert, "mgdl")).toBe(message);
+    expect(formatAlertSummary(alert, "mmol")).toBe(message);
+  });
 });

--- a/apps/web/src/components/dashboard/alert-card.tsx
+++ b/apps/web/src/components/dashboard/alert-card.tsx
@@ -101,34 +101,41 @@ export function AlertCard({
         )}
       </div>
 
-      {/* Glucose values */}
-      <div className="flex items-baseline gap-4 mb-3">
-        <div>
-          <span className={clsx("text-2xl font-bold", config.text)}>
-            {formatGlucose(alert.current_value, unit)}
-          </span>
-          <span className="text-sm text-slate-400 ml-1">{unitLabel(unit)}</span>
-        </div>
-        {alert.predicted_value != null && alert.prediction_minutes != null && (
-          <div className="text-sm text-slate-400">
-            <span className="mr-1">&rarr;</span>
-            <span className={clsx("font-medium", config.text)}>
-              {formatGlucose(alert.predicted_value, unit)}
+      {/* Glucose values. NO_DATA (data-gap) alerts carry only a LAST-KNOWN
+          value in current_value — rendering it as the big headline number
+          would fake a live reading during exactly the blackout the alert
+          reports, so they show their message instead (below). */}
+      {alert.alert_type !== "no_data" && (
+        <div className="flex items-baseline gap-4 mb-3">
+          <div>
+            <span className={clsx("text-2xl font-bold", config.text)}>
+              {formatGlucose(alert.current_value, unit)}
             </span>
-            <span className="ml-1">
-              {unitLabel(unit)} in {alert.prediction_minutes}min
-            </span>
+            <span className="text-sm text-slate-400 ml-1">{unitLabel(unit)}</span>
           </div>
-        )}
-      </div>
+          {alert.predicted_value != null && alert.prediction_minutes != null && (
+            <div className="text-sm text-slate-400">
+              <span className="mr-1">&rarr;</span>
+              <span className={clsx("font-medium", config.text)}>
+                {formatGlucose(alert.predicted_value, unit)}
+              </span>
+              <span className="ml-1">
+                {unitLabel(unit)} in {alert.prediction_minutes}min
+              </span>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* The glucose value/prediction is already rendered live, in the active
           unit, in the block above — so no message echo is shown for glucose
           alerts (and the persisted mg/dL string is never the display source on a
           mmol surface). IoB warnings are the exception: their threshold context
           lives only in the message, and it is in insulin units, so it is never
-          unit-stale and is shown verbatim. */}
-      {alert.alert_type === "iob_warning" && (
+          unit-stale and is shown verbatim. NO_DATA alerts likewise show the
+          message — it carries the gap age and last-known value, the only honest
+          content while no data is arriving. */}
+      {(alert.alert_type === "iob_warning" || alert.alert_type === "no_data") && (
         <p className={clsx("text-sm mb-3", config.text)}>{alert.message}</p>
       )}
 

--- a/apps/web/src/lib/alert-utils.ts
+++ b/apps/web/src/lib/alert-utils.ts
@@ -84,6 +84,7 @@ const ALERT_TYPE_LABELS: Record<string, string> = {
   high_warning: "High Glucose Warning",
   high_urgent: "Urgent High Glucose",
   iob_warning: "Insulin on Board Warning",
+  no_data: "No CGM Data",
 };
 
 /** Convert alert_type to human-readable title */
@@ -123,12 +124,17 @@ interface AlertGlucoseFields {
  *
  * IoB warnings describe insulin units (never converted), so their persisted
  * message is already unit-stable and is shown verbatim.
+ *
+ * NO_DATA (data-gap) alerts carry a LAST-KNOWN value in `current_value`, not a
+ * live reading -- rendering it as the headline number would fake a current
+ * glucose during exactly the blackout the alert reports. Their message
+ * ("No CGM data for Nm (last: ...)") is the only honest summary, shown verbatim.
  */
 export function formatAlertSummary(
   alert: AlertGlucoseFields,
   unit: GlucoseUnit
 ): string {
-  if (alert.alert_type === "iob_warning") {
+  if (alert.alert_type === "iob_warning" || alert.alert_type === "no_data") {
     return alert.message;
   }
   const title = formatAlertTitle(alert.alert_type);


### PR DESCRIPTION
## Summary

When a monitored patient's glucose data stops arriving at the backend, the alert engine correctly suppresses threshold alerts on stale data -- but that leaves the caregiver silently blind during exactly the blackout that can mask a severe low. This adds a caregiver "lost contact" alert: a WARNING `no_data` alert delivered through the existing caregiver SSE/poll fan-out, held open for the duration of the gap, and auto-resolved when data resumes.

## What changed

**Backend (apps/api)**
- New `AlertType.NO_DATA` + migration 080 (`ALTER TYPE alerttype ADD VALUE`, transactional -- deliberate divergence from the pre-PG12 COMMIT-hack idiom in older enum migrations, documented in the migration).
- New `data_gap_alerts` detector service:
  - Gap age is measured off `GlucoseReading.received_at` (backend ingestion clock) -- never `reading_timestamp` (device-clock skew could mask a real blackout) and never phone liveness (cloud-sync users' data flows regardless of their phone).
  - Armed on caregiver link (`can_receive_alerts`) plus a 24h reading baseline (or an open episode), deliberately not on `list_cgm_sources`, which would silently exclude Glooko/Medtronic/CareLink users -- they write readings without a `cgm_role`.
  - Per-patient effective threshold `max(30 min, 2x slowest active pull-source sync interval)`: Glooko and Medtronic Connect default to 30-min pulls, so a flat 30-min threshold would false-alarm every healthy sync cycle. Errored/disconnected sources do not widen the deadline -- a broken sync is the outage to surface.
  - One alert per gap episode, gated on data-having-flowed-since-the-last-episode: a caregiver's manual ack during an ongoing gap does not re-fire; a genuine resume-then-re-gap fires a fresh episode.
  - Held open via short-TTL renewal (2x check interval); auto-resolved (acked) on data resume, so "cleared" means "resumed". A dead detector self-clears within ~2 ticks.
  - Which sources count is decided by the primary-source funnel (GLY-123).
- `check_data_gaps_all_users` scheduler job, flag-gated (`data_gap_alert_enabled`), `max_instances=1`, `coalesce=True`, with a tick-duration warning.
- No patient Telegram push (`notify_user_of_alerts` never called); WARNING severity is invisible to the emergency-contact escalation engine. Telegram/escalation for data gaps is deferred to a follow-up with quiet-hours design.
- Sensor warmup (~2h) fires by design: the caregiver genuinely has no data during warmup; the WARNING tile auto-resolves on resume. Session-aware suppression is a follow-up.

**Clients (honest rendering -- the alert's `current_value` is the last-known reading, not a live one)**
- Web: the alert card suppresses the big glucose headline for `no_data` and shows the gap message; the toast/browser-notification summary returns the message verbatim.
- Android: the notification title states "No CGM data" instead of rendering the last-known value as if current.

## Tests
- 25 new backend tests, written to discriminate: the false-alarm guard seeds a stale `DeviceRegistration.last_seen_at` next to fresh readings (kills a phone-heartbeat implementation); a healthy 30-min Glooko/Medtronic pull cadence must NOT alarm while a 90-min gap must; a future-skewed `reading_timestamp` with an old `received_at` must still fire; manual-ack-during-gap must not create a new row; resume must drop the alert from caregiver `/pending`.
- Web: card + summary tests for the `no_data` branch. Android: title tests.

## Validation
- Full backend suite, ruff check + format, web jest/tsc/eslint, Android unit tests + lint + assemble all green.
- Live validation on a Sentry-enabled stack: forced a 45-min gap for a linked patient; the detector created exactly one WARNING alert ("No CGM data for 49m (last: 112 mg/dL at 08:59 UTC)"), renewed it across ticks with an updated age, delivered it to the caregiver via `/pending` and the web toast, and auto-resolved it on the next tick after data resumed. No new Sentry issues in the run window on glycemicgpt-api or glycemicgpt-web (the only unresolved api issue predates this change by five weeks and is dev-DB test-data noise, source purged).

## Known v1 limitations (documented in code)
- One shared alert row per patient: one caregiver's ack clears it for all caregivers until data resumes and re-gaps (consistent with every alert type today; per-caregiver ack state rides the v2 escalation story).
- A caregiver who links to a patient already dark for more than 24h gets no retroactive alert (the baseline gate prevents alarm storms on dormant accounts).

GLY-137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced “No CGM Data” caregiver data-gap alerts with automatic detection, renewal during ongoing gaps, and auto-resolution when data resumes.
  * Added settings to enable/disable these alerts and control the check interval cadence.

* **Bug Fixes**
  * Updated alert rendering on web, mobile, and notifications so “No CGM Data” shows the gap message (including gap details) instead of a simulated glucose value.
  * Extended severity handling to safely support the new alert type.

* **Tests**
  * Added integration and unit test coverage for the full alert lifecycle and cross-platform display/message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->