### PR TITLE
test(mobile): pin alert floor arming semantics against the real store

### DIFF
--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/AlertThresholdStoreRobolectricTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/AlertThresholdStoreRobolectricTest.kt
@@ -1,0 +1,264 @@
+package com.glycemicgpt.mobile.data.local
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Real-storage proof of the [AlertThresholdStore] arming semantics against actual
+ * SharedPreferences (GLY-151). The fake-based [AlertThresholdStoreTest] re-implements the same
+ * logic in memory, so a regression in the real class ships with a green suite; these tests run
+ * the real class end-to-end. The legacy seed writes the LITERAL on-disk keys a pre-GLY-145
+ * install has, so the persisted schema itself is pinned — renaming a key or changing the
+ * migration fallback silently disarms real users and must fail here.
+ */
+// Plain Application: the manifest's @HiltAndroidApp class would pull keystore-backed
+// injection into a JVM test that only needs a Context for plain SharedPreferences.
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class AlertThresholdStoreRobolectricTest {
+
+    private lateinit var context: Context
+    private lateinit var rawPrefs: SharedPreferences
+    private lateinit var store: AlertThresholdStore
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        // The literal prefs file name the store reads: seeding through this handle writes the
+        // exact bytes-on-disk layout an upgrade migrates from.
+        rawPrefs = context.getSharedPreferences("alert_thresholds", Context.MODE_PRIVATE)
+        store = AlertThresholdStore(context)
+    }
+
+    /** A pre-GLY-145 install: thresholds + fetch timestamp on disk, NO "source" key. */
+    private fun seedLegacySyncedInstall() {
+        rawPrefs.edit()
+            .putInt("urgent_low", 50)
+            .putInt("low_warning", 75)
+            .putInt("high_warning", 170)
+            .putInt("urgent_high", 260)
+            .putLong("last_fetched_ms", System.currentTimeMillis())
+            .commit()
+    }
+
+    // --- AC1: migration getter -- a legacy synced install stays ARMED across the upgrade ---
+
+    @Test
+    fun `legacy install with fetch timestamp and no source key reads as BACKEND and stays armed`() {
+        seedLegacySyncedInstall()
+        assertEquals(ThresholdSource.BACKEND, store.source)
+        assertTrue(store.isConfigured())
+        assertEquals(50, store.urgentLowMgDl)
+        assertEquals(75, store.lowWarningMgDl)
+        assertEquals(170, store.highWarningMgDl)
+        assertEquals(260, store.urgentHighMgDl)
+    }
+
+    @Test
+    fun `pristine install reads as NONE and stays disarmed`() {
+        assertEquals(ThresholdSource.NONE, store.source)
+        assertFalse(store.isConfigured())
+    }
+
+    @Test
+    fun `explicit persisted source wins over the legacy timestamp fallback`() {
+        // A LOCAL store keeps a zero timestamp, but even a corrupt combination (LOCAL source +
+        // nonzero timestamp) must honor the persisted source, not re-derive from the timestamp.
+        rawPrefs.edit()
+            .putString("source", ThresholdSource.LOCAL.name)
+            .putLong("last_fetched_ms", System.currentTimeMillis())
+            .commit()
+        assertEquals(ThresholdSource.LOCAL, store.source)
+    }
+
+    @Test
+    fun `unrecognized persisted source falls back to the timestamp rule instead of crashing`() {
+        // A corrupt or future source string must never take alert evaluation down; the getter
+        // tolerates it and re-derives from the timestamp like a legacy install.
+        rawPrefs.edit()
+            .putString("source", "GARBAGE")
+            .putLong("last_fetched_ms", 123L)
+            .commit()
+        assertEquals(ThresholdSource.BACKEND, store.source)
+        rawPrefs.edit().remove("last_fetched_ms").commit()
+        assertEquals(ThresholdSource.NONE, store.source)
+    }
+
+    // --- AC2: source-gated clear() -- logout wipes BACKEND, must preserve LOCAL ---
+
+    @Test
+    fun `clear after a backend sync disarms and resets to defaults`() {
+        store.updateAll(50, 75, 170, 260)
+        store.clear()
+        assertEquals(ThresholdSource.NONE, store.source)
+        assertFalse(store.isConfigured())
+        assertEquals(AlertThresholdStore.DEFAULT_URGENT_LOW, store.urgentLowMgDl)
+        assertEquals(AlertThresholdStore.DEFAULT_LOW_WARNING, store.lowWarningMgDl)
+        assertEquals(AlertThresholdStore.DEFAULT_HIGH_WARNING, store.highWarningMgDl)
+        assertEquals(AlertThresholdStore.DEFAULT_URGENT_HIGH, store.urgentHighMgDl)
+        assertEquals(0L, store.lastFetchedMs)
+    }
+
+    @Test
+    fun `clear preserves LOCAL thresholds - logout must not disarm a device-configured floor`() {
+        store.updateLocal(60, 80, 160, 240)
+        store.clear()
+        assertEquals(ThresholdSource.LOCAL, store.source)
+        assertTrue(store.isConfigured())
+        assertEquals(60, store.urgentLowMgDl)
+        assertEquals(80, store.lowWarningMgDl)
+        assertEquals(160, store.highWarningMgDl)
+        assertEquals(240, store.urgentHighMgDl)
+    }
+
+    @Test
+    fun `clear on a never-configured store is a no-op`() {
+        store.clear()
+        assertEquals(ThresholdSource.NONE, store.source)
+        assertFalse(store.isConfigured())
+    }
+
+    @Test
+    fun `clear after a legacy migration wipes - the derived BACKEND source drives the logout gate`() {
+        // The upgrade-then-logout sequence a real pre-GLY-145 user hits: the source is only
+        // DERIVED (timestamp, no key), yet logout must still treat it as BACKEND and wipe.
+        seedLegacySyncedInstall()
+        store.clear()
+        assertEquals(ThresholdSource.NONE, store.source)
+        assertFalse(store.isConfigured())
+    }
+
+    // --- AC3: write semantics ---
+
+    @Test
+    fun `updateAll persists thresholds, timestamp and BACKEND source in the real prefs`() {
+        store.updateAll(50, 75, 170, 260)
+        assertEquals(ThresholdSource.BACKEND, store.source)
+        assertTrue(store.isConfigured())
+        assertNotEquals(0L, store.lastFetchedMs)
+        // The on-disk schema itself, so a key rename can't slip through the store's own getters.
+        assertEquals(ThresholdSource.BACKEND.name, rawPrefs.getString("source", null))
+        assertEquals(50, rawPrefs.getInt("urgent_low", -1))
+        assertEquals(75, rawPrefs.getInt("low_warning", -1))
+        assertEquals(170, rawPrefs.getInt("high_warning", -1))
+        assertEquals(260, rawPrefs.getInt("urgent_high", -1))
+        assertEquals(store.lastFetchedMs, rawPrefs.getLong("last_fetched_ms", -1L))
+    }
+
+    @Test
+    fun `updateLocal resets the fetch timestamp so a BACKEND-era one cannot survive`() {
+        store.updateAll(50, 75, 170, 260)
+        assertNotEquals(0L, store.lastFetchedMs)
+        store.updateLocal(60, 80, 160, 240)
+        assertEquals(0L, store.lastFetchedMs)
+        assertEquals(0L, rawPrefs.getLong("last_fetched_ms", -1L))
+        assertEquals(ThresholdSource.LOCAL, store.source)
+    }
+
+    @Test
+    fun `updateAll overwrites LOCAL values - backend is master`() {
+        store.updateLocal(60, 80, 160, 240)
+        store.updateAll(50, 75, 170, 260)
+        assertEquals(ThresholdSource.BACKEND, store.source)
+        assertEquals(50, store.urgentLowMgDl)
+        assertEquals(75, store.lowWarningMgDl)
+        assertEquals(170, store.highWarningMgDl)
+        assertEquals(260, store.urgentHighMgDl)
+    }
+
+    @Test
+    fun `out-of-range updates throw and persist nothing`() {
+        // 19/501 sit one past the bounds, so an off-by-one loosening of 20..500 fails here.
+        assertThrows(IllegalArgumentException::class.java) {
+            store.updateAll(19, 75, 170, 260)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            store.updateLocal(55, 75, 170, 501)
+        }
+        assertFalse(store.isConfigured())
+        assertTrue(rawPrefs.all.isEmpty())
+    }
+
+    @Test
+    fun `the exact 20 and 500 bounds of the safety range are legal`() {
+        // The other half of the off-by-one pin: narrowing 20..500 to 21..499 fails here.
+        store.updateAll(20, 70, 180, 500)
+        assertTrue(store.isConfigured())
+        assertEquals(20, store.urgentLowMgDl)
+        assertEquals(500, store.urgentHighMgDl)
+    }
+
+    @Test
+    fun `disordered updates throw and persist nothing`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            store.updateAll(80, 70, 170, 260)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            store.updateLocal(80, 70, 170, 260)
+        }
+        // The middle bound is STRICT: the low band may never touch the high band, or every
+        // reading would classify as both low and high.
+        assertThrows(IllegalArgumentException::class.java) {
+            store.updateAll(50, 100, 100, 200)
+        }
+        assertFalse(store.isConfigured())
+        assertTrue(rawPrefs.all.isEmpty())
+    }
+
+    @Test
+    fun `a rejected update leaves previously stored values intact`() {
+        store.updateAll(50, 75, 170, 260)
+        assertThrows(IllegalArgumentException::class.java) {
+            store.updateAll(10, 75, 170, 260)
+        }
+        assertEquals(50, store.urgentLowMgDl)
+        assertEquals(260, store.urgentHighMgDl)
+        assertEquals(ThresholdSource.BACKEND, store.source)
+    }
+
+    @Test
+    fun `rounded ties at the urgent boundaries are legal`() {
+        // Float rounding can produce urgent/warning ties (69.8/70.2 -> 70/70); the classifier
+        // checks the urgent band first, so a tie fires the more severe alert.
+        store.updateAll(70, 70, 170, 170)
+        assertTrue(store.isConfigured())
+        assertEquals(70, store.urgentLowMgDl)
+        assertEquals(70, store.lowWarningMgDl)
+        assertEquals(170, store.highWarningMgDl)
+        assertEquals(170, store.urgentHighMgDl)
+    }
+
+    // --- isConfiguredFlow: the reactive channel the claim surfaces disarm through ---
+
+    @Test
+    fun `isConfiguredFlow emits on writes and on the logout clear`() = runTest {
+        // The real listener wiring is the only channel observe() learns about a Settings save
+        // or a logout disarm through. The clear() leg rides the null-key callback the store's
+        // KDoc calls out — dropping that arm would leave a logged-out surface claiming
+        // "watching" until its next cold start.
+        store.isConfiguredFlow().test {
+            assertFalse(awaitItem())
+            store.updateLocal(60, 80, 160, 240)
+            assertTrue(expectMostRecentItem())
+            store.updateAll(50, 75, 170, 260)
+            assertTrue(expectMostRecentItem())
+            store.clear()
+            assertFalse(expectMostRecentItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/AlertThresholdStoreTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/local/AlertThresholdStoreTest.kt
@@ -13,6 +13,8 @@ import org.junit.Test
  * thresholds arrive from a backend sync ([AlertThresholdStore.updateAll]) or the local Settings
  * editor ([AlertThresholdStore.updateLocal]) — the alert floor's never-fire-off-defaults gate
  * keys off it — and [AlertThresholdStore.clear] disarms only BACKEND values, preserving LOCAL.
+ * Kept as fast characterization; the real-storage proof against actual SharedPreferences lives
+ * in [AlertThresholdStoreRobolectricTest].
  */
 class AlertThresholdStoreTest {
 

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorStatusProviderTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/service/AlertFloorStatusProviderTest.kt
@@ -1,0 +1,132 @@
+package com.glycemicgpt.mobile.service
+
+import app.cash.turbine.test
+import com.glycemicgpt.mobile.data.local.AlertThresholdStore
+import com.glycemicgpt.mobile.data.local.AppSettingsStore
+import com.glycemicgpt.mobile.data.local.AuthTokenStore
+import com.glycemicgpt.mobile.data.network.NetworkMonitor
+import com.glycemicgpt.mobile.data.network.NetworkStatus
+import com.glycemicgpt.mobile.data.repository.PumpDataRepository
+import com.glycemicgpt.mobile.domain.alerting.AlertFloorStatus
+import com.glycemicgpt.mobile.domain.alerting.FloorNotWatchingReason
+import com.glycemicgpt.mobile.domain.model.ConnectionState
+import com.glycemicgpt.mobile.domain.pump.PumpConnectionManager
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the store→provider→claim WIRING (GLY-151): [AlertFloorStatusProvider.current] and
+ * [AlertFloorStatusProvider.observe] must actually read `AlertThresholdStore.isConfigured()` /
+ * `isConfiguredFlow()` when deciding the coverage claim. [AlertFloorArmingConsistencyTest] only
+ * exercises the pure [com.glycemicgpt.mobile.domain.alerting.alertFloorStatus] selector with
+ * hand-passed booleans — a provider that stopped consulting the store (or hardcoded the input)
+ * would keep that test green while silently mis-claiming; it fails here.
+ *
+ * Pure JVM: every Android-touching dependency is mocked; only `System.currentTimeMillis()`
+ * runs for real.
+ */
+class AlertFloorStatusProviderTest {
+
+    /**
+     * Provider with every input pinned floor-favorable EXCEPT thresholds: server alerting
+     * degraded (so the floor's claim is decisive), pump connected, notifications allowed,
+     * no backend, wall clock sane. With [thresholdsConfigured] false the ONLY reason the
+     * floor can report is the missing thresholds.
+     */
+    private fun provider(thresholdsConfigured: Boolean): AlertFloorStatusProvider {
+        val networkMonitor = mockk<NetworkMonitor> {
+            every { status } returns MutableStateFlow(NetworkStatus.BACKEND_UNREACHABLE)
+        }
+        val streamStateHolder = mockk<AlertStreamStateHolder> {
+            every { state } returns MutableStateFlow(AlertStreamState.RECONNECTING)
+        }
+        val pumpDataRepository = mockk<PumpDataRepository> {
+            every { observeLatestCgm() } returns flowOf(null)
+        }
+        val pumpConnectionManager = mockk<PumpConnectionManager> {
+            every { connectionState } returns MutableStateFlow(ConnectionState.CONNECTED)
+        }
+        val alertThresholdStore = mockk<AlertThresholdStore> {
+            every { isConfigured() } returns thresholdsConfigured
+            every { isConfiguredFlow() } returns flowOf(thresholdsConfigured)
+        }
+        val authTokenStore = mockk<AuthTokenStore> {
+            every { backendConfiguredFlow() } returns flowOf(false)
+        }
+        val appSettingsStore = mockk<AppSettingsStore> {
+            every { debugFastStaleness } returns false
+            every { debugFastStalenessFlow() } returns flowOf(false)
+        }
+        val alertNotificationManager = mockk<AlertNotificationManager> {
+            every { canPostAlertNotifications() } returns true
+        }
+        val alertFloor = mockk<AlertFloor>(relaxed = true) {
+            every { isWallClockRewound(any()) } returns false
+        }
+        return AlertFloorStatusProvider(
+            networkMonitor,
+            streamStateHolder,
+            pumpDataRepository,
+            pumpConnectionManager,
+            alertThresholdStore,
+            authTokenStore,
+            appSettingsStore,
+            alertNotificationManager,
+            alertFloor,
+        )
+    }
+
+    @Test
+    fun `current reads the store - unconfigured thresholds report THRESHOLDS_NOT_CONFIGURED`() {
+        assertEquals(
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.THRESHOLDS_NOT_CONFIGURED),
+            provider(thresholdsConfigured = false).current(),
+        )
+    }
+
+    @Test
+    fun `observe first emission reads the store flow - unconfigured reports THRESHOLDS_NOT_CONFIGURED`() =
+        runTest {
+            provider(thresholdsConfigured = false).observe().test {
+                assertEquals(
+                    AlertFloorStatus.FloorNotWatching(
+                        FloorNotWatchingReason.THRESHOLDS_NOT_CONFIGURED,
+                    ),
+                    awaitItem(),
+                )
+                // observe() runs an endless ticker; the claim is stable so nothing else arrives.
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `observe consumes the store value - configured thresholds move past the thresholds gate`() =
+        runTest {
+            // The counter-direction to the test above: together they pin that observe() actually
+            // reads isConfiguredFlow()'s VALUE — hardcoding the input either way fails one of
+            // the pair. With no cached CGM the status falls to the residual reason.
+            provider(thresholdsConfigured = true).observe().test {
+                assertEquals(
+                    AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING),
+                    awaitItem(),
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `current seed is pessimistic - never claims watching before the CGM flow spins up`() {
+        // current() deliberately passes no CGM age (the Room read is async): even with
+        // thresholds configured and every other precondition green it must under-claim
+        // ("NOT watching — no fresh reading"), never seed a watching state it can't vouch for.
+        assertEquals(
+            AlertFloorStatus.FloorNotWatching(FloorNotWatchingReason.NO_FRESH_READING),
+            provider(thresholdsConfigured = true).current(),
+        )
+    }
+}

--- a/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
+++ b/apps/mobile/wear-device/src/main/java/com/glycemicgpt/weardevice/presentation/AlertsActivity.kt
@@ -257,8 +257,11 @@ private fun NoAlertContent(coverage: WristCoverage) {
     }
 }
 
-/** Watch-facing copy per wire reason. Unknown reasons fall back to the generic line. */
-private fun notWatchingReasonCopy(reason: String?): String = when (reason) {
+/** Watch-facing copy per wire reason. Unknown reasons fall back to the generic line.
+ *  Internal (not private) so [AlertsCopyTest] can pin every reason to a distinct line — a
+ *  dropped or renamed arm silently degrades to the generic copy, the wear analogue of the
+ *  store's silent-disarm. */
+internal fun notWatchingReasonCopy(reason: String?): String = when (reason) {
     WearDataContract.MONITORING_REASON_NOTIFICATIONS_DENIED ->
         "Monitoring degraded — allow notifications on your phone."
     WearDataContract.MONITORING_REASON_THRESHOLDS_NOT_SYNCED ->

--- a/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/presentation/AlertsCopyTest.kt
+++ b/apps/mobile/wear-device/src/test/java/com/glycemicgpt/weardevice/presentation/AlertsCopyTest.kt
@@ -1,0 +1,77 @@
+package com.glycemicgpt.weardevice.presentation
+
+import com.glycemicgpt.weardevice.data.WearDataContract
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [notWatchingReasonCopy]'s exhaustiveness over the wire reasons (GLY-151). The mapping
+ * is deliberately fail-open — an unknown reason falls back to a generic "nothing is watching"
+ * line — so a dropped or renamed branch doesn't crash, it silently swaps the actionable copy
+ * ("set thresholds in Settings") for the generic one. These tests make that degradation RED.
+ * The reason list is read reflectively off [WearDataContract], so a reason added to the wire
+ * contract without a copy arm (and a keyword below) fails here instead of degrading silently.
+ */
+class AlertsCopyTest {
+
+    private val genericLine = notWatchingReasonCopy(null)
+
+    /** One discriminating keyword per wire reason, binding each reason to ITS copy — a
+     *  merely-distinct assertion would still pass with two arms swapped. */
+    private val discriminatingKeyword = mapOf(
+        WearDataContract.MONITORING_REASON_NOTIFICATIONS_DENIED to "notifications",
+        WearDataContract.MONITORING_REASON_THRESHOLDS_NOT_SYNCED to "synced",
+        WearDataContract.MONITORING_REASON_THRESHOLDS_NOT_CONFIGURED to "Settings",
+        WearDataContract.MONITORING_REASON_PUMP_DISCONNECTED to "pump",
+        WearDataContract.MONITORING_REASON_NO_FRESH_READING to "fresh",
+    )
+
+    /** Every reason constant the wire contract declares, so new ones are swept in
+     *  without anyone remembering to edit this test. */
+    private val wireReasons = WearDataContract::class.java.declaredFields
+        .filter { it.name.startsWith("MONITORING_REASON_") }
+        .map { it.get(null) as String }
+
+    @Test
+    fun `every wire reason maps to a distinct line naming its own cause`() {
+        assertEquals(
+            "Wire contract and keyword map disagree - a new reason needs a copy arm and a keyword",
+            discriminatingKeyword.keys,
+            wireReasons.toSet(),
+        )
+        val lines = wireReasons.map { reason ->
+            val line = notWatchingReasonCopy(reason)
+            assertNotEquals(
+                "Reason '$reason' fell back to the generic line - a copy branch was dropped",
+                genericLine,
+                line,
+            )
+            assertTrue(
+                "Reason '$reason' copy '$line' doesn't name its cause",
+                line.contains(discriminatingKeyword.getValue(reason), ignoreCase = true),
+            )
+            line
+        }
+        assertEquals(
+            "Two reasons share the same copy - the user can't tell the causes apart",
+            wireReasons.size,
+            lines.toSet().size,
+        )
+    }
+
+    @Test
+    fun `null reason falls back to the generic line`() {
+        // Pinned literally on purpose: comparing against genericLine here would be tautological.
+        assertEquals(
+            "Monitoring degraded — nothing is watching for lows or highs.",
+            notWatchingReasonCopy(null),
+        )
+    }
+
+    @Test
+    fun `unknown reason falls back to the generic line instead of crashing`() {
+        assertEquals(genericLine, notWatchingReasonCopy("SOME_FUTURE_REASON"))
+    }
+}


### PR DESCRIPTION
## Summary

The safety-critical arming behaviors of the on-device alert floor were pinned only against hand-written in-memory fakes that re-implement the same logic, so a regression in the real code would ship with a green suite. This adds tests that run the real implementations and genuinely discriminate: for every load-bearing assertion, the corresponding implementation was reverted and the test confirmed to go red (table below).

Test-only, except one visibility widening: `notWatchingReasonCopy` in the wear module goes `private` -> `internal` so the copy test can call it. No behavior change, no Room/schema change (DB stays v13).

## New tests

- `AlertThresholdStoreRobolectricTest` (17 tests) - constructs the real SharedPreferences-backed `AlertThresholdStore` under Robolectric (plain `Application`, no Hilt). The legacy install is seeded via the literal on-disk keys (`urgent_low`, ..., `last_fetched_ms`, no `source` key), so the persisted schema itself is pinned. Covers: the legacy-migration getter (stays armed as BACKEND across upgrade), the source-gated logout `clear()` (LOCAL preserved, BACKEND wiped, derived-BACKEND legacy wiped), `updateLocal` fetch-timestamp reset, backend-master overwrite, exact 20-500 bounds plus ordering atomicity (rejected writes persist nothing), corrupt-source tolerance, and `isConfiguredFlow()`'s write/clear reactivity including the null-key `clear()` callback.
- `AlertFloorStatusProviderTest` (4 tests, pure JVM) - proves `current()` and `observe()` consume `AlertThresholdStore.isConfigured()` / `isConfiguredFlow()` in both directions (unconfigured -> `THRESHOLDS_NOT_CONFIGURED`, configured -> falls through the gate), and that the `current()` seed stays pessimistic (never claims watching before the CGM flow spins up).
- `AlertsCopyTest` (3 tests, pure JVM) - every wire monitoring reason maps to a distinct line naming its own cause (a per-reason keyword binds reason to copy, so swapped arms also fail); null/unknown fall back to the generic line. The reason list is enumerated reflectively off `WearDataContract`, so a new wire reason without a copy arm fails the test instead of silently degrading to the generic copy.

The existing fake-based `AlertThresholdStoreTest` is kept as fast characterization and now cross-links its real-storage counterpart.

## Mutant demonstrations

Each mutant was applied to the real implementation, the suite run, the failure observed, and the mutant reverted:

| # | Mutant (real impl) | Failing test |
|---|---|---|
| 1 | Migration fallback `if (lastFetchedMs != 0L) BACKEND else NONE` -> plain `NONE` (silently disarms every legacy user) | `legacy install with fetch timestamp and no source key reads as BACKEND and stays armed` |
| 2 | Drop the `if (source == BACKEND)` guard in `clear()` (logout disarms a BLE-only user's LOCAL floor) | `clear preserves LOCAL thresholds - logout must not disarm a device-configured floor` |
| 3 | Drop `putLong(KEY_LAST_FETCHED, 0L)` from `updateLocal` (stale BACKEND-era timestamp survives) | `updateLocal resets the fetch timestamp so a BACKEND-era one cannot survive` |
| 4 | Hardcode `thresholdsConfigured = true` in `current()` and `observe()` | both `THRESHOLDS_NOT_CONFIGURED` provider tests |
| 5 | Drop the `THRESHOLDS_NOT_CONFIGURED` copy arm in `notWatchingReasonCopy` | `every wire reason maps to a distinct line naming its own cause` |
| 6 | `current()` seeds `cgmAgeMs = 0` instead of `null` (optimistic seed) | `current seed is pessimistic - never claims watching before the CGM flow spins up` |
| 7 | Hardcode `thresholdsConfigured = false` in `observe()` | `observe consumes the store value - configured thresholds move past the thresholds gate` |
| 8 | Drop the null-key arm from `isConfiguredFlow()`'s listener filter (logout never reactively disarms the claim) | `isConfiguredFlow emits on writes and on the logout clear` |
| 9 | Narrow the safety range `20..500` -> `21..499` | `the exact 20 and 500 bounds of the safety range are legal` |
| 10 | Swap the `PUMP_DISCONNECTED` and `NO_FRESH_READING` copy arms | `every wire reason maps to a distinct line naming its own cause` |

## Known nits documented, deliberately not fixed

Two latent main-thread synchronous prefs reads exist where `current()` is used as a synchronous seed: `AlertsViewModel.kt:63` (`stateIn` initial value) and `PumpConnectionService.kt:195` (`onCreate`). Both are first-touch `alert_thresholds` disk reads (sub-millisecond, cached afterward) and nothing installs a StrictMode policy that would flag them. Moving the seed off-main would be a behavioral change to the pessimistic-seed contract the provider documents, so it is out of scope for this test-only change.

## Verification

- `./gradlew testDebugUnitTest lintDebug assembleDebug` green (covers `:app` and `:wear-device`; all 24 new tests run on the JVM, no emulator needed).
- CodeRabbit CLI review vs develop: no findings.
- Security review of the diff: clean.
- No visual/E2E step: no UI or runtime behavior changes; the verification is the mutant demonstrations above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of alert threshold handling, including saved settings, resets, and migration from older installs.
  * Fixed status reporting so alert “not watching” messages stay consistent across all supported reasons.
* **New Features**
  * Added broader coverage for alert configuration and watch-status behavior to prevent regressions.
* **Documentation**
  * Clarified internal test notes around current alert-threshold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->