### PR TITLE
Fix history timestamps: anchor pump reference time in the device's local zone

### DIFF
--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
@@ -24,7 +24,7 @@ import com.glycemicgpt.mobile.domain.model.PumpActivityMode
 import com.glycemicgpt.mobile.domain.pump.SafetyLimits
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneOffset
+import java.time.ZoneId
 import java.util.Base64
 import kotlin.math.roundToInt
 import timber.log.Timber
@@ -182,7 +182,9 @@ data class MedtronicHistoryRecord(
  * **Record framing & timestamps.** Each record's header is `event_type(u16) seq(u32) offset(u16)`
  * followed by the event body, optionally wrapped in the Medtronic E2E trailer. Records carry only a
  * relative offset; absolute time is resolved against the most recent [MedtronicHistoryEventType.NGP_REFERENCE_TIME]
- * record (interpreted as UTC -- timezone handling is a Milestone D concern). Events before any
+ * record. The pump stores that reference as a naive local wall-clock (no TZ/DST field), so it is
+ * anchored in the device's zone ([ZoneId.systemDefault]); DST gap/overlap hours and a phone zone that
+ * differs from the pump's are inherently ambiguous and remain unresolved. Events before any
  * reference are dropped (and counted) rather than mis-timestamped. Over-the-air behavior rides with
  * 48.A2; nothing here is claimed live-verified.
  */
@@ -445,7 +447,11 @@ object MedtronicHistoryParser {
                     MedtronicCodec.readUIntLe(p, 5, 1), // hour
                     MedtronicCodec.readUIntLe(p, 6, 1), // minute
                     MedtronicCodec.readUIntLe(p, 7, 1), // second
-                ).toInstant(ZoneOffset.UTC)
+                    // The pump stores naive LOCAL wall-clock (no TZ/DST field) — it's set to the
+                    // user's local time. Interpreting it as UTC shifts every history timestamp by the
+                    // local offset (e.g. +2h in CEST), landing readings in the future. Anchor in the
+                    // device's zone instead.
+                ).atZone(ZoneId.systemDefault()).toInstant()
             } catch (e: java.time.DateTimeException) {
                 Timber.w(e, "Invalid reference-time datetime; offsets after it cannot be anchored")
                 null

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParser.kt
@@ -440,6 +440,10 @@ object MedtronicHistoryParser {
         require(p.size >= 8) { "reference-time body too short: ${p.size}" }
         val time =
             try {
+                // The pump stores naive LOCAL wall-clock (no TZ/DST field) — it's set to the
+                // user's local time. Interpreting it as UTC shifts every history timestamp by the
+                // local offset (into the future east of UTC, e.g. +2h in CEST; into the past west
+                // of it). Anchor in the device's zone instead.
                 LocalDateTime.of(
                     MedtronicCodec.readUIntLe(p, 1, 2), // year
                     MedtronicCodec.readUIntLe(p, 3, 1), // month
@@ -447,10 +451,6 @@ object MedtronicHistoryParser {
                     MedtronicCodec.readUIntLe(p, 5, 1), // hour
                     MedtronicCodec.readUIntLe(p, 6, 1), // minute
                     MedtronicCodec.readUIntLe(p, 7, 1), // second
-                    // The pump stores naive LOCAL wall-clock (no TZ/DST field) — it's set to the
-                    // user's local time. Interpreting it as UTC shifts every history timestamp by the
-                    // local offset (e.g. +2h in CEST), landing readings in the future. Anchor in the
-                    // device's zone instead.
                 ).atZone(ZoneId.systemDefault()).toInstant()
             } catch (e: java.time.DateTimeException) {
                 Timber.w(e, "Invalid reference-time datetime; offsets after it cannot be anchored")

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParserTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParserTest.kt
@@ -10,16 +10,18 @@ import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.pump.SafetyLimits
 import java.time.LocalDateTime
-import java.time.ZoneOffset
+import java.time.ZoneId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MedtronicHistoryParserTest {
 
-    private val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+    // Anchored in the system zone to match production (MedtronicHistoryParser.referenceTime), which
+    // treats the pump reference as naive local wall-clock. Using UTC here would go red on non-UTC JVMs.
+    private val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).atZone(ZoneId.systemDefault()).toInstant()
 
-    // NGP_REFERENCE_TIME at seq 100: recording_reason 0x3c + datetime 2026-06-01 12:00:00 UTC.
+    // NGP_REFERENCE_TIME at seq 100: recording_reason 0x3c + datetime 2026-06-01 12:00:00 local.
     private val referenceRecord = record(0xF00E, 100, 0, "3c" + "ea07" + "06" + "01" + "0c" + "00" + "00")
 
     private fun record(typeId: Int, seq: Int, offsetSec: Int, bodyHex: String): HistoryLogRecord =

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParserTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/messages/MedtronicHistoryParserTest.kt
@@ -9,8 +9,10 @@ package com.glycemicgpt.mobile.ble.messages
 import com.glycemicgpt.mobile.domain.model.CgmTrend
 import com.glycemicgpt.mobile.domain.model.HistoryLogRecord
 import com.glycemicgpt.mobile.domain.pump.SafetyLimits
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.util.TimeZone
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -58,6 +60,24 @@ class MedtronicHistoryParserTest {
         assertEquals(120, cgm[0].glucoseMgDl)
         assertEquals(CgmTrend.UNKNOWN, cgm[0].trendArrow)
         assertEquals(reference.plusSeconds(300), cgm[0].timestamp)
+    }
+
+    @Test
+    fun `reference time anchors in the device zone, not UTC`() {
+        // Pinning a fixed non-UTC zone makes this test bite on any JVM: the pump wall-clock
+        // 2026-06-01 12:00:00 in Europe/Oslo (CEST, UTC+2) is 10:00:00Z. A regression back to a UTC
+        // anchor would resolve 12:00:00Z and fail here even on UTC CI runners, which the
+        // system-zone-relative assertions elsewhere in this file cannot catch.
+        val previousZone = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Oslo"))
+        try {
+            val cgm = MedtronicHistoryParser.extractCgmFromHistoryLogs(
+                listOf(referenceRecord, record(0xF00C, 101, 300, "0000780000000000")),
+            )
+            assertEquals(Instant.parse("2026-06-01T10:05:00Z"), cgm.single().timestamp)
+        } finally {
+            TimeZone.setDefault(previousZone)
+        }
     }
 
     @Test

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSourceTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicInsulinSourceTest.kt
@@ -20,7 +20,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneOffset
+import java.time.ZoneId
 
 class MedtronicInsulinSourceTest {
 
@@ -103,7 +103,8 @@ class MedtronicInsulinSourceTest {
         // After the bootstrap seeds the cursor at 99, a poll returning records up to sequence 111
         // must advance the cursor there so the following poll requests only newer records (the AC4
         // incremental cursor path).
-        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+        // System zone: matches MedtronicHistoryParser resolving the pump's naive-local reference time.
+        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).atZone(ZoneId.systemDefault()).toInstant()
         val batch = listOf(
             rawRecord(0xF00E, seq = 100, offsetSec = 0, bodyHex = "3cea0706010c0000"),
             rawRecord(0x0069, seq = 110, offsetSec = 600, bodyHex = "010033190000ff000000000000"),
@@ -139,7 +140,8 @@ class MedtronicInsulinSourceTest {
     @Test
     fun `getBolusHistory extracts delivered boluses and filters by the since instant`() = runTest {
         // One delivered 2.5 IU bolus at reference + 600s, plus the reference-time anchor record.
-        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+        // System zone: matches MedtronicHistoryParser resolving the pump's naive-local reference time.
+        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).atZone(ZoneId.systemDefault()).toInstant()
         val records = listOf(
             rawRecord(0xF00E, seq = 100, offsetSec = 0, bodyHex = "3cea0706010c0000"),
             rawRecord(0x0069, seq = 110, offsetSec = 600, bodyHex = "010033190000ff000000000000"),

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicPumpStatusTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/plugin/MedtronicPumpStatusTest.kt
@@ -22,7 +22,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneOffset
+import java.time.ZoneId
 
 class MedtronicPumpStatusTest {
 
@@ -110,7 +110,8 @@ class MedtronicPumpStatusTest {
     fun `extractCgmFromHistoryLogs actually routes raw records through the parser`() {
         // A reference-time record + one SG record (120 mg/dL at +300s) -- proves the delegate runs the
         // real MedtronicHistoryParser, not a stub that would also pass the empty-list case above.
-        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+        // System zone: matches MedtronicHistoryParser resolving the pump's naive-local reference time.
+        val reference = LocalDateTime.of(2026, 6, 1, 12, 0, 0).atZone(ZoneId.systemDefault()).toInstant()
         val records = listOf(
             rawRecord(0xF00E, seq = 100, offsetSec = 0, bodyHex = "3cea0706010c0000"),
             rawRecord(0xF00C, seq = 101, offsetSec = 300, bodyHex = "0000780000000000"),


### PR DESCRIPTION
## 📋 Summary

( :robot: Partially AI-written, reviewed by me)

Medtronic history records carry only a relative offset; absolute time is resolved against the most recent NGP_REFERENCE_TIME record. The pump stores that reference as a naive local wall-clock (no timezone/DST field), so it must be anchored in the device's zone (ZoneId.systemDefault()) rather than UTC. DST gap/overlap hours and a phone zone differing from the pump's are inherently ambiguous and remain unresolved.

Tests anchor their reference in the system zone to match production, so they pass on non-UTC JVMs/CI.

## 🔗 Related Issues

Somewhat related to lumose-health/GlycemicGPT#708

## 🏷️ Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

* `MedtronicHistoryParser`: resolve `NGP_REFERENCE_TIME` in `ZoneId.systemDefault()` instead of `ZoneOffset.UTC`; update the KDoc to describe the naive-local-wall-clock semantics and the DST/cross-zone caveats.
* `MedtronicHistoryParserTest`, `MedtronicPumpStatusTest`, `MedtronicInsulinSourceTest`: anchor the test reference in the system zone so expectations match production (previously hardcoded to UTC, which went red on non-UTC JVMs).

## 🧪 Test Plan

- [X] Unit tests pass
- [ ] New tests added for new functionality - no but existing tests updated
- [X] Manual/visual testing performed - tested with my pump, I pull the full BG history from the pump and it renders correctly on my Pebble watch, no time offset
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [X] Self-review completed
- [X] Code follows project style guidelines
- [X] No hardcoded secrets, API keys, or credentials
- [X] Changes generate no new warnings
- [X] Documentation updated (if applicable) - kdoc strings updated

## 📸 Screenshots (if applicable)

Here's a pic of my watch with a funcitoning graph, matching the pump (with a dropout that the pump fills in, but probably did correspond with a sensor failure / disconnect):

<img src="https://github.com/user-attachments/assets/3ee769ef-2d5b-473a-80f4-dbed142ba1aa " alt="image" width="1896" data-linear-height="1192" />

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Medtronic pump history timestamp handling by interpreting reference times in the device’s local timezone.
  * Corrected timestamps for historical insulin and CGM records, including bolus history and pump status data.
  * Prevented timezone-related shifts that could cause imported records to appear at incorrect times.
* **Tests**
  * Updated coverage to verify accurate local-time timestamp conversion across Medtronic history and status data.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Medtronic pump history timestamp handling by interpreting device-reported times in the device’s local timezone.
  * Corrected CGM readings, insulin events, and history synchronization timestamps when the device timezone differs from UTC.
  * Improved reliability across systems configured with non-UTC timezones.
* **Tests**
  * Added coverage to verify accurate timestamp conversion across different local timezone settings.