### PR TITLE
ci(security): suppress AES-ECB false positive in the full security suite (#695/#696)

### DIFF
--- a/.github/workflows/security-full-suite.yml
+++ b/.github/workflows/security-full-suite.yml
@@ -46,6 +46,10 @@ jobs:
         id: semgrep
         run: |
           EXIT=0
+          # AesEcb.java is vendored verbatim from OpenMinimed JavaSake (re-vendor, do not
+          # edit). Its single-block AES-ECB is a wire-mandated KDF / key-unwrap in the SAKE
+          # handshake; integrity is AES-CMAC and confidentiality AES-CTR at other layers, so the
+          # ecb-cipher / use-of-aes-ecb findings are false positives (#695/#696, suppressed in PR #751).
           semgrep scan \
             --config p/python \
             --config p/typescript \
@@ -59,6 +63,7 @@ jobs:
             --exclude '*.min.js' \
             --exclude 'apps/api/.venv' \
             --exclude 'Dockerfile*' \
+            --exclude 'AesEcb.java' \
             --json --output semgrep-results.json \
             apps/api/ apps/web/ sidecar/ apps/mobile/ plugins/ scripts/security/ || EXIT=$?
           echo "Semgrep exit code: $EXIT"


### PR DESCRIPTION
## What

Adds `--exclude 'AesEcb.java'` to the Semgrep step in `security-full-suite.yml`, mirroring the exclude PR #751 added to `security-scan.yml`.

## Why

Issues #695 (`ecb-cipher`) and #696 (`use-of-aes-ecb`) are the **same finding** on `plugins/shipped/medtronic/src/main/java/org/openminimed/sake/crypto/AesEcb.java:56`, flagged by two Semgrep rules. Both are **verified false positives**:

- `AesEcb` is a **single-16-byte-block** primitive (it rejects any other size), used only for a one-shot KDF and a CMAC-gated key unwrap in the Medtronic **SAKE** handshake. ECB's cross-block pattern leakage cannot occur on a single block; integrity is provided by AES-CMAC and confidentiality by AES-CTR at other layers.
- The algorithm is **mandated by the wire protocol** — confirmed on #696 by palmarci, who reverse-engineered SAKE.
- The file is **vendored verbatim** from OpenMinimed JavaSake, so an inline `nosemgrep` isn't an option (it would break byte-for-byte vendoring).

PR #751 already documented this and suppressed the finding, but only in `security-scan.yml`. The **full security suite** (`security-full-suite.yml`) kept scanning the file, so `create-finding-issues.py` reopened #695/#696 on every run (230+ "Still detected" comments). The scanner has no allowlist path for SAST findings — a finding can only be suppressed by stopping Semgrep from emitting it. This closes that gap.

## Result

Once merged, the full suite stops emitting the finding and #695/#696 stay closed (they will not reopen). Follow-up (not in this PR): give Semgrep the same fingerprint-based suppression allowlist ZAP already has in `create-finding-issues.py`, so future false positives don't require editing scan configs across workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scan settings to ignore a known false positive from a vendored file.
  * Added clearer notes so future scan results are easier to interpret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->