### PR TITLE
ci: disable credential persistence on dependency-scan checkouts

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -25,6 +25,8 @@ jobs:
       should_scan: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
@@ -59,6 +61,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install OSV-Scanner
         run: |


### PR DESCRIPTION
Both checkout steps in dependency-scan.yml kept the default credential persistence. The workflow only reads the repository, so this sets persist-credentials: false on both, matching the hardening convention the other workflows follow.

Surfaced by CodeRabbit while it was reviewing #886 against a stale base. YAML validated and zizmor clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved workflow security by preventing temporary checkout credentials from being retained during dependency scans.
* **Maintenance**
  * No changes to scan behavior or other workflow functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->