### PR TITLE
Confirm IOB parsing on a live 780G; drop provisional markers

### DIFF
--- a/docs/daily-use/connecting-medtronic-pump.md
+++ b/docs/daily-use/connecting-medtronic-pump.md
@@ -53,7 +53,7 @@ Once paired, the pump is remembered — GlycemicGPT reconnects on its own when t
 - **Bolus history**
 - **Reservoir** level and **pump battery**
 
-> Basal is shown as the active rate the pump reports; SmartGuard auto-basal micro-boluses are not yet fully attributed, and IoB is read straight off the pump as it exposes it. These are documented limitations of the on-device read path while the data mapping is validated against live pumps.
+> Basal is shown as the active rate the pump reports; SmartGuard auto-basal micro-boluses are not yet fully attributed — a documented limitation of the on-device read path while that mapping is validated against live pumps. IoB is read straight off the pump as it exposes it, and has been confirmed to match a live MiniMed 780G's on-screen Active Insulin.
 
 ## If pairing doesn't complete
 

--- a/docs/daily-use/connecting-medtronic-pump.md
+++ b/docs/daily-use/connecting-medtronic-pump.md
@@ -53,7 +53,7 @@ Once paired, the pump is remembered — GlycemicGPT reconnects on its own when t
 - **Bolus history**
 - **Reservoir** level and **pump battery**
 
