### PR TITLE
feat(api): wire AI dosing-safety floor into all chat surfaces (GLY-69)

### DIFF
--- a/apps/api/benchmarks/harness_versions.json
+++ b/apps/api/benchmarks/harness_versions.json
@@ -1,9 +1,9 @@
 {
-  "adversarial": "sha256:bbfe1abd74a725c90fc565c4b76531c3ef02819c8b7541cdb342c41dc21617b9",
-  "chat": "sha256:a02ced396fe124f9a82f6e95c3ba014c61ac72ddb3dda41f3ed94b0791058dd6",
-  "chat_rag": "sha256:99034244f539f1f31fc80a32babbf66a978a1e5abaa686ded66ea482c60066c3",
-  "correction": "sha256:d52ef0fd54e8b2af326f89bd9ba8030b35bf11ff13cd8fe855d185e01e4b1df1",
-  "daily_brief": "sha256:0ca43dfae71933eadc9658491a8ada7feda2c3a043ef287e9ef265807ccd69cc",
-  "meal_analysis": "sha256:25ab7b53b75c62ba8dda21fda7a71b684c7905ef89edf98d1e171edd9b10567c",
+  "adversarial": "sha256:57b2e5f1686605cb18e01363d72a5aea6e656f28c2cd4d41fde7056134f021f3",
+  "chat": "sha256:4dc4485ffba32ea2d6e9f9e18520c5b51bdcdc1a9dbe64c6a40a5861b5baa7c2",
+  "chat_rag": "sha256:1649baf3e6bebefe9903814e561fc563606374e0a099d42f82bddf6ccf3a1787",
+  "correction": "sha256:1feeed47482d522802d5de2636f69296b4993d50e6b3d5107952a300869e20f4",
+  "daily_brief": "sha256:e428266e5ec251d03e0a78df92e8af978c7172cd323e694e716d11c8a1eae723",
+  "meal_analysis": "sha256:b32aa5222a02817d330e7c7d4c557f73ec3b6040f1091bd08770d65b736c42e7",
   "vision_carb": "sha256:2bae1593054d69a64fadd41b4d1bbdd2dc0e39c6f4be0fc93e4e0b21ebcb8e38"
 }

--- a/apps/api/src/services/safety_validation.py
+++ b/apps/api/src/services/safety_validation.py
@@ -6,7 +6,9 @@ ratio/factor changes stay within ±20% limits.
 """
 
 import re
+import uuid
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,6 +34,36 @@ SAFETY_DISCLAIMER = (
     "**Safety Notice:** These are AI-generated observations, not medical advice. "
     "Always discuss changes with your endocrinologist before adjusting pump settings."
 )
+
+# Replacement text for a REJECTED suggestion. Rendered with Markdown emphasis
+# on the analysis/web surfaces and as plain text on the Telegram surfaces
+# (Telegram chat uses HTML parse mode, so literal ``**`` would reach the user).
+_BLOCKED_MESSAGE = (
+    "This suggestion has been blocked by the safety system due to "
+    "potentially dangerous content. Please consult your healthcare "
+    "provider directly for guidance."
+)
+
+
+def _render_blocked_message(*, markdown: bool = True) -> str:
+    """Render the REJECTED replacement message for a given output format."""
+    if markdown:
+        return f"**{_BLOCKED_MESSAGE}**"
+    return f"\u26a0\ufe0f {_BLOCKED_MESSAGE}"
+
+
+def _render_warning_block(
+    flagged_items: Sequence["FlaggedSuggestion"], *, markdown: bool = True
+) -> str:
+    """Render the FLAGGED warning block appended after the AI text."""
+    header = "**Safety Warning:**" if markdown else "\u26a0\ufe0f Safety Warning:"
+    reasons = "\n".join(f"- {item.reason}" for item in flagged_items)
+    return (
+        f"\n\n{header} The following AI statements were flagged "
+        f"by the safety system:\n{reasons}\n"
+        "Discuss these with your endocrinologist before making changes."
+    )
+
 
 # Dangerous keywords/phrases that indicate categorically unsafe content.
 # Specific-insulin-dose instructions are detected separately by
@@ -545,12 +577,21 @@ def _extract_carb_ratio_changes(text: str) -> list[FlaggedSuggestion]:
         List of flagged suggestions that exceed bounds.
     """
     flagged = []
+    seen: set[tuple[float, float]] = set()
     for match in CARB_RATIO_PATTERN.finditer(text):
         original = float(match.group(1))
         suggested = float(match.group(2))
 
         if original == 0:
             continue
+
+        # Deduplicate repeated mentions of the same change -- the warning block
+        # renders one line per flagged item and is appended untruncated on the
+        # Telegram surfaces, so repetition must not bloat it.
+        key = (original, suggested)
+        if key in seen:
+            continue
+        seen.add(key)
 
         # For carb ratios (1:X), a smaller X = stronger ratio = more insulin
         change_pct = abs((suggested - original) / original) * 100
