### PR TITLE
fix(mobile): stop discarding queued pump events during backend outages

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -145,6 +145,9 @@ android {
     }
 
     testOptions {
+        // Robolectric tests (real in-memory Room, e.g. SyncDaoTest) need Android
+        // resources on the unit-test classpath.
+        unitTests.isIncludeAndroidResources = true
         unitTests.all {
             // Default Android test JVM heap (512MB) is too small for our
             // mockk-based tests; relaxed mocks of large interfaces and
@@ -246,6 +249,8 @@ dependencies {
     testImplementation(libs.mockwebserver)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.turbine)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
     testImplementation("org.json:json:20240303")
 
     // Android tests

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/SyncDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/SyncDao.kt
@@ -53,12 +53,12 @@ interface SyncDao {
 
     /**
      * Mark a batch failed WITHOUT counting toward the retry budget: transport failures
-     * (the server never received the batch) and transient server responses (5xx/429/408).
-     * These must not exhaust MAX_RETRIES -- a backend outage longer than the retry budget
-     * (~62s) would otherwise silently discard the whole queue instead of draining it on
-     * reconnect. Setting status='failed' (rather than leaving the rows in 'sending')
-     * keeps them re-selectable by [getPendingBatch] on their current backoff tier instead
-     * of stalling 60s per cycle waiting for [resetStaleSending].
+     * (the server never received the batch) and transient gateway/server responses
+     * (502/503/504/429/408). These must not exhaust MAX_RETRIES -- a backend outage longer
+     * than the retry budget (~62s) would otherwise silently discard the whole queue instead
+     * of draining it on reconnect. Setting status='failed' (rather than leaving the rows in
+     * 'sending') keeps them re-selectable by [getPendingBatch] on their current backoff tier
+     * instead of stalling 60s per cycle waiting for [resetStaleSending].
      */
     @Query(
         """

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/SyncDao.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/local/dao/SyncDao.kt
@@ -51,6 +51,28 @@ interface SyncDao {
         nowMs: Long = System.currentTimeMillis(),
     )
 
+    /**
+     * Mark a batch failed WITHOUT counting toward the retry budget: transport failures
+     * (the server never received the batch) and transient server responses (5xx/429/408).
+     * These must not exhaust MAX_RETRIES -- a backend outage longer than the retry budget
+     * (~62s) would otherwise silently discard the whole queue instead of draining it on
+     * reconnect. Setting status='failed' (rather than leaving the rows in 'sending')
+     * keeps them re-selectable by [getPendingBatch] on their current backoff tier instead
+     * of stalling 60s per cycle waiting for [resetStaleSending].
+     */
+    @Query(
+        """
+        UPDATE sync_queue
+        SET status = 'failed', lastAttemptMs = :nowMs, errorMessage = :error
+        WHERE id IN (:ids)
+        """
+    )
+    suspend fun markTransientFailure(
+        ids: List<Long>,
+        error: String?,
+        nowMs: Long = System.currentTimeMillis(),
+    )
+
     @Query("SELECT COUNT(*) FROM sync_queue WHERE status != 'sending'")
     fun observePendingCount(): Flow<Int>
 
@@ -59,16 +81,18 @@ interface SyncDao {
     suspend fun countAll(): Int
 
     /**
-     * Delete the oldest expendable items (pending or exhausted-failed) to keep queue bounded.
-     * Pending items are safe to drop; exhausted-failed items (retryCount >= 5) will never
-     * succeed so they are also prunable. Items in 'sending' status are preserved.
+     * Delete the oldest items to keep the queue bounded, preserving only in-flight 'sending'
+     * rows. During an outage the backlog dwells in 'failed' below MAX_RETRIES (transport
+     * failures no longer count toward the budget), so limiting the prune to pending/exhausted
+     * rows would starve it and let the queue grow past the cap -- dropping the oldest
+     * retryable rows IS the intended discard policy at MAX_QUEUE_SIZE.
      */
     @Query(
         """
         DELETE FROM sync_queue
         WHERE id IN (
             SELECT id FROM sync_queue
-            WHERE status = 'pending' OR (status = 'failed' AND retryCount >= 5)
+            WHERE status != 'sending'
             ORDER BY createdAtMs ASC
             LIMIT :excess
         )

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugScreen.kt
@@ -102,6 +102,18 @@ fun BleDebugScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
 
+        // Outage-retention harness (GLY-152): seed sync-queue rows the emulator can't
+        // produce (no BLE pump), so the survives-an-outage / drains-on-reconnect E2E
+        // is reproducible with the unreachable fault toggle.
+        OutlinedButton(
+            onClick = viewModel::seedSyncQueue,
+            modifier = Modifier.testTag("seed_sync_queue_button"),
+        ) {
+            Text("Seed sync queue")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         // Connection state indicator
         ConnectionStateBar(connectionState)
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/debug/BleDebugViewModel.kt
@@ -1,16 +1,24 @@
 package com.glycemicgpt.mobile.presentation.debug
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.glycemicgpt.mobile.BuildConfig
 import com.glycemicgpt.mobile.data.local.BleDebugStore
 import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.data.repository.SyncQueueEnqueuer
+import com.glycemicgpt.mobile.domain.model.BasalReading
 import com.glycemicgpt.mobile.domain.model.CgmReading
 import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
+import com.glycemicgpt.mobile.service.PumpConnectionService
 import com.glycemicgpt.mobile.service.PumpPollingOrchestrator
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.time.Instant
@@ -22,6 +30,8 @@ class BleDebugViewModel @Inject constructor(
     private val connectionManager: PumpConnectionManager,
     private val pumpDataRepository: PumpDataRepository,
     private val pollingOrchestrator: PumpPollingOrchestrator,
+    private val syncEnqueuer: SyncQueueEnqueuer,
+    @ApplicationContext private val appContext: Context,
 ) : ViewModel() {
 
     val entries: StateFlow<List<BleDebugStore.Entry>> = debugStore.entries
@@ -58,6 +68,45 @@ class BleDebugViewModel @Inject constructor(
     }
 
     /**
+     * Debug-only: seed a batch of synthetic basal events into the sync queue through the same
+     * production seam the poll loop uses ([SyncQueueEnqueuer.enqueueBasalBatch], so the
+     * backend-configured gate still applies). The emulator has no BLE pump, so nothing else
+     * ever fills the queue there; this makes the outage-retention E2E (queue survives a
+     * sustained transport outage, then drains on reconnect) reproducible. Distinct timestamps
+     * per event keep the backend's natural-key dedupe from collapsing the batch. The
+     * enqueuer's mode gate still applies: with no backend configured this seeds nothing.
+     */
+    fun seedSyncQueue() {
+        if (!BuildConfig.DEBUG) return
+        viewModelScope.launch {
+            try {
+                // The drain loop lives in PumpConnectionService, which only starts on pump
+                // pairing -- never on an emulator. Bring it up the same way a paired cold
+                // start does, so the seeded rows are processed by the real service
+                // lifecycle rather than sitting inert.
+                PumpConnectionService.start(appContext)
+                val now = Instant.now()
+                syncEnqueuer.enqueueBasalBatch(
+                    (0 until SEED_SYNC_EVENT_COUNT).map { i ->
+                        BasalReading(
+                            rate = 0.5f,
+                            isAutomated = true,
+                            activityMode = PumpActivityMode.NONE,
+                            timestamp = now.minusSeconds(i.toLong()),
+                        )
+                    },
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A harness failure (FGS start restriction, DB error) must not crash the
+                // app it exists to debug -- log and move on.
+                Timber.w(e, "Sync queue seed failed")
+            }
+        }
+    }
+
+    /**
      * Writes the synthetic reading to the same Room cache the real poll path uses, then drives
      * [PumpPollingOrchestrator.processCgmReading] — the exact production seam `pollCgm` calls —
      * so the watch relay and the alert floor see the injected reading exactly as they would a
@@ -86,5 +135,7 @@ class BleDebugViewModel @Inject constructor(
         /** Past CGM_DEBUG_FAST's tooStaleAfterMs (45s), so the injected reading lands TOO_STALE
          *  under the compressed policy the E2E runs with. */
         const val TEST_STALE_AGE_SECONDS = 60L
+
+        const val SEED_SYNC_EVENT_COUNT = 20
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -325,12 +325,15 @@ class BackendSyncManager @Inject constructor(
         } else {
             val code = response.code()
             val error = "HTTP $code"
-            // 5xx/429/408 mean the server is reachable but transiently erroring (deploy,
-            // restart, rate limit, gateway timeout) -- like transport failures, they must
-            // not burn the retry budget. The remaining 4xx are treated as client rejections
-            // that will never be accepted, so they keep counting and give up after
-            // MAX_RETRIES.
-            if (code >= 500 || code == 429 || code == 408) {
+            // 502/503/504/429/408 mean the gateway or server is transiently unavailable
+            // (deploy, restart, rate limit, timeout) -- like transport failures, they must
+            // not burn the retry budget. Everything else keeps counting and gives up after
+            // MAX_RETRIES: 4xx is a client rejection that will never be accepted, and a
+            // persistent 500 (a deterministic server error on this batch's payload) must
+            // exhaust rather than head-of-line-block the whole queue -- getPendingBatch
+            // always offers the oldest rows first, so a never-counting poison batch would
+            // stall every row behind it until the retention cutoff.
+            if (code in 502..504 || code == 429 || code == 408) {
                 syncDao.markTransientFailure(validIds.toList(), error)
             } else {
                 syncDao.markFailed(validIds.toList(), error)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -304,8 +304,18 @@ class BackendSyncManager @Inject constructor(
                     response.body()?.rawDuplicates ?: 0,
                 )
             } else {
-                val error = "HTTP ${response.code()}"
-                syncDao.markFailed(validIds.toList(), error)
+                val code = response.code()
+                val error = "HTTP $code"
+                // 5xx/429/408 mean the server is reachable but transiently erroring
+                // (deploy, restart, rate limit, gateway timeout) -- like transport
+                // failures, they must not burn the retry budget. The remaining 4xx are
+                // treated as client rejections that will never be accepted, so they keep
+                // counting and give up after MAX_RETRIES.
+                if (code >= 500 || code == 429 || code == 408) {
+                    syncDao.markTransientFailure(validIds.toList(), error)
+                } else {
+                    syncDao.markFailed(validIds.toList(), error)
+                }
                 _syncStatus.value = _syncStatus.value.copy(lastError = error)
                 Timber.w("Sync push failed: %s", error)
             }
@@ -315,8 +325,12 @@ class BackendSyncManager @Inject constructor(
             // reclaims them if the push never completed.
             throw e
         } catch (e: Exception) {
+            // Thrown = transport failure (Response<> returns all HTTP statuses): the server
+            // never received the batch. Counting these against MAX_RETRIES would exhaust the
+            // queue ~62s into an outage and the hourly cleanup would delete it -- discarding
+            // everything older than a minute instead of draining on reconnect.
             val error = e.message ?: "Unknown network error"
-            syncDao.markFailed(validIds.toList(), error)
+            syncDao.markTransientFailure(validIds.toList(), error)
             _syncStatus.value = _syncStatus.value.copy(lastError = error)
             Timber.w(e, "Sync push network error")
         }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/BackendSyncManager.kt
@@ -279,46 +279,16 @@ class BackendSyncManager @Inject constructor(
             )
         }
 
-        try {
-            val request = PumpPushRequest(
-                events = events,
-                rawEvents = rawEventDtos.ifEmpty { null },
-                pumpInfo = hardwareDto,
-            )
-            val response = api.pushPumpEvents(request)
-            if (response.isSuccessful) {
-                syncDao.deleteSent(validIds.toList())
-                // Mark raw logs as sent on success
-                if (rawLogs.isNotEmpty()) {
-                    rawHistoryLogDao.markSent(rawLogs.map { it.id })
-                }
-                _syncStatus.value = _syncStatus.value.copy(
-                    lastSyncAtMs = System.currentTimeMillis(),
-                    lastError = null,
-                )
-                Timber.d(
-                    "Sync push: accepted=%d, duplicates=%d, raw_accepted=%d, raw_duplicates=%d",
-                    response.body()?.accepted ?: 0,
-                    response.body()?.duplicates ?: 0,
-                    response.body()?.rawAccepted ?: 0,
-                    response.body()?.rawDuplicates ?: 0,
-                )
-            } else {
-                val code = response.code()
-                val error = "HTTP $code"
-                // 5xx/429/408 mean the server is reachable but transiently erroring
-                // (deploy, restart, rate limit, gateway timeout) -- like transport
-                // failures, they must not burn the retry budget. The remaining 4xx are
-                // treated as client rejections that will never be accepted, so they keep
-                // counting and give up after MAX_RETRIES.
-                if (code >= 500 || code == 429 || code == 408) {
-                    syncDao.markTransientFailure(validIds.toList(), error)
-                } else {
-                    syncDao.markFailed(validIds.toList(), error)
-                }
-                _syncStatus.value = _syncStatus.value.copy(lastError = error)
-                Timber.w("Sync push failed: %s", error)
-            }
+        val request = PumpPushRequest(
+            events = events,
+            rawEvents = rawEventDtos.ifEmpty { null },
+            pumpInfo = hardwareDto,
+        )
+        // Only the network call is inside the catch: a DAO failure after the server already
+        // accepted the batch must not be mislabeled as a push failure (rows stay 'sending'
+        // and resetStaleSending reclaims them; the backend dedupes the resend).
+        val response = try {
+            api.pushPumpEvents(request)
         } catch (e: CancellationException) {
             // A mode flip cancels this loop via collectLatest mid-push; that is a clean
             // switch, not a failed upload -- items stay 'sending' and resetStaleSending
@@ -333,6 +303,40 @@ class BackendSyncManager @Inject constructor(
             syncDao.markTransientFailure(validIds.toList(), error)
             _syncStatus.value = _syncStatus.value.copy(lastError = error)
             Timber.w(e, "Sync push network error")
+            return
+        }
+        if (response.isSuccessful) {
+            syncDao.deleteSent(validIds.toList())
+            // Mark raw logs as sent on success
+            if (rawLogs.isNotEmpty()) {
+                rawHistoryLogDao.markSent(rawLogs.map { it.id })
+            }
+            _syncStatus.value = _syncStatus.value.copy(
+                lastSyncAtMs = System.currentTimeMillis(),
+                lastError = null,
+            )
+            Timber.d(
+                "Sync push: accepted=%d, duplicates=%d, raw_accepted=%d, raw_duplicates=%d",
+                response.body()?.accepted ?: 0,
+                response.body()?.duplicates ?: 0,
+                response.body()?.rawAccepted ?: 0,
+                response.body()?.rawDuplicates ?: 0,
+            )
+        } else {
+            val code = response.code()
+            val error = "HTTP $code"
+            // 5xx/429/408 mean the server is reachable but transiently erroring (deploy,
+            // restart, rate limit, gateway timeout) -- like transport failures, they must
+            // not burn the retry budget. The remaining 4xx are treated as client rejections
+            // that will never be accepted, so they keep counting and give up after
+            // MAX_RETRIES.
+            if (code >= 500 || code == 429 || code == 408) {
+                syncDao.markTransientFailure(validIds.toList(), error)
+            } else {
+                syncDao.markFailed(validIds.toList(), error)
+            }
+            _syncStatus.value = _syncStatus.value.copy(lastError = error)
+            Timber.w("Sync push failed: %s", error)
         }
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/dao/SyncDaoTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/dao/SyncDaoTest.kt
@@ -133,6 +133,34 @@ class SyncDaoTest {
     }
 
     @Test
+    fun `counted failures cannot head-of-line-block newer rows`() = runTest {
+        // getPendingBatch offers the oldest rows first, so a poison batch that persistently
+        // 500s occupies every batch slot while it retries. Because the poison rows fail via
+        // the COUNTING verb (the manager's 500 classification, pinned in
+        // BackendSyncManagerTest), they exhaust after MAX_RETRIES and the rows behind them
+        // get offered -- with the non-counting verb this loop would never terminate and
+        // newer rows would never drain.
+        val batchLimit = 3
+        repeat(batchLimit) { i -> dao.enqueue(entity(createdAtMs = T0 + i)) }
+        dao.enqueue(entity(createdAtMs = T0 + 1_000))
+        dao.enqueue(entity(createdAtMs = T0 + 1_001))
+        val poisonIds = dao.getPendingBatch(limit = batchLimit, maxRetries = MAX_RETRIES, nowMs = T0 + 2_000).map { it.id }
+
+        var now = T0 + 2_000
+        repeat(MAX_RETRIES) {
+            val batch = dao.getPendingBatch(limit = batchLimit, maxRetries = MAX_RETRIES, nowMs = now)
+            assertEquals("poison batch occupies the head while it retries", poisonIds, batch.map { it.id })
+            dao.markSending(batch.map { it.id }, nowMs = now)
+            dao.markFailed(batch.map { it.id }, "HTTP 500", nowMs = now)
+            now += BASE_BACKOFF_MS * (1L shl MAX_RETRIES)
+        }
+
+        val offered = dao.getPendingBatch(limit = batchLimit, maxRetries = MAX_RETRIES, nowMs = now)
+        assertEquals("newer rows drain once the poison batch exhausts", 2, offered.size)
+        assertTrue(offered.none { it.id in poisonIds })
+    }
+
+    @Test
     fun `pruneOldest drops transport-failed backlog but preserves in-flight rows`() = runTest {
         // During an outage the whole backlog sits in 'failed' below MAX_RETRIES. The prune
         // must still be able to enforce MAX_QUEUE_SIZE against those rows (oldest first),

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/dao/SyncDaoTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/dao/SyncDaoTest.kt
@@ -1,0 +1,164 @@
+package com.glycemicgpt.mobile.data.local.dao
+
+import android.app.Application
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.glycemicgpt.mobile.data.local.AppDatabase
+import com.glycemicgpt.mobile.data.local.entity.SyncQueueEntity
+import com.glycemicgpt.mobile.service.BackendSyncManager
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Real-SQL proof of the sync retry policy against an in-memory Room database.
+ *
+ * The mock-based [com.glycemicgpt.mobile.service.BackendSyncManagerTest] only asserts
+ * which DAO verb the manager calls; these tests prove the SQL itself retains and
+ * re-offers rows. The core invariant: transport failures ([SyncDao.markTransientFailure])
+ * never exhaust a row out of [SyncDao.getPendingBatch] no matter how long the outage,
+ * while counted failures ([SyncDao.markFailed]) give up after MAX_RETRIES and are
+ * deleted by [SyncDao.cleanup].
+ */
+// Plain Application: the manifest's @HiltAndroidApp class would pull keystore-backed
+// injection into a JVM test that only needs a Context for an in-memory database.
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class SyncDaoTest {
+
+    private companion object {
+        const val MAX_RETRIES = BackendSyncManager.MAX_RETRIES
+
+        /** Mirrors the literal `2000` baked into [SyncDao.getPendingBatch]'s backoff SQL --
+         *  Room can't parameterize it, so keep the two in lockstep. */
+        const val BASE_BACKOFF_MS = 2_000L
+        const val T0 = 1_000_000L
+    }
+
+    private lateinit var db: AppDatabase
+    private lateinit var dao: SyncDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.syncDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun entity(createdAtMs: Long = T0): SyncQueueEntity =
+        SyncQueueEntity(
+            eventType = "basal",
+            eventTimestampMs = createdAtMs,
+            payload = """{"event_type":"basal"}""",
+            createdAtMs = createdAtMs,
+        )
+
+    @Test
+    fun `markTransientFailure never exhausts - row stays selectable across many outage cycles`() = runTest {
+        dao.enqueue(entity())
+        var now = T0
+
+        // Far more cycles than MAX_RETRIES: with markFailed this row would be
+        // excluded after 5 and deleted by cleanup; with markTransientFailure it
+        // must be re-offered every cycle for the whole outage.
+        repeat(MAX_RETRIES * 4) {
+            val batch = dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = now)
+            assertEquals("row must be re-offered on every outage cycle", 1, batch.size)
+            val id = batch.single().id
+            dao.markSending(listOf(id), nowMs = now)
+            dao.markTransientFailure(listOf(id), "timeout", nowMs = now)
+            now += BASE_BACKOFF_MS + 1
+        }
+
+        val survivor = dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = now).single()
+        assertEquals("transport failures must not count toward the retry budget", 0, survivor.retryCount)
+        assertEquals(SyncQueueEntity.STATUS_FAILED, survivor.status)
+
+        // The exhaustion cleanup must not touch it either (retention cutoff in the past).
+        dao.cleanup(maxRetries = MAX_RETRIES, cutoffMs = T0 - 1)
+        assertEquals(1, dao.countAll())
+    }
+
+    @Test
+    fun `markFailed exhausts after MAX_RETRIES and cleanup deletes the row`() = runTest {
+        dao.enqueue(entity())
+        var now = T0
+
+        repeat(MAX_RETRIES) {
+            val batch = dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = now)
+            assertEquals(1, batch.size)
+            val id = batch.single().id
+            dao.markSending(listOf(id), nowMs = now)
+            dao.markFailed(listOf(id), "HTTP 422", nowMs = now)
+            // Jump past the exponential backoff so eligibility is decided purely
+            // by the retryCount < maxRetries exclusion.
+            now += BASE_BACKOFF_MS * (1L shl MAX_RETRIES)
+        }
+
+        assertTrue(
+            "row must be excluded once retryCount reaches MAX_RETRIES",
+            dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = now).isEmpty(),
+        )
+        dao.cleanup(maxRetries = MAX_RETRIES, cutoffMs = T0 - 1)
+        assertEquals(0, dao.countAll())
+    }
+
+    @Test
+    fun `markTransientFailure moves rows out of sending and the base backoff re-offers them`() = runTest {
+        dao.enqueue(entity())
+        val id = dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = T0).single().id
+        dao.markSending(listOf(id), nowMs = T0)
+        dao.markTransientFailure(listOf(id), "connect refused", nowMs = T0)
+
+        // Backoff respected: not re-offered before 2000 * (1 << 0) has elapsed...
+        assertTrue(dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = T0 + BASE_BACKOFF_MS).isEmpty())
+        // ...and re-offered right after -- no 60s resetStaleSending stall.
+        val reoffered = dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = T0 + BASE_BACKOFF_MS + 1)
+        assertEquals(1, reoffered.size)
+        assertEquals("connect refused", reoffered.single().errorMessage)
+    }
+
+    @Test
+    fun `pruneOldest drops transport-failed backlog but preserves in-flight rows`() = runTest {
+        // During an outage the whole backlog sits in 'failed' below MAX_RETRIES. The prune
+        // must still be able to enforce MAX_QUEUE_SIZE against those rows (oldest first),
+        // or a multi-day outage grows the queue unbounded; only 'sending' is off-limits.
+        repeat(4) { i -> dao.enqueue(entity(createdAtMs = T0 + i)) }
+        val ids = dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = T0 + 100).map { it.id }
+        dao.markTransientFailure(ids, "timeout", nowMs = T0 + 100)
+        dao.markSending(listOf(ids.first()), nowMs = T0 + 200)
+
+        dao.pruneOldest(excess = 3)
+
+        assertEquals("only the in-flight 'sending' row survives", 1, dao.countAll())
+        dao.resetStaleSending(staleCutoffMs = T0 + 300)
+        val survivor = dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = T0 + 400).single()
+        assertEquals(ids.first(), survivor.id)
+    }
+
+    @Test
+    fun `cleanup retention cutoff still trims transport-failed rows older than retention`() = runTest {
+        dao.enqueue(entity(createdAtMs = T0))
+        dao.enqueue(entity(createdAtMs = T0 + 100_000))
+        val ids = dao.getPendingBatch(limit = 50, maxRetries = MAX_RETRIES, nowMs = T0 + 200_000).map { it.id }
+        dao.markTransientFailure(ids, "timeout", nowMs = T0 + 200_000)
+
+        // Never-exhaust must not mean never-discard: the retention cutoff still applies.
+        dao.cleanup(maxRetries = MAX_RETRIES, cutoffMs = T0 + 50_000)
+        assertEquals(1, dao.countAll())
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
@@ -254,9 +254,10 @@ class BackendSyncManagerTest {
     }
 
     @Test
-    fun `processQueue marks transient-failure on server error`() = runTest {
-        // 5xx = server reachable but transiently erroring (deploy, restart); it must not
-        // burn the retry budget any more than a dropped connection does.
+    fun `processQueue marks failed on internal server error - retry budget counts`() = runTest {
+        // A 500 can be a deterministic server error on this batch's payload (poison row).
+        // It must keep counting so the batch exhausts after MAX_RETRIES instead of
+        // head-of-line-blocking every newer row until the retention cutoff.
         every { authTokenStore.hasActiveSession() } returns true
         coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
         coEvery { api.pushPumpEvents(any()) } returns Response.error(
@@ -266,7 +267,39 @@ class BackendSyncManagerTest {
 
         manager.processQueue()
 
-        coVerify { syncDao.markTransientFailure(listOf(1L), "HTTP 500", any()) }
+        coVerify { syncDao.markFailed(listOf(1L), "HTTP 500", any()) }
+        coVerify(exactly = 0) { syncDao.markTransientFailure(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processQueue marks transient-failure on gateway unavailability`() = runTest {
+        // 502/503/504 = LB/gateway during a deploy or restart -- genuinely transient; it
+        // must not burn the retry budget any more than a dropped connection does.
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
+        coEvery { api.pushPumpEvents(any()) } returns Response.error(
+            503,
+            "Service Unavailable".toResponseBody(),
+        )
+
+        manager.processQueue()
+
+        coVerify { syncDao.markTransientFailure(listOf(1L), "HTTP 503", any()) }
+        coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processQueue rethrows cancellation without marking anything failed`() = runTest {
+        // A mode flip cancels the loop mid-push: that is a clean switch, not a failed
+        // upload -- rows stay 'sending' for resetStaleSending. Guards the catch order.
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
+        coEvery { api.pushPumpEvents(any()) } throws kotlinx.coroutines.CancellationException("mode flip")
+
+        val result = runCatching { manager.processQueue() }
+
+        assertTrue(result.exceptionOrNull() is kotlinx.coroutines.CancellationException)
+        coVerify(exactly = 0) { syncDao.markTransientFailure(any(), any(), any()) }
         coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
@@ -203,19 +203,40 @@ class BackendSyncManagerTest {
     }
 
     @Test
-    fun `processQueue marks failed on network error`() = runTest {
+    fun `processQueue marks transient-failure on network error - retry budget untouched`() = runTest {
+        // A thrown IOException means the server never received the batch. It must NOT
+        // count toward MAX_RETRIES, or an outage exhausts the queue in ~62s and the
+        // hourly cleanup silently discards it.
         every { authTokenStore.hasActiveSession() } returns true
         coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
         coEvery { api.pushPumpEvents(any()) } throws java.io.IOException("No connection")
 
         manager.processQueue()
 
-        coVerify { syncDao.markFailed(listOf(1L), "No connection", any()) }
+        coVerify { syncDao.markTransientFailure(listOf(1L), "No connection", any()) }
+        coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
         assertEquals("No connection", manager.syncStatus.value.lastError)
     }
 
     @Test
-    fun `processQueue marks failed on HTTP error`() = runTest {
+    fun `processQueue survives sustained outage cycles without ever counting a retry`() = runTest {
+        // Far more cycles than MAX_RETRIES: every one must be non-counting. Reverting the
+        // transport branch to markFailed turns this red (the ~62s exhaustion bug).
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
+        coEvery { api.pushPumpEvents(any()) } throws java.io.IOException("No connection")
+
+        val cycles = BackendSyncManager.MAX_RETRIES * 4
+        repeat(cycles) { manager.processQueue() }
+
+        coVerify(exactly = cycles) { syncDao.markTransientFailure(listOf(1L), "No connection", any()) }
+        coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processQueue marks transient-failure on server error`() = runTest {
+        // 5xx = server reachable but transiently erroring (deploy, restart); it must not
+        // burn the retry budget any more than a dropped connection does.
         every { authTokenStore.hasActiveSession() } returns true
         coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
         coEvery { api.pushPumpEvents(any()) } returns Response.error(
@@ -225,7 +246,57 @@ class BackendSyncManagerTest {
 
         manager.processQueue()
 
-        coVerify { syncDao.markFailed(listOf(1L), "HTTP 500", any()) }
+        coVerify { syncDao.markTransientFailure(listOf(1L), "HTTP 500", any()) }
+        coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processQueue marks transient-failure on rate limit`() = runTest {
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
+        coEvery { api.pushPumpEvents(any()) } returns Response.error(
+            429,
+            "Too Many Requests".toResponseBody(),
+        )
+
+        manager.processQueue()
+
+        coVerify { syncDao.markTransientFailure(listOf(1L), "HTTP 429", any()) }
+        coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processQueue marks transient-failure on request timeout`() = runTest {
+        // 408 is a gateway/request timeout -- transient like 5xx/429, not a payload
+        // rejection; it must not burn the retry budget.
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
+        coEvery { api.pushPumpEvents(any()) } returns Response.error(
+            408,
+            "Request Timeout".toResponseBody(),
+        )
+
+        manager.processQueue()
+
+        coVerify { syncDao.markTransientFailure(listOf(1L), "HTTP 408", any()) }
+        coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processQueue marks failed on client rejection - retry budget counts`() = runTest {
+        // 4xx = the server received and rejected the payload; it will never be accepted,
+        // so it must keep counting toward MAX_RETRIES and give up rather than loop forever.
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
+        coEvery { api.pushPumpEvents(any()) } returns Response.error(
+            422,
+            "Unprocessable Entity".toResponseBody(),
+        )
+
+        manager.processQueue()
+
+        coVerify { syncDao.markFailed(listOf(1L), "HTTP 422", any()) }
+        coVerify(exactly = 0) { syncDao.markTransientFailure(any(), any(), any()) }
     }
 
     @Test

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/BackendSyncManagerTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.Response
 
@@ -230,6 +231,25 @@ class BackendSyncManagerTest {
         repeat(cycles) { manager.processQueue() }
 
         coVerify(exactly = cycles) { syncDao.markTransientFailure(listOf(1L), "No connection", any()) }
+        coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processQueue does not mislabel a post-success DAO failure as a push failure`() = runTest {
+        // The server accepted the batch; a Room failure in the success path must propagate
+        // (rows stay 'sending' for resetStaleSending) rather than be caught and marked as a
+        // failed push -- the catch is scoped to the network call only.
+        every { authTokenStore.hasActiveSession() } returns true
+        coEvery { syncDao.getPendingBatch(any(), any(), any()) } returns listOf(sampleEntity())
+        coEvery { api.pushPumpEvents(any()) } returns Response.success(
+            PumpPushResponse(accepted = 1, duplicates = 0),
+        )
+        coEvery { syncDao.deleteSent(any()) } throws RuntimeException("disk full")
+
+        val result = runCatching { manager.processQueue() }
+
+        assertTrue(result.isFailure)
+        coVerify(exactly = 0) { syncDao.markTransientFailure(any(), any(), any()) }
         coVerify(exactly = 0) { syncDao.markFailed(any(), any(), any()) }
     }
 

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ espresso = "3.7.0"
 coroutines = "1.10.2"
 mockk = "1.14.9"
 turbine = "1.2.0"
+robolectric = "4.15.1"
+androidx-test-core = "1.7.0"
 wear-compose = "1.4.0"
 wear-watchface = "1.3.0"
 # FIXME: Both push and validator are pre-release alphas. Bump when stable versions ship.
@@ -130,6 +132,8 @@ compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-mani
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

During a backend outage with a valid session, every failed push incremented `retryCount`. With the backoff `2000 * (1 << retryCount)`, a queued item exhausted `MAX_RETRIES = 5` within ~62 seconds of its first attempt, after which `getPendingBatch` excluded it and the hourly cleanup deleted it. A multi-hour outage therefore drained only the last minute of pump events on reconnect — everything older was silently discarded, breaking the "temporarily-unreachable backend accumulates a bounded queue and drains on reconnect" behavior.

`pushPumpEvents` uses Retrofit's `Response<>` form, so only transport failures throw; 4xx/5xx arrive as received responses. That gives a clean split:

- **Transport failures** (thrown `IOException`) and **transient server responses** (5xx / 429 / 408) now call the new `SyncDao.markTransientFailure`, which sets `status='failed'` without incrementing `retryCount`. Rows go back through `getPendingBatch` on their backoff (no 60s `resetStaleSending` stall), survive the whole outage, and drain on reconnect. The backend's natural-key + `dedupe_hash` `on_conflict_do_nothing` insert makes indefinite retry duplicate-free.
- **Other 4xx** (payload rejections like 422) and JSON parse failures keep counting, so a permanently bad payload still gives up after `MAX_RETRIES`.
- `pruneOldest` now prunes any non-`'sending'` row oldest-first. With transient failures no longer incrementing `retryCount`, an outage backlog dwells in `'failed'` below `MAX_RETRIES`, which the old predicate (`pending` or exhausted-`failed`) could not prune — the queue would have grown past `MAX_QUEUE_SIZE` unbounded. Dropping the oldest retryable rows at the cap is the intended bounded-queue discard policy.

No schema change: the fix is logic plus one `@Query` on existing columns; `AppDatabase` stays at version 13.

## Testing

- New Robolectric `SyncDaoTest` (first real-Room harness in `:app`, in-memory database): proves at the SQL level that transient failures never exhaust a row (20 outage cycles, `retryCount` stays 0, cleanup-proof), counted failures exclude after `MAX_RETRIES` and are cleanup-deleted, the 2s backoff re-offers without the 60s stall, the broadened prune drops a transient-failed backlog while preserving in-flight rows, and the retention cutoff still trims old rows.
- `BackendSyncManagerTest`: `IOException` → `markTransientFailure` and never `markFailed` (including a 20-cycle sustained-outage test that goes red if the transport branch reverts to counting); 500, 429, and 408 → `markTransientFailure`; 422 → counting `markFailed`.
- Emulator E2E via the debug `SimulateUnreachableInterceptor` fault: with the fault on and the queue seeded, the sync loop kept re-offering the queue for **4+ minutes (81 push attempts, ~3s cadence)** — pre-fix, attempts ceased at ~62s as the queue exhausted. Disabling the fault drained the full retained backlog immediately, and the backend held exactly the distinct events with **zero duplicates** despite the 81 retried pushes.
- A debug-only "Seed sync queue" action was added to the BLE debug screen to make that E2E reproducible on an emulator (no pump feed): it seeds synthetic basal events through the production `SyncQueueEnqueuer` seam (mode gate still applies) and starts `PumpConnectionService` the way a paired cold start does. Compile-time `BuildConfig.DEBUG` gated; R8 strips it from release.
- `./gradlew testDebugUnitTest lintDebug assembleDebug` green.

## Notes for reviewers

- **5xx classification trade-off:** treating all 5xx as non-counting means a hypothetical payload-triggered deterministic 500 would retry until the retention cutoff rather than giving up in ~62s. The default here follows "a 5xx during a backend deploy must not lose data; a persistently-500ing server is a backend bug; the queue stays bounded by the 5000-row cap and retention." If we later prefer the conservative posture, the change is confining the non-counting set to 502/503/504.
- Server-side token revocation while the local session still looks valid produces counted 401s (queue discarded in ~62s) — pre-existing behavior, narrow window, noted as a follow-up candidate.
- Visible behavior change: during an outage the Home pending count now honestly reflects the retained backlog instead of dropping toward zero as items were silently discarded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug option to seed the sync queue with sample events for troubleshooting.

* **Bug Fixes**
  * Improved sync retry handling by treating transport/network issues and select HTTP responses (e.g., 408/429/5xx) as transient, while treating other client errors (e.g., 422) as permanent.
  * Updated queue pruning/cleanup behavior to better preserve in-flight work while trimming older backlog.

* **Tests**
  * Added Robolectric/Room integration tests and expanded sync manager test coverage for transient vs permanent classification and pruning/cleanup edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->