### PR TITLE
fix(mobile): backend-sync subsystem stands down when no backend is configured

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/AuthTokenStore.kt
@@ -4,10 +4,14 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import com.glycemicgpt.mobile.di.IoDispatcher
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,6 +26,7 @@ import javax.inject.Singleton
 @Singleton
 class AuthTokenStore @Inject constructor(
     @ApplicationContext context: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
 
     private val prefs: SharedPreferences
@@ -85,15 +90,30 @@ class AuthTokenStore @Inject constructor(
      * rather than only on the next recomposition.
      */
     fun baseUrlFlow(): Flow<String?> = callbackFlow {
-        trySend(getBaseUrl())
         val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (key == KEY_BASE_URL || key == null) {
                 trySend(getBaseUrl())
             }
         }
+        // Register before the initial read: a write landing between a seed-first read and the
+        // registration would otherwise never be emitted, leaving collectors on a stale mode.
         prefs.registerOnSharedPreferenceChangeListener(listener)
+        trySend(getBaseUrl())
         awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
     }
+
+    /**
+     * Reactive form of [isBackendConfigured] -- the live app-mode signal that the
+     * backend-gated surfaces (Home cloud indicators, alert banner copy, sync stand-down)
+     * observe. All emissions, including the initial read, run on the IO dispatcher: these
+     * collectors are typically built on the main thread, and an encrypted-store read there
+     * can block on the keyset's first load. Consumers should seed pessimistically (false)
+     * until the first emission.
+     */
+    fun backendConfiguredFlow(): Flow<Boolean> =
+        baseUrlFlow()
+            .map { isBackendConfigured(it) }
+            .flowOn(ioDispatcher)
 
     fun getUserEmail(): String? = prefs.getString(KEY_USER_EMAIL, null)
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/RawHistoryLogDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/RawHistoryLogDao.kt
@@ -23,4 +23,19 @@ interface RawHistoryLogDao {
 
     @Query("SELECT MAX(sequenceNumber) FROM raw_history_logs")
     suspend fun getMaxSequenceNumber(): Int?
+
+    /**
+     * Purge every row except the highest-sequence one. Stand-down path only: with no backend
+     * configured the raw upload copies are undeliverable regardless of sent status, but the
+     * max-sequence row must survive -- [getMaxSequenceNumber] is the resume anchor that stops
+     * the poller from re-reading the pump's entire history on the next connect. Returns the
+     * number of rows removed.
+     */
+    @Query(
+        """
+        DELETE FROM raw_history_logs
+        WHERE sequenceNumber < (SELECT MAX(sequenceNumber) FROM raw_history_logs)
+        """
+    )
+    suspend fun deleteAllButMaxSequence(): Int
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/SyncDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/SyncDao.kt
@@ -79,4 +79,11 @@ interface SyncDao {
     /** Reset orphaned 'sending' items back to 'pending' (e.g. after crash/restart). */
     @Query("UPDATE sync_queue SET status = 'pending' WHERE status = 'sending' AND lastAttemptMs < :staleCutoffMs")
     suspend fun resetStaleSending(staleCutoffMs: Long)
+
+    /**
+     * Purge the entire queue. Stand-down path only: with no backend configured every row is
+     * undeliverable, regardless of status. Returns the number of rows removed.
+     */
+    @Query("DELETE FROM sync_queue")
+    suspend fun deleteAll(): Int
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/SyncDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/SyncDao.kt
@@ -12,6 +12,10 @@ interface SyncDao {
     @Insert
     suspend fun enqueue(entity: SyncQueueEntity)
 
+    /** Insert a batch in one transaction -- all rows land or none do. */
+    @Insert
+    suspend fun enqueueAll(entities: List<SyncQueueEntity>)
+
     @Query(
         """
         SELECT * FROM sync_queue

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuer.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuer.kt
@@ -1,5 +1,6 @@
 package com.glycemicgpt.mobile.data.repository
 
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.dao.SyncDao
 import com.glycemicgpt.mobile.data.local.entity.SyncQueueEntity
 import com.glycemicgpt.mobile.data.remote.PumpEventMapper
@@ -16,10 +17,16 @@ import javax.inject.Singleton
 /**
  * Converts domain models to PumpEventDto JSON and inserts them
  * into the sync_queue table for later upload.
+ *
+ * Enqueueing is gated on a backend being configured: with no base URL there is no
+ * destination, so rows would only accumulate as undeliverable dead weight. Pump data
+ * still reaches the local dashboard -- callers write to Room independently before
+ * enqueueing.
  */
 @Singleton
 class SyncQueueEnqueuer @Inject constructor(
     private val syncDao: SyncDao,
+    private val authTokenStore: AuthTokenStore,
     private val moshi: Moshi,
 ) {
 
@@ -50,6 +57,9 @@ class SyncQueueEnqueuer @Inject constructor(
     }
 
     private suspend fun enqueue(dto: PumpEventDto) {
+        // Single funnel for the mode gate. All callers run on the polling orchestrator's
+        // background coroutines, so the encrypted-store read stays off the main thread.
+        if (!authTokenStore.isBackendConfigured()) return
         syncDao.enqueue(
             SyncQueueEntity(
                 eventType = dto.eventType,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuer.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuer.kt
@@ -11,6 +11,8 @@ import com.glycemicgpt.mobile.domain.model.BolusEvent
 import com.glycemicgpt.mobile.domain.model.IoBReading
 import com.glycemicgpt.mobile.domain.model.ReservoirReading
 import com.squareup.moshi.Moshi
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -33,39 +35,52 @@ class SyncQueueEnqueuer @Inject constructor(
     private val adapter = moshi.adapter(PumpEventDto::class.java)
 
     suspend fun enqueueIoB(reading: IoBReading) {
-        enqueue(PumpEventMapper.fromIoB(reading))
+        enqueue(listOf(PumpEventMapper.fromIoB(reading)))
     }
 
     suspend fun enqueueBasal(reading: BasalReading) {
-        enqueue(PumpEventMapper.fromBasal(reading))
+        enqueue(listOf(PumpEventMapper.fromBasal(reading)))
     }
 
     suspend fun enqueueBasalBatch(readings: List<BasalReading>) {
-        readings.forEach { enqueue(PumpEventMapper.fromBasal(it)) }
+        enqueue(readings.map { PumpEventMapper.fromBasal(it) })
     }
 
     suspend fun enqueueBoluses(events: List<BolusEvent>) {
-        events.forEach { enqueue(PumpEventMapper.fromBolus(it)) }
+        enqueue(events.map { PumpEventMapper.fromBolus(it) })
     }
 
     suspend fun enqueueBattery(status: BatteryStatus) {
-        enqueue(PumpEventMapper.fromBattery(status))
+        enqueue(listOf(PumpEventMapper.fromBattery(status)))
     }
 
     suspend fun enqueueReservoir(reading: ReservoirReading) {
-        enqueue(PumpEventMapper.fromReservoir(reading))
+        enqueue(listOf(PumpEventMapper.fromReservoir(reading)))
     }
 
-    private suspend fun enqueue(dto: PumpEventDto) {
-        // Single funnel for the mode gate. All callers run on the polling orchestrator's
-        // background coroutines, so the encrypted-store read stays off the main thread.
-        if (!authTokenStore.isBackendConfigured()) return
-        syncDao.enqueue(
-            SyncQueueEntity(
-                eventType = dto.eventType,
-                eventTimestampMs = dto.eventTimestamp.toEpochMilli(),
-                payload = adapter.toJson(dto),
-            ),
-        )
+    private suspend fun enqueue(dtos: List<PumpEventDto>) {
+        try {
+            // Single funnel for the mode gate, checked once per call so history-backfill
+            // batches don't re-read the encrypted store per event. Callers all run on the
+            // polling orchestrator's background coroutines, keeping the read off the main
+            // thread.
+            if (dtos.isEmpty() || !authTokenStore.isBackendConfigured()) return
+            for (dto in dtos) {
+                syncDao.enqueue(
+                    SyncQueueEntity(
+                        eventType = dto.eventType,
+                        eventTimestampMs = dto.eventTimestamp.toEpochMilli(),
+                        payload = adapter.toJson(dto),
+                    ),
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // The poll loops upstream have no catch of their own: a failed enqueue (keystore
+            // flake, disk full) must not kill pump polling -- a dropped sync row is harmless,
+            // a dead poll loop starves the dashboard and the alert floor.
+            Timber.w(e, "Sync enqueue failed; dropped %d pump event(s)", dtos.size)
+        }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuer.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuer.kt
@@ -65,15 +65,17 @@ class SyncQueueEnqueuer @Inject constructor(
             // polling orchestrator's background coroutines, keeping the read off the main
             // thread.
             if (dtos.isEmpty() || !authTokenStore.isBackendConfigured()) return
-            for (dto in dtos) {
-                syncDao.enqueue(
+            // One transactional insert: all rows land or none do, so the dropped-count log
+            // below is accurate on failure.
+            syncDao.enqueueAll(
+                dtos.map { dto ->
                     SyncQueueEntity(
                         eventType = dto.eventType,
                         eventTimestampMs = dto.eventTimestamp.toEpochMilli(),
                         payload = adapter.toJson(dto),
-                    ),
-                )
-            }
+                    )
+                },
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -12,13 +12,10 @@ import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.service.AlertFloorStatusProvider
 import com.glycemicgpt.mobile.service.AlertNotificationManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -66,15 +63,10 @@ class AlertsViewModel @Inject constructor(
         )
 
     /** Whether a backend is configured, for the banner's two copy modes (GLY-145): server
-     *  phrasing is only honest when a server actually exists. Tracks the live base URL so the
-     *  copy flips the moment a server is added or removed. Seeded pessimistically false rather
-     *  than read synchronously — the ViewModel is built on the main thread and an encrypted-
-     *  store read there can block on the keyset's first load; the flow (whose reads run on IO)
-     *  emits the real value right after, and false only softens the copy toward BLE-only
-     *  phrasing for that first frame. */
-    val backendConfigured: StateFlow<Boolean> = authTokenStore.baseUrlFlow()
-        .map { AuthTokenStore.isBackendConfigured(it) }
-        .flowOn(Dispatchers.IO)
+     *  phrasing is only honest when a server actually exists. Seeded pessimistically false
+     *  (see [AuthTokenStore.backendConfiguredFlow]) -- false only softens the copy toward
+     *  BLE-only phrasing for the first frame. */
+    val backendConfigured: StateFlow<Boolean> = authTokenStore.backendConfiguredFlow()
         .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -82,6 +82,7 @@ fun HomeScreen(
     val reservoir by viewModel.reservoir.collectAsState()
     val syncStatus by viewModel.syncStatus.collectAsState()
     val networkStatus by viewModel.networkStatus.collectAsState()
+    val backendConfigured by viewModel.backendConfigured.collectAsState()
     val cgmFreshnessThresholds by viewModel.cgmFreshnessThresholds.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
     val selectedPeriod by viewModel.selectedPeriod.collectAsState()
@@ -124,7 +125,7 @@ fun HomeScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             // Compact connection + sync status row (BLE pump + outbound sync + backend reachability)
-            ConnectionSyncRow(connectionState, syncStatus, networkStatus)
+            ConnectionSyncRow(connectionState, syncStatus, networkStatus, backendConfigured)
 
             Spacer(modifier = Modifier.height(12.dp))
 
@@ -268,6 +269,7 @@ private fun ConnectionSyncRow(
     state: ConnectionState,
     syncStatus: SyncStatus,
     networkStatus: NetworkStatus,
+    backendConfigured: Boolean,
 ) {
     val (bleIcon, bleA11y, bleColor, bleText) = when (state) {
         ConnectionState.CONNECTED -> Quad(
@@ -308,29 +310,6 @@ private fun ConnectionSyncRow(
         )
     }
 
-    val (syncIcon, syncA11y, syncColor) = when {
-        syncStatus.lastError != null -> Triple(
-            Icons.Default.CloudOff,
-            "Sync error",
-            MaterialTheme.colorScheme.error,
-        )
-        syncStatus.pendingCount > 0 -> Triple(
-            Icons.Default.CloudSync,
-            "${syncStatus.pendingCount} readings pending sync",
-            MaterialTheme.colorScheme.tertiary,
-        )
-        syncStatus.lastSyncAtMs > 0 -> Triple(
-            Icons.Default.CloudDone,
-            "Synced to cloud",
-            MaterialTheme.colorScheme.primary,
-        )
-        else -> Triple(
-            Icons.Default.CloudOff,
-            "Not synced",
-            MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -352,22 +331,51 @@ private fun ConnectionSyncRow(
                 color = bleColor,
             )
         }
-        Spacer(modifier = Modifier.width(12.dp))
-        Icon(
-            imageVector = syncIcon,
-            contentDescription = syncA11y,
-            tint = syncColor,
-            modifier = Modifier.size(16.dp),
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        BackendStatusIndicator(networkStatus)
+        // The cloud indicators only exist when a backend is configured: for a BLE-only user
+        // "pending sync" / "Backend reachable" would describe a server that doesn't exist.
+        // A full-stack user keeps them even while offline -- the climbing pending count and
+        // "Backend unreachable" are the honest outage story.
+        if (backendConfigured) {
+            val (syncIcon, syncA11y, syncColor) = when {
+                syncStatus.lastError != null -> Triple(
+                    Icons.Default.CloudOff,
+                    "Sync error",
+                    MaterialTheme.colorScheme.error,
+                )
+                syncStatus.pendingCount > 0 -> Triple(
+                    Icons.Default.CloudSync,
+                    "${syncStatus.pendingCount} readings pending sync",
+                    MaterialTheme.colorScheme.tertiary,
+                )
+                syncStatus.lastSyncAtMs > 0 -> Triple(
+                    Icons.Default.CloudDone,
+                    "Synced to cloud",
+                    MaterialTheme.colorScheme.primary,
+                )
+                else -> Triple(
+                    Icons.Default.CloudOff,
+                    "Not synced",
+                    MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Icon(
+                imageVector = syncIcon,
+                contentDescription = syncA11y,
+                tint = syncColor,
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            BackendStatusIndicator(networkStatus)
+        }
     }
 }
 
 /**
- * Backend/device reachability chip, distinct from the BLE and sync indicators. Always
- * present so it can be asserted in tests via the `backend_status` tag; only shows text when there's
- * something to warn about, keeping the reachable golden path visually quiet.
+ * Backend/device reachability chip, distinct from the BLE and sync indicators. Present whenever
+ * a backend is configured (asserted in tests via the `backend_status` tag; absent for BLE-only);
+ * only shows text when there's something to warn about, keeping the reachable golden path
+ * visually quiet.
  */
 @Composable
 private fun BackendStatusIndicator(networkStatus: NetworkStatus) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -373,9 +373,9 @@ private fun ConnectionSyncRow(
 
 /**
  * Backend/device reachability chip, distinct from the BLE and sync indicators. Present whenever
- * a backend is configured (asserted in tests via the `backend_status` tag; absent for BLE-only);
- * only shows text when there's something to warn about, keeping the reachable golden path
- * visually quiet.
+ * a backend is configured (locatable in E2E runs via the `backend_status` tag; absent for
+ * BLE-only); only shows text when there's something to warn about, keeping the reachable golden
+ * path visually quiet.
  */
 @Composable
 private fun BackendStatusIndicator(networkStatus: NetworkStatus) {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -50,7 +50,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -121,14 +120,9 @@ class HomeViewModel @Inject constructor(
 
     /** Whether a backend is configured -- the mode signal the cloud/sync indicators key on
      *  (GLY-144): a BLE-only user has no server, so "pending sync" and reachability chips
-     *  would be claims about a cloud that doesn't exist. Tracks the live base URL so the row
-     *  appears/disappears the moment a server is added or removed. Seeded pessimistically
-     *  false rather than read synchronously -- the ViewModel is built on the main thread and
-     *  an encrypted-store read there can block on the keyset's first load; the flow (whose
-     *  reads run on IO) emits the real value right after. */
-    val backendConfigured: StateFlow<Boolean> = authTokenStore.baseUrlFlow()
-        .map { AuthTokenStore.isBackendConfigured(it) }
-        .flowOn(Dispatchers.IO)
+     *  would be claims about a cloud that doesn't exist. Seeded pessimistically false; see
+     *  [AuthTokenStore.backendConfiguredFlow]. */
+    val backendConfigured: StateFlow<Boolean> = authTokenStore.backendConfiguredFlow()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     /** Dashboard cards contributed by active plugins, paired with their plugin ID. */

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpProfileStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
@@ -49,6 +50,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -74,6 +76,7 @@ class HomeViewModel @Inject constructor(
     private val pumpProfileStore: PumpProfileStore,
     private val appSettingsStore: AppSettingsStore,
     private val authRepository: AuthRepository,
+    authTokenStore: AuthTokenStore,
     private val api: GlycemicGptApi,
     private val pluginRegistry: PluginRegistry,
     private val networkMonitor: NetworkMonitor,
@@ -115,6 +118,18 @@ class HomeViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     val syncStatus: StateFlow<SyncStatus> = backendSyncManager.syncStatus
+
+    /** Whether a backend is configured -- the mode signal the cloud/sync indicators key on
+     *  (GLY-144): a BLE-only user has no server, so "pending sync" and reachability chips
+     *  would be claims about a cloud that doesn't exist. Tracks the live base URL so the row
+     *  appears/disappears the moment a server is added or removed. Seeded pessimistically
+     *  false rather than read synchronously -- the ViewModel is built on the main thread and
+     *  an encrypted-store read there can block on the keyset's first load; the flow (whose
+     *  reads run on IO) emits the real value right after. */
+    val backendConfigured: StateFlow<Boolean> = authTokenStore.baseUrlFlow()
+        .map { AuthTokenStore.isBackendConfigured(it) }
+        .flowOn(Dispatchers.IO)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     /** Dashboard cards contributed by active plugins, paired with their plugin ID. */
     val pluginCards: StateFlow<List<PluginCard>> =

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloorStatusProvider.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/AlertFloorStatusProvider.kt
@@ -10,7 +10,6 @@ import com.glycemicgpt.mobile.domain.alerting.alertFloorStatus
 import com.glycemicgpt.mobile.domain.freshness.FreshnessPolicy
 import com.glycemicgpt.mobile.domain.model.ConnectionState
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -18,8 +17,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retryWhen
 import timber.log.Timber
 import javax.inject.Inject
@@ -56,7 +53,7 @@ class AlertFloorStatusProvider @Inject constructor(
     fun observe(): Flow<AlertFloorStatus> =
         combine(
             appSettingsStore.debugFastStalenessFlow(),
-            backendConfiguredFlow(),
+            authTokenStore.backendConfiguredFlow(),
             // Reactive rather than sampled per emission: a Settings save must claim "watching"
             // (and a logout disarm must drop it) immediately, not on the next poll tick.
             alertThresholdStore.isConfiguredFlow(),
@@ -104,16 +101,6 @@ class AlertFloorStatusProvider @Inject constructor(
             delay(RETRY_DELAY_MS)
             true
         }.distinctUntilChanged()
-
-    /**
-     * The live backend-configured mode signal, with the EncryptedSharedPreferences reads kept
-     * off the caller's dispatcher: [observe] is collected (and its seed computed) on the main
-     * thread, and an encrypted-store read there can block on the keyset's first load.
-     */
-    private fun backendConfiguredFlow(): Flow<Boolean> =
-        authTokenStore.baseUrlFlow()
-            .map { AuthTokenStore.isBackendConfigured(it) }
-            .flowOn(Dispatchers.IO)
 
     /**
      * Synchronous snapshot from the current values, for seeding a StateFlow before [observe]'s

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
@@ -71,6 +72,9 @@ class BackendSyncManager @Inject constructor(
 
         /** Cadence of the stand-down sweep while no backend is configured. */
         const val STAND_DOWN_SWEEP_INTERVAL_MS = 3_600_000L // 1 hour
+
+        /** Backoff before resubscribing the mode signal after it fails. */
+        private const val MODE_SIGNAL_RETRY_DELAY_MS = 60_000L
     }
 
     /** Cached pump hardware info, set by PumpPollingOrchestrator on first connect. */
@@ -97,6 +101,14 @@ class BackendSyncManager @Inject constructor(
         // starts syncing without a service restart.
         syncLoopJob = scope.launch {
             authTokenStore.backendConfiguredFlow()
+                // An encrypted-store read failure (keystore flake) must not kill this
+                // collector for the rest of the service's life -- resubscribe after a
+                // backoff, same posture as the alert-floor status pipeline.
+                .retryWhen { cause, attempt ->
+                    Timber.e(cause, "Sync mode signal failed (attempt %d); retrying", attempt + 1)
+                    delay(MODE_SIGNAL_RETRY_DELAY_MS)
+                    true
+                }
                 .distinctUntilChanged()
                 .collectLatest { configured ->
                     if (configured) syncLoop() else standDown()

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -12,6 +12,7 @@ import com.glycemicgpt.mobile.data.remote.dto.PumpPushRequest
 import com.glycemicgpt.mobile.data.remote.dto.PumpRawEventDto
 import com.glycemicgpt.mobile.domain.model.PumpHardwareInfo
 import com.squareup.moshi.Moshi
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -141,7 +142,15 @@ class BackendSyncManager @Inject constructor(
      */
     internal suspend fun standDown() {
         while (true) {
-            purgeUndeliverable()
+            try {
+                purgeUndeliverable()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A failed purge must not kill this collector -- it is also what restarts
+                // syncing when a backend is configured later. Retry on the next sweep.
+                Timber.w(e, "Stand-down purge failed")
+            }
             delay(STAND_DOWN_SWEEP_INTERVAL_MS)
         }
     }
@@ -279,6 +288,11 @@ class BackendSyncManager @Inject constructor(
                 _syncStatus.value = _syncStatus.value.copy(lastError = error)
                 Timber.w("Sync push failed: %s", error)
             }
+        } catch (e: CancellationException) {
+            // A mode flip cancels this loop via collectLatest mid-push; that is a clean
+            // switch, not a failed upload -- items stay 'sending' and resetStaleSending
+            // reclaims them if the push never completed.
+            throw e
         } catch (e: Exception) {
             val error = e.message ?: "Unknown network error"
             syncDao.markFailed(validIds.toList(), error)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -13,16 +13,14 @@ import com.glycemicgpt.mobile.data.remote.dto.PumpRawEventDto
 import com.glycemicgpt.mobile.domain.model.PumpHardwareInfo
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
@@ -61,6 +59,17 @@ class BackendSyncManager @Inject constructor(
         const val MAX_QUEUE_SIZE = 5000
         private const val STALE_SENDING_TIMEOUT_MS = 60_000L // 1 minute
         private const val CLEANUP_INTERVAL_MS = 3_600_000L // 1 hour
+
+        /**
+         * Hygiene cadence while the queue cannot drain (no session / sync disabled). The
+         * enqueue rate is a few rows a minute, so the size bound doesn't need the 3s drain
+         * cadence -- prune scans that often, in a posture that can persist for weeks, would
+         * be pointless flash/WAL churn inside a foreground service.
+         */
+        const val IDLE_HYGIENE_INTERVAL_MS = 60_000L
+
+        /** Cadence of the stand-down sweep while no backend is configured. */
+        const val STAND_DOWN_SWEEP_INTERVAL_MS = 3_600_000L // 1 hour
     }
 
     /** Cached pump hardware info, set by PumpPollingOrchestrator on first connect. */
@@ -76,18 +85,17 @@ class BackendSyncManager @Inject constructor(
     private val triggerChannel = Channel<Unit>(Channel.CONFLATED)
     @Volatile
     private var lastCleanupMs = 0L
+    @Volatile
+    private var lastIdleHygieneMs = 0L
 
     fun start(scope: CoroutineScope) {
         stop()
-        // The sync loop only runs while a backend is configured. Keying on the live base URL
-        // (rather than a one-shot check) makes the whole lifecycle reactive: dropping the server
-        // cancels the loop and purges the now-undeliverable queue, adding one starts syncing
-        // without a service restart. flowOn(IO) keeps the encrypted-store reads off this scope's
-        // thread.
+        // The sync loop only runs while a backend is configured. Keying on the live mode
+        // signal (rather than a one-shot check) makes the whole lifecycle reactive: dropping
+        // the server cancels the loop and purges the now-undeliverable queue, adding one
+        // starts syncing without a service restart.
         syncLoopJob = scope.launch {
-            authTokenStore.baseUrlFlow()
-                .map { AuthTokenStore.isBackendConfigured(it) }
-                .flowOn(Dispatchers.IO)
+            authTokenStore.backendConfiguredFlow()
                 .distinctUntilChanged()
                 .collectLatest { configured ->
                     if (configured) syncLoop() else standDown()
@@ -123,16 +131,32 @@ class BackendSyncManager @Inject constructor(
     }
 
     /**
-     * No backend is configured: queued rows have no destination, so purge them and stay idle
-     * (no 3s wake) until a base URL appears. Running this on every entry into the unconfigured
-     * state covers both the full-stack -> BLE-only transition and a device that accumulated
-     * rows before enqueueing was mode-gated. Logout is NOT this path -- it preserves the base
-     * URL, so the queue survives (bounded by [processQueue]'s prune) to drain on re-login.
+     * No backend is configured: the outbound copies have no destination, so purge them and
+     * idle (no 3s wake) until a base URL appears. Sweeps hourly rather than once because a
+     * BLE-only device keeps producing raw history rows, and an enqueue racing the mode flip
+     * can slip a row in just after a one-shot purge -- the sweep re-collects both. Covers the
+     * full-stack -> BLE-only transition and a device that accumulated rows before enqueueing
+     * was mode-gated. Logout is NOT this path -- it preserves the base URL, so the queue
+     * survives (bounded by [processQueue]'s prune) to drain on re-login.
      */
     internal suspend fun standDown() {
+        while (true) {
+            purgeUndeliverable()
+            delay(STAND_DOWN_SWEEP_INTERVAL_MS)
+        }
+    }
+
+    internal suspend fun purgeUndeliverable() {
         val purged = syncDao.deleteAll()
-        if (purged > 0) {
-            Timber.i("Sync queue purged: %d undeliverable items (no backend configured)", purged)
+        // The raw upload copies are undeliverable too; only the max-sequence row survives as
+        // the poller's resume anchor. Without this a BLE-only device would grow the raw table
+        // forever -- nothing ever marks its rows sent, and cleanup() only deletes sent rows.
+        val rawPurged = rawHistoryLogDao.deleteAllButMaxSequence()
+        if (purged > 0 || rawPurged > 0) {
+            Timber.i(
+                "Stand-down purge: %d sync item(s), %d raw history row(s) (no backend configured)",
+                purged, rawPurged,
+            )
         }
         _syncStatus.value = _syncStatus.value.copy(lastSyncAtMs = 0L, lastError = null)
     }
@@ -158,14 +182,18 @@ class BackendSyncManager @Inject constructor(
         // Local queue hygiene runs BEFORE the drain gates: with sync disabled or no active
         // session (signed out, refresh token expired) the enqueuer keeps writing, so the size
         // bound must not depend on being able to drain. Only the network drain below requires
-        // a session.
-        // Reset orphaned 'sending' items that got stuck after a crash or cancellation
-        syncDao.resetStaleSending(System.currentTimeMillis() - STALE_SENDING_TIMEOUT_MS)
-        pruneQueueIfNeeded()
-        cleanupIfNeeded()
-
-        if (!appSettingsStore.backendSyncEnabled) return
-        if (!authTokenStore.hasActiveSession()) return
+        // a session. When gated, hygiene drops to the idle cadence -- the bound doesn't need
+        // 3s granularity in a posture that can persist for weeks.
+        val canDrain = appSettingsStore.backendSyncEnabled && authTokenStore.hasActiveSession()
+        val now = System.currentTimeMillis()
+        if (canDrain || now - lastIdleHygieneMs >= IDLE_HYGIENE_INTERVAL_MS) {
+            lastIdleHygieneMs = now
+            // Reset orphaned 'sending' items that got stuck after a crash or cancellation
+            syncDao.resetStaleSending(now - STALE_SENDING_TIMEOUT_MS)
+            pruneQueueIfNeeded()
+            cleanupIfNeeded()
+        }
+        if (!canDrain) return
 
         val batch = syncDao.getPendingBatch(limit = BATCH_SIZE, maxRetries = MAX_RETRIES)
         if (batch.isEmpty()) return

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -13,11 +13,16 @@ import com.glycemicgpt.mobile.data.remote.dto.PumpRawEventDto
 import com.glycemicgpt.mobile.domain.model.PumpHardwareInfo
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
@@ -74,7 +79,20 @@ class BackendSyncManager @Inject constructor(
 
     fun start(scope: CoroutineScope) {
         stop()
-        syncLoopJob = scope.launch { syncLoop() }
+        // The sync loop only runs while a backend is configured. Keying on the live base URL
+        // (rather than a one-shot check) makes the whole lifecycle reactive: dropping the server
+        // cancels the loop and purges the now-undeliverable queue, adding one starts syncing
+        // without a service restart. flowOn(IO) keeps the encrypted-store reads off this scope's
+        // thread.
+        syncLoopJob = scope.launch {
+            authTokenStore.baseUrlFlow()
+                .map { AuthTokenStore.isBackendConfigured(it) }
+                .flowOn(Dispatchers.IO)
+                .distinctUntilChanged()
+                .collectLatest { configured ->
+                    if (configured) syncLoop() else standDown()
+                }
+        }
         pendingCountJob = scope.launch {
             syncDao.observePendingCount().collect { count ->
                 _syncStatus.value = _syncStatus.value.copy(pendingCount = count)
@@ -104,6 +122,21 @@ class BackendSyncManager @Inject constructor(
         }
     }
 
+    /**
+     * No backend is configured: queued rows have no destination, so purge them and stay idle
+     * (no 3s wake) until a base URL appears. Running this on every entry into the unconfigured
+     * state covers both the full-stack -> BLE-only transition and a device that accumulated
+     * rows before enqueueing was mode-gated. Logout is NOT this path -- it preserves the base
+     * URL, so the queue survives (bounded by [processQueue]'s prune) to drain on re-login.
+     */
+    internal suspend fun standDown() {
+        val purged = syncDao.deleteAll()
+        if (purged > 0) {
+            Timber.i("Sync queue purged: %d undeliverable items (no backend configured)", purged)
+        }
+        _syncStatus.value = _syncStatus.value.copy(lastSyncAtMs = 0L, lastError = null)
+    }
+
     internal suspend fun pruneQueueIfNeeded() {
         val count = syncDao.countAll()
         if (count > MAX_QUEUE_SIZE) {
@@ -122,14 +155,17 @@ class BackendSyncManager @Inject constructor(
     }
 
     internal suspend fun processQueue() {
-        if (!appSettingsStore.backendSyncEnabled) return
-        if (!authTokenStore.hasActiveSession()) return
-
+        // Local queue hygiene runs BEFORE the drain gates: with sync disabled or no active
+        // session (signed out, refresh token expired) the enqueuer keeps writing, so the size
+        // bound must not depend on being able to drain. Only the network drain below requires
+        // a session.
         // Reset orphaned 'sending' items that got stuck after a crash or cancellation
         syncDao.resetStaleSending(System.currentTimeMillis() - STALE_SENDING_TIMEOUT_MS)
-
         pruneQueueIfNeeded()
         cleanupIfNeeded()
+
+        if (!appSettingsStore.backendSyncEnabled) return
+        if (!authTokenStore.hasActiveSession()) return
 
         val batch = syncDao.getPendingBatch(limit = BATCH_SIZE, maxRetries = MAX_RETRIES)
         if (batch.isEmpty()) return

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -134,7 +134,16 @@ class BackendSyncManager @Inject constructor(
 
     private suspend fun syncLoop() {
         while (true) {
-            processQueue()
+            try {
+                processQueue()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A transient DB failure in the hygiene or drain path must not kill this
+                // collector -- it also carries the stand-down lifecycle. Recover on the
+                // next poll, same posture as standDown().
+                Timber.w(e, "Sync pass failed")
+            }
             // Wait for either a trigger or the poll interval, whichever comes first
             select {
                 triggerChannel.onReceive {}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuerTest.kt
@@ -108,6 +108,15 @@ class SyncQueueEnqueuerTest {
     }
 
     @Test
+    fun `enqueue swallows storage failures instead of crashing the caller`() = runTest {
+        // The polling loops upstream have no catch of their own -- an enqueue failure
+        // (keystore flake, disk full) must not propagate and kill pump polling.
+        coEvery { syncDao.enqueue(any()) } throws RuntimeException("disk full")
+
+        enqueuer.enqueueIoB(IoBReading(iob = 2.5f, timestamp = Instant.now()))
+    }
+
+    @Test
     fun `enqueue inserts again once a backend is configured`() = runTest {
         every { authTokenStore.isBackendConfigured() } returns false
         enqueuer.enqueueIoB(IoBReading(iob = 1.0f, timestamp = Instant.now()))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuerTest.kt
@@ -1,15 +1,19 @@
 package com.glycemicgpt.mobile.data.repository
 
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.dao.SyncDao
 import com.glycemicgpt.mobile.data.local.entity.SyncQueueEntity
 import com.glycemicgpt.mobile.data.remote.InstantAdapter
 import com.glycemicgpt.mobile.domain.model.BasalReading
+import com.glycemicgpt.mobile.domain.model.BatteryStatus
 import com.glycemicgpt.mobile.domain.model.BolusEvent
 import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.domain.model.IoBReading
+import com.glycemicgpt.mobile.domain.model.ReservoirReading
 import com.squareup.moshi.Moshi
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
@@ -21,8 +25,11 @@ import java.time.Instant
 class SyncQueueEnqueuerTest {
 
     private val syncDao = mockk<SyncDao>(relaxed = true)
+    private val authTokenStore = mockk<AuthTokenStore> {
+        every { isBackendConfigured() } returns true
+    }
     private val moshi = Moshi.Builder().add(InstantAdapter()).build()
-    private val enqueuer = SyncQueueEnqueuer(syncDao, moshi)
+    private val enqueuer = SyncQueueEnqueuer(syncDao, authTokenStore, moshi)
 
     @Test
     fun `enqueueIoB creates entity with bg_reading type`() = runTest {
@@ -66,5 +73,48 @@ class SyncQueueEnqueuerTest {
         enqueuer.enqueueBoluses(events)
 
         coVerify(exactly = 2) { syncDao.enqueue(any()) }
+    }
+
+    @Test
+    fun `enqueue is a no-op for every event type when no backend is configured`() = runTest {
+        every { authTokenStore.isBackendConfigured() } returns false
+
+        enqueuer.enqueueIoB(IoBReading(iob = 2.5f, timestamp = Instant.now()))
+        enqueuer.enqueueBasal(
+            BasalReading(
+                rate = 1.2f,
+                isAutomated = true,
+                activityMode = PumpActivityMode.NONE,
+                timestamp = Instant.now(),
+            ),
+        )
+        enqueuer.enqueueBasalBatch(
+            listOf(
+                BasalReading(
+                    rate = 0.5f,
+                    isAutomated = false,
+                    activityMode = PumpActivityMode.NONE,
+                    timestamp = Instant.now(),
+                ),
+            ),
+        )
+        enqueuer.enqueueBoluses(
+            listOf(BolusEvent(units = 3.0f, isAutomated = false, isCorrection = false, timestamp = Instant.now())),
+        )
+        enqueuer.enqueueBattery(BatteryStatus(percentage = 80, isCharging = false, timestamp = Instant.now()))
+        enqueuer.enqueueReservoir(ReservoirReading(unitsRemaining = 150f, timestamp = Instant.now()))
+
+        coVerify(exactly = 0) { syncDao.enqueue(any()) }
+    }
+
+    @Test
+    fun `enqueue inserts again once a backend is configured`() = runTest {
+        every { authTokenStore.isBackendConfigured() } returns false
+        enqueuer.enqueueIoB(IoBReading(iob = 1.0f, timestamp = Instant.now()))
+        coVerify(exactly = 0) { syncDao.enqueue(any()) }
+
+        every { authTokenStore.isBackendConfigured() } returns true
+        enqueuer.enqueueIoB(IoBReading(iob = 1.0f, timestamp = Instant.now()))
+        coVerify(exactly = 1) { syncDao.enqueue(any()) }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/repository/SyncQueueEnqueuerTest.kt
@@ -33,22 +33,23 @@ class SyncQueueEnqueuerTest {
 
     @Test
     fun `enqueueIoB creates entity with bg_reading type`() = runTest {
-        val slot = slot<SyncQueueEntity>()
-        coEvery { syncDao.enqueue(capture(slot)) } returns Unit
+        val slot = slot<List<SyncQueueEntity>>()
+        coEvery { syncDao.enqueueAll(capture(slot)) } returns Unit
 
         val now = Instant.now()
         enqueuer.enqueueIoB(IoBReading(iob = 2.5f, timestamp = now))
 
-        assertEquals("bg_reading", slot.captured.eventType)
-        assertEquals(now.toEpochMilli(), slot.captured.eventTimestampMs)
-        assertTrue(slot.captured.payload.contains("2.5"))
-        assertEquals(SyncQueueEntity.STATUS_PENDING, slot.captured.status)
+        val entity = slot.captured.single()
+        assertEquals("bg_reading", entity.eventType)
+        assertEquals(now.toEpochMilli(), entity.eventTimestampMs)
+        assertTrue(entity.payload.contains("2.5"))
+        assertEquals(SyncQueueEntity.STATUS_PENDING, entity.status)
     }
 
     @Test
     fun `enqueueBasal creates entity with basal type`() = runTest {
-        val slot = slot<SyncQueueEntity>()
-        coEvery { syncDao.enqueue(capture(slot)) } returns Unit
+        val slot = slot<List<SyncQueueEntity>>()
+        coEvery { syncDao.enqueueAll(capture(slot)) } returns Unit
 
         enqueuer.enqueueBasal(
             BasalReading(
@@ -59,8 +60,9 @@ class SyncQueueEnqueuerTest {
             ),
         )
 
-        assertEquals("basal", slot.captured.eventType)
-        assertTrue(slot.captured.payload.contains("exercise"))
+        val entity = slot.captured.single()
+        assertEquals("basal", entity.eventType)
+        assertTrue(entity.payload.contains("exercise"))
     }
 
     @Test
@@ -70,9 +72,12 @@ class SyncQueueEnqueuerTest {
             BolusEvent(units = 1.5f, isAutomated = true, isCorrection = true, timestamp = Instant.now()),
         )
 
+        val slot = slot<List<SyncQueueEntity>>()
+        coEvery { syncDao.enqueueAll(capture(slot)) } returns Unit
+
         enqueuer.enqueueBoluses(events)
 
-        coVerify(exactly = 2) { syncDao.enqueue(any()) }
+        assertEquals(2, slot.captured.size)
     }
 
     @Test
@@ -104,14 +109,14 @@ class SyncQueueEnqueuerTest {
         enqueuer.enqueueBattery(BatteryStatus(percentage = 80, isCharging = false, timestamp = Instant.now()))
         enqueuer.enqueueReservoir(ReservoirReading(unitsRemaining = 150f, timestamp = Instant.now()))
 
-        coVerify(exactly = 0) { syncDao.enqueue(any()) }
+        coVerify(exactly = 0) { syncDao.enqueueAll(any()) }
     }
 
     @Test
     fun `enqueue swallows storage failures instead of crashing the caller`() = runTest {
         // The polling loops upstream have no catch of their own -- an enqueue failure
         // (keystore flake, disk full) must not propagate and kill pump polling.
-        coEvery { syncDao.enqueue(any()) } throws RuntimeException("disk full")
+        coEvery { syncDao.enqueueAll(any()) } throws RuntimeException("disk full")
 
         enqueuer.enqueueIoB(IoBReading(iob = 2.5f, timestamp = Instant.now()))
     }
@@ -120,10 +125,10 @@ class SyncQueueEnqueuerTest {
     fun `enqueue inserts again once a backend is configured`() = runTest {
         every { authTokenStore.isBackendConfigured() } returns false
         enqueuer.enqueueIoB(IoBReading(iob = 1.0f, timestamp = Instant.now()))
-        coVerify(exactly = 0) { syncDao.enqueue(any()) }
+        coVerify(exactly = 0) { syncDao.enqueueAll(any()) }
 
         every { authTokenStore.isBackendConfigured() } returns true
         enqueuer.enqueueIoB(IoBReading(iob = 1.0f, timestamp = Instant.now()))
-        coVerify(exactly = 1) { syncDao.enqueue(any()) }
+        coVerify(exactly = 1) { syncDao.enqueueAll(any()) }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -69,7 +69,7 @@ class AlertsViewModelTest {
             every { current() } answers { floorStatusFlow.value }
         }
         authTokenStore = mockk {
-            every { baseUrlFlow() } returns flowOf("https://test.example.com")
+            every { backendConfiguredFlow() } returns flowOf(true)
         }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -176,7 +176,23 @@ class HomeViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, alertThresholdStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, authTokenStore, api, pluginRegistry, networkMonitor, pollingOrchestrator)
+    private fun createViewModel() = HomeViewModel(
+        pumpDriver,
+        repository,
+        backendSyncManager,
+        glucoseRangeStore,
+        safetyLimitsStore,
+        alertThresholdStore,
+        analyticsSettingsStore,
+        pumpProfileStore,
+        appSettingsStore,
+        authRepository,
+        authTokenStore,
+        api,
+        pluginRegistry,
+        networkMonitor,
+        pollingOrchestrator,
+    )
 
     @Test
     fun `initial state has null readings and not refreshing`() = runTest {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -45,7 +45,6 @@ import retrofit2.Response
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -149,9 +148,9 @@ class HomeViewModelTest {
 
     private val authRepository = mockk<AuthRepository>(relaxed = true)
 
-    private val storedBaseUrl = MutableStateFlow<String?>("https://test.example.com")
+    private val configuredFlow = MutableStateFlow(true)
     private val authTokenStore = mockk<AuthTokenStore>(relaxed = true) {
-        every { baseUrlFlow() } returns storedBaseUrl
+        every { backendConfiguredFlow() } returns configuredFlow
     }
 
     private val api = mockk<GlycemicGptApi>(relaxed = true)
@@ -202,33 +201,27 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `backendConfigured tracks the stored base url, not network status`() = runTest {
+    fun `backendConfigured tracks the mode signal, not network status`() = runTest {
         val vm = createViewModel()
 
-        // Seeded pessimistically false; flips true once the flow (on IO) delivers the URL.
-        // first{} suspends across the Dispatchers.IO hop, so no virtual-time advancing here.
-        assertTrue(vm.backendConfigured.first { it })
-
-        storedBaseUrl.value = null
-        assertFalse(vm.backendConfigured.first { !it })
-
-        storedBaseUrl.value = "https://other.example.com"
-        assertTrue(vm.backendConfigured.first { it })
-    }
-
-    @Test
-    fun `backendConfigured treats a blank base url as not configured`() = runTest {
-        storedBaseUrl.value = "   "
-        val vm = createViewModel()
-
-        val collected = mutableListOf<Boolean>()
-        val job = backgroundScope.launch(testDispatcher) {
-            vm.backendConfigured.collect { collected.add(it) }
-        }
+        // Seeded pessimistically false until a collector activates the WhileSubscribed stateIn.
+        assertFalse(vm.backendConfigured.value)
+        val job = backgroundScope.launch(testDispatcher) { vm.backendConfigured.collect {} }
         runCurrent()
+        assertTrue(vm.backendConfigured.value)
 
-        assertFalse(vm.backendConfigured.first { !it })
-        assertTrue(collected.none { it })
+        configuredFlow.value = false
+        runCurrent()
+        assertFalse(vm.backendConfigured.value)
+
+        // Network status is independent -- flipping it must not resurrect the indicators.
+        networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
+        runCurrent()
+        assertFalse(vm.backendConfigured.value)
+
+        configuredFlow.value = true
+        runCurrent()
+        assertTrue(vm.backendConfigured.value)
         job.cancel()
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/home/HomeViewModelTest.kt
@@ -3,6 +3,7 @@ package com.glycemicgpt.mobile.presentation.home
 import com.glycemicgpt.mobile.data.local.AlertThresholdStore
 import com.glycemicgpt.mobile.data.local.AnalyticsSettingsStore
 import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpProfileStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
@@ -44,6 +45,7 @@ import retrofit2.Response
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -147,6 +149,11 @@ class HomeViewModelTest {
 
     private val authRepository = mockk<AuthRepository>(relaxed = true)
 
+    private val storedBaseUrl = MutableStateFlow<String?>("https://test.example.com")
+    private val authTokenStore = mockk<AuthTokenStore>(relaxed = true) {
+        every { baseUrlFlow() } returns storedBaseUrl
+    }
+
     private val api = mockk<GlycemicGptApi>(relaxed = true)
     private val pluginRegistry = mockk<PluginRegistry>(relaxed = true) {
         every { allActivePlugins } returns MutableStateFlow<List<Plugin>>(emptyList())
@@ -170,7 +177,7 @@ class HomeViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, alertThresholdStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, api, pluginRegistry, networkMonitor, pollingOrchestrator)
+    private fun createViewModel() = HomeViewModel(pumpDriver, repository, backendSyncManager, glucoseRangeStore, safetyLimitsStore, alertThresholdStore, analyticsSettingsStore, pumpProfileStore, appSettingsStore, authRepository, authTokenStore, api, pluginRegistry, networkMonitor, pollingOrchestrator)
 
     @Test
     fun `initial state has null readings and not refreshing`() = runTest {
@@ -192,6 +199,37 @@ class HomeViewModelTest {
 
         networkStatusFlow.value = NetworkStatus.BACKEND_UNREACHABLE
         assertEquals(NetworkStatus.BACKEND_UNREACHABLE, vm.networkStatus.value)
+    }
+
+    @Test
+    fun `backendConfigured tracks the stored base url, not network status`() = runTest {
+        val vm = createViewModel()
+
+        // Seeded pessimistically false; flips true once the flow (on IO) delivers the URL.
+        // first{} suspends across the Dispatchers.IO hop, so no virtual-time advancing here.
+        assertTrue(vm.backendConfigured.first { it })
+
+        storedBaseUrl.value = null
+        assertFalse(vm.backendConfigured.first { !it })
+
+        storedBaseUrl.value = "https://other.example.com"
+        assertTrue(vm.backendConfigured.first { it })
+    }
+
+    @Test
+    fun `backendConfigured treats a blank base url as not configured`() = runTest {
+        storedBaseUrl.value = "   "
+        val vm = createViewModel()
+
+        val collected = mutableListOf<Boolean>()
+        val job = backgroundScope.launch(testDispatcher) {
+            vm.backendConfigured.collect { collected.add(it) }
+        }
+        runCurrent()
+
+        assertFalse(vm.backendConfigured.first { !it })
+        assertTrue(collected.none { it })
+        job.cancel()
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
@@ -13,6 +13,11 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -73,6 +78,132 @@ class BackendSyncManagerTest {
 
         coVerify(exactly = 0) { authTokenStore.hasActiveSession() }
         coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processQueue still prunes an over-cap queue without an active session`() = runTest {
+        // The bound must not depend on being able to drain: a signed-out (or refresh-expired)
+        // user with a paired pump keeps enqueueing, so prune has to run ahead of the session
+        // gate. Reverting that ordering turns this red (unbounded-growth latent bug).
+        every { authTokenStore.hasActiveSession() } returns false
+        coEvery { syncDao.countAll() } returns BackendSyncManager.MAX_QUEUE_SIZE + 500
+
+        manager.processQueue()
+
+        coVerify { syncDao.pruneOldest(500) }
+        coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
+        coVerify(exactly = 0) { api.pushPumpEvents(any()) }
+    }
+
+    @Test
+    fun `processQueue still prunes an over-cap queue when backend sync disabled`() = runTest {
+        every { appSettingsStore.backendSyncEnabled } returns false
+        coEvery { syncDao.countAll() } returns BackendSyncManager.MAX_QUEUE_SIZE + 42
+
+        manager.processQueue()
+
+        coVerify { syncDao.pruneOldest(42) }
+        coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
+        coVerify(exactly = 0) { api.pushPumpEvents(any()) }
+    }
+
+    @Test
+    fun `processQueue prunes and still drains with a valid session`() = runTest {
+        // Regression guard for full-stack-offline resilience: moving prune ahead of the gates
+        // must not detach the drain -- a valid session with a backed-up queue both prunes to
+        // the cap and pushes the next batch.
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.countAll() } returns BackendSyncManager.MAX_QUEUE_SIZE + 10
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
+        coEvery { api.pushPumpEvents(any()) } returns Response.success(
+            PumpPushResponse(accepted = 1, duplicates = 0),
+        )
+
+        manager.processQueue()
+
+        coVerify { syncDao.pruneOldest(10) }
+        coVerify { syncDao.deleteSent(listOf(1L)) }
+    }
+
+    @Test
+    fun `standDown purges the queue and resets sync status`() = runTest {
+        coEvery { syncDao.deleteAll() } returns 42
+
+        manager.standDown()
+
+        coVerify { syncDao.deleteAll() }
+        assertEquals(0L, manager.syncStatus.value.lastSyncAtMs)
+        assertNull(manager.syncStatus.value.lastError)
+    }
+
+    // -- start() lifecycle: gated on the live base URL ---------------------------------------
+    // These use a real dispatcher scope (not virtual time) because the mode flow hops through
+    // Dispatchers.IO; mockk's timeout verification bridges the threads.
+
+    @Test
+    fun `start without a backend purges the queue and never drains`() {
+        val baseUrl = MutableStateFlow<String?>(null)
+        every { authTokenStore.baseUrlFlow() } returns baseUrl
+        coEvery { syncDao.deleteAll() } returns 7
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            manager.start(scope)
+
+            coVerify(timeout = 5_000) { syncDao.deleteAll() }
+            coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
+            coVerify(exactly = 0) { api.pushPumpEvents(any()) }
+        } finally {
+            manager.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `dropping the base url cancels the loop and purges the queue`() {
+        // Server-drop (clearBaseUrl / continue-without-server) purges; this is the AC5 path.
+        val baseUrl = MutableStateFlow<String?>("https://api.example.com")
+        every { authTokenStore.baseUrlFlow() } returns baseUrl
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns emptyList()
+        coEvery { syncDao.deleteAll() } returns 3
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            manager.start(scope)
+            // Loop is live while configured...
+            coVerify(timeout = 5_000, atLeast = 1) { syncDao.getPendingBatch(any(), any(), any()) }
+            coVerify(exactly = 0) { syncDao.deleteAll() }
+
+            baseUrl.value = null
+
+            // ...and stands down (purge, no further drains) the moment the server is dropped.
+            coVerify(timeout = 5_000) { syncDao.deleteAll() }
+        } finally {
+            manager.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `logout does not purge - queue is preserved and bounded while the url remains`() {
+        // Logout keeps the base URL, so the stand-down purge must NOT fire: the queue is
+        // preserved (bounded by the prune) to drain on re-login.
+        val baseUrl = MutableStateFlow<String?>("https://api.example.com")
+        every { authTokenStore.baseUrlFlow() } returns baseUrl
+        every { authTokenStore.hasActiveSession() } returns false
+        coEvery { syncDao.countAll() } returns BackendSyncManager.MAX_QUEUE_SIZE + 5
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            manager.start(scope)
+
+            // The bounded-no-drain posture is active (prune ran)...
+            coVerify(timeout = 5_000, atLeast = 1) { syncDao.pruneOldest(5) }
+            // ...but nothing was purged and nothing drained.
+            coVerify(exactly = 0) { syncDao.deleteAll() }
+            coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
+        } finally {
+            manager.stop()
+            scope.cancel()
+        }
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
@@ -13,11 +13,10 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -25,6 +24,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import retrofit2.Response
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class BackendSyncManagerTest {
 
     private val syncDao = mockk<SyncDao>(relaxed = true)
@@ -126,84 +126,80 @@ class BackendSyncManagerTest {
     }
 
     @Test
-    fun `standDown purges the queue and resets sync status`() = runTest {
+    fun `purgeUndeliverable clears both outbound tables and resets sync status`() = runTest {
         coEvery { syncDao.deleteAll() } returns 42
+        coEvery { rawHistoryLogDao.deleteAllButMaxSequence() } returns 7
 
-        manager.standDown()
+        manager.purgeUndeliverable()
 
         coVerify { syncDao.deleteAll() }
+        coVerify { rawHistoryLogDao.deleteAllButMaxSequence() }
         assertEquals(0L, manager.syncStatus.value.lastSyncAtMs)
         assertNull(manager.syncStatus.value.lastError)
     }
 
-    // -- start() lifecycle: gated on the live base URL ---------------------------------------
-    // These use a real dispatcher scope (not virtual time) because the mode flow hops through
-    // Dispatchers.IO; mockk's timeout verification bridges the threads.
+    // -- start() lifecycle: gated on the live mode signal ------------------------------------
 
     @Test
-    fun `start without a backend purges the queue and never drains`() {
-        val baseUrl = MutableStateFlow<String?>(null)
-        every { authTokenStore.baseUrlFlow() } returns baseUrl
-        coEvery { syncDao.deleteAll() } returns 7
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        try {
-            manager.start(scope)
+    fun `start without a backend purges the queue and never drains`() = runTest {
+        every { authTokenStore.backendConfiguredFlow() } returns MutableStateFlow(false)
 
-            coVerify(timeout = 5_000) { syncDao.deleteAll() }
-            coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
-            coVerify(exactly = 0) { api.pushPumpEvents(any()) }
-        } finally {
-            manager.stop()
-            scope.cancel()
-        }
+        manager.start(backgroundScope)
+        runCurrent()
+
+        coVerify { syncDao.deleteAll() }
+        coVerify { rawHistoryLogDao.deleteAllButMaxSequence() }
+        coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
+        coVerify(exactly = 0) { api.pushPumpEvents(any()) }
+
+        // The stand-down sweep re-collects hourly (racing enqueues, ongoing raw rows) --
+        // no 3s cadence.
+        advanceTimeBy(BackendSyncManager.STAND_DOWN_SWEEP_INTERVAL_MS + 1)
+        runCurrent()
+        coVerify(exactly = 2) { syncDao.deleteAll() }
+        manager.stop()
     }
 
     @Test
-    fun `dropping the base url cancels the loop and purges the queue`() {
-        // Server-drop (clearBaseUrl / continue-without-server) purges; this is the AC5 path.
-        val baseUrl = MutableStateFlow<String?>("https://api.example.com")
-        every { authTokenStore.baseUrlFlow() } returns baseUrl
+    fun `dropping the backend cancels the loop and purges the queue`() = runTest {
+        // Server-drop (clearBaseUrl / continue-without-server) purges; this is the story's
+        // purge-on-server-drop path.
+        val configured = MutableStateFlow(true)
+        every { authTokenStore.backendConfiguredFlow() } returns configured
         every { authTokenStore.hasActiveSession() } returns true
         coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns emptyList()
-        coEvery { syncDao.deleteAll() } returns 3
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        try {
-            manager.start(scope)
-            // Loop is live while configured...
-            coVerify(timeout = 5_000, atLeast = 1) { syncDao.getPendingBatch(any(), any(), any()) }
-            coVerify(exactly = 0) { syncDao.deleteAll() }
 
-            baseUrl.value = null
+        manager.start(backgroundScope)
+        runCurrent()
+        // Loop is live while configured...
+        coVerify(atLeast = 1) { syncDao.getPendingBatch(any(), any(), any()) }
+        coVerify(exactly = 0) { syncDao.deleteAll() }
 
-            // ...and stands down (purge, no further drains) the moment the server is dropped.
-            coVerify(timeout = 5_000) { syncDao.deleteAll() }
-        } finally {
-            manager.stop()
-            scope.cancel()
-        }
+        configured.value = false
+        runCurrent()
+
+        // ...and stands down (purge, no further drains) the moment the server is dropped.
+        coVerify { syncDao.deleteAll() }
+        manager.stop()
     }
 
     @Test
-    fun `logout does not purge - queue is preserved and bounded while the url remains`() {
-        // Logout keeps the base URL, so the stand-down purge must NOT fire: the queue is
-        // preserved (bounded by the prune) to drain on re-login.
-        val baseUrl = MutableStateFlow<String?>("https://api.example.com")
-        every { authTokenStore.baseUrlFlow() } returns baseUrl
+    fun `logout does not purge - queue is preserved and bounded while the url remains`() = runTest {
+        // Logout keeps the base URL (mode stays configured), so the stand-down purge must NOT
+        // fire: the queue is preserved (bounded by the prune) to drain on re-login.
+        every { authTokenStore.backendConfiguredFlow() } returns MutableStateFlow(true)
         every { authTokenStore.hasActiveSession() } returns false
         coEvery { syncDao.countAll() } returns BackendSyncManager.MAX_QUEUE_SIZE + 5
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        try {
-            manager.start(scope)
 
-            // The bounded-no-drain posture is active (prune ran)...
-            coVerify(timeout = 5_000, atLeast = 1) { syncDao.pruneOldest(5) }
-            // ...but nothing was purged and nothing drained.
-            coVerify(exactly = 0) { syncDao.deleteAll() }
-            coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
-        } finally {
-            manager.stop()
-            scope.cancel()
-        }
+        manager.start(backgroundScope)
+        runCurrent()
+
+        // The bounded-no-drain posture is active (prune ran)...
+        coVerify(atLeast = 1) { syncDao.pruneOldest(5) }
+        // ...but nothing was purged and nothing drained.
+        coVerify(exactly = 0) { syncDao.deleteAll() }
+        coVerify(exactly = 0) { syncDao.getPendingBatch(any(), any(), any()) }
+        manager.stop()
     }
 
     @Test


### PR DESCRIPTION
## Summary

The pump-event `sync_queue` grew without bound whenever it could not drain: forever for a BLE-only user (no backend configured), and for a full-stack user who signed out or let the refresh token expire while a pump stayed paired -- the only pruner sat behind the session gate. Home also showed a dishonest "pending sync" icon and a green "Backend reachable" chip for BLE-only devices.

The fix has two independent parts:

**Stand down when no backend is configured.** The enqueuer no-ops (checked once per call, off the main thread, guarded so a storage failure can never kill the pump polling loops). `BackendSyncManager` keys its lifecycle on the live mode signal: unconfigured, it purges the undeliverable outbound copies (`sync_queue` plus `raw_history_logs`, preserving the max-sequence resume anchor) and idles with an hourly sweep instead of waking every 3s; dropping the server purges immediately and adding one starts syncing without a service restart.

**Bound the queue whenever it cannot drain.** Queue hygiene (stale-sending reset, prune to `MAX_QUEUE_SIZE`, cleanup) now runs ahead of the `backendSyncEnabled`/`hasActiveSession` gates, on a 60s cadence while gated. The drain stays behind the session gate, so full-stack offline resilience is unchanged: a configured backend that is temporarily unreachable still accumulates a bounded queue and drains on reconnect (regression-guarded by test).

Logout intentionally does not purge -- it preserves the base URL, so the queue stays bounded and drains on re-login. Only removing the server purges.

**Honest Home.** The sync icon and backend-reachability chip render only when a backend is configured, keyed on the live mode signal (not network status). Full-stack users keep them while offline -- the climbing pending count and "Backend unreachable" are the honest outage story.

The reactive mode signal is now a single shared helper, `AuthTokenStore.backendConfiguredFlow()` (injected IO dispatcher), replacing four hand-rolled copies of the same mapping across the sync manager, Home, the alerts banner, and the alert-floor status provider. The preference listener registers before the initial emission so a write can no longer land unobserved.

No Room schema change: `AppDatabase` stays at v13; the purges are plain DELETE queries.

## Testing

- Unit: mutant-proven guards -- reverting the enqueue gate or moving hygiene back behind the session gate turns the new tests red; drain-with-valid-session, purge-on-drop, logout-no-purge, and the hourly sweep are covered on virtual time.
- Emulator E2E (mobile-mcp): BLE-only onboarding shows no cloud indicators; signing in to a server shows them reactively; simulated unreachable keeps them with honest copy; sign-out preserves the server URL; choosing "Use without a server" removes the indicators immediately. No crashes.
- `testDebugUnitTest`, `lintDebug`, `assembleDebug` green; CodeRabbit CLI findings addressed; security review clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend sync now automatically pauses when no server is configured and resumes when it becomes available.

* **Bug Fixes**
  * Prevented missed backend configuration updates during startup.
  * Improved sync reliability with batched queue writes, safer error handling, and improved cancellation behavior.
  * Reduced growth of stale local sync/transfer data via bounded pruning and safer “stand-down” purges.

* **Behavior Changes**
  * Cloud/sync indicators are hidden when backend features aren’t configured, leaving only local device connection status visible.

* **Tests**
  * Updated and expanded unit tests to cover the new backend-gating and queue lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->