### PR TITLE
Medtronic history sync fixes

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -443,8 +443,9 @@ class PumpPollingOrchestrator @Inject constructor(
         const val MAX_BACKFILL_DURATION_MS = 120_000L     // 2 minutes
 
         /** Max time for initial pump history sync on fresh install.
-         *  Allows downloading the full pump history (months of data) in one pass. */
-        const val MAX_INITIAL_SYNC_DURATION_MS = 600_000L  // 10 minutes for full pump download
+         *  Allows downloading the full pump history (months of data) in one pass.
+         *  Increased from 10m to 20m because Medtronic initial sync can take 15+ min. */
+        const val MAX_INITIAL_SYNC_DURATION_MS = 1_200_000L  // 20 minutes for full pump download
 
         /** Pause between consecutive history log batch fetches during catch-up.
          *  Gives fast loop (IoB/CGM) a window to fire between batches. */
@@ -595,6 +596,9 @@ class PumpPollingOrchestrator @Inject constructor(
             }
             lastSequenceNumber = newMaxSeq
             Timber.d("Fetched batch %d: %d history records (seq up to %d)", batchCount, records.size, lastSequenceNumber)
+            if (batchCount > 1) {
+                Timber.d("Cumulative progress: %d records across %d batches (seq up to %d)", totalRecords, batchCount, lastSequenceNumber)
+            }
 
             // Extract and save CGM readings to fill chart gaps
             val cgmReadings = historyLogParser.extractCgmFromHistoryLogs(records, limits)
@@ -617,11 +621,6 @@ class PumpPollingOrchestrator @Inject constructor(
                 repository.saveBasalBatch(basalReadings)
                 syncEnqueuer.enqueueBasalBatch(basalReadings)
                 totalBasal += basalReadings.size
-            }
-
-            if (isInitialSync) {
-                Timber.i("Initial sync: fetched %d records total (%d CGM, %d bolus, %d basal) in %d batches",
-                    totalRecords, totalCgm, totalBolus, totalBasal, batchCount)
             }
 
             // Trigger backend sync after each batch so data is uploaded incrementally

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/service/PumpPollingOrchestrator.kt
@@ -595,10 +595,10 @@ class PumpPollingOrchestrator @Inject constructor(
                 break
             }
             lastSequenceNumber = newMaxSeq
-            Timber.d("Fetched batch %d: %d history records (seq up to %d)", batchCount, records.size, lastSequenceNumber)
-            if (batchCount > 1) {
-                Timber.d("Cumulative progress: %d records across %d batches (seq up to %d)", totalRecords, batchCount, lastSequenceNumber)
-            }
+            Timber.d(
+                "Fetched batch %d: %d history records, %d total so far (seq up to %d)",
+                batchCount, records.size, totalRecords, lastSequenceNumber,
+            )
 
             // Extract and save CGM readings to fill chart gaps
             val cgmReadings = historyLogParser.extractCgmFromHistoryLogs(records, limits)

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
@@ -451,9 +451,6 @@ object MedtronicHistoryParser {
             }
             out += parsed to ref.plusSeconds(parsed.relativeOffsetSeconds.toLong())
         }
-        if (droppedNoReference > 0) {
-            Timber.d("Dropped %d history record(s) with no preceding reference time", droppedNoReference)
-        }
         return out
     }
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
@@ -266,6 +266,36 @@ object MedtronicHistoryParser {
         return MedtronicHistoryRecord(sequence, type, relativeOffset, event)
     }
 
+    /**
+     * True when [frame] decodes as a structurally complete history record: the E2E trailer (when
+     * [useE2e]) CRC-verifies, the 8-byte header parses, and a *handled* event type's payload parses
+     * to its typed event without tripping a length check. Event types [parseEvent] does not handle
+     * are accepted -- they extract as [MedtronicHistoryEvent.Unparsed] either way and feed no dosing
+     * math, so completeness cannot be judged and rejecting them would fail legitimate records.
+     *
+     * Used by [com.glycemicgpt.mobile.ble.read.HistoryReader] to vet a flush-recovered final record
+     * (the NotificationReassembler exact-multiple ambiguity): a genuinely truncated known-type
+     * payload is rejected here so the read stays fail-loud instead of silently skipping a record
+     * the cursors then advance past.
+     */
+    fun isStructurallyCompleteRecordFrame(frame: ByteArray, useE2e: Boolean): Boolean {
+        val record = toHistoryLogRecord(frame, useE2e) ?: return false
+        val body = Base64.getDecoder().decode(record.rawBytesB64)
+        if (body.size < HEADER_SIZE) return false
+        val type = MedtronicHistoryEventType.from(MedtronicCodec.readUIntLe(body, 0, 2))
+        val payload = body.copyOfRange(HEADER_SIZE, body.size)
+        // Re-run the typed parse WITHOUT parseRecordBody's Unparsed fallback: a handled type that
+        // throws here is truncated/corrupt; an unhandled type returns Unparsed without throwing.
+        return try {
+            parseEvent(type, payload)
+            true
+        } catch (e: MedtronicReadException) {
+            false
+        } catch (e: IllegalArgumentException) {
+            false
+        }
+    }
+
     private fun parseEvent(type: MedtronicHistoryEventType, p: ByteArray): MedtronicHistoryEvent =
         when (type) {
             MedtronicHistoryEventType.BOLUS_PROGRAMMED_P1 -> bolusAmounts(p, delivered = false)
@@ -450,6 +480,11 @@ object MedtronicHistoryParser {
                 continue
             }
             out += parsed to ref.plusSeconds(parsed.relativeOffsetSeconds.toLong())
+        }
+        if (droppedNoReference > 0) {
+            // Verbose, not debug: each extractor calls timedRecords() on the same batch, so this
+            // fires up to three times per batch with the same count.
+            Timber.v("Dropped %d history record(s) with no preceding reference time", droppedNoReference)
         }
         return out
     }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/HistoryReader.kt
