### PR TITLE
feat(mobile): hide full-stack-only surfaces in BLE-only mode

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -251,6 +251,7 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
+    testImplementation(libs.work.testing)
     testImplementation("org.json:json:20240303")
 
     // Android tests

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngine.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngine.kt
@@ -1,5 +1,6 @@
 package com.glycemicgpt.mobile.plugin.nightscout
 
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.dao.PumpDao
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
@@ -14,6 +15,12 @@ import javax.inject.Singleton
 sealed interface SyncOutcome {
     /** The plugin is disabled -- nothing to do. */
     data object Disabled : SyncOutcome
+
+    /**
+     * No backend is configured (BLE-only mode): the cloud-mediated sync cannot run at all.
+     * Terminal for the run -- retrying cannot help until the user adds a server.
+     */
+    data object NoBackend : SyncOutcome
 
     /** No active Nightscout connection is available on this account. */
     data object NoConnection : SyncOutcome
@@ -46,10 +53,17 @@ class NightscoutSyncEngine @Inject constructor(
     private val api: GlycemicGptApi,
     private val pumpDao: PumpDao,
     private val store: NightscoutSyncStore,
+    private val authTokenStore: AuthTokenStore,
 ) {
 
     suspend fun syncOnce(nowMs: Long = System.currentTimeMillis()): SyncOutcome {
         if (!store.enabled) return SyncOutcome.Disabled
+        // BLE-only backstop: NightscoutSyncManager cancels the schedule when no backend is
+        // configured, but a periodic run already in flight (or racing the mode flip) would
+        // otherwise hit the BaseUrlInterceptor's IOException and be classified Transient --
+        // an infinite retry loop for a condition only the user can resolve. No status is
+        // recorded: "no server at all" is a mode, not a sync failure of this plugin.
+        if (!authTokenStore.isBackendConfigured()) return SyncOutcome.NoBackend
         return try {
             val connections = api.listNightscoutConnections().bodyOrThrow().connections
             val connection = resolveConnection(connections)

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncManager.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncManager.kt
@@ -8,6 +8,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
@@ -21,16 +22,25 @@ import javax.inject.Singleton
  * the periodic sync, and kicks off an immediate one-shot sync. Disabling cancels the
  * schedule but **retains** the cached Room data (AC8). Both the periodic and one-shot
  * requests require connectivity (AC6); offline simply leaves the last-cached data in place.
+ *
+ * The plugin is cloud-mediated -- every sync goes through the backend read API -- so with no
+ * backend configured (BLE-only mode) there is nothing to schedule: a request would only be
+ * refused by the BaseUrlInterceptor and retried forever. Enable/sync-now therefore stand
+ * down instead of enqueueing, and cancel any schedule left over from a full-stack life.
+ * The activation flag still persists, so sync resumes when a backend (re)appears and the
+ * plugin is restored or re-enabled.
  */
 @Singleton
 class NightscoutSyncManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val store: NightscoutSyncStore,
+    private val authTokenStore: AuthTokenStore,
 ) {
 
     /** Enable syncing: persist the flag, schedule periodic work, and run an initial sync. */
     fun enable() {
         store.enabled = true
+        if (standDownWithoutBackend("enable")) return
         enqueuePeriodic()
         syncNow()
         Timber.i("Nightscout-source sync enabled")
@@ -45,6 +55,7 @@ class NightscoutSyncManager @Inject constructor(
 
     /** Trigger an immediate one-shot sync (the detail screen's "Sync now" action, AC8). */
     fun syncNow() {
+        if (standDownWithoutBackend("syncNow")) return
         val request = OneTimeWorkRequestBuilder<NightscoutSyncWorker>()
             .setConstraints(networkConstraint())
             .build()
@@ -53,6 +64,20 @@ class NightscoutSyncManager @Inject constructor(
             ExistingWorkPolicy.REPLACE,
             request,
         )
+    }
+
+    /**
+     * BLE-only stand-down: true when no backend is configured, after cancelling both unique
+     * works so a schedule from a previous full-stack life cannot keep waking a sync that can
+     * never succeed.
+     */
+    private fun standDownWithoutBackend(caller: String): Boolean {
+        if (authTokenStore.isBackendConfigured()) return false
+        val workManager = WorkManager.getInstance(context)
+        workManager.cancelUniqueWork(PERIODIC_WORK)
+        workManager.cancelUniqueWork(ONESHOT_WORK)
+        Timber.i("Nightscout-source %s skipped: no backend configured", caller)
+        return true
     }
 
     private fun enqueuePeriodic() {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -35,7 +36,7 @@ class AlertsViewModel @Inject constructor(
     private val alertNotificationManager: AlertNotificationManager,
     private val appSettingsStore: AppSettingsStore,
     alertFloorStatusProvider: AlertFloorStatusProvider,
-    authTokenStore: AuthTokenStore,
+    private val authTokenStore: AuthTokenStore,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AlertsUiState())
@@ -80,6 +81,13 @@ class AlertsViewModel @Inject constructor(
 
     fun refreshAlerts() {
         viewModelScope.launch {
+            // BLE-only gate (GLY-146): with no backend there is nothing to fetch from, and the
+            // failed request would nag "Can't reach your server" for a server that was never
+            // configured. Local alerts keep flowing via observeRecentAlerts(). Checked here --
+            // not just in init -- so a pull-to-refresh stays honest too. Read from the flow
+            // (first emission is on IO) rather than [backendConfigured], whose pessimistic
+            // false seed would drop a full-stack user's fetch at cold start.
+            if (!authTokenStore.backendConfiguredFlow().first()) return@launch
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
             alertRepository.fetchPendingAlerts()
                 .onSuccess {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/home/HomeScreen.kt
@@ -246,7 +246,10 @@ fun HomeScreen(
         // Camera FAB overlaid in the pull-to-refresh BoxScope, hidden when the user's per-account
         // meal-intelligence setting is off (instant on toggle) or the server reports it disabled.
         // Draggable so the user can move it off the data underneath; its position persists per device.
-        if (mealState.mealLoggingAvailable) {
+        // Meal analysis is backend-only (server vision, no local meal store), so the whole surface
+        // is additionally absent in BLE-only mode -- gated here at composition, above
+        // HomeMealViewModel, whose within-configured availability logic is a separate concern.
+        if (backendConfigured && mealState.mealLoggingAvailable) {
             DraggableMealFab(
                 containerSizePx = containerSizePx,
                 savedOffset = savedFabOffset,

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
@@ -91,7 +92,17 @@ sealed class Screen(val route: String, val label: String, val icon: ImageVector)
     data object CommonFoods : Screen("common_foods", "Common Foods", Icons.Default.Fastfood)
 }
 
-private val bottomNavItems = listOf(Screen.Home, Screen.AiChat, Screen.Alerts, Screen.Settings)
+/**
+ * Bottom-nav policy: capability-driven, not static. AI Chat is backend-only (there is no
+ * on-device model), so in BLE-only mode the tab is absent rather than dead-ending on a
+ * "check your server URL" error for a server the user deliberately never configured.
+ */
+internal fun bottomNavItems(backendConfigured: Boolean): List<Screen> = buildList {
+    add(Screen.Home)
+    if (backendConfigured) add(Screen.AiChat)
+    add(Screen.Alerts)
+    add(Screen.Settings)
+}
 
 /**
  * Start-destination policy: keyed on onboarding completion ALONE, deliberately
@@ -111,10 +122,16 @@ internal fun startDestinationRoute(onboardingComplete: Boolean): String =
  * would flash "not signed in" at cold start before
  * [com.glycemicgpt.mobile.data.auth.AuthManager.validateOnStartup] resolves
  * the real state. Refreshing and Authenticated are live sessions.
+ *
+ * Unauthenticated additionally requires a configured backend: a BLE-only user
+ * is permanently Unauthenticated by design, and there is nothing to sign in
+ * to. Expired stays unconditional -- it can only be reached from a session
+ * that once existed, and that lapsed-session nudge must survive even if the
+ * base URL is momentarily unreadable.
  */
-internal fun sessionBannerMessage(state: AuthState): String? = when (state) {
+internal fun sessionBannerMessage(state: AuthState, backendConfigured: Boolean): String? = when (state) {
     is AuthState.Expired -> state.message
-    is AuthState.Unauthenticated -> "Not signed in, tap to sign in"
+    is AuthState.Unauthenticated -> if (backendConfigured) "Not signed in, tap to sign in" else null
     is AuthState.Initializing, is AuthState.Refreshing, is AuthState.Authenticated -> null
 }
 
@@ -164,6 +181,14 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
         UrlSecurityPolicy.isActiveInsecureHttp(it, BuildConfig.DEBUG, insecureHttpEnabled)
     } == true
 
+    // App mode (GLY-146): full-stack vs BLE-only, via the canonical predicate over the SAME
+    // reactive baseUrl collected above (backendConfiguredFlow() is exactly this mapping over
+    // baseUrlFlow()). Deriving from the existing collection -- whose initial value is a
+    // synchronous read -- avoids a pessimistic false seed that would yank a restored AI-chat
+    // back stack to Home on the first frame for a full-stack user.
+    val backendConfigured = AuthTokenStore.isBackendConfigured(baseUrl)
+    val navItems = bottomNavItems(backendConfigured)
+
     // Observe logout -> onboarding navigation event
     LaunchedEffect(Unit) {
         settingsViewModel.navigateToOnboarding.collect {
@@ -188,7 +213,7 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
         bottomBar = {
             if (showBottomNav) {
                 NavigationBar {
-                    bottomNavItems.forEach { screen ->
+                    navItems.forEach { screen ->
                         NavigationBarItem(
                             icon = { Icon(screen.icon, contentDescription = screen.label) },
                             label = { Text(screen.label) },
@@ -221,7 +246,7 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
             // (incl. staying silent while Initializing) lives in
             // sessionBannerMessage().
             if (!isOnboarding) {
-                sessionBannerMessage(authState)?.let { message ->
+                sessionBannerMessage(authState, backendConfigured)?.let { message ->
                     SessionExpiredBanner(
                         message = message,
                         onClick = {
@@ -265,7 +290,16 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                         onNavigateToMealHistory = { navController.navigate(Screen.MealHistory.route) },
                     )
                 }
-                composable(Screen.AiChat.route) { AiChatScreen() }
+                // Backend-only destinations keep their registration in BLE-only mode but
+                // redirect to Home: dropping the composable instead would blank the screen
+                // for a restored back stack or deep link that still points at the route.
+                composable(Screen.AiChat.route) {
+                    if (backendConfigured) {
+                        AiChatScreen()
+                    } else {
+                        RedirectToHome(navController)
+                    }
+                }
                 composable(Screen.Alerts.route) { AlertsScreen() }
                 composable(Screen.Settings.route) {
                     SettingsScreen(
@@ -282,17 +316,29 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                     )
                 }
                 composable(Screen.MealLog.route) {
-                    MealLogScreen(
-                        onBack = { navController.popBackStack() },
-                        onNavigateToHistory = { navController.navigate(Screen.MealHistory.route) },
-                        onNavigateToCommonFoods = { navController.navigate(Screen.CommonFoods.route) },
-                    )
+                    if (backendConfigured) {
+                        MealLogScreen(
+                            onBack = { navController.popBackStack() },
+                            onNavigateToHistory = { navController.navigate(Screen.MealHistory.route) },
+                            onNavigateToCommonFoods = { navController.navigate(Screen.CommonFoods.route) },
+                        )
+                    } else {
+                        RedirectToHome(navController)
+                    }
                 }
                 composable(Screen.MealHistory.route) {
-                    MealHistoryScreen(onBack = { navController.popBackStack() })
+                    if (backendConfigured) {
+                        MealHistoryScreen(onBack = { navController.popBackStack() })
+                    } else {
+                        RedirectToHome(navController)
+                    }
                 }
                 composable(Screen.CommonFoods.route) {
-                    CommonFoodsScreen(onBack = { navController.popBackStack() })
+                    if (backendConfigured) {
+                        CommonFoodsScreen(onBack = { navController.popBackStack() })
+                    } else {
+                        RedirectToHome(navController)
+                    }
                 }
                 composable(Screen.Pairing.route) {
                     PairingScreen(
@@ -363,6 +409,21 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Guard body for a backend-only route rendered in BLE-only mode. Renders nothing and
+ * replaces the current entry with Home, so neither back navigation nor state restoration
+ * can land on the empty guard frame.
+ */
+@Composable
+private fun RedirectToHome(navController: NavHostController) {
+    LaunchedEffect(Unit) {
+        navController.navigate(Screen.Home.route) {
+            popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+            launchSingleTop = true
         }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/navigation/NavHost.kt
@@ -32,9 +32,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -42,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.NavType
@@ -188,6 +191,11 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
     // back stack to Home on the first frame for a full-stack user.
     val backendConfigured = AuthTokenStore.isBackendConfigured(baseUrl)
     val navItems = bottomNavItems(backendConfigured)
+    // The NavHost builder's content lambdas are long-lived closures (the graph can be cached
+    // across recompositions), so the route guards must read the mode through State rather
+    // than capture the plain Boolean -- a by-value capture would freeze the gating decision
+    // at graph-build time and ignore a server added or removed mid-session.
+    val backendConfiguredState = rememberUpdatedState(backendConfigured)
 
     // Observe logout -> onboarding navigation event
     LaunchedEffect(Unit) {
@@ -290,15 +298,8 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                         onNavigateToMealHistory = { navController.navigate(Screen.MealHistory.route) },
                     )
                 }
-                // Backend-only destinations keep their registration in BLE-only mode but
-                // redirect to Home: dropping the composable instead would blank the screen
-                // for a restored back stack or deep link that still points at the route.
-                composable(Screen.AiChat.route) {
-                    if (backendConfigured) {
-                        AiChatScreen()
-                    } else {
-                        RedirectToHome(navController)
-                    }
+                backendGatedComposable(Screen.AiChat.route, navController, backendConfiguredState) {
+                    AiChatScreen()
                 }
                 composable(Screen.Alerts.route) { AlertsScreen() }
                 composable(Screen.Settings.route) {
@@ -315,30 +316,18 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                         onNavigateToMealLog = { navController.navigate(Screen.MealLog.route) },
                     )
                 }
-                composable(Screen.MealLog.route) {
-                    if (backendConfigured) {
-                        MealLogScreen(
-                            onBack = { navController.popBackStack() },
-                            onNavigateToHistory = { navController.navigate(Screen.MealHistory.route) },
-                            onNavigateToCommonFoods = { navController.navigate(Screen.CommonFoods.route) },
-                        )
-                    } else {
-                        RedirectToHome(navController)
-                    }
+                backendGatedComposable(Screen.MealLog.route, navController, backendConfiguredState) {
+                    MealLogScreen(
+                        onBack = { navController.popBackStack() },
+                        onNavigateToHistory = { navController.navigate(Screen.MealHistory.route) },
+                        onNavigateToCommonFoods = { navController.navigate(Screen.CommonFoods.route) },
+                    )
                 }
-                composable(Screen.MealHistory.route) {
-                    if (backendConfigured) {
-                        MealHistoryScreen(onBack = { navController.popBackStack() })
-                    } else {
-                        RedirectToHome(navController)
-                    }
+                backendGatedComposable(Screen.MealHistory.route, navController, backendConfiguredState) {
+                    MealHistoryScreen(onBack = { navController.popBackStack() })
                 }
-                composable(Screen.CommonFoods.route) {
-                    if (backendConfigured) {
-                        CommonFoodsScreen(onBack = { navController.popBackStack() })
-                    } else {
-                        RedirectToHome(navController)
-                    }
+                backendGatedComposable(Screen.CommonFoods.route, navController, backendConfiguredState) {
+                    CommonFoodsScreen(onBack = { navController.popBackStack() })
                 }
                 composable(Screen.Pairing.route) {
                     PairingScreen(
@@ -409,6 +398,28 @@ fun GlycemicGptNavHost(appSettingsStore: AppSettingsStore, authTokenStore: AuthT
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Registers a backend-only destination (GLY-146). The registration is kept in BLE-only mode
+ * -- dropping the composable instead would blank the screen for a restored back stack or
+ * deep link that still points at the route -- but the content is guarded: with no backend
+ * the route redirects to Home. The mode arrives as [State] so the guard reads the live
+ * value on every composition of the destination.
+ */
+private fun NavGraphBuilder.backendGatedComposable(
+    route: String,
+    navController: NavHostController,
+    backendConfigured: State<Boolean>,
+    content: @Composable () -> Unit,
+) {
+    composable(route) {
+        if (backendConfigured.value) {
+            content()
+        } else {
+            RedirectToHome(navController)
         }
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -84,6 +84,7 @@ import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
+import com.glycemicgpt.mobile.plugin.nightscout.NightscoutSourcePlugin
 import com.glycemicgpt.mobile.presentation.common.InsecureHttpConfirmDialog
 import com.glycemicgpt.mobile.presentation.plugin.PluginSettingsRenderer
 import com.glycemicgpt.mobile.presentation.theme.ThemeMode
@@ -826,8 +827,16 @@ private fun PluginsSection(
         )
     }
 
-    // Available plugins list
-    if (state.availablePlugins.isNotEmpty()) {
+    // Available plugins list. The Nightscout source is cloud-mediated (every sync goes
+    // through the backend), so in BLE-only mode its activation control is hidden -- arming
+    // it could only schedule work the request layer refuses. An already-active instance
+    // stays listed so its Deactivate control remains reachable.
+    val visiblePlugins = state.availablePlugins.filter { plugin ->
+        state.backendConfigured ||
+            plugin.id != NightscoutSourcePlugin.PLUGIN_ID ||
+            plugin.id in state.activePluginIds
+    }
+    if (visiblePlugins.isNotEmpty()) {
         Spacer(modifier = Modifier.height(8.dp))
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(
@@ -840,7 +849,7 @@ private fun PluginsSection(
                     style = MaterialTheme.typography.titleSmall,
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                state.availablePlugins.forEach { plugin ->
+                visiblePlugins.forEach { plugin ->
                     val isActive = plugin.id in state.activePluginIds
                     Row(
                         modifier = Modifier
@@ -1279,47 +1288,50 @@ private fun SyncSection(
     onBackendSyncToggle: (Boolean) -> Unit,
     onRetentionChange: (Int) -> Unit,
 ) {
-    // Backend Sync toggle
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
+    // Backend Sync toggle. Row-level gate (GLY-146): pushing pump events needs a server, so
+    // the card is hidden in BLE-only mode while the local Data Retention card below stays.
+    if (state.backendConfigured) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.Sync,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(24.dp),
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column {
-                        Text(
-                            text = "Backend Sync",
-                            style = MaterialTheme.typography.titleSmall,
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Sync,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(24.dp),
                         )
-                        Text(
-                            text = "Push pump events to GlycemicGPT server",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                text = "Backend Sync",
+                                style = MaterialTheme.typography.titleSmall,
+                            )
+                            Text(
+                                text = "Push pump events to GlycemicGPT server",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
+                    Switch(
+                        checked = state.backendSyncEnabled,
+                        onCheckedChange = onBackendSyncToggle,
+                    )
                 }
-                Switch(
-                    checked = state.backendSyncEnabled,
-                    onCheckedChange = onBackendSyncToggle,
-                )
             }
         }
-    }
 
-    Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(8.dp))
+    }
 
     // Data Retention
     Card(modifier = Modifier.fillMaxWidth()) {
@@ -1433,18 +1445,22 @@ private fun AlertSoundsSection(
                 onSoundSelected = { uri -> onSoundSelected(AlertSoundCategory.HIGH_ALERT, uri) },
             )
 
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            // Row-level gate (GLY-146): AI notifications are backend-generated, so the
+            // sound picker for a channel that can never fire is hidden in BLE-only mode.
+            if (state.backendConfigured) {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
-            SoundPickerRow(
-                label = "AI Notification",
-                description = "AI analysis insights and daily briefs",
-                currentSoundName = state.aiNotificationSoundName,
-                currentSoundUri = state.aiNotificationSoundUri,
-                ringtoneType = RingtoneManager.TYPE_NOTIFICATION,
-                showSilent = true,
-                testTag = "ai_notification_sound",
-                onSoundSelected = { uri -> onSoundSelected(AlertSoundCategory.AI_NOTIFICATION, uri) },
-            )
+                SoundPickerRow(
+                    label = "AI Notification",
+                    description = "AI analysis insights and daily briefs",
+                    currentSoundName = state.aiNotificationSoundName,
+                    currentSoundUri = state.aiNotificationSoundUri,
+                    ringtoneType = RingtoneManager.TYPE_NOTIFICATION,
+                    showSilent = true,
+                    testTag = "ai_notification_sound",
+                    onSoundSelected = { uri -> onSoundSelected(AlertSoundCategory.AI_NOTIFICATION, uri) },
+                )
+            }
 
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -84,7 +84,6 @@ import com.glycemicgpt.mobile.domain.format.GlucoseFormat
 import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import com.glycemicgpt.mobile.domain.plugin.PluginMetadata
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
-import com.glycemicgpt.mobile.plugin.nightscout.NightscoutSourcePlugin
 import com.glycemicgpt.mobile.presentation.common.InsecureHttpConfirmDialog
 import com.glycemicgpt.mobile.presentation.plugin.PluginSettingsRenderer
 import com.glycemicgpt.mobile.presentation.theme.ThemeMode
@@ -827,16 +826,8 @@ private fun PluginsSection(
         )
     }
 
-    // Available plugins list. The Nightscout source is cloud-mediated (every sync goes
-    // through the backend), so in BLE-only mode its activation control is hidden -- arming
-    // it could only schedule work the request layer refuses. An already-active instance
-    // stays listed so its Deactivate control remains reachable.
-    val visiblePlugins = state.availablePlugins.filter { plugin ->
-        state.backendConfigured ||
-            plugin.id != NightscoutSourcePlugin.PLUGIN_ID ||
-            plugin.id in state.activePluginIds
-    }
-    if (visiblePlugins.isNotEmpty()) {
+    // Available plugins list (mode-filtered -- see SettingsUiState.visibleAvailablePlugins).
+    if (state.visibleAvailablePlugins.isNotEmpty()) {
         Spacer(modifier = Modifier.height(8.dp))
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(
@@ -849,7 +840,7 @@ private fun PluginsSection(
                     style = MaterialTheme.typography.titleSmall,
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                visiblePlugins.forEach { plugin ->
+                state.visibleAvailablePlugins.forEach { plugin ->
                     val isActive = plugin.id in state.activePluginIds
                     Row(
                         modifier = Modifier

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -20,6 +20,7 @@ import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsDescriptor
 import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
 import com.glycemicgpt.mobile.plugin.PluginRegistry
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
+import com.glycemicgpt.mobile.plugin.nightscout.NightscoutSourcePlugin
 import com.glycemicgpt.mobile.data.local.GlucoseRangeStore
 import com.glycemicgpt.mobile.data.local.PumpCredentialStore
 import com.glycemicgpt.mobile.data.local.SafetyLimitsStore
@@ -235,7 +236,22 @@ data class SettingsUiState(
     // Meal-intelligence feature toggle (per-account preference). Defaults ON.
     val mealIntelligenceEnabled: Boolean = true,
     val mealIntelligenceSyncError: String? = null,
-)
+) {
+    /**
+     * The plugin list Settings actually renders (GLY-146). The Nightscout source is
+     * cloud-mediated -- every sync goes through the backend read API -- so in BLE-only mode
+     * its activation control is withheld: arming it could only schedule work the request
+     * layer refuses. An already-active instance stays listed so Deactivate remains
+     * reachable. Derived here (not filtered at the copy() sites) so it can never go stale
+     * against [availablePlugins]/[activePluginIds]/[backendConfigured].
+     */
+    val visibleAvailablePlugins: List<PluginMetadata>
+        get() = availablePlugins.filter { plugin ->
+            backendConfigured ||
+                plugin.id != NightscoutSourcePlugin.PLUGIN_ID ||
+                plugin.id in activePluginIds
+        }
+}
 
 private const val AUTO_DISMISS_MS = 5_000L
 private const val PUSH_TIMEOUT_MS = 150_000L

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearChatRelayService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearChatRelayService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.repository.AlertRepository
 import com.glycemicgpt.mobile.data.repository.ChatRepository
 import com.google.android.gms.wearable.MessageEvent
@@ -40,6 +41,7 @@ class WearChatRelayService : WearableListenerService() {
     @Inject lateinit var chatRepository: ChatRepository
     @Inject lateinit var alertRepository: AlertRepository
     @Inject lateinit var wearDataSender: WearDataSender
+    @Inject lateinit var authTokenStore: AuthTokenStore
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -99,6 +101,17 @@ class WearChatRelayService : WearableListenerService() {
         if (requestText.length > MAX_MESSAGE_LENGTH) {
             Timber.w("Chat request too long (%d chars), rejecting", requestText.length)
             serviceScope.launch { sendError(sourceNodeId, "Message too long (max $MAX_MESSAGE_LENGTH chars)") }
+            return
+        }
+
+        // BLE-only mode (GLY-146): the relay's only job is forwarding to the backend chat API,
+        // so with no server configured it answers honestly and terminally instead of letting
+        // the send fail into a retryable-sounding "Something went wrong". Checked before the
+        // foreground promotion -- there is no long-running work to protect.
+        // onMessageReceived runs on a binder background thread, so the sync read is off-main.
+        if (!authTokenStore.isBackendConfigured()) {
+            Timber.i("Chat request from watch refused: no backend configured")
+            serviceScope.launch { sendError(sourceNodeId, NO_BACKEND_MESSAGE) }
             return
         }
 
@@ -243,6 +256,15 @@ class WearChatRelayService : WearableListenerService() {
 
     companion object {
         const val MAX_MESSAGE_LENGTH = 500
+
+        /**
+         * Honest terminal copy for a chat request in BLE-only mode: names the permanent
+         * condition and where to fix it, and deliberately never says "try again" -- retrying
+         * cannot help until a server is set up on the phone.
+         */
+        const val NO_BACKEND_MESSAGE =
+            "AI chat needs a GlycemicGPT server — none is set up on your phone."
+
         private const val CHAT_API_TIMEOUT_MS = 90_000L
         private const val CHANNEL_ID = "watch_chat_relay"
         private const val NOTIFICATION_ID = 3

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearChatRelayService.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/wear/WearChatRelayService.kt
@@ -107,8 +107,8 @@ class WearChatRelayService : WearableListenerService() {
         // BLE-only mode (GLY-146): the relay's only job is forwarding to the backend chat API,
         // so with no server configured it answers honestly and terminally instead of letting
         // the send fail into a retryable-sounding "Something went wrong". Checked before the
-        // foreground promotion -- there is no long-running work to protect.
-        // onMessageReceived runs on a binder background thread, so the sync read is off-main.
+        // foreground promotion — there is no long-running work to protect.
+        // onMessageReceived runs on a background binder thread, so the sync read is off-main.
         if (!authTokenStore.isBackendConfigured()) {
             Timber.i("Chat request from watch refused: no backend configured")
             serviceScope.launch { sendError(sourceNodeId, NO_BACKEND_MESSAGE) }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngineTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncEngineTest.kt
@@ -1,5 +1,6 @@
 package com.glycemicgpt.mobile.plugin.nightscout
 
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
 import com.glycemicgpt.mobile.data.local.dao.PumpDao
 import com.glycemicgpt.mobile.data.remote.GlycemicGptApi
 import com.glycemicgpt.mobile.data.remote.dto.NightscoutConnectionDto
@@ -9,6 +10,7 @@ import com.glycemicgpt.mobile.data.remote.dto.NightscoutGlucoseReadingDto
 import com.glycemicgpt.mobile.data.remote.dto.NightscoutPumpEventDto
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -24,7 +26,10 @@ class NightscoutSyncEngineTest {
     private val dao: PumpDao = mockk(relaxed = true)
     private val backing = FakePluginSettingsStore()
     private val store = NightscoutSyncStore(backing)
-    private val engine = NightscoutSyncEngine(api, dao, store)
+    private val authTokenStore: AuthTokenStore = mockk {
+        every { isBackendConfigured() } returns true
+    }
+    private val engine = NightscoutSyncEngine(api, dao, store, authTokenStore)
 
     private val connId = "conn-1"
 
@@ -33,6 +38,21 @@ class NightscoutSyncEngineTest {
         store.enabled = false
         val outcome = engine.syncOnce(nowMs = 1000L)
         assertEquals(SyncOutcome.Disabled, outcome)
+        coVerify(exactly = 0) { api.listNightscoutConnections() }
+    }
+
+    @Test
+    fun `no backend returns terminal NoBackend without api calls or a recorded status`() = runTest {
+        // A periodic run racing the BLE-only stand-down must end terminally (the worker maps
+        // NoBackend to success, not retry) -- classifying it Transient would retry forever
+        // against a request layer that refuses every call.
+        store.enabled = true
+        every { authTokenStore.isBackendConfigured() } returns false
+
+        val outcome = engine.syncOnce(nowMs = 1000L)
+
+        assertEquals(SyncOutcome.NoBackend, outcome)
+        assertEquals(NightscoutSyncStatus.NEVER, store.state.value.status)
         coVerify(exactly = 0) { api.listNightscoutConnections() }
     }
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncManagerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncManagerTest.kt
@@ -1,0 +1,119 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the BLE-only stand-down (GLY-146) against a real (test-initialized) WorkManager:
+ * with no backend configured, neither enable() nor syncNow() may leave any Nightscout
+ * work scheduled -- the cloud-mediated sync would only ever be refused by the request
+ * layer and retried forever. A schedule left over from a full-stack life is cancelled,
+ * and full-stack behavior (schedule periodic + one-shot) stays intact.
+ */
+// Plain Application: the manifest's @HiltAndroidApp class would pull keystore-backed
+// injection into a JVM test that only needs a Context for WorkManager.
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class NightscoutSyncManagerTest {
+
+    private lateinit var context: Context
+    private lateinit var workManager: WorkManager
+    private lateinit var store: NightscoutSyncStore
+    private lateinit var authTokenStore: AuthTokenStore
+    private lateinit var manager: NightscoutSyncManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
+        workManager = WorkManager.getInstance(context)
+        store = NightscoutSyncStore(FakePluginSettingsStore())
+        authTokenStore = mockk {
+            every { isBackendConfigured() } returns true
+        }
+        manager = NightscoutSyncManager(context, store, authTokenStore)
+    }
+
+    private fun workInfos(uniqueName: String): List<WorkInfo> =
+        workManager.getWorkInfosForUniqueWork(uniqueName).get()
+
+    private fun activeWorkCount(uniqueName: String): Int =
+        workInfos(uniqueName).count { !it.state.isFinished }
+
+    @Test
+    fun `enable with a backend schedules periodic and one-shot work`() {
+        manager.enable()
+
+        assertTrue(store.enabled)
+        assertEquals(1, activeWorkCount(NightscoutSyncManager.PERIODIC_WORK))
+        assertEquals(1, activeWorkCount(NightscoutSyncManager.ONESHOT_WORK))
+    }
+
+    @Test
+    fun `enable without a backend keeps the flag but schedules nothing`() {
+        every { authTokenStore.isBackendConfigured() } returns false
+
+        manager.enable()
+
+        // The activation intent persists (sync resumes when a backend appears and the
+        // plugin is restored), but no work may exist for it to retry against nothing.
+        assertTrue(store.enabled)
+        assertEquals(0, activeWorkCount(NightscoutSyncManager.PERIODIC_WORK))
+        assertEquals(0, activeWorkCount(NightscoutSyncManager.ONESHOT_WORK))
+    }
+
+    @Test
+    fun `enable without a backend cancels a schedule left over from a full-stack life`() {
+        manager.enable()
+        assertEquals(1, activeWorkCount(NightscoutSyncManager.PERIODIC_WORK))
+
+        every { authTokenStore.isBackendConfigured() } returns false
+        manager.enable()
+
+        assertEquals(0, activeWorkCount(NightscoutSyncManager.PERIODIC_WORK))
+        assertEquals(0, activeWorkCount(NightscoutSyncManager.ONESHOT_WORK))
+    }
+
+    @Test
+    fun `syncNow without a backend schedules nothing and cancels stale work`() {
+        manager.enable()
+        assertEquals(1, activeWorkCount(NightscoutSyncManager.ONESHOT_WORK))
+
+        every { authTokenStore.isBackendConfigured() } returns false
+        manager.syncNow()
+
+        assertEquals(0, activeWorkCount(NightscoutSyncManager.PERIODIC_WORK))
+        assertEquals(0, activeWorkCount(NightscoutSyncManager.ONESHOT_WORK))
+    }
+
+    @Test
+    fun `syncNow with a backend schedules the one-shot`() {
+        manager.syncNow()
+
+        assertEquals(1, activeWorkCount(NightscoutSyncManager.ONESHOT_WORK))
+    }
+
+    @Test
+    fun `disable clears the flag and cancels the periodic schedule`() {
+        manager.enable()
+
+        manager.disable()
+
+        assertTrue(!store.enabled)
+        assertEquals(0, activeWorkCount(NightscoutSyncManager.PERIODIC_WORK))
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncWorkerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/plugin/nightscout/NightscoutSyncWorkerTest.kt
@@ -1,0 +1,71 @@
+package com.glycemicgpt.mobile.plugin.nightscout
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the outcome -> WorkManager Result mapping. The load-bearing cases: Transient is the
+ * ONLY retrying outcome, and NoBackend (GLY-146) is terminal -- mapping it to retry would
+ * re-create the infinite BLE-only retry loop the stand-down exists to prevent.
+ */
+// Plain Application: the manifest's @HiltAndroidApp class would pull keystore-backed
+// injection into a JVM test; the worker gets its engine from an explicit factory instead.
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class NightscoutSyncWorkerTest {
+
+    private val engine: NightscoutSyncEngine = mockk()
+
+    private fun buildWorker(): NightscoutSyncWorker {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        return TestListenableWorkerBuilder<NightscoutSyncWorker>(context)
+            .setWorkerFactory(object : WorkerFactory() {
+                override fun createWorker(
+                    appContext: Context,
+                    workerClassName: String,
+                    workerParameters: WorkerParameters,
+                ): ListenableWorker = NightscoutSyncWorker(appContext, workerParameters, engine)
+            })
+            .build()
+    }
+
+    private fun assertOutcomeMapsTo(outcome: SyncOutcome, expected: ListenableWorker.Result) = runTest {
+        coEvery { engine.syncOnce(any()) } returns outcome
+        assertEquals(expected, buildWorker().doWork())
+    }
+
+    @Test
+    fun `NoBackend is terminal - success, never retry`() {
+        assertOutcomeMapsTo(SyncOutcome.NoBackend, ListenableWorker.Result.success())
+    }
+
+    @Test
+    fun `Transient retries`() {
+        assertOutcomeMapsTo(SyncOutcome.Transient, ListenableWorker.Result.retry())
+    }
+
+    @Test
+    fun `Disabled and AuthError end the run without retrying`() {
+        assertOutcomeMapsTo(SyncOutcome.Disabled, ListenableWorker.Result.success())
+        assertOutcomeMapsTo(SyncOutcome.AuthError, ListenableWorker.Result.success())
+    }
+
+    @Test
+    fun `an engine crash retries instead of failing the chain`() = runTest {
+        coEvery { engine.syncOnce(any()) } throws IllegalStateException("boom")
+        assertEquals(ListenableWorker.Result.retry(), buildWorker().doWork())
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -161,6 +161,50 @@ class AlertsViewModelTest {
         coVerify(atLeast = 2) { repository.fetchPendingAlerts() }
     }
 
+    // -- BLE-only fetch gate (GLY-146) ---------------------------------------------
+    // With no backend there is no server to fetch from: neither the init auto-fetch nor a
+    // manual pull-to-refresh may hit the repository or surface the "Can't reach your
+    // server" nag. Local alerts still flow via observeRecentAlerts().
+
+    @Test
+    fun `BLE-only mode never auto-fetches and shows no server nag`() = runTest {
+        every { authTokenStore.backendConfiguredFlow() } returns flowOf(false)
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.fetchPendingAlerts() }
+        assertNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `BLE-only manual refresh is a silent no-op`() = runTest {
+        every { authTokenStore.backendConfiguredFlow() } returns flowOf(false)
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.refreshAlerts()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.fetchPendingAlerts() }
+        assertNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `BLE-only mode still displays cached local alerts`() = runTest {
+        every { authTokenStore.backendConfiguredFlow() } returns flowOf(false)
+        alertsFlow.value = listOf(makeAlert())
+
+        val vm = createViewModel()
+        val job = backgroundScope.launch(testDispatcher) { vm.alerts.collect { } }
+        advanceUntilIdle()
+
+        assertEquals(1, vm.alerts.value.size)
+        job.cancel()
+    }
+
     @Test
     fun `refreshAlerts sets user-facing error on failure, never the raw exception message`() = runTest {
         coEvery { repository.fetchPendingAlerts() } returns

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/DetailRoutesTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/DetailRoutesTest.kt
@@ -7,14 +7,8 @@ import org.junit.Test
 
 class DetailRoutesTest {
 
-    // Note: bottomNavItems is private in NavHost.kt. This list mirrors it for assertions.
-    // If bottomNavItems changes, update this list accordingly.
-    private val bottomNavRoutes = listOf(
-        Screen.Home.route,
-        Screen.AiChat.route,
-        Screen.Alerts.route,
-        Screen.Settings.route,
-    )
+    // The full-stack bottom nav -- the superset; BLE-only only ever removes items from it.
+    private val bottomNavRoutes = bottomNavItems(backendConfigured = true).map { it.route }
 
     private val detailRoutes = listOf(
         Screen.ChartDetail.route,
@@ -43,6 +37,24 @@ class DetailRoutesTest {
     @Test
     fun `AlertHistory has correct route`() {
         assertEquals("alert_history", Screen.AlertHistory.route)
+    }
+
+    // -- Bottom nav capability gating (GLY-146) -----------------------------------
+
+    @Test
+    fun `full-stack bottom nav includes AI Chat in order`() {
+        assertEquals(
+            listOf(Screen.Home, Screen.AiChat, Screen.Alerts, Screen.Settings),
+            bottomNavItems(backendConfigured = true),
+        )
+    }
+
+    @Test
+    fun `BLE-only bottom nav omits AI Chat and nothing else`() {
+        assertEquals(
+            listOf(Screen.Home, Screen.Alerts, Screen.Settings),
+            bottomNavItems(backendConfigured = false),
+        )
     }
 
     // -- Not in bottom nav -------------------------------------------------------

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/SessionBannerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/navigation/SessionBannerTest.kt
@@ -11,37 +11,54 @@ import org.junit.Test
  * nothing -- keying the banner off it would flash "not signed in" at cold
  * start for every authenticated user before startup validation resolves
  * the real state.
+ *
+ * Unauthenticated is additionally mode-aware (GLY-146): a BLE-only user is
+ * permanently Unauthenticated by design, so with no backend configured the
+ * sign-in prompt must not render. Expired stays unconditional -- a lapsed
+ * full-stack session still needs the nudge.
  */
 class SessionBannerTest {
 
     @Test
     fun `initializing shows no banner`() {
-        assertNull(sessionBannerMessage(AuthState.Initializing))
+        assertNull(sessionBannerMessage(AuthState.Initializing, backendConfigured = true))
+        assertNull(sessionBannerMessage(AuthState.Initializing, backendConfigured = false))
     }
 
     @Test
     fun `refreshing shows no banner`() {
-        assertNull(sessionBannerMessage(AuthState.Refreshing))
+        assertNull(sessionBannerMessage(AuthState.Refreshing, backendConfigured = true))
+        assertNull(sessionBannerMessage(AuthState.Refreshing, backendConfigured = false))
     }
 
     @Test
     fun `authenticated shows no banner`() {
-        assertNull(sessionBannerMessage(AuthState.Authenticated))
+        assertNull(sessionBannerMessage(AuthState.Authenticated, backendConfigured = true))
+        assertNull(sessionBannerMessage(AuthState.Authenticated, backendConfigured = false))
     }
 
     @Test
-    fun `expired shows its message`() {
+    fun `expired shows its message regardless of mode`() {
         assertEquals(
             "Session expired, please sign in again",
-            sessionBannerMessage(AuthState.Expired()),
+            sessionBannerMessage(AuthState.Expired(), backendConfigured = true),
+        )
+        assertEquals(
+            "Session expired, please sign in again",
+            sessionBannerMessage(AuthState.Expired(), backendConfigured = false),
         )
     }
 
     @Test
-    fun `unauthenticated shows the sign-in prompt`() {
+    fun `unauthenticated with a backend shows the sign-in prompt`() {
         assertEquals(
             "Not signed in, tap to sign in",
-            sessionBannerMessage(AuthState.Unauthenticated),
+            sessionBannerMessage(AuthState.Unauthenticated, backendConfigured = true),
         )
+    }
+
+    @Test
+    fun `unauthenticated without a backend shows no banner`() {
+        assertNull(sessionBannerMessage(AuthState.Unauthenticated, backendConfigured = false))
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -33,6 +33,7 @@ import com.glycemicgpt.mobile.domain.plugin.ui.PluginSettingsSection
 import com.glycemicgpt.mobile.domain.plugin.ui.SettingDescriptor
 import com.glycemicgpt.mobile.plugin.PluginRegistry
 import com.glycemicgpt.mobile.plugin.RuntimePluginInfo
+import com.glycemicgpt.mobile.plugin.nightscout.NightscoutSourcePlugin
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -1029,5 +1030,55 @@ class SettingsViewModelTest {
         assertEquals(75, vm.uiState.value.alertThresholdLowMgDl)
         assertEquals(170, vm.uiState.value.alertThresholdHighMgDl)
         assertEquals(260, vm.uiState.value.alertThresholdUrgentHighMgDl)
+    }
+
+    // -- SettingsUiState.visibleAvailablePlugins (GLY-146) -------------------------
+    // The cloud-mediated Nightscout source must not offer an activation control in
+    // BLE-only mode, while an already-active instance keeps its Deactivate control.
+
+    private val pumpMetadata = PluginMetadata(
+        id = "com.glycemicgpt.test-pump",
+        name = "Test Pump",
+        version = "1.0.0",
+        apiVersion = 1,
+    )
+
+    @Test
+    fun `BLE-only mode hides the inactive Nightscout plugin but keeps device plugins`() {
+        val state = SettingsUiState(
+            backendConfigured = false,
+            availablePlugins = listOf(pumpMetadata, NightscoutSourcePlugin.METADATA),
+            activePluginIds = emptySet(),
+        )
+
+        assertEquals(listOf(pumpMetadata), state.visibleAvailablePlugins)
+    }
+
+    @Test
+    fun `BLE-only mode keeps an ACTIVE Nightscout plugin listed so Deactivate stays reachable`() {
+        val state = SettingsUiState(
+            backendConfigured = false,
+            availablePlugins = listOf(pumpMetadata, NightscoutSourcePlugin.METADATA),
+            activePluginIds = setOf(NightscoutSourcePlugin.PLUGIN_ID),
+        )
+
+        assertEquals(
+            listOf(pumpMetadata, NightscoutSourcePlugin.METADATA),
+            state.visibleAvailablePlugins,
+        )
+    }
+
+    @Test
+    fun `full-stack mode lists every available plugin`() {
+        val state = SettingsUiState(
+            backendConfigured = true,
+            availablePlugins = listOf(pumpMetadata, NightscoutSourcePlugin.METADATA),
+            activePluginIds = emptySet(),
+        )
+
+        assertEquals(
+            listOf(pumpMetadata, NightscoutSourcePlugin.METADATA),
+            state.visibleAvailablePlugins,
+        )
     }
 }

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -91,6 +91,7 @@ security-crypto = { group = "androidx.security", name = "security-crypto", versi
 
 # Background work
 work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work" }
 
 # Logging
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }


### PR DESCRIPTION
## Summary

A mobile-only (BLE-only) user still saw AI chat, meal analysis, cloud-sync, Nightscout, and sign-in surfaces that can never work without a backend. This hides, disables, or cancels every one of them, keyed on the shared mode signal (`AuthTokenStore.isBackendConfigured()` / `backendConfiguredFlow()`). Nothing is stubbed locally, and everything reappears the moment a server is configured.

Closes GLY-146. This completes the backend-optional tier: install -> pair over BLE -> monitor -> set local thresholds -> honest UI, with the full-stack experience one Settings entry away.

## Changes

- **Bottom nav / routes**: the nav bar is capability-driven; the AI Chat tab is absent with no backend. The AI Chat and meal routes stay registered but redirect to Home through a shared `backendGatedComposable` guard that reads the mode as `State`, so a restored back stack or deep link never lands on a blank frame and a server added or removed mid-session takes effect immediately.
- **Session banner**: the "Not signed in, tap to sign in" nag is suppressed for a permanently-unauthenticated BLE-only user; the session-expired nudge stays unconditional.
- **Meal FAB**: gated at composition on the mode, above `HomeMealViewModel` (whose within-configured availability logic is unchanged).
- **Nightscout**: the sync manager stands down with no backend - enable/sync-now cancel the WorkManager schedule instead of enqueueing, the sync engine returns a terminal `NoBackend` outcome so a run racing the mode flip cannot retry forever, and the activation control is withheld from Settings via a derived `SettingsUiState.visibleAvailablePlugins` (an already-active instance keeps its Deactivate control).
- **Watch chat relay**: answers honestly and terminally ("AI chat needs a GlycemicGPT server - none is set up on your phone.") instead of a retryable-sounding generic error. Phone-side only; the complication itself is a follow-up.
- **Settings**: the Backend Sync card and AI Notification sound row are hidden in BLE-only mode; the local Data Retention card and the Account/Server card (the add-a-backend entry point) stay.
- **Alerts**: no more unconditional startup fetch - in BLE-only mode neither the auto-fetch nor pull-to-refresh hits the server or shows "Can't reach your server"; local alerts and the on-device alert-floor banner are untouched.

No schema change (Room stays v13). No backend change. Phone-only (:wear-device untouched).

## Testing

- New/updated unit tests: bottom-nav gating (mutation-verified), session-banner matrix, Alerts fetch gate (auto + manual + cached-alerts-still-flow), Nightscout manager stand-down against a real test WorkManager, engine `NoBackend` terminal outcome, worker outcome-to-Result mapping, and `visibleAvailablePlugins`.
- `./gradlew testDebugUnitTest lintDebug assembleDebug` green.
- Emulator E2E, both modes: BLE-only sweep (no AI Chat tab, no sign-in banner, no meal FAB, no server nag on Alerts, correct Settings rows, Nightscout hidden with zero WorkManager jobs) and full-stack (all surfaces return on sign-in; Nightscout schedules real work and cancels on deactivate, verified in the WorkManager database).
- Watch-relay message and the wear complication are follow-ups tracked separately (require a paired physical watch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer behavior for BLE-only mode when no backend is configured, including hidden backend-only actions and more relevant in-app messaging.
  * Updated sync and chat flows to stop retrying or scheduling backend tasks when a server isn’t set up.

* **Bug Fixes**
  * Prevented backend-only screens, controls, and alerts from appearing when they can’t be used.
  * Improved handling of sync outcomes so “no backend configured” is treated as a terminal state instead of a transient failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->