### PR TITLE
feat(mobile): backendless onboarding — BLE-only entry (GLY-144)

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
@@ -54,7 +54,30 @@ class AuthTokenStore @Inject constructor(
             .apply()
     }
 
+    /**
+     * Removes the stored base URL, leaving tokens untouched. Used by the BLE-only onboarding
+     * path to guarantee no backend is configured even if the user had previously typed and
+     * connection-tested a URL (which persists it via [saveBaseUrl] before the test resolves).
+     * After this, [isBackendConfigured] is false and [BaseUrlInterceptor] refuses any request.
+     */
+    fun clearBaseUrl() {
+        prefs.edit()
+            .remove(KEY_BASE_URL)
+            .apply()
+    }
+
     fun getBaseUrl(): String? = prefs.getString(KEY_BASE_URL, null)
+
+    /**
+     * Canonical "is a backend configured?" signal: true iff a non-blank base URL is stored.
+     *
+     * This is the single source of truth for the app's mode -- full-stack (backend configured)
+     * vs BLE-only (no backend). The backend-optional stories (local thresholds, capability
+     * gating, sync stand-down) observe this rather than re-deriving it from ad-hoc
+     * [getBaseUrl] null-checks. A BLE-only user who left onboarding without a server reads
+     * false here; a signed-in or server-configured user reads true.
+     */
+    fun isBackendConfigured(): Boolean = isBackendConfigured(getBaseUrl())
 
     /**
      * Emits the current base URL and re-emits whenever it changes, so surfaces that must track the
@@ -175,6 +198,13 @@ class AuthTokenStore @Inject constructor(
 
         /** Proactive refresh window: refresh token 5 minutes before expiry. */
         const val PROACTIVE_REFRESH_WINDOW_MS = 5 * 60 * 1000L