@@ -89,6 +89,13 @@ class HistoryReader(
             dataChar = MedtronicProtocol.IDD_HISTORY_DATA_UUID,
             controlPoint = MedtronicProtocol.RACP_UUID,
             request = request,
+            // Vet a flush-recovered final record (the exact-multiple ambiguity) before accepting it:
+            // with E2E on, a truncated frame fails the record CRC; with E2E off, a truncated
+            // known-type payload fails its typed parse. Rejection keeps the exchange fail-loud so
+            // the cursors stay put and the page is retried (see reportRecords' KDoc).
+            validateRecoveredFrame = { frame ->
+                MedtronicHistoryParser.isStructurallyCompleteRecordFrame(frame, useE2e)
+            },
             isSuccess = { response ->
                 when {
                     response.contentEquals(EXPECTED_REPORT_SUCCESS) -> true

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -56,11 +56,11 @@ import timber.log.Timber
  *     is connected (see the class header).
  * @param ioDispatcher dispatcher for the blocking SIG reads (Device Info / Battery).
  * @param operationTimeoutMs hard upper bound on every read; expiry surfaces as a failed [Result].
-* @param maxTotalHistoryRecords ceiling on one [getHistoryLogs] walk's total accumulation, across
+ * @param maxTotalHistoryRecords ceiling on one [getHistoryLogs] walk's total accumulation, across
  *     all pages -- the cross-page analog of the per-exchange [MedtronicSessionReader.MAX_RECORDS_PER_REPORT]
  *     bound, so a malfunctioning (but authenticated) pump reporting a bogus huge last-sequence and
-     *     answering every window cannot grow memory without limit.
-     */
+ *     answering every window cannot grow memory without limit.
+ */
 class MedtronicReadGateway(
     private val sessionProvider: () -> MedtronicSakeSession?,
     private val linkProvider: () -> MedtronicGattLink?,
@@ -94,13 +94,14 @@ class MedtronicReadGateway(
     private val historyMutex = Mutex()
 
     /**
-     * Latest history sequence number (one lightweight read-last-record call, no paging). Used by
-     * [MedtronicInsulinSource] to seed its bolus cursor without re-fetching all history.
+     * Latest history sequence number (one lightweight read-last-record call, no paging), or `0` when
+     * the pump's log is empty -- a legitimate state on a new or just-reset pump, not a failure. Used
+     * by [MedtronicInsulinSource] to seed its bolus cursor without re-fetching all history.
      */
     suspend fun getHistoryCursor(): Result<Int> =
         sessionRead("history-cursor") { link, session, onResult ->
             HistoryReader(link, session).readLastRecord(onResult)
-        }.map { records -> records?.sequenceNumber ?: return Result.failure(MedtronicReadException("No history records found")) }
+        }.map { lastRecord -> lastRecord?.sequenceNumber ?: 0 }
 
     /** Latest sensor glucose (CGM RACP "report last record"). */
     suspend fun getCgmReading(): Result<CgmReading> =
@@ -130,12 +131,22 @@ class MedtronicReadGateway(
      * Incremental history fetch: every record newer than [sinceSequence] (raw, preserved for dedup).
      *
      * Paged newest-first in [HISTORY_BATCH_SIZE]-sequence windows, each page its own [sessionRead]
-     * with its own operation timeout. The walk is driven by the *requested window* (`highSeq = lowSeq - 1`),
-     * never by page content: a page routinely parses smaller than its window (duplicate frames dedup
-     * away; the window can straddle the oldest retained record). A page with any undecodable frame
-     * fails outright. A page that comes back *empty* ends the walk: the pump purges oldest-first, so
-     * nothing older remains. A failed page fails the whole call. Serialized via [historyMutex] so
-     * concurrent callers (orchestrator + insulin source) don't interleave their paging loops.
+     * with its own operation timeout (one unbounded range read overran the 30s budget and orphaned
+     * the session). [readMutex] is released between pages so a CGM/keep-alive read can interleave
+     * with a long backfill; each individual RACP exchange stays single-flight, and the whole walk is
+     * serialized via [historyMutex] so concurrent callers (orchestrator + insulin source) don't
+     * interleave their paging loops.
+     *
+     * The walk is driven by the *requested window* (`highSeq = lowSeq - 1`), never by page content:
+     * a page routinely parses smaller than its window (duplicate frames dedup away; the window can
+     * straddle the oldest retained record), and ending the walk on page content would let the
+     * cursor-advancing callers (the insulin source's bolus cursor, the orchestrator's persisted
+     * sequence cursor) advance to the max sequence seen and permanently skip the older records. A
+     * page with any undecodable frame fails outright in [HistoryReader] for the same reason. A page
+     * that comes back *empty* (the pump's "no records found") does end the walk: the
+     * pump purges oldest-first, so its retained sequences are contiguous and nothing older remains.
+     * A failed page fails the whole call -- returning the newer pages collected so far would advance
+     * the callers' cursors past the un-fetched older window (the same permanent skip).
      */
     suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
         historyMutex.withLock {
@@ -150,12 +161,9 @@ class MedtronicReadGateway(
         if (lastRecord == null || lastRecord.sequenceNumber <= sinceSequence) {
             return Result.success(emptyList())
         }
-        val totalCount = sessionRead("history-count") { link, session, onResult ->
-            HistoryReader(link, session).readRecordCount(onResult)
-        }.getOrNull() ?: 0
         var highSeq = lastRecord.sequenceNumber
         val all = mutableListOf<HistoryLogRecord>()
-        Timber.d("History sync start: sinceSequence=%d, lastSequence=%d, totalRecords=%d", sinceSequence, highSeq, totalCount)
+        Timber.d("History sync start: sinceSequence=%d, lastSequence=%d", sinceSequence, highSeq)
         while (highSeq > sinceSequence) {
             val lowSeq = maxOf(sinceSequence + 1, highSeq - HISTORY_BATCH_SIZE + 1)
             Timber.d("History page: requesting sequences %d..%d", lowSeq, highSeq)
@@ -164,8 +172,10 @@ class MedtronicReadGateway(
             }
             val records = batchResult.getOrElse { return Result.failure(it) }
             all.addAll(records)
-            Timber.d("History page complete: %d records (range %d..%d) — %d total this call", records.size, lowSeq, highSeq, all.size)
+            Timber.d("History page complete: %d records (range %d..%d) -- %d total this call", records.size, lowSeq, highSeq, all.size)
             if (all.size > maxTotalHistoryRecords) {
+                // Defense-in-depth (see the constructor KDoc): fail loudly rather than accumulate
+                // without bound; the cursors stay put, so nothing is silently skipped.
                 return Result.failure(
                     MedtronicReadException("Medtronic history fetch exceeded $maxTotalHistoryRecords records; aborting"),
                 )

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -56,11 +56,11 @@ import timber.log.Timber
  *     is connected (see the class header).
  * @param ioDispatcher dispatcher for the blocking SIG reads (Device Info / Battery).
  * @param operationTimeoutMs hard upper bound on every read; expiry surfaces as a failed [Result].
- * @param maxTotalHistoryRecords ceiling on one [getHistoryLogs] walk's total accumulation, across
+* @param maxTotalHistoryRecords ceiling on one [getHistoryLogs] walk's total accumulation, across
  *     all pages -- the cross-page analog of the per-exchange [MedtronicSessionReader.MAX_RECORDS_PER_REPORT]
  *     bound, so a malfunctioning (but authenticated) pump reporting a bogus huge last-sequence and
- *     answering every window cannot grow memory without limit.
- */
+     *     answering every window cannot grow memory without limit.
+     */
 class MedtronicReadGateway(
     private val sessionProvider: () -> MedtronicSakeSession?,
     private val linkProvider: () -> MedtronicGattLink?,
@@ -83,6 +83,24 @@ class MedtronicReadGateway(
      * releases the link between history-backfill batches); this seam only guarantees non-overlap.
      */
     private val readMutex = Mutex()
+
+    /**
+     * Single-flight guard for [getHistoryLogs] across concurrent callers (orchestrator slow loop +
+     * insulin source bolus poll). Without this, two callers both calling [getHistoryLogs] would
+     * interleave their page-fetch loops through [readMutex] -- each acquires/releases per page,
+     * letting the other's pages sneak in -- corrupting the sequence ranges and re-downloading
+     * overlapping windows.
+     */
+    private val historyMutex = Mutex()
+
+    /**
+     * Latest history sequence number (one lightweight read-last-record call, no paging). Used by
+     * [MedtronicInsulinSource] to seed its bolus cursor without re-fetching all history.
+     */
+    suspend fun getHistoryCursor(): Result<Int> =
+        sessionRead("history-cursor") { link, session, onResult ->
+            HistoryReader(link, session).readLastRecord(onResult)
+        }.map { records -> records?.sequenceNumber ?: return Result.failure(MedtronicReadException("No history records found")) }
 
     /** Latest sensor glucose (CGM RACP "report last record"). */
     suspend fun getCgmReading(): Result<CgmReading> =
@@ -112,22 +130,19 @@ class MedtronicReadGateway(
      * Incremental history fetch: every record newer than [sinceSequence] (raw, preserved for dedup).
      *
      * Paged newest-first in [HISTORY_BATCH_SIZE]-sequence windows, each page its own [sessionRead]
-     * with its own operation timeout (one unbounded range read overran the 30s budget and orphaned
-     * the session). [readMutex] is released between pages so a CGM/keep-alive read can interleave
-     * with a long backfill; each individual RACP exchange stays single-flight.
-     *
-     * The walk is driven by the *requested window* (`highSeq = lowSeq - 1`), never by page content:
-     * a page routinely parses smaller than its window (duplicate frames dedup away; the window can
-     * straddle the oldest retained record), and ending the walk on page content would let the
-     * cursor-advancing callers (the insulin source's bolus cursor, the orchestrator's persisted
-     * sequence cursor) advance to the max sequence seen and permanently skip the older records. A
-     * page with any undecodable frame fails outright in [HistoryReader] for the same reason. A page
-     * that comes back *empty* (the pump's "no records found") does end the walk: the
-     * pump purges oldest-first, so its retained sequences are contiguous and nothing older remains.
-     * A failed page fails the whole call -- returning the newer pages collected so far would advance
-     * the callers' cursors past the un-fetched older window (the same permanent skip).
+     * with its own operation timeout. The walk is driven by the *requested window* (`highSeq = lowSeq - 1`),
+     * never by page content: a page routinely parses smaller than its window (duplicate frames dedup
+     * away; the window can straddle the oldest retained record). A page with any undecodable frame
+     * fails outright. A page that comes back *empty* ends the walk: the pump purges oldest-first, so
+     * nothing older remains. A failed page fails the whole call. Serialized via [historyMutex] so
+     * concurrent callers (orchestrator + insulin source) don't interleave their paging loops.
      */
-    suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> {
+    suspend fun getHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> =
+        historyMutex.withLock {
+            innerGetHistoryLogs(sinceSequence)
+        }
+
+    private suspend fun innerGetHistoryLogs(sinceSequence: Int): Result<List<HistoryLogRecord>> {
         val lastResult = sessionRead("history-last") { link, session, onResult ->
             HistoryReader(link, session).readLastRecord(onResult)
         }
@@ -135,18 +150,22 @@ class MedtronicReadGateway(
         if (lastRecord == null || lastRecord.sequenceNumber <= sinceSequence) {
             return Result.success(emptyList())
         }
+        val totalCount = sessionRead("history-count") { link, session, onResult ->
+            HistoryReader(link, session).readRecordCount(onResult)
+        }.getOrNull() ?: 0
         var highSeq = lastRecord.sequenceNumber
         val all = mutableListOf<HistoryLogRecord>()
+        Timber.d("History sync start: sinceSequence=%d, lastSequence=%d, totalRecords=%d", sinceSequence, highSeq, totalCount)
         while (highSeq > sinceSequence) {
             val lowSeq = maxOf(sinceSequence + 1, highSeq - HISTORY_BATCH_SIZE + 1)
+            Timber.d("History page: requesting sequences %d..%d", lowSeq, highSeq)
             val batchResult = sessionRead("history-page") { link, session, onResult ->
                 HistoryReader(link, session).readRecordsInRange(lowSeq, highSeq, onResult)
             }
             val records = batchResult.getOrElse { return Result.failure(it) }
             all.addAll(records)
+            Timber.d("History page complete: %d records (range %d..%d) — %d total this call", records.size, lowSeq, highSeq, all.size)
             if (all.size > maxTotalHistoryRecords) {
-                // Defense-in-depth (see the constructor KDoc): fail loudly rather than accumulate
-                // without bound; the cursors stay put, so nothing is silently skipped.
                 return Result.failure(
                     MedtronicReadException("Medtronic history fetch exceeded $maxTotalHistoryRecords records; aborting"),
                 )

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -25,8 +25,11 @@ import timber.log.Timber
  * exact multiple of [maxPduSize].
  *
  * The exact-multiple ambiguity (a frame that fragments into all-full fragments has no short
- * terminator) is handled here: when the exchange terminates with fragments pending, those fragments
- * are flushed as one last frame via [flush].
+ * terminator) is recoverable for the *final* record of an exchange: fragments still pending at the
+ * terminal indication can be flushed as one last frame via [flush] -- live 780G reads hit this on
+ * real records, so callers recover (with validation) instead of failing the exchange. An
+ * *intermediate* exact-multiple record still merges silently with its successor; pinning the exact
+ * on-wire fragment sizes rides with the 48.A2 capture work.
  */
 internal class NotificationReassembler(
     private val maxPduSize: Int = PduFramer.MAX_PDU_SIZE,
@@ -36,14 +39,17 @@ internal class NotificationReassembler(
     private var accumulated = 0
 
     /**
-     * Offer one inbound PDU; returns the reassembled frame once complete, or `null` if more PDUs
-     * are expected. Empty PDUs are ignored.
+     * Offer one inbound PDU; returns the reassembled frame once complete, or `null` if more PDUs are
+     * expected. Empty PDUs are ignored (a real encrypted frame is never empty, so an empty
+     * notification is noise and must not falsely terminate a multi-PDU frame).
      *
-     * @throws MedtronicReadException if the accumulated frame exceeds [maxFrameSize].
+     * @throws MedtronicReadException if the accumulated frame exceeds [maxFrameSize] -- a peer that
+     *     streams only full-size PDUs with no short terminator cannot grow memory without bound.
      */
     fun offer(pdu: ByteArray): ByteArray? {
         if (pdu.isEmpty()) return null
-        // Defensive copy: the link may recycle the delivery buffer after the callback returns.
+        // Defensive copy: the link may recycle the delivery buffer after the callback returns (the
+        // same discipline SakeHandshakeDriver uses on inbound writes).
         fragments.add(pdu.copyOf())
         accumulated += pdu.size
         if (accumulated > maxFrameSize) {
@@ -58,12 +64,18 @@ internal class NotificationReassembler(
         return null
     }
 
-    /** True while fragments are accumulated but no short terminator has arrived. */
+    /**
+     * True while fragments are accumulated but no short terminator has arrived. Lets an exchange's
+     * terminal indication distinguish "all records delivered" from "a record is still unterminated"
+     * (the exact-multiple ambiguity) so the handler can decide between recovery and failing loudly.
+     */
     fun hasPartialFrame(): Boolean = fragments.isNotEmpty()
 
     /**
-     * Flush pending fragments as one frame. Used when the exchange terminates with a partial
-     * frame (a record whose plaintext ends on a PDU boundary with no short terminator).
+     * Flush pending fragments as one frame: recovery for a *final* record whose plaintext is an
+     * exact multiple of [maxPduSize] (so no short terminator ever arrives). The flushed bytes are
+     * indistinguishable at this layer from a record truncated mid-stream -- callers must validate
+     * the frame before accepting it (see HistoryReader's structural check) or fail the exchange.
      */
     fun flush(): ByteArray {
         val frame = PduFramer.reassemble(fragments)
@@ -74,14 +86,18 @@ internal class NotificationReassembler(
     /** Number of accumulated fragments in the pending frame. */
     fun fragmentCount(): Int = fragments.size
 
-    /** Discard accumulated state. */
+    /** Discard any partially-accumulated frame. */
     fun reset() {
         fragments.clear()
         accumulated = 0
     }
 
     companion object {
-        /** Upper bound on a single reassembled frame. */
+        /**
+         * Upper bound on a single reassembled application frame. Far above any CGM/SOCP record, it
+         * caps the memory a malfunctioning or hostile central can force by streaming full-size PDUs
+         * without a short terminator. Record-level paging for the larger history reads is 48.C2.
+         */
         const val MAX_FRAME_SIZE = 512
     }
 }
@@ -162,11 +178,21 @@ class MedtronicSessionReader(
             when {
                 response.contentEquals(RACP_REPORT_SUCCESS) -> {
                     val r = record
-                    if (assembler.hasPartialFrame()) {
+                    if (assembler.hasPartialFrame() && r == null) {
+                        // The single record never got its short terminator (the exact-multiple
+                        // ambiguity). Recover it: the CGM caller's parse validates the frame and a
+                        // failed read is simply retried next poll -- no cursor advances here, so a
+                        // bad recovery cannot skip data (contrast the IDD history path, which
+                        // validates before accepting).
                         val n = assembler.fragmentCount()
                         val recovered = assembler.flush()
-                        Timber.w("CGM RACP success with unterminated record (%d fragment(s)) — recovered (%d bytes)", n, recovered.size)
+                        Timber.i("CGM RACP success with unterminated record (%d fragment(s)) -- recovered %d bytes", n, recovered.size)
                         finish(Result.success(recovered))
+                    } else if (assembler.hasPartialFrame()) {
+                        // A complete record already arrived AND fragments are pending: report-last
+                        // returns exactly one record, so this is a protocol anomaly -- fail rather
+                        // than guess which bytes are the reading.
+                        finish(Result.failure(MedtronicReadException("CGM RACP reported success with an unterminated record beyond the delivered one")))
                     } else if (r == null) {
                         finish(Result.failure(MedtronicReadException("CGM RACP reported success but no record arrived")))
                     } else {
@@ -250,12 +276,23 @@ class MedtronicSessionReader(
      * after all records. Records are delimited by the same short-PDU rule [NotificationReassembler]
      * uses; see the record-framing notes on [HistoryReader]. The caller imposes the operation
      * timeout (class-level contract).
+     *
+     * **Unterminated final record.** Fragments still pending at a success indication are the
+     * exact-multiple ambiguity: a final record whose plaintext length is an exact multiple of the
+     * PDU size never gets a short terminator (live 780G history reads hit this on real records).
+     * The pending fragments are flushed and offered to [validateRecoveredFrame]; if it accepts, the
+     * frame is delivered as the final record, otherwise the exchange fails loudly -- the flushed
+     * bytes are transport-indistinguishable from a record truncated mid-stream, and accepting a
+     * truncated record would let history cursors advance past a record the pump sent (permanent
+     * skip; the PR #847 review guarantee). Default rejects, preserving fail-loud for callers that
+     * pass no validator.
      */
     fun reportRecords(
         dataChar: UUID,
         controlPoint: UUID,
         request: ByteArray,
         isSuccess: (ByteArray) -> Boolean,
+        validateRecoveredFrame: (ByteArray) -> Boolean = { false },
         onResult: (Result<List<ByteArray>>) -> Unit,
     ) {
         val assembler = NotificationReassembler()
@@ -273,10 +310,15 @@ class MedtronicSessionReader(
         link.subscribe(dataChar) { pdu ->
             if (finished) return@subscribe
             try {
+                // Each notification PDU is individually SAKE-encrypted with its own 3-byte trailer.
+                // Decrypt first, then reassemble plaintext fragments into the complete record.
                 val plaintext = session.decryptFromPump(pdu)
                 val message = assembler.offer(plaintext) ?: return@subscribe
                 records.add(message)
-             //   Timber.v("IDD batch record #%d (%d bytes)", records.size, message.size)
+                // Defense-in-depth: a misbehaving (but authenticated) pump that streams records but
+                // never sends the terminating RACP indication must not grow memory without bound. The
+                // ceiling is far above any realistic single-fetch window; the operation timeout the C3
+                // caller imposes is the primary bound (mirrors NotificationReassembler's frame cap).
                 if (records.size > MAX_RECORDS_PER_REPORT) {
                     finish(
                         Result.failure(
@@ -298,8 +340,21 @@ class MedtronicSessionReader(
                 if (assembler.hasPartialFrame()) {
                     val n = assembler.fragmentCount()
                     val recovered = assembler.flush()
-                    Timber.w("IDD RACP success with unterminated record: %d complete, %d fragment(s) recovered (%d bytes) — proceeding", records.size, n, recovered.size)
-                    records.add(recovered)
+                    if (validateRecoveredFrame(recovered)) {
+                        Timber.i("IDD RACP success with unterminated final record: %d complete, %d fragment(s) recovered (%d bytes) -- validated and accepted", records.size, n, recovered.size)
+                        records.add(recovered)
+                    } else {
+                        // The recovered bytes did not validate as a complete record: treat as the
+                        // truncation case and fail so the read is retried with nothing skipped.
+                        finish(
+                            Result.failure(
+                                MedtronicReadException(
+                                    "IDD RACP reported success with an unterminated record that failed validation ($n fragment(s), ${recovered.size} bytes)",
+                                ),
+                            ),
+                        )
+                        return@subscribe
+                    }
                 }
                 Timber.d("IDD batch complete: %d records", records.size)
                 finish(Result.success(records.toList()))
@@ -369,9 +424,11 @@ class MedtronicSessionReader(
             onResult(result)
         }
 
-            link.subscribe(char) { pdu ->
+        link.subscribe(char) { pdu ->
             if (finished) return@subscribe
             try {
+                // Each notification PDU is individually SAKE-encrypted with its own 3-byte trailer.
+                // Decrypt first, then reassemble plaintext fragments into the complete response.
                 val plaintext = session.decryptFromPump(pdu)
                 val message = assembler.offer(plaintext) ?: return@subscribe
                 Timber.d("SOCP/SRCP response received (%d bytes) %s", message.size, message.toHex())

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReader.kt
@@ -25,8 +25,8 @@ import timber.log.Timber
  * exact multiple of [maxPduSize].
  *
  * The exact-multiple ambiguity (a frame that fragments into all-full fragments has no short
- * terminator) has not bitten on live multi-PDU history reads (PR #852); pinning the exact on-wire
- * fragment sizes rides with the 48.A2 capture work.
+ * terminator) is handled here: when the exchange terminates with fragments pending, those fragments
+ * are flushed as one last frame via [flush].
  */
 internal class NotificationReassembler(
     private val maxPduSize: Int = PduFramer.MAX_PDU_SIZE,
@@ -36,17 +36,14 @@ internal class NotificationReassembler(
     private var accumulated = 0
 
     /**
-     * Offer one inbound PDU; returns the reassembled frame once complete, or `null` if more PDUs are
-     * expected. Empty PDUs are ignored (a real encrypted frame is never empty, so an empty
-     * notification is noise and must not falsely terminate a multi-PDU frame).
+     * Offer one inbound PDU; returns the reassembled frame once complete, or `null` if more PDUs
+     * are expected. Empty PDUs are ignored.
      *
-     * @throws MedtronicReadException if the accumulated frame exceeds [maxFrameSize] -- a peer that
-     *     streams only full-size PDUs with no short terminator cannot grow memory without bound.
+     * @throws MedtronicReadException if the accumulated frame exceeds [maxFrameSize].
      */
     fun offer(pdu: ByteArray): ByteArray? {
         if (pdu.isEmpty()) return null
-        // Defensive copy: the link may recycle the delivery buffer after the callback returns (the
-        // same discipline SakeHandshakeDriver uses on inbound writes).
+        // Defensive copy: the link may recycle the delivery buffer after the callback returns.
         fragments.add(pdu.copyOf())
         accumulated += pdu.size
         if (accumulated > maxFrameSize) {
@@ -61,25 +58,30 @@ internal class NotificationReassembler(
         return null
     }
 
-    /**
-     * True while fragments are accumulated but no short terminator has arrived. Lets an exchange's
-     * terminal indication distinguish "all records delivered" from "a record is still unterminated"
-     * (the exact-multiple ambiguity) and fail loudly instead of silently dropping the partial frame.
-     */
+    /** True while fragments are accumulated but no short terminator has arrived. */
     fun hasPartialFrame(): Boolean = fragments.isNotEmpty()
 
-    /** Discard any partially-accumulated frame. */
+    /**
+     * Flush pending fragments as one frame. Used when the exchange terminates with a partial
+     * frame (a record whose plaintext ends on a PDU boundary with no short terminator).
+     */
+    fun flush(): ByteArray {
+        val frame = PduFramer.reassemble(fragments)
+        reset()
+        return frame
+    }
+
+    /** Number of accumulated fragments in the pending frame. */
+    fun fragmentCount(): Int = fragments.size
+
+    /** Discard accumulated state. */
     fun reset() {
         fragments.clear()
         accumulated = 0
     }
 
     companion object {
-        /**
-         * Upper bound on a single reassembled application frame. Far above any CGM/SOCP record, it
-         * caps the memory a malfunctioning or hostile central can force by streaming full-size PDUs
-         * without a short terminator. Record-level paging for the larger history reads is 48.C2.
-         */
+        /** Upper bound on a single reassembled frame. */
         const val MAX_FRAME_SIZE = 512
     }
 }
@@ -143,8 +145,9 @@ class MedtronicSessionReader(
                 // Each notification PDU is individually SAKE-encrypted with its own 3-byte trailer.
                 // Decrypt first, then reassemble plaintext fragments into the complete record.
                 val plaintext = session.decryptFromPump(pdu)
-                val frame = assembler.offer(plaintext) ?: return@subscribe
-                record = frame
+                val message = assembler.offer(plaintext) ?: return@subscribe
+                record = message
+                Timber.d("CGM measurement record received (%d bytes) %s", message.size, message.toHex())
             } catch (e: Exception) {
                 // Any decrypt/auth failure (MacFailureException) or session-state/length error
                 // (IllegalState/IllegalArgument from SeqCrypt) must fail the read cleanly rather than
@@ -160,9 +163,10 @@ class MedtronicSessionReader(
                 response.contentEquals(RACP_REPORT_SUCCESS) -> {
                     val r = record
                     if (assembler.hasPartialFrame()) {
-                        // The record never got its short terminator (the exact-multiple ambiguity):
-                        // returning r (or null) would silently misreport what the pump sent.
-                        finish(Result.failure(MedtronicReadException("CGM RACP reported success with an unterminated record pending")))
+                        val n = assembler.fragmentCount()
+                        val recovered = assembler.flush()
+                        Timber.w("CGM RACP success with unterminated record (%d fragment(s)) — recovered (%d bytes)", n, recovered.size)
+                        finish(Result.success(recovered))
                     } else if (r == null) {
                         finish(Result.failure(MedtronicReadException("CGM RACP reported success but no record arrived")))
                     } else {
@@ -269,15 +273,10 @@ class MedtronicSessionReader(
         link.subscribe(dataChar) { pdu ->
             if (finished) return@subscribe
             try {
-                // Each notification PDU is individually SAKE-encrypted with its own 3-byte trailer.
-                // Decrypt first, then reassemble plaintext fragments into the complete record.
                 val plaintext = session.decryptFromPump(pdu)
-                val frame = assembler.offer(plaintext) ?: return@subscribe
-                records.add(frame)
-                // Defense-in-depth: a misbehaving (but authenticated) pump that streams records but
-                // never sends the terminating RACP indication must not grow memory without bound. The
-                // ceiling is far above any realistic single-fetch window; the operation timeout the C3
-                // caller imposes is the primary bound (mirrors NotificationReassembler's frame cap).
+                val message = assembler.offer(plaintext) ?: return@subscribe
+                records.add(message)
+             //   Timber.v("IDD batch record #%d (%d bytes)", records.size, message.size)
                 if (records.size > MAX_RECORDS_PER_REPORT) {
                     finish(
                         Result.failure(
@@ -297,17 +296,13 @@ class MedtronicSessionReader(
             if (finished) return@subscribe
             if (isSuccess(response)) {
                 if (assembler.hasPartialFrame()) {
-                    // A record is still unterminated at the terminal indication (the exact-multiple
-                    // ambiguity). Dropping it silently would let the history cursors advance past a
-                    // record the pump sent -- fail instead so the read is retried with nothing skipped.
-                    finish(
-                        Result.failure(
-                            MedtronicReadException("IDD RACP reported success with an unterminated record pending"),
-                        ),
-                    )
-                } else {
-                    finish(Result.success(records.toList()))
+                    val n = assembler.fragmentCount()
+                    val recovered = assembler.flush()
+                    Timber.w("IDD RACP success with unterminated record: %d complete, %d fragment(s) recovered (%d bytes) — proceeding", records.size, n, recovered.size)
+                    records.add(recovered)
                 }
+                Timber.d("IDD batch complete: %d records", records.size)
+                finish(Result.success(records.toList()))
             } else {
                 finish(
                     Result.failure(MedtronicReadException("Unexpected/failed IDD RACP response: ${response.toHex()}")),
@@ -374,14 +369,13 @@ class MedtronicSessionReader(
             onResult(result)
         }
 
-        link.subscribe(char) { pdu ->
+            link.subscribe(char) { pdu ->
             if (finished) return@subscribe
             try {
-                // Each notification PDU is individually SAKE-encrypted with its own 3-byte trailer.
-                // Decrypt first, then reassemble plaintext fragments into the complete response.
                 val plaintext = session.decryptFromPump(pdu)
-                val frame = assembler.offer(plaintext) ?: return@subscribe
-                finish(Result.success(frame))
+                val message = assembler.offer(plaintext) ?: return@subscribe
+                Timber.d("SOCP/SRCP response received (%d bytes) %s", message.size, message.toHex())
+                finish(Result.success(message))
             } catch (e: Exception) {
                 finish(Result.failure(asReadException(e, failMessage)))
             }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
@@ -66,12 +66,22 @@ class MedtronicInsulinSource(
      * This replaces the earlier O(all-history) `getHistoryLogs(sinceSequence = 0)` full-window scan
      * (closing the C3 cost note): each medium poll is now an incremental delta over the same IDD stream
      * the slow loop backfills. See [bolusCursor] for the durability / dedup model.
+     *
+     * **Cursor bootstrap.** On the very first call ([bolusCursor] == 0), a lightweight
+     * [getHistoryCursor] reads only the pump's latest record (one GATT exchange, no paging) to seed the
+     * cursor past all existing history. The slow loop's raw-history sync is the durable bolus path, so
+     * no full scan is needed here -- the first call returns empty and subsequent calls are incremental.
      */
     override suspend fun getBolusHistory(
         since: Instant,
         limits: SafetyLimits,
     ): Result<List<BolusEvent>> =
         bolusSyncMutex.withLock {
+            if (bolusCursor == 0) {
+                val cursor = gateway.getHistoryCursor().getOrElse { return@withLock Result.failure(it) }
+                bolusCursor = cursor
+                return@withLock Result.success(emptyList())
+            }
             gateway.getHistoryLogs(sinceSequence = bolusCursor).map { records ->
                 bolusCursor = records.maxOfOrNull { it.sequenceNumber } ?: bolusCursor
                 MedtronicHistoryParser.extractBolusesFromHistoryLogs(records, limits)

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSource.kt
@@ -50,10 +50,14 @@ class MedtronicInsulinSource(
      * tolerated because the **slow loop's raw-history sync is the durable, self-healing bolus path** --
      * it persists each raw [HistoryLogRecord] to Room (keyed by sequence) before advancing its own
      * cursor, restores that cursor from Room on restart, and re-extracts the same boluses from the same
-     * IDD stream. Persisted bolus rows are de-duplicated by the repository's insert-conflict key, so the
-     * one-time full re-read after a restart (cursor 0) yields no duplicate rows.
+     * IDD stream.
+     *
+     * `null` = not yet seeded this process. Each restart re-seeds from the pump's latest sequence
+     * (one read-last exchange, see the bootstrap note on [getBolusHistory]) rather than rescanning
+     * the full history; boluses delivered while the app was down reach the platform through the slow
+     * loop's backfill, not this path.
      */
-    private var bolusCursor: Int = 0
+    private var bolusCursor: Int? = null
 
     /**
      * Boluses delivered at or after [since]. Fetches only the history records newer than [bolusCursor]
@@ -67,23 +71,25 @@ class MedtronicInsulinSource(
      * (closing the C3 cost note): each medium poll is now an incremental delta over the same IDD stream
      * the slow loop backfills. See [bolusCursor] for the durability / dedup model.
      *
-     * **Cursor bootstrap.** On the very first call ([bolusCursor] == 0), a lightweight
-     * [getHistoryCursor] reads only the pump's latest record (one GATT exchange, no paging) to seed the
-     * cursor past all existing history. The slow loop's raw-history sync is the durable bolus path, so
-     * no full scan is needed here -- the first call returns empty and subsequent calls are incremental.
+     * **Cursor bootstrap.** On the first call of the process ([bolusCursor] == null), a lightweight
+     * [MedtronicReadGateway.getHistoryCursor] reads only the pump's latest record (one GATT exchange,
+     * no paging) to seed the cursor past all existing history -- an empty pump log seeds `0`, so the
+     * first records the pump ever logs are still picked up incrementally. The slow loop's raw-history
+     * sync is the durable bolus path, so no full scan is needed here: the seeding call returns empty
+     * and subsequent calls are incremental.
      */
     override suspend fun getBolusHistory(
         since: Instant,
         limits: SafetyLimits,
     ): Result<List<BolusEvent>> =
         bolusSyncMutex.withLock {
-            if (bolusCursor == 0) {
-                val cursor = gateway.getHistoryCursor().getOrElse { return@withLock Result.failure(it) }
-                bolusCursor = cursor
+            val cursor = bolusCursor ?: run {
+                val seeded = gateway.getHistoryCursor().getOrElse { return@withLock Result.failure(it) }
+                bolusCursor = seeded
                 return@withLock Result.success(emptyList())
             }
-            gateway.getHistoryLogs(sinceSequence = bolusCursor).map { records ->
-                bolusCursor = records.maxOfOrNull { it.sequenceNumber } ?: bolusCursor
+            gateway.getHistoryLogs(sinceSequence = cursor).map { records ->
+                bolusCursor = records.maxOfOrNull { it.sequenceNumber } ?: cursor
                 MedtronicHistoryParser.extractBolusesFromHistoryLogs(records, limits)
                     .filter { !it.timestamp.isBefore(since) }
             }

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/HistoryReaderTest.kt
@@ -201,15 +201,17 @@ class HistoryReaderTest {
     }
 
     @Test
-    fun `readRecordsInRange fails when a record is still unterminated at the success indication`() {
+    fun `readRecordsInRange recovers a validated unterminated final record`() {
         // A record whose plaintext is an exact PDU multiple has no short terminator (the documented
-        // reassembler ambiguity). Dropping it silently would let the cursors advance past a record
-        // the pump sent; the page must fail so the read is retried with nothing skipped.
+        // reassembler ambiguity) -- live 780G reads hit this on real records. The pending fragments
+        // are flushed and structurally validated (known type, payload parses); on success the record
+        // is delivered instead of failing the page.
         val two = TwoSidedSession()
         val link = FakeGattLink()
         link.reads[features] = two.pumpEncrypt(featuresPlain)
-        // 20-byte record: header (8) + 12-byte body -- exactly one full fragment, never terminated.
-        val exactMultiple = le16(0x0099) + le32(121) + le16(0) + ByteArray(12) { it.toByte() }
+        // 20-byte record: header (8) + 12-byte basal body (parses) -- exactly one full fragment.
+        val exactMultiple = le16(0x0099) + le32(121) + le16(0) + hex("01" + "0a0000ff" + "050000ff" + "55") + ByteArray(2)
+        check(exactMultiple.size == PduFramer.MAX_PDU_SIZE) { "test record must be an exact PDU multiple" }
         link.onWrite = { characteristic, value ->
             if (characteristic == racp && value.size > 3 &&
                 value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
@@ -222,7 +224,36 @@ class HistoryReaderTest {
         var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
         HistoryReader(link, two.server).readRecordsInRange(100, 130) { result = it }
 
+        val records = result!!.getOrThrow()
+        assertEquals(1, records.size)
+        assertEquals(121, records[0].sequenceNumber)
+    }
+
+    @Test
+    fun `readRecordsInRange fails when the unterminated final record is truncated`() {
+        // Same exact-multiple shape, but the recovered frame's known-type payload is too short to
+        // parse (a genuinely truncated record): validation rejects it and the page fails so the
+        // cursors stay put and the read is retried with nothing skipped (the PR #847 guarantee).
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        link.reads[features] = two.pumpEncrypt(featuresPlain)
+        // 20-byte frame: header (8) + 12-byte body for a BOLUS type that requires >= 13 bytes.
+        val truncated = le16(0x0069) + le32(121) + le16(0) + ByteArray(12) { it.toByte() }
+        check(truncated.size == PduFramer.MAX_PDU_SIZE) { "test record must be an exact PDU multiple" }
+        link.onWrite = { characteristic, value ->
+            if (characteristic == racp && value.size > 3 &&
+                value[0] == HistoryReader.REQUEST_REPORT_WITHIN_RANGE_PREFIX[0]
+            ) {
+                PduFramer.fragment(truncated).forEach { emit(data, two.pumpEncrypt(it)) }
+                emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<List<com.glycemicgpt.mobile.domain.model.HistoryLogRecord>>? = null
+        HistoryReader(link, two.server).readRecordsInRange(100, 130) { result = it }
+
         assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull()!!.message!!.contains("failed validation"))
     }
 
     @Test

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGatewayTest.kt
@@ -250,6 +250,43 @@ class MedtronicReadGatewayTest {
     }
 
     @Test
+    fun `concurrent history walks are serialized so their paging loops cannot interleave`() = runTest {
+        // Two callers walk history concurrently (orchestrator slow loop + insulin source bolus poll).
+        // readMutex is released between pages by design, so without the history-level single-flight
+        // the second walk's requests would interleave with the first's pages. Deferred responses keep
+        // each exchange in flight until released, exposing any interleaving in the wire order.
+        val two = TwoSidedSession()
+        val pump = ScriptedHistoryPump(two, retainedSequences = (1..400).toList())
+        pump.deferResponses = true
+        val io = UnconfinedTestDispatcher(testScheduler)
+        val gw = MedtronicReadGateway(
+            sessionProvider = { two.server },
+            linkProvider = { pump.link },
+            ioDispatcher = io,
+            operationTimeoutMs = 30_000L,
+        )
+
+        val a = async(io) { gw.getHistoryLogs(sinceSequence = 0) }
+        val b = async(io) { gw.getHistoryLogs(sinceSequence = 0) }
+
+        // Drive both walks to completion one deferred response at a time.
+        var safety = 0
+        while ((!a.isCompleted || !b.isCompleted) && safety++ < 32) {
+            check(pump.pendingCount > 0) { "walks parked with no pending response" }
+            pump.releaseNext()
+        }
+
+        assertEquals(400, a.await().getOrThrow().size)
+        assertEquals(400, b.await().getOrThrow().size)
+        // The proof is the wire order: the full first walk (last-record + both pages) completes
+        // before the second walk's first request reaches the pump.
+        assertEquals(
+            listOf("last", "201..400", "1..200", "last", "201..400", "1..200"),
+            pump.requestLog,
+        )
+    }
+
+    @Test
     fun `getHistoryLogs fails the whole fetch when a page fails`() = runTest {
         // Older pages are still un-fetched when a page fails; returning the newer pages collected so
         // far would let the callers advance their cursor past the gap and skip those records for good.
@@ -276,8 +313,19 @@ class MedtronicReadGatewayTest {
         val link = FakeGattLink()
         val rangeRequests = mutableListOf<IntRange>()
 
+        /** Every RACP request in wire order ("last" or "first..last"), for interleaving assertions. */
+        val requestLog = mutableListOf<String>()
+
         /** Windows whose first sequence is below this fail with an RACP error (for failure tests). */
         var failWindowsBelow = Int.MIN_VALUE
+
+        /** When set, responses queue until [releaseNext] so an exchange stays in flight. */
+        var deferResponses = false
+        private val pending = ArrayDeque<() -> Unit>()
+
+        val pendingCount: Int get() = pending.size
+
+        fun releaseNext() = pending.removeFirst().invoke()
 
         private val retained = retainedSequences.toSortedSet()
         private val racp = MedtronicProtocol.RACP_UUID
@@ -288,13 +336,16 @@ class MedtronicReadGatewayTest {
                 if (characteristic == MedtronicProtocol.IDD_FEATURES_UUID) two.pumpEncrypt(hex(IDD_FEATURES_E2E_DISABLED_HEX)) else null
             }
             link.onWrite = { characteristic, value ->
-                if (characteristic == racp) respond(value)
+                if (characteristic == racp) {
+                    if (deferResponses) pending.addLast { respond(value) } else respond(value)
+                }
             }
         }
 
         private fun respond(request: ByteArray) {
             when {
                 request.contentEquals(HistoryReader.REQUEST_REPORT_LAST_RECORD) -> {
+                    requestLog.add("last")
                     val newest = retained.last()
                     emitRecord(newest)
                     link.emit(racp, HistoryReader.EXPECTED_REPORT_SUCCESS)
@@ -303,6 +354,7 @@ class MedtronicReadGatewayTest {
                     val first = MedtronicCodec.readULongLe(request, 3, 4).toInt()
                     val last = MedtronicCodec.readULongLe(request, 7, 4).toInt()
                     rangeRequests.add(first..last)
+                    requestLog.add("$first..$last")
                     if (first < failWindowsBelow) {
                         link.emit(racp, byteArrayOf(0x0F, 0x0F, 0x33, 0x02)) // op-code-not-supported
                         return

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/MedtronicSessionReaderTest.kt
@@ -67,10 +67,11 @@ class MedtronicSessionReaderTest {
     }
 
     @Test
-    fun `reportLastRecord fails when the record is still unterminated at the RACP success response`() {
+    fun `reportLastRecord recovers an unterminated record at the RACP success response`() {
         // The exact-multiple ambiguity: a record whose plaintext is an exact multiple of the PDU size
         // has no short terminator, so the reassembler is still holding fragments when the terminal
-        // indication arrives. Reporting "no record" here would silently misreport what the pump sent.
+        // indication arrives. With no other record delivered, the pending fragments ARE the record --
+        // recover them (the CGM caller's parse validates the frame; no cursor advances here).
         val two = TwoSidedSession()
         val link = FakeGattLink()
         val record = ByteArray(PduFramer.MAX_PDU_SIZE * 2) { it.toByte() } // 40 bytes: two full fragments
@@ -85,8 +86,57 @@ class MedtronicSessionReaderTest {
         var result: Result<ByteArray>? = null
         MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { result = it }
 
+        assertArrayEquals(record, result!!.getOrThrow())
+    }
+
+    @Test
+    fun `reportLastRecord fails when an unterminated record follows a delivered one`() {
+        // Report-last returns exactly one record. A complete record plus pending fragments at the
+        // success indication is a protocol anomaly -- fail rather than guess which bytes are the
+        // reading.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        val complete = ByteArray(14) { it.toByte() } // short PDU terminates immediately
+        val unterminated = ByteArray(PduFramer.MAX_PDU_SIZE) { (it + 1).toByte() } // one full fragment
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                emit(dataChar, two.pumpEncrypt(complete))
+                PduFramer.fragment(unterminated).forEach { emit(dataChar, two.pumpEncrypt(it)) }
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<ByteArray>? = null
+        MedtronicSessionReader(link, two.server).reportLastRecord(dataChar, racp) { result = it }
+
         assertTrue(result!!.isFailure)
         assertTrue(result!!.exceptionOrNull()!!.message!!.contains("unterminated"))
+    }
+
+    @Test
+    fun `reportRecords fails an unterminated final record when no validator is supplied`() {
+        // The default validateRecoveredFrame rejects: flushed bytes are transport-indistinguishable
+        // from a truncated record, so callers must opt in with a validator to accept recovery.
+        val two = TwoSidedSession()
+        val link = FakeGattLink()
+        val exactMultiple = ByteArray(PduFramer.MAX_PDU_SIZE) { it.toByte() }
+        link.onWrite = { characteristic, _ ->
+            if (characteristic == racp) {
+                PduFramer.fragment(exactMultiple).forEach { emit(dataChar, two.pumpEncrypt(it)) }
+                emit(racp, MedtronicSessionReader.RACP_REPORT_SUCCESS)
+            }
+        }
+
+        var result: Result<List<ByteArray>>? = null
+        MedtronicSessionReader(link, two.server).reportRecords(
+            dataChar = dataChar,
+            controlPoint = racp,
+            request = MedtronicSessionReader.RACP_REPORT_LAST_RECORD,
+            isSuccess = { it.contentEquals(MedtronicSessionReader.RACP_REPORT_SUCCESS) },
+        ) { result = it }
+
+        assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull()!!.message!!.contains("failed validation"))
     }
 
     @Test

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSourceTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSourceTest.kt
@@ -51,45 +51,85 @@ class MedtronicInsulinSourceTest {
     }
 
     @Test
-    fun `the first bolus poll fetches from sequence 0`() = runTest {
-        // No records -> no boluses; this asserts the wiring (the initial cursor is 0 + empty extraction),
-        // not the parser internals (covered by MedtronicHistoryParserTest).
-        coEvery { gateway.getHistoryLogs(0) } returns Result.success(emptyList())
+    fun `the first bolus poll seeds the cursor from the pump and returns empty`() = runTest {
+        // Bootstrap: one lightweight read-last exchange seeds the cursor past existing history --
+        // no full-history scan, no getHistoryLogs call. The slow loop's raw-history sync is the
+        // durable bolus path for anything older.
+        coEvery { gateway.getHistoryCursor() } returns Result.success(500)
 
         val result = source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits())
 
         assertTrue(result.isSuccess)
         assertEquals(emptyList<Any>(), result.getOrThrow())
-        coVerify { gateway.getHistoryLogs(0) }
+        coVerify(exactly = 1) { gateway.getHistoryCursor() }
+        coVerify(exactly = 0) { gateway.getHistoryLogs(any()) }
+    }
+
+    @Test
+    fun `an empty pump log seeds cursor 0 and later polls fetch incrementally from 0`() = runTest {
+        // A new/just-reset pump has no history: the bootstrap seeds 0 (success, not an error) and
+        // the pump's first-ever records are still picked up by the next incremental poll.
+        coEvery { gateway.getHistoryCursor() } returns Result.success(0)
+        coEvery { gateway.getHistoryLogs(0) } returns Result.success(emptyList())
+
+        val first = source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits())
+        val second = source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits())
+
+        assertTrue(first.isSuccess)
+        assertTrue(second.isSuccess)
+        coVerify(exactly = 1) { gateway.getHistoryCursor() }
+        coVerify(exactly = 1) { gateway.getHistoryLogs(0) }
+    }
+
+    @Test
+    fun `a failed cursor bootstrap is retried on the next poll`() = runTest {
+        // The seed failing must not poison the cursor: the poll surfaces the failure and the next
+        // call attempts the bootstrap again.
+        coEvery { gateway.getHistoryCursor() } returnsMany listOf(
+            Result.failure(IllegalStateException("not connected")),
+            Result.success(500),
+        )
+
+        val first = source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits())
+        val second = source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits())
+
+        assertTrue(first.isFailure)
+        assertTrue(second.isSuccess)
+        coVerify(exactly = 2) { gateway.getHistoryCursor() }
     }
 
     @Test
     fun `bolus polling advances the sequence cursor so the next poll is incremental`() = runTest {
-        // First poll returns records up to sequence 111; the cursor must advance there so the second
-        // poll requests only newer records (the AC4 incremental cursor path) instead of rescanning the
-        // full window from sequence 0.
+        // After the bootstrap seeds the cursor at 99, a poll returning records up to sequence 111
+        // must advance the cursor there so the following poll requests only newer records (the AC4
+        // incremental cursor path).
         val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
-        val firstBatch = listOf(
+        val batch = listOf(
             rawRecord(0xF00E, seq = 100, offsetSec = 0, bodyHex = "3cea0706010c0000"),
             rawRecord(0x0069, seq = 110, offsetSec = 600, bodyHex = "010033190000ff000000000000"),
             rawRecord(0x0096, seq = 111, offsetSec = 600, bodyHex = "01000000005a"),
         )
-        coEvery { gateway.getHistoryLogs(0) } returns Result.success(firstBatch)
+        coEvery { gateway.getHistoryCursor() } returns Result.success(99)
+        coEvery { gateway.getHistoryLogs(99) } returns Result.success(batch)
         coEvery { gateway.getHistoryLogs(111) } returns Result.success(emptyList())
 
-        source.getBolusHistory(reference, SafetyLimits()).getOrThrow()
+        assertTrue(source.getBolusHistory(reference, SafetyLimits()).getOrThrow().isEmpty()) // seeds
         val second = source.getBolusHistory(reference, SafetyLimits()).getOrThrow()
+        val third = source.getBolusHistory(reference, SafetyLimits()).getOrThrow()
 
-        assertTrue(second.isEmpty())
-        coVerify(exactly = 1) { gateway.getHistoryLogs(0) }
+        assertEquals(1, second.size)
+        assertTrue(third.isEmpty())
+        coVerify(exactly = 1) { gateway.getHistoryLogs(99) }
         coVerify(exactly = 1) { gateway.getHistoryLogs(111) }
     }
 
     @Test
     fun `getBolusHistory propagates a history fetch failure`() = runTest {
         val failure = IllegalStateException("not connected")
-        coEvery { gateway.getHistoryLogs(0) } returns Result.failure(failure)
+        coEvery { gateway.getHistoryCursor() } returns Result.success(99)
+        coEvery { gateway.getHistoryLogs(99) } returns Result.failure(failure)
 
+        source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits()).getOrThrow() // seeds
         val result = source.getBolusHistory(Instant.ofEpochSecond(0), SafetyLimits())
 
         assertTrue(result.isFailure)
@@ -105,18 +145,23 @@ class MedtronicInsulinSourceTest {
             rawRecord(0x0069, seq = 110, offsetSec = 600, bodyHex = "010033190000ff000000000000"),
             rawRecord(0x0096, seq = 111, offsetSec = 600, bodyHex = "01000000005a"),
         )
-        coEvery { gateway.getHistoryLogs(0) } returns Result.success(records)
+        coEvery { gateway.getHistoryCursor() } returns Result.success(99)
+        coEvery { gateway.getHistoryLogs(99) } returns Result.success(records)
 
         // Fresh sources per assertion so each exercises the since filter from a clean cursor (the
-        // incremental cursor advance is covered separately above).
+        // incremental cursor advance is covered separately above). The first call on each source
+        // seeds the cursor and returns empty; the second fetches.
         // since at the reference -> the bolus (at +600s) is included.
-        val included = MedtronicInsulinSource(gateway).getBolusHistory(reference, SafetyLimits()).getOrThrow()
+        val includedSource = MedtronicInsulinSource(gateway)
+        includedSource.getBolusHistory(reference, SafetyLimits()).getOrThrow() // seeds
+        val included = includedSource.getBolusHistory(reference, SafetyLimits()).getOrThrow()
         assertEquals(1, included.size)
         assertEquals(2.5f, included[0].units, 1e-4f)
 
         // since after the bolus -> filtered out.
-        val excluded = MedtronicInsulinSource(gateway)
-            .getBolusHistory(reference.plusSeconds(601), SafetyLimits()).getOrThrow()
+        val excludedSource = MedtronicInsulinSource(gateway)
+        excludedSource.getBolusHistory(reference.plusSeconds(601), SafetyLimits()).getOrThrow() // seeds
+        val excluded = excludedSource.getBolusHistory(reference.plusSeconds(601), SafetyLimits()).getOrThrow()
         assertTrue(excluded.isEmpty())
     }
 


### PR DESCRIPTION

## 📋 Summary

Fix Medtronic history sync issues: recover unterminated records instead of failing, prevent bolus poll from re-scanning all history, add concurrent history walk safety, and fix misleading progress tracking.

## 🔗 Related Issues

non reported yet

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

- MedtronicSessionReader.kt: Recover unterminated CGM/IDD records via NotificationReassembler.flush() instead of failing. Add flush()/fragmentCount() API. Add logging for measurement receipt and SOCP/SRCP responses.
- MedtronicReadGateway.kt: Add historyMutex to serialize concurrent history walks. Add lightweight getHistoryCursor() for reading the pump's latest sequence without a full scan. Remove misleading per-call progress percentage. Add per-page logging.
- MedtronicHistoryParser.kt: Remove noisy Timber.d from timedRecords() (fired 3x per batch with the same count — orchestrator already logs per-batch fetch totals).
- **MedtronicInsulinSource.kt`: Seed bolusCursor from getHistoryCursor() instead of starting at 0, avoiding full re-scan on first bolus poll. The slow loop's raw-history backfill is the durable bolus path.
- PumpPollingOrchestrator.kt: Add cumulative progress log for batch 2+. Remove redundant in-loop "Initial sync" summary. Increase initial sync timeout from 10m to 20m.

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [x] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [x] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the initial pump history sync window and added cursor-based bolus history bootstrapping for smoother incremental updates.
  * Improved recovery/validation of edge-case history frames so reads complete successfully more often.
* **Bug Fixes**
  * Serialized concurrent history paging to avoid interfering requests and incomplete coverage.
  * Reduced noisy debug logging during history parsing and sync, with clearer progress updates during long downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->