@@ -635,6 +676,7 @@ def validate_ai_suggestion(
     suggestion_type: str,
     records: Sequence[int] | None = None,
     unit: GlucoseUnit = GlucoseUnit.MGDL,
+    provenance: object | None = None,
 ) -> ValidationResult:
     """Validate an AI-generated suggestion against safety bounds.
 
@@ -653,6 +695,9 @@ def validate_ai_suggestion(
             the display-rounding band) is flagged. Omitted by callers that quote
             no glucose data.
         unit: The user's configured display unit (for the flag reason rendering).
+        provenance: Reserved for provenance-aware span exemptions (GLY-138).
+            Accepted and currently unused so ``apply_ai_safety_floor`` can
+            already thread it through the single chat call site.
 
     Returns:
         ValidationResult with status and any flagged items.
@@ -690,21 +735,9 @@ def validate_ai_suggestion(
     # Build sanitized text
     sanitized = ai_text
     if has_dangerous:
-        sanitized = (
-            "**This suggestion has been blocked by the safety system due to "
-            "potentially dangerous content. Please consult your healthcare "
-            "provider directly for guidance.**"
-        )
+        sanitized = _render_blocked_message()
     elif flagged_items:
-        warnings = []
-        for item in flagged_items:
-            warnings.append(f"- {item.reason}")
-        warning_block = (
-            "\n\n**Safety Warning:** The following AI statements were flagged "
-            "by the safety system:\n" + "\n".join(warnings) + "\n"
-            "Discuss these with your endocrinologist before making changes."
-        )
-        sanitized = ai_text + warning_block
+        sanitized = ai_text + _render_warning_block(flagged_items)
 
     # Always append safety disclaimer
     sanitized += SAFETY_DISCLAIMER
@@ -759,6 +792,115 @@ async def log_safety_validation(
     )
 
     return log_entry
+
+
+@dataclass
+class SafetyFloorResult:
+    """Outcome of applying the AI dosing-safety floor to a chat response.
+
+    ``body`` and ``safety_block`` are exposed separately so the Telegram
+    surfaces can length-truncate the model body while keeping the safety
+    block intact -- truncating the combined text would silently chop the
+    FLAGGED warning off a long response, leaving the raw suggestion visible.
+    """
+
+    status: SafetyStatus
+    body: str
+    safety_block: str = ""
+
+    @property
+    def text(self) -> str:
+        """The full sanitized text (body plus any safety block)."""
+        return self.body + self.safety_block
+
+
+async def apply_ai_safety_floor(
+    db: AsyncSession,
+    user_id: "str | object",
+    content: str,
+    surface: str,
+    *,
+    records: Sequence[int] | None = None,
+    unit: GlucoseUnit = GlucoseUnit.MGDL,
+    analysis_id: "str | object | None" = None,
+    provenance: object | None = None,
+    markdown: bool = True,
+) -> SafetyFloorResult:
+    """Apply the dosing-safety floor to an AI chat response (GLY-69).
+
+    The single choke point all four chat handlers funnel through: runs
+    ``validate_ai_suggestion``, commits the ``SafetyLog`` audit row
+    best-effort, and returns the sanitized text. This is also the one call
+    site GLY-138 threads provenance through.
+
+    Unlike the analysis surfaces, the returned text carries NO standing
+    ``SAFETY_DISCLAIMER`` -- every chat surface appends (or renders) its own
+    local disclaimer, and doubling it wastes the Telegram truncation budget.
+    The REJECTED block and FLAGGED warning always apply.
+
+    The helper commits the audit row itself: the two caregiver chat
+    surfaces never commit their session, so relying on the caller would
+    silently drop the row on session close. Note the commit (and the
+    rollback on failure) applies to the WHOLE session, not just the
+    ``SafetyLog`` -- call sites must have no unrelated pending writes when
+    the floor runs (all four handlers only read before this point). A
+    commit/log failure never drops the response.
+
+    Args:
+        db: Database session (the audit row is committed on it).
+        user_id: The data owner's UUID -- for caregiver chat this is the
+            PATIENT (whose AI provider and data produced the response),
+            matching the citation verifiers.
+        content: The citation-verified AI response text.
+        surface: Audit tag ("chat", "chat_web", "caregiver", "caregiver_web").
+        records: Optional canonical mg/dL readings for the advisory
+            glucose-trace flag (not wired in v1).
+        unit: The data owner's display unit (flag reason rendering).
+        analysis_id: Audit correlation id; a UUID is generated when omitted
+            (chat validates before the message row exists).
+        provenance: Reserved for GLY-138; forwarded into the validator.
+        markdown: When False, the blocked message / warning block render as
+            plain text for Telegram's HTML parse mode instead of Markdown.
+
+    Returns:
+        SafetyFloorResult with the sanitized ``body``/``safety_block``.
+    """
+    result = validate_ai_suggestion(
+        content, surface, records, unit, provenance=provenance
+    )
+
+    try:
+        await log_safety_validation(
+            user_id, surface, analysis_id or uuid.uuid4(), result, db
+        )
+        await db.commit()
+    except Exception:
+        try:
+            await db.rollback()
+        except Exception:
+            logger.warning(
+                "Rollback failed after safety audit commit failure", exc_info=True
+            )
+        logger.warning(
+            "Failed to commit safety audit log for chat response",
+            user_id=str(user_id),
+            surface=surface,
+            status=result.status.value,
+            exc_info=True,
+        )
+
+    if result.status is SafetyStatus.REJECTED:
+        return SafetyFloorResult(
+            status=result.status,
+            body=_render_blocked_message(markdown=markdown),
+        )
+    if result.status is SafetyStatus.FLAGGED:
+        return SafetyFloorResult(
+            status=result.status,
+            body=content,
+            safety_block=_render_warning_block(result.flagged_items, markdown=markdown),
+        )
+    return SafetyFloorResult(status=result.status, body=content)
 
 
 async def list_safety_logs(

--- a/apps/api/src/services/telegram_chat.py
+++ b/apps/api/src/services/telegram_chat.py
@@ -16,6 +16,7 @@ the last N turns are included as context in every AI request.
 """
 
 import html