+
+        /**
+         * Pure predicate backing the instance [isBackendConfigured]; extracted so the mode logic
+         * is unit-testable without an Android [Context]/EncryptedSharedPreferences. A backend is
+         * configured iff [baseUrl] is non-null and not blank (whitespace-only counts as unset).
+         */
+        internal fun isBackendConfigured(baseUrl: String?): Boolean = !baseUrl.isNullOrBlank()
 
         /**
          * Extracts the `exp` claim from a JWT token payload.

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/AuthRepository.kt
@@ -181,6 +181,11 @@ class AuthRepository @Inject constructor(
         authTokenStore.saveBaseUrl(url)
     }
 
+    /** Clears the stored base URL (BLE-only onboarding) so no backend is configured. */
+    fun clearBaseUrl() {
+        authTokenStore.clearBaseUrl()
+    }
+
     fun getBaseUrl(): String? = authTokenStore.getBaseUrl()
 
     /**

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingScreen.kt
@@ -136,6 +136,7 @@ fun OnboardingScreen(
                     onTestConnection = viewModel::testConnection,
                     showInsecureHttpOptIn = state.showInsecureHttpOptIn,
                     onEnableInsecureHttp = viewModel::requestEnableInsecureHttp,
+                    onContinueWithoutServer = viewModel::continueWithoutServer,
                 )
                 PAGE_LOGIN -> LoginPage(
                     email = state.email,
@@ -310,7 +311,7 @@ private fun WelcomePage() {
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(
-            text = "AI-powered diabetes management companion",
+            text = "Your diabetes management companion",
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -319,7 +320,7 @@ private fun WelcomePage() {
         Spacer(modifier = Modifier.height(32.dp))
 
         Text(
-            text = "Your on-call endo at home",
+            text = "A direct pump monitor on its own — your on-call endo when you connect a server.",
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -357,7 +358,7 @@ private fun FeaturesPage() {
         FeatureCard(
             icon = Icons.Default.Psychology,
             title = "AI-Powered Analysis",
-            description = "Get daily briefs, meal analysis, and pattern recognition powered by your choice of AI provider.",
+            description = "With a connected server, get daily briefs, meal analysis, and pattern recognition powered by your choice of AI provider.",
         )
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -365,7 +366,7 @@ private fun FeaturesPage() {
         FeatureCard(
             icon = Icons.Default.Notifications,
             title = "Smart Alerts",
-            description = "Configurable glucose alerts with Telegram delivery and caregiver escalation.",
+            description = "Configurable glucose alerts, with Telegram delivery and caregiver escalation when you connect a server.",
         )
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -373,7 +374,7 @@ private fun FeaturesPage() {
         FeatureCard(
             icon = Icons.Default.Lock,
             title = "Self-Hosted Privacy",
-            description = "Your data stays on your infrastructure. No cloud dependency, full control.",
+            description = "Run your own server and your data stays on your infrastructure — no cloud dependency, full control.",
         )
 
         Spacer(modifier = Modifier.height(32.dp))
@@ -533,6 +534,7 @@ private fun ServerSetupPage(
     onTestConnection: () -> Unit,
     showInsecureHttpOptIn: Boolean,
     onEnableInsecureHttp: () -> Unit,
+    onContinueWithoutServer: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -553,7 +555,7 @@ private fun ServerSetupPage(
         Spacer(modifier = Modifier.height(16.dp))
 
         Text(
-            text = "Connect to Your Server",
+            text = "Connect a Server (Optional)",
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
@@ -562,7 +564,8 @@ private fun ServerSetupPage(
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(
-            text = "Enter the URL of your self-hosted GlycemicGPT server.",
+            text = "A server adds AI, meal analysis, and caregiver features. " +
+                "You can skip it and use the app as a direct BLE pump monitor.",
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -629,6 +632,24 @@ private fun ServerSetupPage(
                 Text("Allow insecure LAN HTTP")
             }
         }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            text = "Don't run a server?",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        // BLE-only entry: leaves onboarding with no server URL and no login. The completion
+        // sequence (in the ViewModel) still requests notification permission so the alert floor
+        // is not silently suppressed for a tier-1 user.
+        TextButton(
+            onClick = onContinueWithoutServer,
+            modifier = Modifier.testTag("onboarding_continue_without_server"),
+        ) {
+            Text("Use without a server (BLE-only)")
+        }
     }
 }
 
@@ -660,7 +681,7 @@ private fun LoginPage(
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(
-            text = "Sign in to your GlycemicGPT account to start monitoring.",
+            text = "Sign in to your GlycemicGPT server account to enable AI, meal, and caregiver features.",
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModel.kt
@@ -6,6 +6,7 @@ import com.glycemicgpt.mobile.data.local.AppSettingsStore
 import com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,6 +44,13 @@ class OnboardingViewModel @Inject constructor(
 
     /** Minimum interval between connection tests to prevent server hammering. */
     private var lastConnectionTestMs = 0L
