### PR TITLE
fix(mobile): honest offline write surfaces

### DIFF
--- a/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/settings/MealIntelligenceSectionUiTest.kt
+++ b/apps/mobile/app/src/androidTest/java/com/glycemicgpt/mobile/presentation/settings/MealIntelligenceSectionUiTest.kt
@@ -1,0 +1,50 @@
+package com.glycemicgpt.mobile.presentation.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.glycemicgpt.mobile.presentation.theme.GlycemicGptTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Meal intelligence is backend-only, so the Settings section gates itself on the mode signal
+ * (`backendConfigured`), not the session (GLY-110): hidden in BLE-only mode even while a stale
+ * session flag is set, shown whenever a backend is configured even across a session lapse.
+ */
+@RunWith(AndroidJUnit4::class)
+class MealIntelligenceSectionUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun setContent(state: SettingsUiState) {
+        compose.setContent {
+            GlycemicGptTheme {
+                MealIntelligenceSection(
+                    state = state,
+                    onToggle = {},
+                    onNavigateToMealLog = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun bleOnly_sectionHidden_evenWhenSessionFlagIsSet() {
+        // isLoggedIn = true pins the predicate itself: a regression back to the session flag
+        // would render the section here and fail this test.
+        setContent(SettingsUiState(backendConfigured = false, isLoggedIn = true))
+
+        compose.onNodeWithTag("meal_intelligence_toggle").assertDoesNotExist()
+    }
+
+    @Test
+    fun backendConfigured_sectionShown_evenAcrossSessionLapse() {
+        setContent(SettingsUiState(backendConfigured = true, isLoggedIn = false))
+
+        compose.onNodeWithTag("meal_intelligence_toggle").assertIsDisplayed()
+    }
+}

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModel.kt
@@ -110,6 +110,10 @@ class AlertsViewModel @Inject constructor(
             // so the dedup id is cleared unconditionally too — the alert is silenced either way.
             alertNotificationManager.markAcknowledged(serverId)
             result.onFailure { e ->
+                // BLE-only gate: with no backend the local ack IS the whole operation, so the
+                // phantom POST failure must not surface a "will sync" snackbar for a server that
+                // was never configured. Read from the flow off-main, as in refreshAlerts().
+                if (!authTokenStore.backendConfiguredFlow().first()) return@onFailure
                 Timber.w(e, "Alert acknowledged locally; server sync failed")
                 _uiState.value = _uiState.value.copy(error = acknowledgeFailureMessage(e))
             }

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsScreen.kt
@@ -176,16 +176,12 @@ fun SettingsScreen(
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        // -- Meal Intelligence Section (Epic 50) -- per-account state, so render it
-        // only when signed in (the toggle writes the local cache optimistically).
-        if (state.isLoggedIn) {
-            MealIntelligenceSection(
-                state = state,
-                onToggle = settingsViewModel::setMealIntelligenceEnabled,
-                onNavigateToMealLog = onNavigateToMealLog,
-            )
-            Spacer(modifier = Modifier.height(20.dp))
-        }
+        // -- Meal Intelligence Section (Epic 50) -- gates itself on the mode signal.
+        MealIntelligenceSection(
+            state = state,
+            onToggle = settingsViewModel::setMealIntelligenceEnabled,
+            onNavigateToMealLog = onNavigateToMealLog,
+        )
 
         // -- Notifications Section --
         SectionHeader(title = "Notifications")
@@ -1137,11 +1133,15 @@ private fun PumpSection(
 }
 
 @Composable
-private fun MealIntelligenceSection(
+internal fun MealIntelligenceSection(
     state: SettingsUiState,
     onToggle: (Boolean) -> Unit,
     onNavigateToMealLog: () -> Unit,
 ) {
+    // Meal intelligence is backend-only (photo analysis runs on the server), so visibility
+    // tracks the mode signal like the Home meal FAB -- hidden in BLE-only mode, shown whenever
+    // a backend is configured, even across a transient session lapse.
+    if (!state.backendConfigured) return
     SectionHeader(title = "Meal Intelligence")
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(
@@ -1219,6 +1219,9 @@ private fun MealIntelligenceSection(
             modifier = Modifier.padding(top = 4.dp),
         )
     }
+    // Trailing gap to the next section, gated with the section itself so BLE-only mode
+    // does not render a stray double-space.
+    Spacer(modifier = Modifier.height(20.dp))
 }
 
 @Composable

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModel.kt
@@ -72,6 +72,10 @@ import kotlin.math.roundToInt
 private const val DEFAULT_ALARM_NAME = "Default Alarm"
 private const val DEFAULT_NOTIFICATION_NAME = "Default Notification"
 
+// Honest copy for a per-account setting whose backend PATCH failed: the local save succeeded
+// and persists, the sync did not, and nothing re-PATCHes it later -- so promise neither.
+private const val SETTING_SYNC_FAILED_MESSAGE = "Saved on this device. Couldn't sync to your account."
+
 sealed class UpdateUiState {
     object Idle : UpdateUiState()
     object Checking : UpdateUiState()
@@ -1318,12 +1322,13 @@ class SettingsViewModel @Inject constructor(
 
     /**
      * Set the glucose display unit. The unit is a per-account preference, so this does an
-     * optimistic local-cache set for instant feedback AND a backend PATCH so the choice
-     * propagates to web, watch, and AI text. (Unlike [setThemeMode], which is per-device.)
+     * optimistic local-cache set for instant feedback AND, when a backend is configured, a PATCH
+     * so the choice propagates to web, watch, and AI text. (Unlike [setThemeMode], which is
+     * per-device.) In BLE-only mode the local write is the whole save -- no PATCH is attempted
+     * (it could only fail against a server that is not there) and no error is surfaced.
      * On success the selector reflects whatever unit the server resolved to (in case it ever
-     * coerces the value); on PATCH failure the optimistic value stays and a transient error is
-     * surfaced; the next `/api/settings/glucose-unit` reconcile corrects it rather than reverting
-     * mid-session.
+     * coerces the value); on PATCH failure the optimistic value stays and an honest
+     * saved-locally-but-not-synced notice is surfaced.
      */
     fun setGlucoseUnit(unit: GlucoseUnit) {
         appSettingsStore.glucoseUnit = unit
@@ -1334,6 +1339,7 @@ class SettingsViewModel @Inject constructor(
             glucoseUnitSyncError = null,
             seedNeedsConfirm = false,
         )
+        if (!_uiState.value.backendConfigured) return
         viewModelScope.launch {
             authRepository.updateGlucoseUnit(unit)
                 .onSuccess { resolved ->
@@ -1346,7 +1352,7 @@ class SettingsViewModel @Inject constructor(
                 .onFailure { e ->
                     Timber.w(e, "Failed to sync glucose unit to backend")
                     _uiState.value = _uiState.value.copy(
-                        glucoseUnitSyncError = "Couldn't save to your account. It will retry on next sign-in.",
+                        glucoseUnitSyncError = SETTING_SYNC_FAILED_MESSAGE,
                     )
                 }
         }
@@ -1355,9 +1361,10 @@ class SettingsViewModel @Inject constructor(
     /**
      * Enable or disable meal intelligence. Per-account, so this does an optimistic local-cache set
      * for instant feedback -- the Home FAB hides/shows immediately via the settings-store flow --
-     * AND a backend PATCH so the choice propagates to web and watch. On PATCH failure the optimistic
-     * value stays and a transient error is surfaced; the next `/api/settings/meal-intelligence`
-     * reconcile corrects it rather than reverting mid-session.
+     * AND, when a backend is configured, a PATCH so the choice propagates to web and watch. In
+     * BLE-only mode the local write is the whole save -- no PATCH, no error (the section is hidden
+     * then anyway, but the setter stays honest on its own). On PATCH failure the optimistic value
+     * stays and an honest saved-locally-but-not-synced notice is surfaced.
      */
     // Guards against a stale PATCH response winning: a rapid second toggle bumps
     // the version and cancels the prior request, so an older response is ignored.
@@ -1370,8 +1377,11 @@ class SettingsViewModel @Inject constructor(
             mealIntelligenceEnabled = enabled,
             mealIntelligenceSyncError = null,
         )
+        // Bump the version and cancel any in-flight PATCH even when the gate below skips a new
+        // one, so a response from a request launched before a mode flip can never win.
         val requestVersion = ++mealIntelligenceRequestVersion
         mealIntelligenceUpdateJob?.cancel()
+        if (!_uiState.value.backendConfigured) return
         mealIntelligenceUpdateJob = viewModelScope.launch {
             authRepository.updateMealIntelligence(enabled)
                 .onSuccess { resolved ->
@@ -1384,7 +1394,7 @@ class SettingsViewModel @Inject constructor(
                     if (requestVersion != mealIntelligenceRequestVersion) return@onFailure
                     Timber.w(e, "Failed to sync meal intelligence to backend")
                     _uiState.value = _uiState.value.copy(
-                        mealIntelligenceSyncError = "Couldn't save to your account. It will retry on next sign-in.",
+                        mealIntelligenceSyncError = SETTING_SYNC_FAILED_MESSAGE,
                     )
                 }
         }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/alerts/AlertsViewModelTest.kt
@@ -273,6 +273,25 @@ class AlertsViewModelTest {
     }
 
     @Test
+    fun `acknowledgeAlert in BLE-only mode stays silent - the local ack is the whole operation`() = runTest {
+        // With no backend configured the POST fails at the interceptor by construction; the ack
+        // already succeeded locally, so no "will sync" snackbar may appear for a server that was
+        // never configured (GLY-110).
+        every { authTokenStore.backendConfiguredFlow() } returns flowOf(false)
+        coEvery { repository.acknowledgeAlert("alert-1") } returns
+            Result.failure(IOException("Server URL not configured"))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.acknowledgeAlert("alert-1")
+        advanceUntilIdle()
+
+        verify { notificationManager.markAcknowledged("alert-1") }
+        assertNull(vm.uiState.value.error)
+    }
+
+    @Test
     fun `acknowledgeAlert terminal rejection surfaces a real sync error, never the raw message`() = runTest {
         coEvery { repository.acknowledgeAlert("alert-1") } returns
             Result.failure(AlertAckHttpException(403, terminal = true))

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/presentation/settings/SettingsViewModelTest.kt
@@ -90,6 +90,9 @@ class SettingsViewModelTest {
         every { isLoggedIn() } returns false
         every { hasActiveSession() } returns false
         every { getUserEmail() } returns null
+        // Relaxed default: isBackendConfigured() returns false, i.e. the fixture is BLE-only
+        // (the alert-threshold tests depend on that -- thresholds are editable only without a
+        // backend). Tests that exercise the settings PATCH override this to true.
     }
     private val glucoseRangeStore = mockk<GlucoseRangeStore>(relaxed = true) {
         every { isStale(any()) } returns false
@@ -160,6 +163,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `setGlucoseUnit optimistically caches locally and PATCHes the account`() = runTest {
+        every { authRepository.isBackendConfigured() } returns true
         coEvery { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) } returns
             Result.success(GlucoseUnit.MMOL)
         val vm = createViewModel()
@@ -176,6 +180,7 @@ class SettingsViewModelTest {
     fun `setGlucoseUnit folds the server-resolved unit back into state`() = runTest {
         // Optimistically applied MMOL, but the server resolves to MGDL; the selector must reflect
         // whatever the backend returned rather than the optimistic value.
+        every { authRepository.isBackendConfigured() } returns true
         coEvery { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) } returns
             Result.success(GlucoseUnit.MGDL)
         val vm = createViewModel()
@@ -187,7 +192,8 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `setGlucoseUnit keeps the optimistic value and surfaces an error on PATCH failure`() = runTest {
+    fun `setGlucoseUnit keeps the optimistic value and surfaces honest copy on PATCH failure`() = runTest {
+        every { authRepository.isBackendConfigured() } returns true
         coEvery { authRepository.updateGlucoseUnit(GlucoseUnit.MMOL) } returns
             Result.failure(RuntimeException("offline"))
         val vm = createViewModel()
@@ -195,12 +201,33 @@ class SettingsViewModelTest {
         vm.setGlucoseUnit(GlucoseUnit.MMOL)
 
         assertEquals(GlucoseUnit.MMOL, vm.uiState.value.glucoseUnit)
-        assertNotNull(vm.uiState.value.glucoseUnitSyncError)
+        // The local save succeeded and nothing re-PATCHes it later, so the copy must claim
+        // neither a failed save nor a future retry.
+        assertEquals(
+            "Saved on this device. Couldn't sync to your account.",
+            vm.uiState.value.glucoseUnitSyncError,
+        )
+    }
+
+    @Test
+    fun `setGlucoseUnit in BLE-only mode saves locally with no PATCH and no error`() = runTest {
+        every { authRepository.isBackendConfigured() } returns false
+        val vm = createViewModel()
+
+        vm.setGlucoseUnit(GlucoseUnit.MMOL)
+
+        // The local write is the whole save: no account to sync to, so no PATCH is attempted
+        // and no error is surfaced for a change that succeeded and persists.
+        verify { appSettingsStore.glucoseUnit = GlucoseUnit.MMOL }
+        coVerify(exactly = 0) { authRepository.updateGlucoseUnit(any()) }
+        assertEquals(GlucoseUnit.MMOL, vm.uiState.value.glucoseUnit)
+        assertNull(vm.uiState.value.glucoseUnitSyncError)
     }
 
     @Test
     fun `setMealIntelligenceEnabled optimistically caches locally and PATCHes the account`() =
         runTest {
+            every { authRepository.isBackendConfigured() } returns true
             coEvery { authRepository.updateMealIntelligence(false) } returns Result.success(false)
             val vm = createViewModel()
 
@@ -215,6 +242,7 @@ class SettingsViewModelTest {
     @Test
     fun `setMealIntelligenceEnabled folds the server-resolved value back into state`() = runTest {
         // Optimistically disabled, but the server resolves to enabled; state must reflect the server.
+        every { authRepository.isBackendConfigured() } returns true
         coEvery { authRepository.updateMealIntelligence(false) } returns Result.success(true)
         val vm = createViewModel()
 
@@ -225,8 +253,9 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `setMealIntelligenceEnabled keeps the optimistic value and surfaces an error on failure`() =
+    fun `setMealIntelligenceEnabled keeps the optimistic value and surfaces honest copy on failure`() =
         runTest {
+            every { authRepository.isBackendConfigured() } returns true
             coEvery { authRepository.updateMealIntelligence(false) } returns
                 Result.failure(RuntimeException("offline"))
             val vm = createViewModel()
@@ -234,7 +263,24 @@ class SettingsViewModelTest {
             vm.setMealIntelligenceEnabled(false)
 
             assertFalse(vm.uiState.value.mealIntelligenceEnabled)
-            assertNotNull(vm.uiState.value.mealIntelligenceSyncError)
+            assertEquals(
+                "Saved on this device. Couldn't sync to your account.",
+                vm.uiState.value.mealIntelligenceSyncError,
+            )
+        }
+
+    @Test
+    fun `setMealIntelligenceEnabled in BLE-only mode saves locally with no PATCH and no error`() =
+        runTest {
+            every { authRepository.isBackendConfigured() } returns false
+            val vm = createViewModel()
+
+            vm.setMealIntelligenceEnabled(false)
+
+            verify { appSettingsStore.mealIntelligenceEnabled = false }
+            coVerify(exactly = 0) { authRepository.updateMealIntelligence(any()) }
+            assertFalse(vm.uiState.value.mealIntelligenceEnabled)
+            assertNull(vm.uiState.value.mealIntelligenceSyncError)
         }
 
     @Test
@@ -242,6 +288,7 @@ class SettingsViewModelTest {
         runTest {
             // The first (off) PATCH is slow; a second (on) toggle supersedes it. The stale
             // off-response must not win -- the version guard + job cancel keep the newer value.
+            every { authRepository.isBackendConfigured() } returns true
             coEvery { authRepository.updateMealIntelligence(false) } coAnswers {
                 delay(1_000)
                 Result.success(false)


### PR DESCRIPTION
## Summary

Every offline write surface now tells the truth. This is copy + gating on the existing mode signal (`AuthTokenStore` backend-configured) — no new sync behavior, no schema change (Room stays v13), no backend change.

- **Glucose unit / Meal Intelligence setters (`SettingsViewModel`):** with no backend configured (BLE-only), the optimistic local write is the whole save — the account PATCH is no longer attempted and no error is surfaced for a change that succeeded and persists. With a backend configured but unreachable, the failure copy no longer claims "Couldn't save to your account. It will retry on next sign-in" (the save succeeded locally, and no write-retry mechanism exists); it now reads **"Saved on this device. Couldn't sync to your account."** The meal setter still bumps its request version and cancels the in-flight PATCH before the gate, so a stale response can never win across a mode flip.
- **Meal Intelligence settings section (`SettingsScreen`):** gates on `backendConfigured` instead of `isLoggedIn` — meal intelligence is backend-only, so the section tracks the mode signal like the Home meal FAB and stays visible across a transient session lapse. The gate moved inside the section composable (now `internal`, mirroring `AlertsContent`) so the real predicate is directly testable; the trailing spacer moved with it, keeping spacing identical in both modes.
- **Alert acknowledge (`AlertsViewModel`):** in BLE-only mode the failure snackbar is suppressed — the local ack fully succeeded and there is no server to sync to, so "Acknowledged locally — will sync when reconnected" no longer appears for a server that was never configured. With a backend configured, the honest deferred-sync copy is unchanged.

## Testing

- `testDebugUnitTest`, `lintDebug`, `assembleDebug` green.
- Revised the two `SettingsViewModelTest` failure tests that previously pinned the false copy; they now assert the exact honest string. Added BLE-only tests asserting the PATCH is not attempted (`coVerify(exactly = 0)`) and no error is set.
- Added an `AlertsViewModelTest` BLE-only ack test (error stays null, notification still cleared) and a new `MealIntelligenceSectionUiTest` Compose test (section hidden when no backend even with a session flag set, shown with a backend even across a session lapse); ran green on-device via `connectedDebugAndroidTest`.
- Mutation-verified: reverting each gate, the copy, or the visibility predicate turns exactly the corresponding tests red.
- Emulator E2E in both modes: BLE-only — unit change applies with no error and survives process death, no Meal Intelligence section, Alerts empty state intact; server mode (local API, fault injection on) — honest copy shown on-screen for both setters, normal sync resumes when the fault is cleared, alert ack under fault records locally and keeps the honest deferred-sync path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings now show the Meal Intelligence section based on backend availability, not sign-in state.
  * Local-only mode is supported for glucose unit and Meal Intelligence changes.

* **Bug Fixes**
  * Prevented misleading sync-failure messages when actions are completed locally without a backend.
  * Improved error copy so failed cloud syncs clearly indicate the change was saved on the device first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->