### PR TITLE
fix(mobile): honest Alerts empty state in BLE-only mode

### DIFF
--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/alerts/AlertsDegradedUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/alerts/AlertsDegradedUiTest.kt
@@ -111,6 +111,48 @@ class AlertsDegradedUiTest {
 
         compose.onNodeWithTag(TAG_ALERTING_DEGRADED_BANNER).assertIsDisplayed()
         compose.onNodeWithText("No alerts").assertIsDisplayed()
+        compose.onNodeWithText("Pull down to refresh").assertIsDisplayed()
+        compose.onNodeWithTag(TAG_ALERTS_PULL_TO_REFRESH).assertIsDisplayed()
+        compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
+    }
+
+    @Test
+    fun bleOnly_emptyState_showsNotificationCopy_andNoPullToRefresh() {
+        setContent(status = notWatching, alerts = emptyList(), backendConfigured = false)
+
+        // The BLE-only contract (GLY-157): banner preserved, PM-pinned honest empty copy shown
+        // verbatim, and no pull-to-refresh copy or affordance anywhere in the tree.
+        compose.onNodeWithTag(TAG_ALERTING_DEGRADED_BANNER).assertIsDisplayed()
+        compose.onNodeWithText("No alert history").assertIsDisplayed()
+        compose.onNodeWithText("On-device alarms appear as notifications, not in this list.")
+            .assertIsDisplayed()
+        compose.onNodeWithText("Pull down to refresh").assertDoesNotExist()
+        compose.onNodeWithTag(TAG_ALERTS_PULL_TO_REFRESH).assertDoesNotExist()
+    }
+
+    @Test
+    fun bleOnly_withCachedAlerts_keepsHistory_withoutPullAffordance() {
+        setContent(status = notWatching, alerts = listOf(cachedAlert()), backendConfigured = false)
+
+        // Leftover cached server alerts must stay readable in BLE-only mode -- the empty-state
+        // gate may not swallow a non-empty list -- while the pull affordance stays absent.
+        compose.onNodeWithText("High glucose warning").assertIsDisplayed()
+        compose.onNodeWithText("No alert history").assertDoesNotExist()
+        compose.onNodeWithTag(TAG_ALERTS_PULL_TO_REFRESH).assertDoesNotExist()
+    }
+
+    @Test
+    fun bleOnly_emptyState_ignoresStaleLoadingFlag() {
+        setContent(
+            status = notWatching,
+            alerts = emptyList(),
+            isLoading = true,
+            backendConfigured = false,
+        )
+
+        // A fetch orphaned by signing out mid-refresh leaves isLoading=true behind; BLE-only
+        // must still show the honest empty state, never a blank screen or a spinner.
+        compose.onNodeWithText("No alert history").assertIsDisplayed()
         compose.onAllNodes(indeterminateSpinner).assertCountEquals(0)
     }
 }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsScreen.kt
