### PR TITLE
fix: classify CareLink import errors as transport vs unexpected (#810)

### DIFF
--- a/apps/api/src/routers/integrations.py
+++ b/apps/api/src/routers/integrations.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
+import sentry_sdk
 from fastapi import (
     APIRouter,
     Cookie,
@@ -209,6 +210,7 @@ from src.services.integrations.medtronic.client import (
     CareLinkClient,
     CareLinkError,
     CareLinkReportTimeoutError,
+    CareLinkTransportError,
 )
 from src.services.integrations.medtronic.connect_auth import (
     ConnectTokenError,
@@ -1917,10 +1919,27 @@ async def get_medtronic_availability(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="CareLink session is invalid or expired. Reconnect and try again.",
         ) from e
-    except CareLinkError as e:
+    except CareLinkTransportError as e:
+        logger.warning(
+            "CareLink availability failed - transport error",
+            user_id=str(current_user.id),
+            error=str(e),
+        )
+        sentry_sdk.capture_exception(e)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to reach CareLink. Please try again later.",
+        ) from e
+    except CareLinkError as e:
+        logger.warning(
+            "CareLink availability failed - unexpected response",
+            user_id=str(current_user.id),
+            error=str(e),
+        )
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="CareLink returned an unexpected response. Please try again later.",
         ) from e
     finally:
         await client.aclose()
@@ -1977,10 +1996,27 @@ async def import_medtronic_range(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
             detail="CareLink took too long to generate the report. Try a smaller range.",
         ) from e
-    except CareLinkError as e:
+    except CareLinkTransportError as e:
+        logger.warning(
+            "CareLink import failed - transport error",
+            user_id=str(current_user.id),
+            error=str(e),
+        )
+        sentry_sdk.capture_exception(e)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to reach CareLink. Please try again later.",
+        ) from e
+    except CareLinkError as e:
+        logger.warning(
+            "CareLink import failed - unexpected response",
+            user_id=str(current_user.id),
+            error=str(e),
+        )
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="CareLink returned an unexpected response. Please try again later.",
         ) from e
     finally:
         await client.aclose()

--- a/apps/api/src/services/integrations/medtronic/client.py
+++ b/apps/api/src/services/integrations/medtronic/client.py
@@ -75,6 +75,13 @@ class CareLinkAuthError(CareLinkError):
     """401/403 from CareLink -- the session/bearer is invalid or expired."""
 
 
+class CareLinkTransportError(CareLinkError):
+    """A network/transport-level failure reaching CareLink (DNS, TLS, connection
+    timeout, etc.). Distinguished from ``CareLinkError`` so callers can tell a
+    true connectivity failure from a reachable-host that returned a bad
+    response (4xx/5xx, unexpected body shape, etc.)."""
+
+
 class CareLinkReportTimeoutError(CareLinkError):
     """The CSV-export job did not become ready within the poll budget."""
 
@@ -175,7 +182,7 @@ class CareLinkClient:
                     **kwargs,
                 )
             except httpx.HTTPError as e:
-                raise CareLinkError(
+                raise CareLinkTransportError(
                     f"CareLink network error on {method} {path}: {e}"
                 ) from e
 

--- a/apps/api/tests/test_medtronic_endpoints.py
+++ b/apps/api/tests/test_medtronic_endpoints.py
@@ -20,6 +20,7 @@ from src.services.integrations.medtronic.client import (
     CareLinkAvailability,
     CareLinkError,
     CareLinkReportTimeoutError,
+    CareLinkTransportError,
 )
 from src.services.integrations.medtronic.sync import CareLinkSyncResult
 
@@ -143,7 +144,11 @@ async def test_availability_expired_token_401(mock_build):
 
 @patch("src.routers.integrations._build_carelink_client")
 async def test_availability_service_error_503(mock_build):
-    mock_build.return_value = _FakeClient(raise_exc=CareLinkError("boom"))
+    """A reachable-host failure (4xx/5xx, bad response shape) surfaces the
+    'unexpected response' message, not the generic 'unable to reach' message."""
+    mock_build.return_value = _FakeClient(
+        raise_exc=CareLinkError("CareLink request to /patient/users/me failed: 404")
+    )
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -152,6 +157,27 @@ async def test_availability_service_error_503(mock_build):
             AVAIL_PATH, json={"region": "US"}, headers=_HDR, cookies=cookies
         )
     assert resp.status_code == 503, resp.text
+    assert "unexpected response" in resp.json()["detail"].lower()
+
+
+@patch("src.routers.integrations._build_carelink_client")
+async def test_availability_transport_error_503(mock_build):
+    """A true transport failure (DNS, TLS, connection timeout) keeps the
+    'unable to reach CareLink' connectivity message."""
+    mock_build.return_value = _FakeClient(
+        raise_exc=CareLinkTransportError(
+            "CareLink network error on GET /patient/users/me: timed out"
+        )
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            AVAIL_PATH, json={"region": "US"}, headers=_HDR, cookies=cookies
+        )
+    assert resp.status_code == 503, resp.text
+    assert "unable to reach carelink" in resp.json()["detail"].lower()
 
 
 async def test_availability_bad_region_422():
@@ -264,6 +290,44 @@ async def test_import_timeout_504(mock_build, mock_sync):
             IMPORT_PATH, json=_import_body(), headers=_HDR, cookies=cookies
         )
     assert resp.status_code == 504, resp.text
+
+
+@patch("src.routers.integrations.sync_carelink_for_user", new_callable=AsyncMock)
+@patch("src.routers.integrations._build_carelink_client")
+async def test_import_transport_error_503(mock_build, mock_sync):
+    """A true transport failure during import keeps the 'unable to reach
+    CareLink' connectivity message."""
+    mock_build.return_value = _FakeClient()
+    mock_sync.side_effect = CareLinkTransportError(
+        "CareLink network error on GET /patient/reports/reportCsv: timed out"
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            IMPORT_PATH, json=_import_body(), headers=_HDR, cookies=cookies
+        )
+    assert resp.status_code == 503, resp.text
+    assert "unable to reach carelink" in resp.json()["detail"].lower()
+
+
+@patch("src.routers.integrations.sync_carelink_for_user", new_callable=AsyncMock)
+@patch("src.routers.integrations._build_carelink_client")
+async def test_import_unexpected_response_503(mock_build, mock_sync):
+    """A reachable-host failure during import (4xx/5xx, bad CSV shape) surfaces
+    the 'unexpected response' message, not the connectivity message."""
+    mock_build.return_value = _FakeClient()
+    mock_sync.side_effect = CareLinkError("generateReport did not return a report uuid")
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookies = await _login(client)
+        resp = await client.post(
+            IMPORT_PATH, json=_import_body(), headers=_HDR, cookies=cookies
+        )
+    assert resp.status_code == 503, resp.text
+    assert "unexpected response" in resp.json()["detail"].lower()
 
 
 async def test_token_not_leaked_in_validation_error():


### PR DESCRIPTION
## Summary
- Add `CareLinkTransportError(CareLinkError)` exception class.
- Change `httpx.HTTPError` catch in `_request()` to raise `CareLinkTransportError`.
- Distinguishes network/transport failures from unexpected HTTP responses.

Closes #810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Medtronic CareLink error handling with clearer messages for connectivity issues versus unexpected responses.
  * Service outages during availability checks and imports now return more specific 503 responses, making failures easier to understand.
  * Related errors are now reported for monitoring when CareLink requests fail unexpectedly.

* **Tests**
  * Expanded coverage for Medtronic availability and import failure cases, including transport-related and unexpected-response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->