### PR TITLE
docs(governance): adopt fork-based contribution model (main)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,19 +16,15 @@
 /apps/mobile/ @jlengelbrecht
 /plugins/ @jlengelbrecht
 
-# Web / frontend: web maintainers own this area. The project lead is
-# co-listed so code-owner review can be satisfied regardless of which
-# party authors the PR.
-/apps/web/ @lumose-health/web @jlengelbrecht
-
-# AI / evals / benchmarks: AI maintainers own this area (BYOAI
-# benchmark harness, eval scenarios, sidecar AI-provider layer, and
-# benchmarking docs). Project lead co-listed as above.
-/apps/api/benchmarks/ @lumose-health/ai @jlengelbrecht
-/apps/api/tests/benchmarks/ @lumose-health/ai @jlengelbrecht
-/evals/ @lumose-health/ai @jlengelbrecht
-/sidecar/ @lumose-health/ai @jlengelbrecht
-/docs/benchmarking/ @lumose-health/ai @jlengelbrecht
+# Web / frontend and AI / evals / benchmarks: project lead.
+# Code owners must hold Write; only the lead does (see GOVERNANCE.md,
+# repository access policy), so area ownership cannot be a team here.
+/apps/web/ @jlengelbrecht
+/apps/api/benchmarks/ @jlengelbrecht
+/apps/api/tests/benchmarks/ @jlengelbrecht
+/evals/ @jlengelbrecht
+/sidecar/ @jlengelbrecht
+/docs/benchmarking/ @jlengelbrecht
 
 # Governance & project policy: project lead only.
 /.github/CODEOWNERS @jlengelbrecht

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ GlycemicGPT has three roles: **Contributor**, **Maintainer**, and **Project Lead
 
 If you contribute consistently and demonstrate good judgment (especially around medical safety), you may be invited to become a maintainer -- an invitation-only stewardship role: triaging issues, reviewing PRs in your area of expertise, and mentoring other contributors.
 
-One thing to know up front: **every contribution arrives as a pull request from a fork, at every role.** No one other than the project lead holds write (push) access to the repository. This is an org-wide security policy -- GitHub runs a same-repo PR's workflow files from the PR head with repository secrets in scope, before any human review -- not a statement about trust in any contributor.
+One thing to know up front: **every contribution arrives as a pull request from a fork, at every role.** No one other than the project lead holds write (push) access to the repository. This is an org-wide security policy -- for a same-repo PR, GitHub runs the workflow files from the PR's merge commit (including any workflow the PR adds or edits) with repository secrets in scope, before any human review -- not a statement about trust in any contributor.
 
 For the full details -- including the reasoning behind the fork-based policy, how decisions are made, what each role can and can't do, and how branch protection works -- see [GOVERNANCE.md](GOVERNANCE.md).
 
@@ -84,28 +84,28 @@ For the full details -- including the reasoning behind the fork-based policy, ho
 
 There are many ways to help, not all of them involve writing code:
 