+import re
 import uuid
 from dataclasses import dataclass
 
@@ -43,6 +44,7 @@ from src.services.diabetes_context import (
     verify_glucose_reading_citations,
     verify_meal_citations,
 )
+from src.services.safety_validation import apply_ai_safety_floor
 
 logger = get_logger(__name__)
 
@@ -148,22 +150,35 @@ def _build_system_prompt(
     return _compose_system_prompt(_SYSTEM_PROMPT_PREFIX, diabetes_context, unit)
 
 
-def _truncate_response(text: str) -> str:
+# A truncation cut can land inside an ``html.escape`` entity (e.g. "&am" of
+# "&amp;"); Telegram's HTML parse mode rejects the whole message over it.
+# Matches an unterminated trailing entity -- a complete one ends in ";".
+_PARTIAL_ENTITY_RE = re.compile(r"&[#a-zA-Z0-9]{0,6}$")
+
+
+def _truncate_response(text: str, safety_block: str = "") -> str:
     """Truncate text to fit within Telegram's message length limit.
 
-    Reserves space for the safety disclaimer. If the response
-    exceeds the limit, it is truncated with an ellipsis.
+    Reserves space for the safety block and disclaimer. If the response
+    exceeds the limit, only the model body is truncated with an ellipsis --
+    the safety block and disclaimer are always appended intact, so a long
+    FLAGGED response can never lose its safety warning to truncation.
 
     Args:
-        text: The full response text (before disclaimer).
+        text: The escaped model body text (before safety block and disclaimer).
+        safety_block: Optional safety-floor warning to append untruncated.
 
     Returns:
-        Text truncated to fit within TELEGRAM_MAX_LENGTH with disclaimer.
+        Text truncated to fit within TELEGRAM_MAX_LENGTH with the safety
+        block and disclaimer appended.
     """
-    max_content_length = TELEGRAM_MAX_LENGTH - len(SAFETY_DISCLAIMER)
+    max_content_length = max(
+        TELEGRAM_MAX_LENGTH - len(safety_block) - len(SAFETY_DISCLAIMER), 0
+    )
     if len(text) <= max_content_length:
-        return text + SAFETY_DISCLAIMER
-    return text[: max_content_length - 3] + "..." + SAFETY_DISCLAIMER
+        return text + safety_block + SAFETY_DISCLAIMER
+    cut = _PARTIAL_ENTITY_RE.sub("", text[: max(max_content_length - 3, 0)])
+    return cut + "..." + safety_block + SAFETY_DISCLAIMER
 
 
 async def handle_chat(
@@ -276,6 +291,14 @@ async def handle_chat(
         db, user_id, content, surface="chat"
     )
 
+    # Dosing-safety floor (GLY-69): block/flag prescriptive dosing advice
+    # before the response is persisted or delivered. Plain-text rendering --
+    # this surface delivers via Telegram HTML parse mode, not Markdown.
+    floor = await apply_ai_safety_floor(
+        db, user_id, content, "chat", unit=unit, markdown=False
+    )
+    content = floor.text
+
     # Persist both messages (non-fatal -- still return the AI response on failure)
     try:
         await store_message(db, user_id, conversation_id, ChatRole.USER, truncated_text)
@@ -298,8 +321,11 @@ async def handle_chat(
             exc_info=True,
         )
 
-    # Escape any HTML in the AI response to prevent injection
-    safe_content = html.escape(content)
+    # Escape any HTML in the AI response to prevent injection. The body and
+    # the safety block are escaped separately because only the body may be
+    # truncated -- the safety block must survive truncation intact.
+    safe_content = html.escape(floor.body)
+    safe_block = html.escape(floor.safety_block)
 
     logger.info(
         "Telegram AI chat response generated",
@@ -312,7 +338,7 @@ async def handle_chat(
         history_turns=len(history) // 2,
     )
 
-    return _truncate_response(safe_content)
+    return _truncate_response(safe_content, safe_block)
 
 
 # ── Story 11.2: Web-optimized user AI chat ──
@@ -433,6 +459,12 @@ async def handle_chat_web(
     content = await verify_glucose_reading_citations(
         db, user_id, content, surface="chat_web"
     )
+
+    # Dosing-safety floor (GLY-69): block/flag prescriptive dosing advice
+    # before the response is persisted or returned. The web UI renders
+    # Markdown, so the floor's default rendering applies.
+    floor = await apply_ai_safety_floor(db, user_id, content, "chat_web", unit=unit)
+    content = floor.text
 
     # Persist both messages (non-fatal -- still return the AI response on failure)
     user_msg_id: uuid.UUID | None = None
@@ -647,7 +679,16 @@ async def handle_caregiver_chat(
         db, patient_id, content, surface="caregiver"
     )
 
-    safe_content = html.escape(content)
+    # Dosing-safety floor (GLY-69), keyed on the patient like the citation
+    # verifiers. The helper commits its own audit row -- this handler's
+    # session is never committed by its callers. Plain-text rendering for
+    # Telegram HTML parse mode; the safety block survives truncation intact.
+    floor = await apply_ai_safety_floor(
+        db, patient_id, content, "caregiver", unit=unit, markdown=False
+    )
+
+    safe_content = html.escape(floor.body)
+    safe_block = html.escape(floor.safety_block)
 
     logger.info(
         "Caregiver Telegram AI chat response generated",
@@ -659,7 +700,7 @@ async def handle_caregiver_chat(
         output_tokens=ai_response.usage.output_tokens,
     )
 
-    return _truncate_response(safe_content)
+    return _truncate_response(safe_content, safe_block)
 
 
 # ── Story 8.4: Web-optimized caregiver AI chat ──
@@ -762,6 +803,14 @@ async def handle_caregiver_chat_web(
     content = await verify_glucose_reading_citations(
         db, patient_id, content, surface="caregiver_web"
     )
+
+    # Dosing-safety floor (GLY-69), keyed on the patient like the citation
+    # verifiers. The helper commits its own audit row -- the caregiver web
+    # router never commits this session.
+    floor = await apply_ai_safety_floor(
+        db, patient_id, content, "caregiver_web", unit=unit
+    )
+    content = floor.text
 
     logger.info(
         "Web caregiver AI chat response generated",

--- a/apps/api/tests/test_ai_safety_floor.py
+++ b/apps/api/tests/test_ai_safety_floor.py
@@ -1,0 +1,522 @@
+"""GLY-69: Tests for the AI dosing-safety floor on the chat path.
+
+The floor (``apply_ai_safety_floor``) wires ``validate_ai_suggestion`` into
+all four chat handlers. These tests assert on the RETURNED text (not on a
+patched validator), so they discriminate: every REJECTED/FLAGGED case fails
+on the pre-GLY-69 code, which returned the raw dosing text.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import delete, select
+
+from src.core.units import GlucoseUnit
+from src.models.ai_provider import AIProviderType
+from src.models.safety_log import SafetyLog
+from src.models.user import User
+from src.schemas.ai_response import AIResponse, AIUsage
+from src.schemas.safety_validation import SafetyStatus
+from src.services.safety_validation import apply_ai_safety_floor
+from src.services.telegram_chat import (
+    SAFETY_DISCLAIMER,
+    TELEGRAM_MAX_LENGTH,
+    _truncate_response,
+    handle_caregiver_chat,
+    handle_caregiver_chat_web,
+    handle_chat,
+    handle_chat_web,
+)
+
+# Matches the prescriptive-dose patterns -> REJECTED (whole message replaced).
+DANGEROUS_TEXT = "increase your ISF to 45 and take 6 units now"
+BLOCKED_SNIPPET = "blocked by the safety system"
+
+# A 30% carb-ratio change -> FLAGGED (warning appended, body kept). A bare
+# "increase your ISF to 45" is APPROVED -- the ISF flag needs a from->to pair.
+FLAGGED_TEXT = "You could change your carb ratio from 1:10 to 1:7 for breakfast."
+WARNING_SNIPPET = "Safety Warning"
+
+BENIGN_TEXT = "Your glucose has been steady in range today. Keep it up."
+
+
+def _make_ai_response(content: str) -> AIResponse:
+    return AIResponse(
+        content=content,
+        model="claude-sonnet-4-5-20250929",
+        provider=AIProviderType.CLAUDE,
+        usage=AIUsage(input_tokens=100, output_tokens=50),
+    )
+
+
+def _make_user() -> MagicMock:
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.email = "floor-test@integration.test"
+    user.glucose_unit = GlucoseUnit.MGDL
+    return user
+
+
+def _make_bare_db() -> AsyncMock:
+    """A session mock whose sync ``add`` doesn't emit un-awaited coroutines."""
+    db = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+def _make_db(user: MagicMock) -> AsyncMock:
+    db = _make_bare_db()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = user
+    db.execute.return_value = mock_result
+    return db
+
+
+async def _passthrough_citations(db, user_id, content, **kwargs) -> str:
+    return content
+
+
+@pytest.fixture
+def _isolate_handler_dependencies():
+    """Neutralize context/citation/history dependencies for handler tests.
+
+    The citation verifiers are patched to pass-through so the floor's input is
+    exactly the mocked AI text (the glucose verifier could otherwise rewrite
+    the very figures these tests assert on).
+    """
+    with (
+        patch(
+            "src.services.telegram_chat.build_diabetes_context",
+            new=AsyncMock(return_value=""),
+        ),
+        patch(
+            "src.services.telegram_chat.verify_meal_citations",
+            new=_passthrough_citations,
+        ),
+        patch(
+            "src.services.telegram_chat.verify_glucose_reading_citations",
+            new=_passthrough_citations,
+        ),
+        patch(
+            "src.services.telegram_chat.get_or_create_conversation",
+            new=AsyncMock(return_value=uuid.uuid4()),
+        ),
+        patch(
+            "src.services.telegram_chat.get_recent_messages",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        yield
+
+
+def _patch_ai(content: str):
+    """Patch get_ai_client to return a client emitting *content*."""
+    mock_client = AsyncMock()
+    mock_client.generate.return_value = _make_ai_response(content)
+    return patch(
+        "src.services.telegram_chat.get_ai_client",
+        new=AsyncMock(return_value=mock_client),
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply_ai_safety_floor unit tests
+# ---------------------------------------------------------------------------
+class TestApplyAiSafetyFloor:
+    """Unit tests for the shared floor helper."""
+
+    @pytest.mark.asyncio
+    async def test_rejected_replaces_whole_text(self):
+        result = await apply_ai_safety_floor(
+            _make_bare_db(), uuid.uuid4(), DANGEROUS_TEXT, "chat"
+        )
+
+        assert result.status is SafetyStatus.REJECTED
+        assert BLOCKED_SNIPPET in result.text
+        assert "6 units" not in result.text
+        assert "ISF to 45" not in result.text
+        assert result.safety_block == ""
+
+    @pytest.mark.asyncio
+    async def test_flagged_keeps_body_and_appends_warning(self):
+        result = await apply_ai_safety_floor(
+            _make_bare_db(), uuid.uuid4(), FLAGGED_TEXT, "chat_web"
+        )
+
+        assert result.status is SafetyStatus.FLAGGED
+        assert result.body == FLAGGED_TEXT
+        assert WARNING_SNIPPET in result.safety_block
+        assert "exceeds maximum allowed change" in result.safety_block
+        assert result.text.startswith(FLAGGED_TEXT)
+
+    @pytest.mark.asyncio
+    async def test_approved_returns_content_without_standing_disclaimer(self):
+        """Chat surfaces carry their own disclaimer (D5): the floor must not
+        add the analysis-surface SAFETY_DISCLAIMER on top."""
+        result = await apply_ai_safety_floor(
+            _make_bare_db(), uuid.uuid4(), BENIGN_TEXT, "chat"
+        )
+
+        assert result.status is SafetyStatus.APPROVED
+        assert result.text == BENIGN_TEXT
+        assert "Safety Notice" not in result.text
+
+    @pytest.mark.asyncio
+    async def test_plain_rendering_contains_no_markdown(self):
+        rejected = await apply_ai_safety_floor(
+            _make_bare_db(), uuid.uuid4(), DANGEROUS_TEXT, "chat", markdown=False
+        )
+        flagged = await apply_ai_safety_floor(
+            _make_bare_db(), uuid.uuid4(), FLAGGED_TEXT, "chat", markdown=False
+        )
+
+        assert BLOCKED_SNIPPET in rejected.text
+        assert "**" not in rejected.text
+        assert WARNING_SNIPPET in flagged.safety_block
+        assert "**" not in flagged.text
+
+    @pytest.mark.asyncio
+    async def test_repeated_flagged_change_renders_one_warning_line(self):
+        """A model repeating the same over-limit change must not bloat the
+        warning block -- it is appended untruncated on the Telegram surfaces,
+        so unbounded repetition would push the message past the length cap."""
+        result = await apply_ai_safety_floor(
+            _make_bare_db(), uuid.uuid4(), FLAGGED_TEXT * 5, "chat"
+        )
+
+        assert result.status is SafetyStatus.FLAGGED
+        assert result.safety_block.count("exceeds maximum allowed change") == 1
+
+    @pytest.mark.asyncio
+    async def test_audit_row_added_and_committed(self):
+        db = _make_bare_db()
+
+        await apply_ai_safety_floor(db, uuid.uuid4(), DANGEROUS_TEXT, "chat")
+
+        added = [call.args[0] for call in db.add.call_args_list]
+        logs = [obj for obj in added if isinstance(obj, SafetyLog)]
+        assert len(logs) == 1
+        assert logs[0].status == SafetyStatus.REJECTED.value
+        assert logs[0].analysis_type == "chat"
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_commit_failure_never_drops_the_response(self):
+        db = _make_bare_db()
+        db.commit.side_effect = RuntimeError("db down")
+
+        result = await apply_ai_safety_floor(db, uuid.uuid4(), DANGEROUS_TEXT, "chat")
+
+        assert BLOCKED_SNIPPET in result.text
+        db.rollback.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_audit_row_actually_written(self, db_session):
+        """The helper's own commit persists the SafetyLog even on sessions the
+        caller never commits (the caregiver surfaces, AC4)."""
+        user = User(
+            email=f"gly69-{uuid.uuid4().hex}@integration.test",
+            hashed_password="x" * 60,  # noqa: S106 -- not a real hash, test-only
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        try:
+            await apply_ai_safety_floor(
+                db_session, user.id, DANGEROUS_TEXT, "caregiver"
+            )
+
+            rows = (
+                (
+                    await db_session.execute(
+                        select(SafetyLog).where(SafetyLog.user_id == user.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].analysis_type == "caregiver"
+            assert rows[0].status == SafetyStatus.REJECTED.value
+            assert rows[0].has_dangerous_content is True
+        finally:
+            await db_session.execute(
+                delete(SafetyLog).where(SafetyLog.user_id == user.id)
+            )
+            await db_session.execute(delete(User).where(User.id == user.id))
+            await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Handler wiring -- REJECTED backstop on every chat surface
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("_isolate_handler_dependencies")
+class TestRejectedOnAllSurfaces:
+    """A prescriptive dosing response is blocked on all 4 handlers.
+
+    Each case fails on pre-GLY-69 code (raw dosing text was returned).
+    """
+
+    @pytest.mark.asyncio
+    async def test_handle_chat_blocks_dosing_text(self):
+        user = _make_user()
+        with (
+            _patch_ai(DANGEROUS_TEXT),
+            patch("src.services.telegram_chat.store_message", new=AsyncMock()),
+        ):
+            msg = await handle_chat(_make_db(user), user.id, "How much insulin?")
+
+        assert BLOCKED_SNIPPET in msg
+        assert "6 units" not in msg
+        assert "ISF to 45" not in msg
+
+    @pytest.mark.asyncio
+    async def test_handle_chat_web_blocks_dosing_text(self):
+        user = _make_user()
+        with (
+            _patch_ai(DANGEROUS_TEXT),
+            patch("src.services.telegram_chat.store_message", new=AsyncMock()),
+        ):
+            result = await handle_chat_web(_make_db(user), user.id, "How much?")
+
+        assert BLOCKED_SNIPPET in result.content
+        assert "6 units" not in result.content
+        assert "ISF to 45" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_handle_caregiver_chat_blocks_dosing_text(self):
+        patient = _make_user()
+        with _patch_ai(DANGEROUS_TEXT):
+            msg = await handle_caregiver_chat(
+                _make_db(patient), uuid.uuid4(), patient.id, "How much?"
+            )
+
+        assert BLOCKED_SNIPPET in msg
+        assert "6 units" not in msg
+        assert "ISF to 45" not in msg
+
+    @pytest.mark.asyncio
+    async def test_handle_caregiver_chat_web_blocks_dosing_text(self):
+        patient = _make_user()
+        with _patch_ai(DANGEROUS_TEXT):
+            msg = await handle_caregiver_chat_web(
+                _make_db(patient), uuid.uuid4(), patient.id, "How much?"
+            )
+
+        assert BLOCKED_SNIPPET in msg
+        assert "6 units" not in msg
+        assert "ISF to 45" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Handler wiring -- FLAGGED warning delivery
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("_isolate_handler_dependencies")
+class TestFlaggedWarningDelivery:
+    """A >20% ratio change gets a visible warning on both render paths."""
+
+    @pytest.mark.asyncio
+    async def test_telegram_flagged_warning_present_and_plain(self):
+        user = _make_user()
+        with (
+            _patch_ai(FLAGGED_TEXT),
+            patch("src.services.telegram_chat.store_message", new=AsyncMock()),
+        ):
+            msg = await handle_chat(_make_db(user), user.id, "Should I change it?")
+
+        assert WARNING_SNIPPET in msg
+        assert "exceeds maximum allowed change" in msg
+        assert "carb ratio" in msg
+        assert "**" not in msg  # Telegram is HTML parse mode, never Markdown
+
+    @pytest.mark.asyncio
+    async def test_web_flagged_warning_present(self):
+        user = _make_user()
+        with (
+            _patch_ai(FLAGGED_TEXT),
+            patch("src.services.telegram_chat.store_message", new=AsyncMock()),
+        ):
+            result = await handle_chat_web(_make_db(user), user.id, "Change it?")
+
+        assert result.content.startswith(FLAGGED_TEXT)
+        assert WARNING_SNIPPET in result.content
+
+    @pytest.mark.asyncio
+    async def test_telegram_warning_survives_truncation(self):
+        """A near-ceiling FLAGGED response keeps its warning: the model body
+        is truncated, never the safety block (D2). Fails if the floored text
+        is fed whole to the truncator."""
+        long_flagged = ("lorem ipsum dolor sit amet " * 200) + FLAGGED_TEXT
+        assert len(long_flagged) > TELEGRAM_MAX_LENGTH
+
+        user = _make_user()
+        with (
+            _patch_ai(long_flagged),
+            patch("src.services.telegram_chat.store_message", new=AsyncMock()),
+        ):
+            msg = await handle_chat(_make_db(user), user.id, "Tell me everything")
+
+        assert len(msg) <= TELEGRAM_MAX_LENGTH
+        assert "..." in msg
+        assert WARNING_SNIPPET in msg
+        assert "exceeds maximum allowed change" in msg
+        assert msg.endswith(SAFETY_DISCLAIMER)
+
+    @pytest.mark.asyncio
+    async def test_telegram_exactly_one_disclaimer(self):
+        """One standing disclaimer per message -- the floor's analysis-surface
+        disclaimer is suppressed on chat (D5)."""
+        user = _make_user()
+        for content in (BENIGN_TEXT, FLAGGED_TEXT, DANGEROUS_TEXT):
+            with (
+                _patch_ai(content),
+                patch("src.services.telegram_chat.store_message", new=AsyncMock()),
+            ):
+                msg = await handle_chat(_make_db(user), user.id, "hi")
+
+            assert msg.count("Not medical advice") == 1
+            assert "Safety Notice" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Persistence and robustness
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("_isolate_handler_dependencies")
+class TestPersistenceAndRobustness:
+    """The persisted text is the sanitized text; persistence failures never
+    bypass the floor."""
+
+    @pytest.mark.asyncio
+    async def test_persisted_assistant_message_is_sanitized_flagged(self):
+        user = _make_user()
+        store = AsyncMock()
+        with (
+            _patch_ai(FLAGGED_TEXT),
+            patch("src.services.telegram_chat.store_message", new=store),
+        ):
+            await handle_chat(_make_db(user), user.id, "Change my ratio?")
+
+        assistant_content = store.call_args_list[1].args[4]
+        assert assistant_content.startswith(FLAGGED_TEXT)
+        assert WARNING_SNIPPET in assistant_content
+
+    @pytest.mark.asyncio
+    async def test_persisted_assistant_message_is_sanitized_rejected(self):
+        user = _make_user()
+        store = AsyncMock()
+        with (
+            _patch_ai(DANGEROUS_TEXT),
+            patch("src.services.telegram_chat.store_message", new=store),
+        ):
+            result = await handle_chat_web(_make_db(user), user.id, "How much?")
+
+        assistant_content = store.call_args_list[1].args[4]
+        assert BLOCKED_SNIPPET in assistant_content
+        assert "6 units" not in assistant_content
+        assert assistant_content == result.content
+
+    @pytest.mark.asyncio
+    async def test_floor_applies_when_persist_raises(self):
+        """The floor runs before (and independent of) the non-fatal persist
+        step: a storage failure still returns the blocked message (AC5)."""
+        user = _make_user()
+        store = AsyncMock(side_effect=RuntimeError("storage down"))
+        with (
+            _patch_ai(DANGEROUS_TEXT),
+            patch("src.services.telegram_chat.store_message", new=store),
+        ):
+            msg = await handle_chat(_make_db(user), user.id, "How much?")
+
+        assert BLOCKED_SNIPPET in msg
+        assert "6 units" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Audit commit on the caregiver surfaces (AC4)
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("_isolate_handler_dependencies")
+class TestCaregiverAuditCommit:
+    """The caregiver handlers/routers never commit their session, so the
+    helper must commit the SafetyLog itself or the row is silently dropped."""
+
+    @staticmethod
+    def _added_safety_logs(db: AsyncMock) -> list[SafetyLog]:
+        return [
+            call.args[0]
+            for call in db.add.call_args_list
+            if isinstance(call.args[0], SafetyLog)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_caregiver_telegram_audit_committed(self):
+        patient = _make_user()
+        db = _make_db(patient)
+        with _patch_ai(DANGEROUS_TEXT):
+            await handle_caregiver_chat(db, uuid.uuid4(), patient.id, "How much?")
+
+        logs = self._added_safety_logs(db)
+        assert len(logs) == 1
+        assert logs[0].analysis_type == "caregiver"
+        assert logs[0].user_id == patient.id
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_caregiver_web_audit_committed(self):
+        patient = _make_user()
+        db = _make_db(patient)
+        with _patch_ai(BENIGN_TEXT):
+            await handle_caregiver_chat_web(db, uuid.uuid4(), patient.id, "Status?")
+
+        logs = self._added_safety_logs(db)
+        assert len(logs) == 1
+        assert logs[0].analysis_type == "caregiver_web"
+        assert logs[0].status == SafetyStatus.APPROVED.value
+        db.commit.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _truncate_response with a safety block
+# ---------------------------------------------------------------------------
+class TestTruncateResponseWithSafetyBlock:
+    """The safety block reserves budget and is never truncated."""
+
+    def test_block_appended_between_body_and_disclaimer(self):
+        result = _truncate_response("body", "\n\nWARNING BLOCK")
+
+        assert result == "body\n\nWARNING BLOCK" + SAFETY_DISCLAIMER
+
+    def test_long_body_truncated_block_intact(self):
+        block = "\n\nWARNING BLOCK"
+        result = _truncate_response("x" * (TELEGRAM_MAX_LENGTH * 2), block)
+
+        assert len(result) <= TELEGRAM_MAX_LENGTH
+        assert result.endswith(block + SAFETY_DISCLAIMER)
+        assert "..." in result
+
+    def test_no_block_preserves_existing_behavior(self):
+        result = _truncate_response("hello")
+
+        assert result == "hello" + SAFETY_DISCLAIMER
+
+    def test_cut_never_splits_an_html_entity(self):
+        """Telegram HTML parse mode rejects a message ending in a partial
+        entity like "&am" -- the cut must trim it, not send it."""
+        keep = TELEGRAM_MAX_LENGTH - len(SAFETY_DISCLAIMER) - 3
+        prefix = "a" * (keep - 2)
+        text = prefix + "&amp;" + "z" * 50  # cut lands after "&a"
+
+        result = _truncate_response(text)
+
+        assert result == prefix + "..." + SAFETY_DISCLAIMER
+
+    def test_oversized_block_drops_body_not_block(self):
+        """A safety block past the length cap clamps the body budget to zero
+        (no negative slice keeping almost the whole body); the block is
+        still delivered intact."""
+        block = "w" * (TELEGRAM_MAX_LENGTH + 10)
+
+        result = _truncate_response("body text", block)
+
+        assert result == "..." + block + SAFETY_DISCLAIMER


### PR DESCRIPTION
## Summary

The AI dosing-safety floor (`validate_ai_suggestion`) was wired into the analysis surfaces (meal analysis, correction analysis, daily brief) but not into chat, leaving the persona prompt as the only defense against prescriptive dosing advice on the highest-traffic AI surface. This PR closes that gap.

- Adds one shared helper, `apply_ai_safety_floor`, that runs the validator, commits the `SafetyLog` audit row best-effort (the two caregiver handlers' sessions are never committed by their callers, so relying on the caller silently dropped the row), and returns the sanitized text as a `body`/`safety_block` pair.
- All four chat handlers (`handle_chat`, `handle_chat_web`, `handle_caregiver_chat`, `handle_caregiver_chat_web`) funnel through it right after citation verification and before persist/return. These four handlers are the universal choke point: `/api/ai/chat`, the Telegram bots, caregiver web, and the Wear relay all delegate into them, so this also covers the unvalidated `/api/ai/chat` path from #846.
- A REJECTED response replaces the message with the blocked text on every surface; a FLAGGED response (over-limit ISF or carb-ratio change) carries a visible safety warning; both the returned and the persisted chat text are the sanitized version.

## Telegram specifics

- The blocked message and warning block render as plain text (Telegram uses HTML parse mode; the validator's Markdown would reach users literally).
- `_truncate_response` now truncates only the model body: the safety block and the single standing disclaimer are appended intact, so a near-limit FLAGGED response can never lose its warning to truncation. The truncation cut also trims a partial HTML entity at the boundary (Telegram rejects messages ending in e.g. `&am`), and the body budget is clamped at zero.
- The safety block is HTML-escaped alongside the body, and the floor suppresses the analysis-surface standing disclaimer on chat so exactly one disclaimer is delivered per message.
- Carb-ratio flag extraction deduplicates repeated mentions (mirroring the existing ISF dedup) so the untruncatable warning block stays bounded.

## Forward seam

`validate_ai_suggestion` and the helper accept a `provenance` parameter (unused for now) so provenance-aware validation can later thread through the single chat call site instead of four.

The benchmark harness version lock is re-recorded for the intentional `safety_validation.py` change.

## Testing

- 26 new tests in `tests/test_ai_safety_floor.py`, asserting on returned text so they fail on the pre-change code: REJECTED backstop on all four handlers, FLAGGED warning visibility including a near-ceiling truncation case, exactly-one-disclaimer, plain-text rendering, persisted-message-is-sanitized, floor-applies-when-persist-fails, audit-commit failure tolerance, committed `SafetyLog` rows on the caregiver surfaces (including a real-database write), entity-split and oversized-block truncation edges.
- Full API suite green; `ruff check` and `ruff format --check` clean.
- Verified live against the running stack: benign and prescriptive prompts on the user web chat and caregiver web chat (audit rows committed on both, including the caregiver session that is never committed by its router), and both Telegram handlers with a dangerous response (blocked message delivered and persisted, rejected audit rows committed). No new Sentry issues attributable to the change.

Closes #846


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat responses now preserve important safety warnings even when messages are shortened, including on Telegram and web chat.
  * Safety-related outputs can now be shown in a cleaner format, with better handling for plain text and markdown.
* **Bug Fixes**
  * Repeated warning text is now deduplicated, preventing duplicate safety messages from growing unnecessarily.
  * Telegram messages are now truncated more safely, reducing the chance of broken formatting or dropped safety text.
  * Safety decisions are now applied more consistently across chat surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->