### PR TITLE
fix(api): filter bolus CGM-freshness gate to the primary CGM source

### DIFF
--- a/apps/api/src/core/treatment_safety/validator.py
+++ b/apps/api/src/core/treatment_safety/validator.py
@@ -24,7 +24,6 @@ from src.core.treatment_safety.models import (
     BolusValidationResult,
     SafetyCheckResult,
 )
-from src.models.glucose import GlucoseReading
 from src.models.pump_data import PumpEvent, PumpEventType
 from src.models.safety_limits import SafetyLimits
 
@@ -175,14 +174,19 @@ class TreatmentSafetyValidator:
         db: AsyncSession,
         now: datetime,
     ) -> SafetyCheckResult:
-        """Check that the latest CGM reading is recent enough."""
-        result = await db.execute(
-            select(GlucoseReading)
-            .where(GlucoseReading.user_id == request.user_id)
-            .order_by(GlucoseReading.reading_timestamp.desc())
-            .limit(1)
-        )
-        latest = result.scalar_one_or_none()
+        """Check that the latest CGM reading is recent enough.
+
+        Reads through the GLY-123 primary-source funnel
+        (``get_latest_glucose_reading``), so a fresh SECONDARY reading can
+        never satisfy the gate while the PRIMARY the user actually sees is
+        stale. Fail-safe: with no designated primary, nothing is excluded
+        and behaviour matches the pre-GLY-125 any-source check.
+        """
+        # Imported lazily to keep src/core free of module-level service
+        # imports (same pattern as src/core/auth.py).
+        from src.services.dexcom_sync import get_latest_glucose_reading
+
+        latest = await get_latest_glucose_reading(db, request.user_id)
 
         if latest is None:
             return SafetyCheckResult(

--- a/apps/api/tests/test_treatment_validator.py
+++ b/apps/api/tests/test_treatment_validator.py
@@ -10,6 +10,8 @@ dedicated session managed within each test to avoid teardown conflicts.
 import uuid
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from src.core.treatment_safety.constants import (
     CGM_FRESHNESS_MAX_MINUTES,
     LOW_GLUCOSE_THRESHOLD_MGDL,
@@ -19,9 +21,27 @@ from src.core.treatment_safety.models import BolusRequest
 from src.core.treatment_safety.validator import TreatmentSafetyValidator
 from src.database import get_session_maker
 from src.models.glucose import GlucoseReading, TrendDirection
+from src.models.integration import (
+    IntegrationCredential,
+    IntegrationStatus,
+    IntegrationType,
+)
+from src.models.nightscout_connection import (
+    NightscoutApiVersion,
+    NightscoutAuthType,
+    NightscoutConnection,
+    NightscoutSyncStatus,
+)
 from src.models.pump_data import PumpEvent, PumpEventType
 from src.models.safety_limits import SafetyLimits
 from src.models.user import User, UserRole
+from src.services.cgm_source import (
+    CGM_ROLE_PRIMARY,
+    CGM_ROLE_SECONDARY,
+    DEXCOM_SOURCE,
+    get_excluded_cgm_sources,
+    nightscout_source,
+)
 
 _NOW = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
 
@@ -355,6 +375,218 @@ class TestCheckCgmFreshness:
             request = _make_request(user_id=user.id)
             result = await validator._check_cgm_freshness(request, db, _NOW)
             assert result.passed is True
+
+
+async def _add_dexcom_credential(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    role: str,
+    status: IntegrationStatus = IntegrationStatus.CONNECTED,
+) -> None:
+    db.add(
+        IntegrationCredential(
+            user_id=user_id,
+            integration_type=IntegrationType.DEXCOM,
+            encrypted_username="x",
+            encrypted_password="y",
+            status=status,
+            cgm_role=role,
+        )
+    )
+    await db.commit()
+
+
+async def _add_nightscout_connection(
+    db: AsyncSession, user_id: uuid.UUID, role: str
+) -> uuid.UUID:
+    conn = NightscoutConnection(
+        user_id=user_id,
+        name="Test NS",
+        base_url="https://ns.example.com",
+        auth_type=NightscoutAuthType.TOKEN,
+        encrypted_credential="enc",
+        api_version=NightscoutApiVersion.V1,
+        last_sync_status=NightscoutSyncStatus.NEVER,
+        cgm_role=role,
+    )
+    db.add(conn)
+    await db.commit()
+    await db.refresh(conn)
+    return conn.id
+
+
+def _make_reading(user_id: uuid.UUID, source: str, age: timedelta) -> GlucoseReading:
+    return GlucoseReading(
+        user_id=user_id,
+        value=180,
+        reading_timestamp=_NOW - age,
+        trend=TrendDirection.FLAT,
+        received_at=_NOW - age,
+        source=source,
+    )
+
+
+class TestCheckCgmFreshnessPrimarySource:
+    """GLY-125: the freshness gate must read through the GLY-123 primary
+    funnel -- a fresh SECONDARY reading must never green-light dosing while
+    the PRIMARY the user actually sees is stale.
+    """
+
+    async def test_fail_stale_primary_fresh_secondary(self):
+        """A stale primary must fail freshness even when a secondary is fresh.
+
+        This is the GLY-125 regression guard: an any-source implementation
+        would pass off the fresh secondary reading the user cannot see.
+        """
+        session_maker = get_session_maker()
+        async with session_maker() as db:
+            user = _make_user()
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+            await _add_dexcom_credential(db, user.id, CGM_ROLE_PRIMARY)
+            ns_id = await _add_nightscout_connection(db, user.id, CGM_ROLE_SECONDARY)
+
+            db.add(_make_reading(user.id, DEXCOM_SOURCE, timedelta(minutes=30)))
+            db.add(
+                _make_reading(user.id, nightscout_source(ns_id), timedelta(minutes=1))
+            )
+            await db.commit()
+
+            # Pin that the fixture actually engages the exclusion filter --
+            # without real role rows the funnel excludes nothing and this
+            # test would pass vacuously.
+            assert await get_excluded_cgm_sources(db, user.id) == [
+                nightscout_source(ns_id)
+            ]
+
+            validator = TreatmentSafetyValidator()
+            request = _make_request(user_id=user.id)
+            result = await validator._check_cgm_freshness(request, db, _NOW)
+            assert result.passed is False
+            assert "exceeds" in result.message
+
+    async def test_fail_primary_has_no_readings_fresh_secondary(self):
+        """A silent primary fails freshness even when a secondary is fresh.
+
+        The funnel excludes the secondary, so no reading survives and the
+        check fails with the no-readings message (the safe direction).
+        """
+        session_maker = get_session_maker()
+        async with session_maker() as db:
+            user = _make_user()
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+            await _add_dexcom_credential(db, user.id, CGM_ROLE_PRIMARY)
+            ns_id = await _add_nightscout_connection(db, user.id, CGM_ROLE_SECONDARY)
+
+            db.add(
+                _make_reading(user.id, nightscout_source(ns_id), timedelta(minutes=1))
+            )
+            await db.commit()
+
+            assert await get_excluded_cgm_sources(db, user.id) == [
+                nightscout_source(ns_id)
+            ]
+
+            validator = TreatmentSafetyValidator()
+            request = _make_request(user_id=user.id)
+            result = await validator._check_cgm_freshness(request, db, _NOW)
+            assert result.passed is False
+            assert "No CGM readings" in result.message
+
+    async def test_pass_no_primary_designated_fresh_survivor(self):
+        """Fail-safe: with no primary designated, nothing is excluded and
+        the fresh survivor satisfies the check.
+        """
+        session_maker = get_session_maker()
+        async with session_maker() as db:
+            user = _make_user()
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+            await _add_dexcom_credential(db, user.id, CGM_ROLE_SECONDARY)
+            ns_id = await _add_nightscout_connection(db, user.id, CGM_ROLE_SECONDARY)
+
+            db.add(_make_reading(user.id, DEXCOM_SOURCE, timedelta(minutes=30)))
+            db.add(
+                _make_reading(user.id, nightscout_source(ns_id), timedelta(minutes=1))
+            )
+            await db.commit()
+
+            assert await get_excluded_cgm_sources(db, user.id) == []
+
+            validator = TreatmentSafetyValidator()
+            request = _make_request(user_id=user.id)
+            result = await validator._check_cgm_freshness(request, db, _NOW)
+            assert result.passed is True
+
+    async def test_pass_disconnected_primary_fresh_secondary(self):
+        """Fail-safe: a non-CONNECTED Dexcom is not an active CGM source, so
+        no primary survives and the fresh secondary counts (no false block).
+        """
+        session_maker = get_session_maker()
+        async with session_maker() as db:
+            user = _make_user()
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+            await _add_dexcom_credential(
+                db, user.id, CGM_ROLE_PRIMARY, status=IntegrationStatus.DISCONNECTED
+            )
+            ns_id = await _add_nightscout_connection(db, user.id, CGM_ROLE_SECONDARY)
+
+            db.add(_make_reading(user.id, DEXCOM_SOURCE, timedelta(minutes=30)))
+            db.add(
+                _make_reading(user.id, nightscout_source(ns_id), timedelta(minutes=1))
+            )
+            await db.commit()
+
+            validator = TreatmentSafetyValidator()
+            request = _make_request(user_id=user.id)
+            result = await validator._check_cgm_freshness(request, db, _NOW)
+            assert result.passed is True
+
+    async def test_pass_single_source_primary_fresh(self):
+        """Single-source user with a designated primary: fresh still passes."""
+        session_maker = get_session_maker()
+        async with session_maker() as db:
+            user = _make_user()
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+            await _add_dexcom_credential(db, user.id, CGM_ROLE_PRIMARY)
+            db.add(_make_reading(user.id, DEXCOM_SOURCE, timedelta(minutes=5)))
+            await db.commit()
+
+            validator = TreatmentSafetyValidator()
+            request = _make_request(user_id=user.id)
+            result = await validator._check_cgm_freshness(request, db, _NOW)
+            assert result.passed is True
+
+    async def test_fail_single_source_primary_stale(self):
+        """Single-source user with a designated primary: stale still fails."""
+        session_maker = get_session_maker()
+        async with session_maker() as db:
+            user = _make_user()
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+            await _add_dexcom_credential(db, user.id, CGM_ROLE_PRIMARY)
+            db.add(_make_reading(user.id, DEXCOM_SOURCE, timedelta(minutes=30)))
+            await db.commit()
+
+            validator = TreatmentSafetyValidator()
+            request = _make_request(user_id=user.id)
+            result = await validator._check_cgm_freshness(request, db, _NOW)
+            assert result.passed is False
 
 
 class TestCheckRateLimit:


### PR DESCRIPTION
## 📋 Summary

The bolus safety validator's CGM-freshness check read the newest glucose reading across ALL sources. A multi-source user with a stale primary CGM and a fresh secondary passed the gate off a secondary reading they cannot see (the dashboard and widgets are primary-only), so the advisory dosing check was green-lit off a stale primary. This PR routes the check through the primary-source funnel, the same helper predictive alerts already use.

This is a dosing-behavior change: for multi-source users with a designated primary, a stale primary now fails the `cgm_freshness` check even when a secondary is fresh. Single-source users and users with no designated primary are unaffected (the funnel's fail-safe excludes nothing when no primary exists).

**Clinical review requested:** this changes when a bolus is flagged unsafe. The product decision (filter to primary) is made; please confirm the clinical rationale: the user only sees the primary reading, so blocking prevents dosing off a value the display says is stale and pushes toward a fingerstick or CGM refresh. `/validate-bolus` remains advisory only; it never triggers delivery.

## 🔗 Related Issues

Relates to GLY-125. Builds on the GLY-123 primary-source funnel.

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔨 Changes Made

- `_check_cgm_freshness` now reads the latest reading via `get_latest_glucose_reading` (the primary-source funnel) instead of an inline any-source query. Ordering (`reading_timestamp desc`), the 15-minute limit, the `SafetyCheckResult` shape, and the `passed=False` semantics are unchanged; no other safety check is touched.
- The import is function-local, matching the established lazy `core -> services` pattern in `src/core/auth.py`.
- New multi-source tests (`TestCheckCgmFreshnessPrimarySource`): stale-primary/fresh-secondary fails (the discriminating regression guard - it fails against the previous any-source implementation), silent-primary fails in the safe direction, no-primary and disconnected-primary survivors still pass, single-source behavior unchanged. The exclusion set is asserted directly so the fixtures cannot pass vacuously.

Known limitation (deliberate, follow-up candidate): when a designated primary has produced no readings but a secondary is fresh, the check fails with the existing "No CGM readings available" message, which does not distinguish "primary silent" from "no data at all". Safe direction, advisory-only; message enrichment was kept out of this PR to keep the dosing-path diff minimal.

## 🧪 Test Plan

- [x] Unit tests pass (`pytest`; new tests verified to fail against the pre-change implementation)
- [x] New tests added for new functionality
- [x] Manual/visual testing performed (live `/validate-bolus` against the local stack: stale-primary/fresh-secondary rejected on `cgm_freshness`; no-primary fail-safe passes; golden path approves; silent-primary blocks)
- [x] Docker integration tested (if applicable)

## ✅ Checklist

- [x] Self-review completed
- [x] Code follows project style guidelines
- [x] No hardcoded secrets, API keys, or credentials
- [x] Changes generate no new warnings
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CGM freshness checking so it can fall back to an alternate source when the primary source is unavailable or missing data.
  * Ensured freshness decisions still use the most recent available reading and handle stale or disconnected sources more reliably.
  * Added clearer behavior when no primary source is configured, helping prevent unnecessary safety check failures.

* **Tests**
  * Expanded coverage for CGM freshness scenarios, including primary/secondary source combinations and stale, missing, or disconnected readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->