+
+    /**
+     * The in-flight connection test, if any. Tracked so the BLE-only path can cancel it: the test
+     * persists the typed URL (and its failure branch can restore a previous one), which would
+     * otherwise re-configure a backend after [continueWithoutServer] cleared it.
+     */
+    private var connectionTestJob: Job? = null
 
     init {
         // Pre-fill server URL if returning after logout
@@ -94,7 +102,7 @@ class OnboardingViewModel @Inject constructor(
         if (!force && now - lastConnectionTestMs < 1_000L) return
         lastConnectionTestMs = now
 
-        viewModelScope.launch {
+        connectionTestJob = viewModelScope.launch {
             _uiState.update {
                 it.copy(
                     isTestingConnection = true,
@@ -198,6 +206,39 @@ class OnboardingViewModel @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * BLE-only entry: leave onboarding without a server URL, login, or any network call, so a
+     * mobile-only user can reach Home and pair a pump over BLE. Mirrors the login-success tail
+     * (`login()` above) minus auth: persist onboarding completion, then request the notification
+     * permission so [onNotificationPermissionHandled] flips the navigate-to-Home flag.
+     *
+     * Requesting POST_NOTIFICATIONS here is safety-critical: the on-device alert floor (armed by a
+     * sibling story) is silently suppressed without the permission, so a tier-1 user could later
+     * believe they are monitored when they are not.
+     *
+     * Cancels any in-flight connection test and clears any stored base URL: the user shares this
+     * page with the URL field + "Test Connection", which persists a URL before its result resolves
+     * (and its failure branch can restore a previous one). Cancelling then clearing guarantees
+     * [AuthTokenStore.isBackendConfigured] is false and BaseUrlInterceptor is never pointed at a
+     * server, regardless of anything typed or tested above.
+     */
+    fun continueWithoutServer() {
+        connectionTestJob?.cancel()
+        authRepository.clearBaseUrl()
+        appSettingsStore.onboardingComplete = true
+        _uiState.update {
+            it.copy(
+                baseUrl = "",
+                isTestingConnection = false,
+                connectionTestResult = null,
+                connectionTestSuccess = false,
+                showInsecureHttpOptIn = false,
+                showInsecureHttpConfirm = false,
+                requestNotificationPermission = true,
+            )
         }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthTokenStoreTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/auth/AuthTokenStoreTest.kt
@@ -2,6 +2,8 @@ package com.glycemicgpt.mobile.data.auth
 
 import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AuthTokenStoreTest {
@@ -42,5 +44,13 @@ class AuthTokenStoreTest {
     @Test
     fun `PROACTIVE_REFRESH_WINDOW_MS is 5 minutes`() {
         assertEquals(5 * 60 * 1000L, AuthTokenStore.PROACTIVE_REFRESH_WINDOW_MS)
+    }
+
+    @Test
+    fun `isBackendConfigured is true only for a non-blank base URL`() {
+        assertFalse(AuthTokenStore.isBackendConfigured(null))
+        assertFalse(AuthTokenStore.isBackendConfigured(""))
+        assertFalse(AuthTokenStore.isBackendConfigured("   "))
+        assertTrue(AuthTokenStore.isBackendConfigured("https://server.example.com"))
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/onboarding/OnboardingViewModelTest.kt
@@ -5,12 +5,15 @@ import com.glycemicgpt.mobile.data.remote.UrlSecurityPolicy
 import com.glycemicgpt.mobile.data.repository.AuthRepository
 import com.glycemicgpt.mobile.data.repository.LoginResult
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -246,6 +249,79 @@ class OnboardingViewModelTest {
 
         assertFalse(vm.uiState.value.requestNotificationPermission)
         assertTrue(vm.uiState.value.onboardingComplete)
+    }
+
+    @Test
+    fun `continueWithoutServer requests notifications and persists onboarding without any auth`() = runTest {
+        val vm = createViewModel()
+
+        vm.continueWithoutServer()
+
+        // SAFETY (AC2): the notification prompt is requested on the BLE-only path.
+        assertTrue(vm.uiState.value.requestNotificationPermission)
+        // Home navigation flips only after the permission is handled, mirroring the login tail.
+        assertFalse(vm.uiState.value.onboardingComplete)
+        // Persisted so the start destination becomes Home on relaunch.
+        verify { appSettingsStore.onboardingComplete = true }
+        // AC1: no base URL configured and no login performed on this path.
+        coVerify(exactly = 0) { authRepository.login(any(), any(), any(), any()) }
+        assertEquals("", vm.uiState.value.baseUrl)
+    }
+
+    @Test
+    fun `continueWithoutServer clears a base URL persisted by a prior connection test`() = runTest {
+        // A prior Test Connection persists the URL (AuthRepository.saveBaseUrl) before its result
+        // resolves. Tapping BLE-only afterwards must leave NO backend configured (AC1/AC5), so the
+        // completion clears the stored URL rather than merely not writing one.
+        every { authRepository.isValidUrl(any()) } returns true
+        coEvery { authRepository.testConnection() } returns Result.success("Connected successfully")
+        val vm = createViewModel()
+        vm.updateBaseUrl("https://typed.example.com")
+        vm.testConnection()
+        verify { authRepository.saveBaseUrl("https://typed.example.com") }
+
+        vm.continueWithoutServer()
+
+        // The invariant is enforced by clearing the store, not by hoping saveBaseUrl was never hit.
+        verify { authRepository.clearBaseUrl() }
+        assertEquals("", vm.uiState.value.baseUrl)
+        assertFalse(vm.uiState.value.connectionTestSuccess)
+    }
+
+    @Test
+    fun `continueWithoutServer cancels an in-flight connection test so it cannot re-save a URL`() = runTest {
+        // Queue (don't eagerly run) the testConnection coroutine so we can tap BLE-only while it is
+        // still in flight -- the race CodeRabbit flagged: the coroutine persists the typed URL
+        // (and its failure branch restores a previous one), which would re-configure a backend
+        // after continueWithoutServer cleared it.
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        every { authRepository.isValidUrl(any()) } returns true
+        coEvery { authRepository.testConnection() } returns Result.failure(Exception("boom"))
+        val vm = createViewModel()
+        vm.updateBaseUrl("https://typed.example.com")
+
+        vm.testConnection() // coroutine queued, not yet executed under StandardTestDispatcher
+        vm.continueWithoutServer() // cancels the queued job before it can saveBaseUrl
+        advanceUntilIdle() // drain: the cancelled job must not run its body
+
+        verify { authRepository.clearBaseUrl() }
+        verify(exactly = 0) { authRepository.saveBaseUrl(any()) }
+    }
+
+    @Test
+    fun `BLE-only completion reaches onboarding done with no login`() = runTest {
+        val vm = createViewModel()
+
+        vm.continueWithoutServer()
+        // Mutant proof: reverting the continueWithoutServer wiring leaves this false, so a
+        // never-backend user never triggers the notification launcher and can't leave onboarding.
+        assertTrue(vm.uiState.value.requestNotificationPermission)
+
+        vm.onNotificationPermissionHandled()
+
+        assertFalse(vm.uiState.value.requestNotificationPermission)
+        assertTrue(vm.uiState.value.onboardingComplete)
+        coVerify(exactly = 0) { authRepository.login(any(), any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a **"Use without a server (BLE-only)"** path to onboarding so a mobile-only user can finish setup with **no login and no server URL**, land on the (already session-optional) Home, and pair a pump over BLE. Today a fresh install cannot leave onboarding without a successful backend login and a passing server health-check; this is the keystone that unblocks the backend-optional tier.

## What changed

- **`OnboardingViewModel.continueWithoutServer()`** — completes onboarding without auth: mirrors the login-success tail (persist completion, then request `POST_NOTIFICATIONS`) minus the network call. Cancels any in-flight connection test and clears any stored base URL first, so no backend is ever configured on this path.
- **`OnboardingScreen`** — new "Use without a server (BLE-only)" action on the server page. The server "Next" button remains hard-gated on a passing health-check (full-stack path unchanged).
- **`AuthTokenStore.isBackendConfigured()`** — canonical "is a backend configured?" predicate (base URL present vs absent), plus a focused `clearBaseUrl()`. This is the single source of truth for app mode that the follow-up mobile stories consume.
- **Honest onboarding copy** — the Welcome/Features/Server/Login copy now qualifies backend-only features (AI, meal analysis, caregiver/Telegram, self-hosted) as "with a connected server" rather than promising them to a BLE-only user.

## Safety

The BLE-only completion **requests notification permission** on the same launcher the login path uses. Without it, the on-device alert floor is silently suppressed and a mobile-only user could believe they are monitored when they are not. Verified on device: the runtime prompt fires on this path and `POST_NOTIFICATIONS` is granted.

## Testing

- `./gradlew testDebugUnitTest lintDebug assembleDebug` — green.
- Unit tests: BLE-only completion requests notifications + writes no auth (mutant-proven); clears a base URL a prior connection test persisted; cancels an in-flight test so it cannot re-save a URL (mutant-proven); `isBackendConfigured()` true iff base URL non-blank.
- E2E on emulator (mobile-mcp): clean install → server page → "Use without a server" → notification prompt granted → Home with no session → onboarding persists across relaunch → Settings → Plugins → pump pairing screen reachable with no backend. Logcat confirms no base URL is configured (interceptor refuses every request). The "type + test a URL, then choose BLE-only" edge case leaves no base URL.
- Mobile-only change — no Sentry gate. No schema/Room changes (state is EncryptedSharedPreferences).

## Out of scope (follow-ups)

Hiding backend-only surfaces on the BLE-only Home (AI Chat tab, meal FAB, cloud-sync row, "Not signed in" banner), arming the alert floor from local thresholds, and bounding offline sync growth are tracked separately and intentionally left visible here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “continue without server” onboarding path for BLE-only setup.
  * Updated onboarding screens with clearer, more user-friendly messaging.

* **Bug Fixes**
  * Clearing server settings now removes only the saved backend address, preserving login tokens.
  * Improved handling of blank or whitespace-only server addresses.
  * Cancels in-progress server checks when switching to BLE-only onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->