@@ -39,7 +39,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -50,6 +52,9 @@ import com.glycemicgpt.mobile.domain.model.GlucoseUnit
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+
+/** testTag for the pull-to-refresh wrapper — full-stack only, absent in BLE-only mode. */
+const val TAG_ALERTS_PULL_TO_REFRESH = "alerts_pull_to_refresh"
 
 @Composable
 fun AlertsScreen(
@@ -102,33 +107,37 @@ internal fun AlertsContent(
                 backendConfigured = backendConfigured,
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
             )
-            PullToRefreshBox(
-                isRefreshing = uiState.isLoading,
-                onRefresh = onRefresh,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-            ) {
-                if (alerts.isEmpty() && !uiState.isLoading) {
-                    EmptyAlertsState()
-                } else {
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(horizontal = 16.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        item { Spacer(Modifier.height(8.dp)) }
-                        items(alerts, key = { it.serverId }) { alert ->
-                            AlertCard(
-                                alert = alert,
-                                glucoseUnit = glucoseUnit,
-                                onAcknowledge = { onAcknowledge(alert.serverId) },
-                            )
-                        }
-                        item { Spacer(Modifier.height(8.dp)) }
-                    }
+            if (backendConfigured) {
+                PullToRefreshBox(
+                    isRefreshing = uiState.isLoading,
+                    onRefresh = onRefresh,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .testTag(TAG_ALERTS_PULL_TO_REFRESH),
+                ) {
+                    AlertHistory(
+                        isLoading = uiState.isLoading,
+                        alerts = alerts,
+                        glucoseUnit = glucoseUnit,
+                        backendConfigured = backendConfigured,
+                        onAcknowledge = onAcknowledge,
+                    )
                 }
+            } else {
+                // BLE-only: refreshAlerts() stands down, so a pull would be a dead gesture --
+                // the indicator would track the drag and retract without ever refreshing.
+                // Offer no pull affordance at all.
+                AlertHistory(
+                    isLoading = uiState.isLoading,
+                    alerts = alerts,
+                    glucoseUnit = glucoseUnit,
+                    backendConfigured = backendConfigured,
+                    onAcknowledge = onAcknowledge,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                )
             }
         }
         SnackbarHost(
@@ -138,13 +147,59 @@ internal fun AlertsContent(
     }
 }
 
+/**
+ * The alerts list, or the mode-aware empty state when there is no history to show.
+ *
+ * In BLE-only mode [isLoading] is ignored: the refresh gate stands down without a backend, so a
+ * stale in-flight flag (a fetch orphaned by signing out mid-refresh) must not blank the screen.
+ */
 @Composable
-private fun EmptyAlertsState() {
+private fun AlertHistory(
+    isLoading: Boolean,
+    alerts: List<AlertEntity>,
+    glucoseUnit: GlucoseUnit,
+    backendConfigured: Boolean,
+    onAcknowledge: (serverId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (alerts.isEmpty() && (!isLoading || !backendConfigured)) {
+        EmptyAlertsState(backendConfigured = backendConfigured, modifier = modifier)
+    } else {
+        LazyColumn(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { Spacer(Modifier.height(8.dp)) }
+            items(alerts, key = { it.serverId }) { alert ->
+                AlertCard(
+                    alert = alert,
+                    glucoseUnit = glucoseUnit,
+                    onAcknowledge = { onAcknowledge(alert.serverId) },
+                )
+            }
+            item { Spacer(Modifier.height(8.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun EmptyAlertsState(backendConfigured: Boolean, modifier: Modifier = Modifier) {
+    // Selected as a pair so the title and subtitle can never drift into a mismatched combination.
+    val (title, subtitle) = if (backendConfigured) {
+        "No alerts" to "Pull down to refresh"
+    } else {
+        "No alert history" to "On-device alarms appear as notifications, not in this list."
+    }
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            modifier = Modifier.padding(horizontal = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
             Icon(
                 imageVector = Icons.Default.Notifications,
                 contentDescription = null,
@@ -153,15 +208,16 @@ private fun EmptyAlertsState() {
             )
             Spacer(Modifier.height(16.dp))
             Text(
-                text = "No alerts",
+                text = title,
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "Pull down to refresh",
+                text = subtitle,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                textAlign = TextAlign.Center,
             )
         }
     }


### PR DESCRIPTION
## Summary

In BLE-only mode the Alerts tab's empty history advertised a dead affordance: the `alerts` table has no writers without a backend (the on-device floor never persists, by design) and `refreshAlerts()` stands down, yet the empty state still said "No alerts / Pull down to refresh" with a pull gesture that could never fetch anything.

This keeps the Alerts tab and the floor-status banner exactly as they are (the banner is the only in-app place a BLE-only user can confirm the on-device floor is armed) and makes only the empty history honest:

- BLE-only, empty list: "No alert history" / "On-device alarms appear as notifications, not in this list." and no pull-to-refresh wrapper at all (no gesture, no indicator).
- Full-stack: unchanged. Same "No alerts" / "Pull down to refresh" copy, same `PullToRefreshBox`, pull still triggers a real fetch.
- Hardening found in review: a stale in-flight loading flag orphaned by a mid-refresh sign-out can no longer blank the BLE-only screen (loading is ignored where no fetch can be running), and cached server alerts stay readable in BLE-only.

Confined to `AlertsScreen.kt` plus its Compose UI test. No nav, ViewModel, banner, persistence, or schema changes (Room stays v13).

## Tests

- `AlertsDegradedUiTest` extended (8/8 green on emulator): BLE-only empty state shows the pinned copy verbatim with no pull affordance anywhere in the tree; BLE-only with cached alerts keeps the list readable without the pull wrapper; BLE-only with a stale loading flag still shows the empty state; full-stack empty state now pins "Pull down to refresh" and the refresh wrapper so the copy cannot silently change.
- Mutation-checked: reverting the copy branch and reverting the affordance gate were each verified to turn the BLE-only test red before finalizing.
- `./gradlew testDebugUnitTest lintDebug assembleDebug` green.
- Verified on the emulator in both modes: BLE-only onboarding shows banner + honest empty copy and a dead-free surface (no spinner, no fetch on drag); full-stack sign-in shows unchanged copy, a working pull (fetch observed in API logs, spinner rendered), and a server alert rendering in the list.

## Notes for reviewers

- The empty-state column gained `textAlign = TextAlign.Center` and horizontal padding so the longer BLE-only subtitle wraps cleanly; invisible for the short full-stack strings at default font scale.
- Pull-to-refresh over the *empty* full-stack state does not engage the gesture (the empty state is not scrollable content) — this is pre-existing behavior, identical on develop, and untouched here; pull over the list works and was verified.
- Known follow-ups, deliberately out of scope for this surface-only change: the mode signal's pessimistic `false` seed can flash the BLE-only empty copy for a frame on a full-stack cold start (same seed behavior the banner already has), the `backendConfigured` KDoc in the ViewModel now understates what the flag drives, and the acknowledge snackbar copy in BLE-only still implies a server. Tracked in Linear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alerts now support a clearer empty state in both backend-connected and BLE-only modes.
  * Pull-to-refresh is shown only when backend sync is available.

* **Bug Fixes**
  * BLE-only alerts no longer show pull-to-refresh affordances or stale loading spinners.
  * Cached alerts remain visible even if a loading flag is still set in BLE-only mode.
  * Empty-state copy now matches the current connection mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->