-- 🐛 **Report bugs** -- Use the [Bug Report](https://github.com/GlycemicGPT/GlycemicGPT/issues/new?template=bug_report.yml) or [Mobile App Issue](https://github.com/GlycemicGPT/GlycemicGPT/issues/new?template=mobile_report.yml) template
-- ✨ **Request features** -- Use the [Feature Request](https://github.com/GlycemicGPT/GlycemicGPT/issues/new?template=feature_request.yml) template
+- 🐛 **Report bugs** -- Use the [Bug Report](https://github.com/lumose-health/GlycemicGPT/issues/new?template=bug_report.yml) or [Mobile App Issue](https://github.com/lumose-health/GlycemicGPT/issues/new?template=mobile_report.yml) template
+- ✨ **Request features** -- Use the [Feature Request](https://github.com/lumose-health/GlycemicGPT/issues/new?template=feature_request.yml) template
 - 📝 **Improve documentation** -- Typos, unclear instructions, missing guides
 - 🧪 **Write tests** -- More coverage is always welcome
 - 🔍 **Review PRs** -- Fresh eyes catch things automated checks can't
-- 💬 **Answer questions** -- Help others in [Discussions](https://github.com/GlycemicGPT/GlycemicGPT/discussions)
+- 💬 **Answer questions** -- Help others in [Discussions](https://github.com/lumose-health/GlycemicGPT/discussions)
 
-Before opening an issue, please search [existing issues](https://github.com/GlycemicGPT/GlycemicGPT/issues?q=is%3Aissue) to avoid duplicates. For general questions and support, use [Discussions](https://github.com/GlycemicGPT/GlycemicGPT/discussions/categories/q-a) instead of creating an issue.
+Before opening an issue, please search [existing issues](https://github.com/lumose-health/GlycemicGPT/issues?q=is%3Aissue) to avoid duplicates. For general questions and support, use [Discussions](https://github.com/lumose-health/GlycemicGPT/discussions/categories/q-a) instead of creating an issue.
 
 ---
 
 ## 🔍 Finding Something to Work On
 
-Not sure where to start? Browse [open issues](https://github.com/GlycemicGPT/GlycemicGPT/issues) and look for these labels:
+Not sure where to start? Browse [open issues](https://github.com/lumose-health/GlycemicGPT/issues) and look for these labels:
 
 - 🏷️ **`good first issue`** -- Small, well-scoped tasks ideal for new contributors
 - 🏷️ **`help wanted`** -- We'd love community help on these
 - 🏷️ **`bug`** -- Known bugs waiting for a fix
 
-> **Tip:** Not every label will have open issues at all times. If none are tagged yet, browse the full [issue list](https://github.com/GlycemicGPT/GlycemicGPT/issues) or check the [Ideas discussion board](https://github.com/GlycemicGPT/GlycemicGPT/discussions/categories/ideas) for inspiration.
+> **Tip:** Not every label will have open issues at all times. If none are tagged yet, browse the full [issue list](https://github.com/lumose-health/GlycemicGPT/issues) or check the [Ideas discussion board](https://github.com/lumose-health/GlycemicGPT/discussions/categories/ideas) for inspiration.
 
-If you'd like to work on something, comment on the issue to let others know. For larger changes, please open an issue or start a [discussion](https://github.com/GlycemicGPT/GlycemicGPT/discussions) first to discuss the approach before investing time in a PR.
+If you'd like to work on something, comment on the issue to let others know. For larger changes, please open an issue or start a [discussion](https://github.com/lumose-health/GlycemicGPT/discussions) first to discuss the approach before investing time in a PR.
 
 ---
 
@@ -422,7 +422,7 @@ Additionally, PRs that modify `apps/mobile/**` will trigger the **Android Gate**
 
 ### How CI handles fork PRs
 
-If you opened this PR from your own fork (the normal contributor flow), every required CI check above runs automatically. The one exception: on your very first contribution to the repo, the project lead has to click "Approve and run" once before CI starts. Beyond that you don't need to do anything special, and nobody needs to grant you any permissions.
+If you opened this PR from your own fork (the normal contributor flow), every required CI check above runs automatically. The one exception comes from the repo's fork-approval policy, which is set to require approval for **first-time contributors only**: on your very first contribution to the repo, the project lead has to click "Approve and run" once before CI starts. Beyond that you don't need to do anything special, and nobody needs to grant you any permissions.
 
 A few details on how that works, in case you're auditing:
 
@@ -767,10 +767,10 @@ GlycemicGPT is licensed under the [GNU General Public License v3.0](LICENSE). By
 
 ## 💬 Questions?
 
-- 🙏 **General questions & help** -- Post in [Q&A Discussions](https://github.com/GlycemicGPT/GlycemicGPT/discussions/categories/q-a)
-- 💡 **Feature ideas & brainstorming** -- Post in [Ideas Discussions](https://github.com/GlycemicGPT/GlycemicGPT/discussions/categories/ideas)
-- 🐛 **Bug reports** -- Open an [Issue](https://github.com/GlycemicGPT/GlycemicGPT/issues/new/choose) using the appropriate template
-- 🙌 **Show off your setup** -- Post in [Show and Tell](https://github.com/GlycemicGPT/GlycemicGPT/discussions/categories/show-and-tell)
+- 🙏 **General questions & help** -- Post in [Q&A Discussions](https://github.com/lumose-health/GlycemicGPT/discussions/categories/q-a)
+- 💡 **Feature ideas & brainstorming** -- Post in [Ideas Discussions](https://github.com/lumose-health/GlycemicGPT/discussions/categories/ideas)
+- 🐛 **Bug reports** -- Open an [Issue](https://github.com/lumose-health/GlycemicGPT/issues/new/choose) using the appropriate template
+- 🙌 **Show off your setup** -- Post in [Show and Tell](https://github.com/lumose-health/GlycemicGPT/discussions/categories/show-and-tell)
 
 Please **do not** open Issues for general questions -- use Discussions instead. Issues are for actionable bugs and feature requests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Both drivers are **read-only** — they read data from the pump and never issue 
 
 ## 📑 Table of Contents
 
-- [Project Roles](#project-roles)
+- [Project Roles](#-project-roles)
 - [Ways to Contribute](#ways-to-contribute)
 - [Finding Something to Work On](#finding-something-to-work-on)
 - [Development Setup](#development-setup)
@@ -70,13 +70,13 @@ Both drivers are **read-only** — they read data from the pump and never issue 
 
 ## 👥 Project Roles
 
-GlycemicGPT has three roles: **Contributor**, **Committer**, and **Maintainer**. Most people start as contributors -- just open a PR, file an issue, or join a discussion.
+GlycemicGPT has three roles: **Contributor**, **Maintainer**, and **Project Lead**. Most people start as contributors -- just open a PR, file an issue, or join a discussion.
 
-If you contribute consistently and demonstrate good judgment (especially around medical safety), you may be invited to become a committer with Write access. Committers can approve PRs, triage issues, and own specific components.
+If you contribute consistently and demonstrate good judgment (especially around medical safety), you may be invited to become a maintainer -- an invitation-only stewardship role: triaging issues, reviewing PRs in your area of expertise, and mentoring other contributors.
 
-Maintainers are project stewards responsible for releases, security, and architectural decisions. It's an invitation-only role that comes after sustained involvement as a committer.
+One thing to know up front: **every contribution arrives as a pull request from a fork, at every role.** No one other than the project lead holds write (push) access to the repository. This is an org-wide security policy -- GitHub runs a same-repo PR's workflow files from the PR head with repository secrets in scope, before any human review -- not a statement about trust in any contributor.
 
-For the full details -- including how decisions are made, what each role can and can't do, and how branch protection works -- see [GOVERNANCE.md](GOVERNANCE.md).
+For the full details -- including the reasoning behind the fork-based policy, how decisions are made, what each role can and can't do, and how branch protection works -- see [GOVERNANCE.md](GOVERNANCE.md).
 
 ---
 
@@ -138,7 +138,7 @@ git clone https://github.com/<your-username>/GlycemicGPT.git
 cd GlycemicGPT
 
 # 2. Add upstream remote
-git remote add upstream https://github.com/GlycemicGPT/GlycemicGPT.git
+git remote add upstream https://github.com/lumose-health/GlycemicGPT.git
 
 # 3. Install the git commit-msg hook (strips prohibited attribution lines)
 #    If scripts/hooks/commit-msg doesn't exist, skip this step -- CI enforces it too
@@ -246,9 +246,12 @@ feature branch --> squash merge --> develop --> merge --> main
 
 ### Creating a Feature Branch
 
+Contributions come in from forks (see [Project Roles](#-project-roles)), so `origin` below is your fork; add the project repo as `upstream` once:
+
 ```bash
-git checkout develop && git pull
-git checkout -b feat/my-feature
+git remote add upstream https://github.com/lumose-health/GlycemicGPT.git  # one-time
+git fetch upstream
+git checkout -b feat/my-feature upstream/develop
 # ... make changes ...
 git push -u origin feat/my-feature
 # Create PR targeting develop
@@ -396,9 +399,9 @@ The CLI auto-detects the project's `.coderabbit.yaml` configuration, so your loc
 
 1. **CI runs automatically** -- all required checks must pass (see below)
 2. **CodeRabbit review** -- an AI-powered code review runs automatically on every PR, checking for bugs, security issues, medical safety concerns, and code quality. It posts comments directly on your PR with findings and suggestions. This is the same engine you can run locally with the [CodeRabbit CLI](#pre-review-with-coderabbit-cli-optional-but-recommended).
-3. **Code owner review** -- a maintainer will review your PR
+3. **Code owner review** -- the project lead reviews your PR; area maintainers may review too, and their review informs the lead's approval
 4. **Feedback** -- you may be asked to make changes; push new commits to the same branch
-5. **Merge** -- once approved and CI passes, a maintainer will squash-merge your PR
+5. **Merge** -- once approved and CI passes, the project lead squash-merges your PR
 
 ### Required CI Checks
 
@@ -419,7 +422,7 @@ Additionally, PRs that modify `apps/mobile/**` will trigger the **Android Gate**
 
 ### How CI handles fork PRs
 
-If you opened this PR from your own fork (the normal contributor flow), every required CI check above runs automatically. You don't need to do anything special and the maintainer doesn't need to grant you any permissions first.
+If you opened this PR from your own fork (the normal contributor flow), every required CI check above runs automatically. The one exception: on your very first contribution to the repo, the project lead has to click "Approve and run" once before CI starts. Beyond that you don't need to do anything special, and nobody needs to grant you any permissions.
 
 A few details on how that works, in case you're auditing:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,31 +8,40 @@ GlycemicGPT is a diabetes management platform. Code changes can affect how gluco
 
 ## Roles
 
-GlycemicGPT has four roles with increasing levels of access and responsibility. Each role maps to a specific GitHub permission level enforced through org teams and CODEOWNERS.
+GlycemicGPT has three roles with increasing levels of responsibility. Each role maps to a specific GitHub permission level enforced through org team permissions and branch-protection rulesets; CODEOWNERS routes review requests.
+
+### Repository access policy (fork-based contribution)
+
+**No one other than the project lead holds write (push) access to a repository that carries secrets** -- release-signing material, bot credentials, or deploy tokens. Everyone else, maintainers included, contributes through the standard fork-and-PR workflow.
+
+This is an organization-wide security policy, not a trust judgment about any individual:
+
+- For a pull request from a same-repo branch, GitHub Actions runs the `pull_request` workflow files **from the PR head commit**, with the repository and organization secret set in scope -- and GitHub provides no approval gate for runs triggered by members with write access. The workflows execute before any human reviews the change.
+- Write access to a secret-bearing repository is therefore equivalent to access to its secret set, and a single compromised account could reach the release pipeline from one pull request.
+- Workflow runs triggered by a fork PR's `pull_request` events carry no secrets, so every contributor gets the same CI feedback with none of that exposure. (The privileged `pull_request_target` workflows do see secrets on fork PRs -- which is why they execute only the trusted base-branch copy of the code, never the PR's.)
+
+The policy applies uniformly to all current and future collaborators. Project automation is unaffected: the bot identities are GitHub Apps, not team members with write access.
 
 ### Permissions
 
-| Permission | Contributor | Committer | Maintainer | Project Lead |
-|------------|:-----------:|:---------:|:----------:|:------------:|
-| Open issues and PRs | Yes | Yes | Yes | Yes |
-| Participate in discussions | Yes | Yes | Yes | Yes |
-| Review code (comments) | Yes | Yes | Yes | Yes |
-| Report security vulnerabilities | Yes | Yes | Yes | Yes |
-| Push to feature branches | - | Yes | Yes | Yes |
-| Approve PRs on develop | - | Yes | Yes | Yes |
-| Triage issues (labels, milestones) | - | Yes | Yes | Yes |
-| Merge PRs to develop | - | - | Yes | Yes |
-| Approve promotion PRs (main) | - | - | Yes | Yes |
-| Merge promotion PRs (main) | - | - | - | Yes |
-| Publish releases | - | - | Yes | Yes |
-| Change governance files | - | - | - | Yes |
-| Change security infrastructure | - | - | - | Yes |
-| Change branch protection | - | - | - | Yes |
-| Manage org settings and teams | - | - | - | Yes |
-| Nominate committers | - | - | Yes | Yes |
-| Approve committer nominations | - | - | - | Yes |
-| Nominate maintainers | - | - | Yes | Yes |
-| Approve maintainer nominations | - | - | - | Yes |
+| Permission | Contributor | Maintainer | Project Lead |
+|------------|:-----------:|:----------:|:------------:|
+| Open issues and PRs (from a fork) | Yes | Yes | Yes |
+| Participate in discussions | Yes | Yes | Yes |
+| Review code (comments and reviews) | Yes | Yes | Yes |
+| Report security vulnerabilities | Yes | Yes | Yes |
+| Triage issues (labels, milestones) | - | Yes | Yes |
+| Push branches to project repositories | - | - | Yes |
+| Give the code-owner approval required by branch protection | - | - | Yes |
+| Merge PRs to develop | - | - | Yes |
+| Merge promotion PRs (main) | - | - | Yes |
+| Publish releases | - | - | Yes |
+| Change governance files | - | - | Yes |
+| Change security infrastructure | - | - | Yes |
+| Change branch protection | - | - | Yes |
+| Manage org settings and teams | - | - | Yes |
+| Nominate maintainers | - | Yes | Yes |
+| Approve maintainer nominations | - | - | Yes |
 
 ### Contributor
 
@@ -42,27 +51,20 @@ GlycemicGPT has four roles with increasing levels of access and responsibility. 
 
 **How to become one:** Just show up. Open a PR, file an issue, join a discussion.
 
-### Committer
-
-**Who:** Trusted contributors with Write access to the repository.
-
-**GitHub team:** [`@GlycemicGPT/committers`](https://github.com/orgs/GlycemicGPT/teams/committers) (Write permission)
-
-**What you cannot do:**
-- Merge to `develop` or `main` (branch protection requires maintainer approval)
-- Change governance files (CODEOWNERS, GOVERNANCE.md, CONTRIBUTING.md, LICENSE)
-- Modify security infrastructure (security scan workflows, suppression configs)
-- Publish releases
-- Modify org settings, teams, or branch protection
-
 ### Maintainer
 
-**Who:** Project stewards with Maintain access. Responsible for the day-to-day health of the project.
+**Who:** Project stewards trusted with the day-to-day health of the project or a specific area of it (web frontend, AI/evals). Maintainers triage issues, review pull requests in their areas, and mentor contributors.
 
-**GitHub team:** [`@GlycemicGPT/maintainers`](https://github.com/orgs/GlycemicGPT/teams/maintainers) (Maintain permission)
+**GitHub teams:** `maintainers`, plus the area teams `web` and `ai` (all **Triage** permission, per the repository access policy above).
+
+**What maintainers do:**
+- Triage issues: labels, milestones, duplicates, reproduction requests
+- Review PRs in their area of expertise -- their review informs the project lead's required approval
+- Steward architecture discussions for their area
+- Nominate new maintainers
 
 **What you cannot do:**
-- Merge promotion PRs to `main` (project lead only)
+- Push branches to project repositories or merge PRs (fork-based policy above)
 - Change governance files (project lead only via CODEOWNERS)
 - Change security infrastructure (project lead only via CODEOWNERS)
 - Change branch protection rules or org settings
@@ -79,28 +81,19 @@ GlycemicGPT has four roles with increasing levels of access and responsibility. 
 
 This is a standard BDFL (Benevolent Dictator for Life) model, common in projects with a single founder. The project lead retains authority over governance, security, branch protection, org settings, and maintainer promotions. This ensures the project's medical safety standards cannot be changed without the founder's explicit approval.
 
-## Becoming a Committer
-
-1. Contribute consistently over **3+ months** (no specific PR count -- quality matters more than quantity)
-2. Demonstrate understanding of [medical safety requirements](CONTRIBUTING.md#-safety-first----please-read) in your contributions
-3. Follow project conventions without repeated correction
-4. Any maintainer nominates you in a [Discussion](https://github.com/GlycemicGPT/GlycemicGPT/discussions) thread
-5. **1-week consensus period** -- the nomination passes if no existing maintainer objects
-6. The project lead retains veto power over any nomination
-7. On approval: added to `@GlycemicGPT/committers` team, org seat funded from project fund
-
-There is no formal application process. Maintainers watch for contributors who demonstrate reliability, good judgment, and safety awareness. If you're interested, just keep contributing -- it will be noticed.
-
 ## Becoming a Maintainer
 
-1. Active committer for **6+ months**
-2. Has reviewed PRs and mentored other contributors
-3. Understands the full stack (or deep expertise in one area + awareness of others)
-4. Demonstrated sound judgment on safety-critical decisions
-5. Any maintainer nominates in a Discussion thread
-6. 1-week consensus period among existing maintainers
-7. **Project lead must explicitly approve** (not just absence of objections)
-8. On approval: moved from `@GlycemicGPT/committers` to `@GlycemicGPT/maintainers` team, eligible for stipend
+1. Contribute consistently over **6+ months** (no specific PR count -- quality matters more than quantity)
+2. Demonstrate understanding of [medical safety requirements](CONTRIBUTING.md#-safety-first----please-read) in your contributions
+3. Have reviewed PRs and mentored other contributors
+4. Understand the full stack, or have deep expertise in one area (web, AI/evals) plus awareness of the others
+5. Demonstrate sound judgment on safety-critical decisions
+6. Any maintainer nominates you in a [Discussion](https://github.com/GlycemicGPT/GlycemicGPT/discussions) thread
+7. **1-week consensus period** among existing maintainers
+8. **Project lead must explicitly approve** (not just absence of objections)
+9. On approval: added to the `maintainers` team (or an area team) at Triage permission, org seat funded from project fund, eligible for stipend
+
+There is no formal application process. Maintainers watch for contributors who demonstrate reliability, good judgment, and safety awareness. If you're interested, just keep contributing -- it will be noticed.
 
 Maintainer status reflects sustained trust built over time. For a medical platform, this trust includes demonstrated understanding of patient safety implications, not just technical skill.
 
@@ -118,14 +111,14 @@ Maintainer status reflects sustained trust built over time. For a medical platfo
 
 ### Day-to-day decisions
 
-Maintainers make routine decisions: merging PRs, triaging issues, choosing implementation approaches. These don't need formal process.
+Maintainers make routine decisions: reviewing PRs, triaging issues, choosing implementation approaches. These don't need formal process. The project lead performs the actual merge (the only role with write access), normally on the strength of the area maintainer's review.
 
 ### Architecture and safety decisions
 
 Major changes that affect the platform's architecture or safety properties should be discussed before implementation:
 
 1. Open a [Discussion](https://github.com/GlycemicGPT/GlycemicGPT/discussions) in the Ideas category describing the proposal
-2. Tag relevant maintainers and committers
+2. Tag relevant maintainers
 3. Allow at least 7 days for feedback on safety-critical proposals
 4. Document the decision in the PR that implements it
 
@@ -149,7 +142,7 @@ If contributors disagree on an approach:
 
 GlycemicGPT is funded through a single channel: [Open Collective](https://opencollective.com/glycemicgpt), fiscally hosted by Open Source Collective. All project income, expenses, and balances are public by default.
 
-Routing every dollar -- including any compensation paid to the project lead, maintainers, or committers -- through one transparent ledger is a deliberate choice in support of full financial transparency. The project does not solicit funds through any other channel.
+Routing every dollar -- including any compensation paid to the project lead or maintainers -- through one transparent ledger is a deliberate choice in support of full financial transparency. The project does not solicit funds through any other channel.
 
 <p align="center">
   <a href="https://opencollective.com/glycemicgpt"><img src="https://opencollective.com/glycemicgpt/contribute/button@2x.png?color=blue" alt="Contribute to GlycemicGPT on Open Collective" width="300"></a>
@@ -158,7 +151,7 @@ Routing every dollar -- including any compensation paid to the project lead, mai
 ### What the fund covers
 
 1. **Infrastructure**: hosting, domain (glycemicgpt.org), CI costs, signing certificates
-2. **Org seats**: per-seat cost for each committer/maintainer on the GitHub Teams plan
+2. **Org seats**: per-seat cost for each maintainer on the GitHub Teams plan
 3. **Maintainer stipends**: when the fund supports it, active maintainers may receive monthly stipends
 4. **Bounties**: specific issues may carry bounties funded from Open Collective (future)
 
@@ -168,7 +161,6 @@ Routing every dollar -- including any compensation paid to the project lead, mai
 |------|:--------:|:----------------:|-----|
 | **Project lead** | N/A (owner) | Yes | Open Collective stipend |
 | **Maintainer** | Paid from fund | Yes | Open Collective stipend |
-| **Committer** | Paid from fund | No | Volunteer role |
 | **Contributor** | N/A | No | Bounties on specific issues (future) |
 
 The project lead is stipend-eligible from the Open Collective fund on the same basis as any other maintainer. Routing all compensation -- regardless of role -- through Open Collective keeps every payout on the public ledger.
@@ -193,10 +185,9 @@ GlycemicGPT also receives in-kind support from open-source-friendly vendors (don
 - **Who gets access:**
   - **Project lead:** full access, vault admin.
   - **Maintainers** (per the [Roles](#roles) hierarchy): access to operational vaults relevant to their responsibilities. Scoped per need; no blanket access.
-  - **Committers:** access only on request, scoped to specific items needed for the work they're doing. Default is no access.
-  - **External contributors:** time-bounded access to a specifically scoped vault (e.g., a "Contributor Dev Stack" vault) for credentials needed to spin up the local environment, when the alternative would be DM'ing plaintext credentials. Revoked when their PR merges or work concludes.
+  - **Contributors:** time-bounded access to a specifically scoped vault (e.g., a "Contributor Dev Stack" vault) for credentials needed to spin up the local environment, when the alternative would be DM'ing plaintext credentials. Revoked when their PR merges or work concludes. Default is no access.
 - **Granting access:** requests go to the project lead. Access decisions are logged in a Discussions thread (audit trail) and respect the per-need scoping above.
-- **Loss of access:** triggered by role change (committer → emeritus, maintainer stepping down) or completion of bounded work (external contributor). The project lead is responsible for the off-boarding sweep.
+- **Loss of access:** triggered by role change (maintainer → emeritus or stepping down) or completion of bounded work (external contributor). The project lead is responsible for the off-boarding sweep.
 - **Why this matters:** before the 1Password account, project credentials were shared over Discord DMs and inline in dev docs. The 1Password account exists to fix that. The point is **shared, audit-able, revocable** credential handling -- not a single "team admin password" that everyone gets a copy of.
 
 A separate operational adoption sequence (vault setup, dev-stack credential migration, CI integration) is tracked by the project lead outside this governance doc; this section only sets the policy.
@@ -244,17 +235,9 @@ This is not bureaucracy -- it's the checkpoint between "code that works" and "co
 
 Code owners are defined in [`.github/CODEOWNERS`](.github/CODEOWNERS). When a PR touches files owned by a specific team or person, GitHub automatically requests their review.
 
-The `@GlycemicGPT/maintainers` team owns all files by default. Governance files, security infrastructure, and release configuration list the project lead individually alongside the maintainers team. The project lead's individual listing ensures they are always explicitly requested as a reviewer on external PRs. The team co-listing ensures review is still requested when the project lead authors the PR -- GitHub skips review requests for sole code owners who are also the PR author, so the team serves as a fallback to maintain audit trail.
+The project lead owns all paths. GitHub only accepts principals with **write** access as code owners, and under the [repository access policy](#repository-access-policy-fork-based-contribution) only the project lead holds write -- so team-based code ownership is structurally precluded. Area maintainers review the PRs in their areas as ordinary requested reviewers; those reviews inform the project lead's required code-owner approval.
 
-> **Note:** CODEOWNERS controls who is *requested* for review, not who *must* approve. The requirement that the project lead personally reviews governance, security, and release changes is enforced by process (this document), not by GitHub's code owner mechanism. Any code owner approval satisfies the branch protection check.
-
-As the project grows, component-specific committer teams will be added:
-
-```
-# Future component ownership example:
-/apps/api/ @GlycemicGPT/maintainers @GlycemicGPT/backend-committers
-/apps/mobile/ @GlycemicGPT/maintainers @GlycemicGPT/mobile-committers
-```
+> **Note:** CODEOWNERS controls who is *requested* for review, not who *must* approve. For contributor PRs, branch protection's code-owner review requirement resolves to the project lead, the sole code owner. PRs authored by the lead can't be self-approved: those merge via the org-admin bypass, with review coming from requested maintainer reviews and automated review rather than the code-owner mechanism.
 
 ## Automation
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,7 +16,7 @@ GlycemicGPT has three roles with increasing levels of responsibility. Each role 
 
 This is an organization-wide security policy, not a trust judgment about any individual:
 
-- For a pull request from a same-repo branch, GitHub Actions runs the `pull_request` workflow files **from the PR head commit**, with the repository and organization secret set in scope -- and GitHub provides no approval gate for runs triggered by members with write access. The workflows execute before any human reviews the change.
+- For a pull request from a same-repo branch, GitHub Actions runs the `pull_request` workflow files **from the PR's merge commit** -- the PR branch merged into the base, so any workflow the PR adds or edits is exactly what runs -- with the repository and organization secret set in scope. GitHub provides no approval gate for runs triggered by members with write access, so the workflows execute before any human reviews the change.
 - Write access to a secret-bearing repository is therefore equivalent to access to its secret set, and a single compromised account could reach the release pipeline from one pull request.
 - Workflow runs triggered by a fork PR's `pull_request` events carry no secrets, so every contributor gets the same CI feedback with none of that exposure. (The privileged `pull_request_target` workflows do see secrets on fork PRs -- which is why they execute only the trusted base-branch copy of the code, never the PR's.)
 
@@ -88,7 +88,7 @@ This is a standard BDFL (Benevolent Dictator for Life) model, common in projects
 3. Have reviewed PRs and mentored other contributors
 4. Understand the full stack, or have deep expertise in one area (web, AI/evals) plus awareness of the others
 5. Demonstrate sound judgment on safety-critical decisions
-6. Any maintainer nominates you in a [Discussion](https://github.com/GlycemicGPT/GlycemicGPT/discussions) thread
+6. Any maintainer nominates you in a [Discussion](https://github.com/lumose-health/GlycemicGPT/discussions) thread
 7. **1-week consensus period** among existing maintainers
 8. **Project lead must explicitly approve** (not just absence of objections)
 9. On approval: added to the `maintainers` team (or an area team) at Triage permission, org seat funded from project fund, eligible for stipend
@@ -117,7 +117,7 @@ Maintainers make routine decisions: reviewing PRs, triaging issues, choosing imp
 
 Major changes that affect the platform's architecture or safety properties should be discussed before implementation:
 
-1. Open a [Discussion](https://github.com/GlycemicGPT/GlycemicGPT/discussions) in the Ideas category describing the proposal
+1. Open a [Discussion](https://github.com/lumose-health/GlycemicGPT/discussions) in the Ideas category describing the proposal
 2. Tag relevant maintainers
 3. Allow at least 7 days for feedback on safety-critical proposals
 4. Document the decision in the PR that implements it
@@ -185,7 +185,7 @@ GlycemicGPT also receives in-kind support from open-source-friendly vendors (don
 - **Who gets access:**
   - **Project lead:** full access, vault admin.
   - **Maintainers** (per the [Roles](#roles) hierarchy): access to operational vaults relevant to their responsibilities. Scoped per need; no blanket access.
-  - **Contributors:** time-bounded access to a specifically scoped vault (e.g., a "Contributor Dev Stack" vault) for credentials needed to spin up the local environment, when the alternative would be DM'ing plaintext credentials. Revoked when their PR merges or work concludes. Default is no access.
+  - **Contributors:** time-bounded access to a specifically scoped vault (e.g., a "Contributor Dev Stack" vault) for credentials needed to spin up the local environment, when the alternative would be DM'ing plaintext credentials. Default is no access. Credentials shared this way are dev-stack scope only -- never signing, deployment, or production secrets -- and are treated as disposable: revoked *and rotated* when the contributor's PR merges or the work concludes, since revocation alone cannot un-copy a value.
 - **Granting access:** requests go to the project lead. Access decisions are logged in a Discussions thread (audit trail) and respect the per-need scoping above.
 - **Loss of access:** triggered by role change (maintainer → emeritus or stepping down) or completion of bounded work (external contributor). The project lead is responsible for the off-boarding sweep.
 - **Why this matters:** before the 1Password account, project credentials were shared over Discord DMs and inline in dev docs. The 1Password account exists to fix that. The point is **shared, audit-able, revocable** credential handling -- not a single "team admin password" that everyone gets a copy of.
@@ -261,7 +261,7 @@ Security findings are handled automatically by CI (see [docs/dev/security-testin
 
 - **Suppression decisions** (accepting a known risk) require project lead approval
 - **Security infrastructure changes** (scan workflows, evaluator scripts) require project lead review (enforced via CODEOWNERS)
-- **Vulnerability reports** from external researchers should follow the [Security Policy](https://github.com/GlycemicGPT/.github/blob/main/SECURITY.md)
+- **Vulnerability reports** from external researchers should follow the [Security Policy](https://github.com/lumose-health/.github/blob/main/SECURITY.md)
 - **Platform-level (GitHub-native) alerts** -- Dependabot alerts and Secret Scanning surface findings in the repo's Security tab. The project lead reviews open alerts weekly; real findings convert to tracked issues and follow the same triage flow as CI findings. See [CONTRIBUTING.md § Platform-level security scanning](CONTRIBUTING.md#platform-level-security-scanning-github-native) for the contributor-facing view.
 
 ## Changes to This Document


### PR DESCRIPTION
## Summary

Adopts the fork-based contribution model as org policy: no one other than the project lead holds write (push) access to repositories that carry secrets, and all contributions -- including from maintainers -- arrive as pull requests from forks. The `web` and `ai` teams move from Write to Triage (the permission change itself is applied at the org level, not in this PR).

## Why

For a pull request from a same-repo branch, GitHub Actions runs the `pull_request` workflow files from the PR head commit with the repository and organization secret set in scope, and provides no approval gate for members with write access -- the workflows execute before any human reviews the change. Write access to a secret-bearing repository is therefore equivalent to access to its secret set. Fork PRs run without secrets, so contributors keep full CI feedback with none of that exposure. This is a preventive, org-wide security posture, not a judgment about any contributor.

## Changes

- `.github/CODEOWNERS`: area ownership for `/apps/web/`, `/evals/`, `/sidecar/`, and the benchmark paths collapses from the area teams to the project lead. GitHub only accepts write-access principals as code owners, so once the teams hold Triage a team entry would silently break to "Unknown owner" and disable review requests for those areas. No rule is weakened; the safety-critical insulin/dosing surface is unchanged (lead-only, last-match-wins).
- `GOVERNANCE.md`: retires the write-access Committer tier; documents the repository access policy and the reasoning above; reworks the roles/permissions table (Contributor / Maintainer / Project Lead); updates the Code Ownership section to match how review requirements actually resolve, including how lead-authored PRs merge.
- `CONTRIBUTING.md`: Project Roles section updated to the three-role model; feature-branch instructions written for the fork flow; upstream remote points at the canonical org; notes the one-time "Approve and run" for first-time contributors; fixes the dead Project Roles TOC anchor.

## Sequencing

This PR must merge (on develop and main) **before** the team permission change is applied, so area review never silently turns off in the window between the two.

## Verification

- CODEOWNERS API reports 0 errors for the branch.
- No ruleset or branch-protection change is part of this PR.
- Fork-PR flows are unaffected (labels and attribution run on `pull_request_target` from the trusted base ref).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution instructions with clearer fork-based workflows, branch setup, CI approval steps, and pull request review expectations.
  - Corrected project-role documentation and clarified responsibilities for contributors, maintainers, and project leadership.
  - Revised governance guidance covering repository access, decision-making, maintainer eligibility, compensation, credential handling, and code review approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->