-> Basal is shown as the active rate the pump reports; SmartGuard auto-basal micro-boluses are not yet fully attributed — a documented limitation of the on-device read path while that mapping is validated against live pumps. IoB is read straight off the pump as it exposes it, and has been confirmed to match a live MiniMed 780G's on-screen Active Insulin.
+> Basal is shown as the active rate the pump reports; SmartGuard auto-basal micro-boluses are not yet fully attributed — a documented limitation of the on-device read path while that mapping is validated against live pumps. IoB is read straight off the pump as it exposes it, and has been confirmed to match a live MiniMed 780G's on-screen Active Insulin, subject to display rounding.
 
 ## If pairing doesn't complete
 

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatus.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatus.kt
@@ -121,8 +121,7 @@ data class IddStatusRecord(
 /**
  * Decoded Insulin-On-Board response (SRCP opcode `0x03F3` -> response `0x03FC`).
  *
- * ⚠️ **PROVISIONAL.** Upstream marks IOB parsing "not tested" (`iob.py`); this is implemented
- * faithfully but must be validated against a real pump before it is trusted. `TODO(48.A2)`.
+ * The optional IOB-partial-status sub-fields are length-checked in [parse] but not interpreted.
  *
  * @property insulinOnBoardIu active insulin on board (IU, medfloat32).
  */

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatusReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatusReader.kt
@@ -37,7 +37,7 @@ data class MedtronicIddStatusState(
 
 /**
  * Reads the pump's Insulin Delivery (IDD) status surface over the C1 session-read framework into the
- * shared domain models: reservoir ([ReservoirReading]), IOB ([IoBReading], **provisional**), active
+ * shared domain models: reservoir ([ReservoirReading]), IOB ([IoBReading]), active
  * basal ([BasalReading]) and the therapy/sensor [MedtronicIddStatusState].
  *
  * Every numeric value is gated by [safetyLimits]: an out-of-physiological-range reservoir/IOB/basal
@@ -89,13 +89,7 @@ class IddStatusReader(
         )
     }
 
-    /**
-     * Active insulin on board.
-     *
-     * ⚠️ **PROVISIONAL** -- upstream marks IOB parsing "not tested" (`iob.py`). It is parsed faithfully
-     * and safety-gated, but emitted with a warning marker and **must not be presented as trusted**
-     * until a live pump confirms the layout. `TODO(48.A2)`.
-     */
+    /** Active insulin on board; range-checked in [toIoBReading]. */
     fun readIoB(onResult: (Result<IoBReading>) -> Unit) {
         val features =
             try {
@@ -189,8 +183,8 @@ class IddStatusReader(
 
         /**
          * Plausible upper bound on insulin-on-board (IU). Real IOB rarely exceeds the low tens of
-         * units; this generous ceiling rejects a garbled/misaligned PROVISIONAL IOB read rather than
-         * surfacing a wrong value. `TODO(48.A2)`: revisit once IOB is validated on a real pump.
+         * units; this generous ceiling rejects a garbled/misaligned read rather than surfacing a wrong
+         * value.
          */
         const val MAX_IOB_UNITS = 100.0
     }

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatusReader.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/IddStatusReader.kt
@@ -40,9 +40,11 @@ data class MedtronicIddStatusState(
  * shared domain models: reservoir ([ReservoirReading]), IOB ([IoBReading]), active
  * basal ([BasalReading]) and the therapy/sensor [MedtronicIddStatusState].
  *
- * Every numeric value is gated by [safetyLimits]: an out-of-physiological-range reservoir/IOB/basal
- * is **rejected** (a [MedtronicReadException]), never clamped, matching [CgmReader]. Over-the-air
- * behavior rides with 48.A2; nothing here is claimed live-verified.
+ * Every numeric value is range-gated — reservoir/IOB by [MAX_RESERVOIR_UNITS]/[MAX_IOB_UNITS],
+ * basal by [safetyLimits]: an out-of-physiological-range value is **rejected** (a
+ * [MedtronicReadException]), never clamped, matching [CgmReader]. Over-the-air behavior rides with
+ * 48.A2. The IOB read is live-verified on a MiniMed 780G (2026-07, matched the pump's on-screen
+ * Active Insulin modulo display rounding); the other reads are not yet claimed live-verified.
  *
  * The IDD Features read supplies two per-model facts (avoiding the upstream 780G hard-codes): the
  * E2E-protection flag (whether records carry the E2E trailer) and the SmartGuard capability tier

--- a/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
+++ b/plugins/shipped/medtronic/src/main/java/com/glycemicgpt/mobile/ble/read/MedtronicReadGateway.kt
@@ -109,7 +109,7 @@ class MedtronicReadGateway(
             CgmReader(link, session).readLatest(onResult)
         }
 
-    /** Insulin on board (IDD SRCP). PROVISIONAL until live-validated (the reader logs the marker). */
+    /** Insulin on board (IDD SRCP). */
     suspend fun getIoB(): Result<IoBReading> =
         sessionRead("IOB") { link, session, onResult ->
             IddStatusReader(link, session).readIoB(onResult)

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/IddStatusReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/IddStatusReaderTest.kt
@@ -85,7 +85,7 @@ class IddStatusReaderTest {
     }
 
     @Test
-    fun `readIoB rejects an implausible provisional IOB`() {
+    fun `readIoB rejects an implausible IOB`() {
         val two = TwoSidedSession()
         val link = FakeGattLink()
         link.reads[features] = two.pumpEncrypt(featuresPlain)

--- a/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/IddStatusReaderTest.kt
+++ b/plugins/shipped/medtronic/src/test/java/com/glycemicgpt/mobile/ble/read/IddStatusReaderTest.kt
@@ -98,6 +98,7 @@ class IddStatusReaderTest {
         IddStatusReader(link, two.server).readIoB { result = it }
 
         assertTrue(result!!.isFailure)
+        assertTrue(result!!.exceptionOrNull() is MedtronicReadException)
     }
 
     @Test


### PR DESCRIPTION
## 📋 Summary

<!-- Brief description of what this PR does -->

The Insulin On Board f32 read was flagged provisional/untested (upstream iob.py never validated it). Confirmed live on a MiniMed 780G: the parsed value matched the pump's on-screen Active Insulin (modulo the pump's display rounding). Lift the PROVISIONAL markers and keep the defensive plausible-range gate. The optional IOB partial-status sub-fields stay uninterpreted (they are length-checked only, never decoded).

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

https://github.com/lumose-health/GlycemicGPT/issues/708

IoB is mentioned specifically there and I can confirm it seems to work perfectly!

Related to 

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [x] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

- Remove the `PROVISIONAL` / "not tested" markers on the IOB read across `IddStatus`, `IddStatusReader`, and `MedtronicReadGateway`, noting it is confirmed live on a 780G.
- Keep the plausible-range sanity gate (reworded from "reject a PROVISIONAL read" to a plain defensive bound).
- Rename the range-gate test to drop "provisional". No behavior change.

## 🧪 Test Plan

- [x] Unit tests pass
- [ ] New tests added for new functionality
- [x] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [x] Self-review completed
- [x] Code follows project style guidelines
- [x] No hardcoded secrets, API keys, or credentials
- [x] Changes generate no new warnings
- [x] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

Here you can see the same IoB value on my pump and watch (rounded to one decimal place). I've used this for a few days and it's always matched my pump values when I've checked.

<img width="2162" height="1192" alt="image" src="https://github.com/user-attachments/assets/90ef088c-457f-4954-9a0d-86582c15f23a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined Insulin-on-Board (IoB) guidance to remove “provisional” wording and clarify validation behavior.
  * Added that IoB is read directly from the pump and matches a live MiniMed 780G “Active Insulin.”
  * Clarified that optional IoB partial-status fields are length-checked but not interpreted.

* **Tests**
  * Updated the IoB failure test description to refer to “implausible IoB” (not “implausible provisional IOB”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->