### PR TITLE
ci(security): secret-placement invariants and environment drift checks

### DIFF
--- a/.github/workflows/secrets-hygiene.yml
+++ b/.github/workflows/secrets-hygiene.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install dependencies
+        # pyyaml is for check-secret-invariants.py trigger parsing.
+        run: pip install pyyaml==6.0.2
+
       # Fail-closed proof first: every red-team fixture must still be
       # caught before the live audit's "clean" can be trusted.
       - name: Red-team self-test
@@ -56,6 +60,10 @@ jobs:
           private-key: ${{ secrets.SECURITY_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
+      # Failure surfacing: a red run on the Actions tab plus the
+      # repository's scheduled-workflow failure email to maintainers.
+      # If that proves too quiet in practice, wire
+      # scripts/security/create-finding-issues.py in as a follow-up.
       - name: Live org audit
         env:
           GH_TOKEN: ${{ steps.audit-token.outputs.token }}

--- a/.github/workflows/secrets-hygiene.yml
+++ b/.github/workflows/secrets-hygiene.yml
@@ -1,0 +1,62 @@
+name: Secrets Hygiene Audit
+
+# Org-wide enforcement of the two standing secret-placement invariants
+# and the gated-environment drift checks. The full statement of each
+# invariant lives in scripts/security/check-secret-invariants.py.
+#
+# No pull_request trigger, deliberately: this workflow mints an app
+# token, and the bypass invariant it enforces forbids exactly that shape.
+# push/schedule/dispatch run the trusted default-branch copy only.
+on:
+  schedule:
+    # Weekly; drift in secret placement is slow-moving but must not be
+    # discovered only at the next migration.
+    - cron: "17 6 * * 1"
+  push:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/secrets-hygiene.yml'
+      - 'scripts/security/check-secret-invariants.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secrets-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Secret Invariant Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Fail-closed proof first: every red-team fixture must still be
+      # caught before the live audit's "clean" can be trusted.
+      - name: Red-team self-test
+        run: python3 scripts/security/check-secret-invariants.py --self-test
+
+      # SHA-pinned because this step mints a token used to read org-wide
+      # secret metadata (names/placement only, never values).
+      #
+      # NOTE: the glycemicgpt-security app must be granted read on
+      # repo Secrets, Environments, Administration and org Secrets for
+      # the live audit to run; until then this step fails closed with an
+      # HTTP 403 rather than reporting a hollow "clean".
+      - name: Generate token for glycemicgpt-security
+        id: audit-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SECURITY_APP_ID }}
+          private-key: ${{ secrets.SECURITY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Live org audit
+        env:
+          GH_TOKEN: ${{ steps.audit-token.outputs.token }}
+        run: python3 scripts/security/check-secret-invariants.py --live

--- a/.github/workflows/secrets-hygiene.yml
+++ b/.github/workflows/secrets-hygiene.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Python
+        # Toolcache Python; avoids the PEP 668 externally-managed-environment
+        # pip failure on ubuntu-latest (24.04+).
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
       - name: Install dependencies
         # pyyaml is for check-secret-invariants.py trigger parsing.
         run: pip install pyyaml==6.0.2

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -150,6 +150,47 @@ jobs:
             fi
           done <<< "$CANDIDATES"
 
+          # 3. Bypass invariant: a workflow that references a
+          # ruleset-bypass credential (MERGE/RELEASE app keys) must never
+          # carry a pull_request or pull_request_target trigger -- those
+          # events run PR-controlled code, handing the bypass credential
+          # to anyone who can open a pull request. workflow_run is the
+          # safe replacement (see the website repo's renovate-automerge.yml).
+          # auto-merge-renovate.yml is the one known offender, pinned until
+          # its workflow_run redesign lands -- remove the allowlist line in
+          # that same PR. scripts/security/check-secret-invariants.py
+          # enforces the same invariant org-wide on a schedule.
+          BYPASS_ALLOW="auto-merge-renovate.yml"
+          CANDIDATES=$(grep -rl --include='*.yml' --include='*.yaml' \
+                            -E 'secrets\.(MERGE|RELEASE)_APP_(ID|PRIVATE_KEY)' .github/workflows/ 2>/dev/null \
+                       | grep -v "/$SELF$" || true)
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ "$(basename "$f")" = "$BYPASS_ALLOW" ] && continue
+            if grep -nE '^[[:space:]]*pull_request(_target)?:' "$f" >/dev/null; then
+              echo "::error file=$f::Ruleset-bypass credential (MERGE/RELEASE app key) referenced in a workflow with a pull_request/pull_request_target trigger. Use workflow_run so only the trusted default-branch copy can mint the token."
+              FAILED=1
+            fi
+          done <<< "$CANDIDATES"
+
+          # 4. SA invariant (reference form): a 1Password service-account
+          # token unlocks a vault, and for secret exfiltration the attack
+          # is a read -- so it must never be referenced in a workflow that
+          # a pull request can trigger. No allowlist: there are zero such
+          # references today and none may be added. The scheduled
+          # secrets-hygiene audit enforces the existence form (no SA token
+          # as a plain secret on a repo with write actors) org-wide.
+          CANDIDATES=$(grep -rl --include='*.yml' --include='*.yaml' \
+                            -E 'secrets\.[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT' .github/workflows/ 2>/dev/null \
+                       | grep -v "/$SELF$" || true)
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if grep -nE '^[[:space:]]*pull_request(_target)?:' "$f" >/dev/null; then
+              echo "::error file=$f::Service-account token referenced in a workflow with a pull_request/pull_request_target trigger. A poisoned PR could read the vault credential; mint it only in push/schedule/workflow_run contexts, ideally behind a gated environment."
+              FAILED=1
+            fi
+          done <<< "$CANDIDATES"
+
           if [ "$FAILED" -ne 0 ]; then
             echo "::error::Drift guard failed -- see annotations above."
             exit 1

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -58,7 +58,8 @@ jobs:
           python-version: '3.12'
 
       - name: Install zizmor
-        run: pip install zizmor==1.5.2
+        # pyyaml is for check-secret-invariants.py trigger parsing.
+        run: pip install zizmor==1.5.2 pyyaml==6.0.2
 
       - name: Run zizmor (advisory)
         # ADVISORY MODE: does not fail the build. We collect findings,
@@ -150,49 +151,26 @@ jobs:
             fi
           done <<< "$CANDIDATES"
 
-          # 3. Bypass invariant: a workflow that references a
-          # ruleset-bypass credential (MERGE/RELEASE app keys) must never
-          # carry a pull_request or pull_request_target trigger -- those
-          # events run PR-controlled code, handing the bypass credential
-          # to anyone who can open a pull request. workflow_run is the
-          # safe replacement (see the website repo's renovate-automerge.yml).
-          # auto-merge-renovate.yml is the one known offender, pinned until
-          # its workflow_run redesign lands -- remove the allowlist line in
-          # that same PR. scripts/security/check-secret-invariants.py
-          # enforces the same invariant org-wide on a schedule.
-          BYPASS_ALLOW="auto-merge-renovate.yml"
-          CANDIDATES=$(grep -rl --include='*.yml' --include='*.yaml' \
-                            -E 'secrets\.(MERGE|RELEASE)_APP_(ID|PRIVATE_KEY)' .github/workflows/ 2>/dev/null \
-                       | grep -v "/$SELF$" || true)
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            [ "$(basename "$f")" = "$BYPASS_ALLOW" ] && continue
-            if grep -nE '^[[:space:]]*pull_request(_target)?:' "$f" >/dev/null; then
-              echo "::error file=$f::Ruleset-bypass credential (MERGE/RELEASE app key) referenced in a workflow with a pull_request/pull_request_target trigger. Use workflow_run so only the trusted default-branch copy can mint the token."
-              FAILED=1
-            fi
-          done <<< "$CANDIDATES"
-
-          # 4. SA invariant (reference form): a 1Password service-account
-          # token unlocks a vault, and for secret exfiltration the attack
-          # is a read -- so it must never be referenced in a workflow that
-          # a pull request can trigger. No allowlist: there are zero such
-          # references today and none may be added. The scheduled
-          # secrets-hygiene audit enforces the existence form (no SA token
-          # as a plain secret on a repo with write actors) org-wide.
-          CANDIDATES=$(grep -rl --include='*.yml' --include='*.yaml' \
-                            -E 'secrets\.[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT' .github/workflows/ 2>/dev/null \
-                       | grep -v "/$SELF$" || true)
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            if grep -nE '^[[:space:]]*pull_request(_target)?:' "$f" >/dev/null; then
-              echo "::error file=$f::Service-account token referenced in a workflow with a pull_request/pull_request_target trigger. A poisoned PR could read the vault credential; mint it only in push/schedule/workflow_run contexts, ideally behind a gated environment."
-              FAILED=1
-            fi
-          done <<< "$CANDIDATES"
-
           if [ "$FAILED" -ne 0 ]; then
             echo "::error::Drift guard failed -- see annotations above."
             exit 1
           fi
           echo "Drift guard passed."
+
+      # Bypass + SA invariants (GLY-56.24): no workflow referencing a
+      # ruleset-bypass credential (MERGE/RELEASE app keys) or a 1Password
+      # service-account token may carry a pull_request/pull_request_target
+      # trigger. One implementation shared with the scheduled org-wide
+      # secrets-hygiene audit -- the script parses trigger YAML (catching
+      # `on: [pull_request]` and quoted/flow forms a grep would miss),
+      # runs its red-team self-test first, and carries the allowlist pins
+      # with their removal conditions.
+      #
+      # PR-time runs execute the PR's copy of this workflow and script, so
+      # this gate is a tripwire for mistakes; the scheduled audit of the
+      # trusted develop/main copies is the control for deliberate evasion.
+      - name: Secret-placement invariants
+        run: |
+          python3 scripts/security/check-secret-invariants.py --self-test
+          python3 scripts/security/check-secret-invariants.py \
+            --repo-local .github/workflows --repo-name "${GITHUB_REPOSITORY##*/}"

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -166,9 +166,12 @@ SA_ALLOWLIST: dict[tuple[str, str], str] = {
 # pull_request/pull_request_target context today. Both are replaced by
 # the workflow_run + direct-REST merge redesign (the website
 # renovate-automerge.yml template); remove each entry in that PR.
-# NOTE: a pin skips the whole file, so the pinned file is a blind spot
-# for ADDITIONAL bypass misuse until its entry is removed -- another
-# reason these pins must be short-lived.
+# SCOPE: a pin ONLY downgrades this file's BYPASS-PR finding (the known,
+# tracked bypass-credential mint) to a warning. It is NOT a whole-file
+# skip -- a SECRETS-DUMP (toJSON(secrets)/dynamic index) or an SA-REF-PR
+# in the same file still fails, so pinning cannot be used to smuggle a
+# different exfil into a known-offender file. Keep the pins short-lived
+# anyway: the tracked bypass mint itself stays live until removed.
 BYPASS_ALLOWLIST: set[tuple[str, str]] = {
     ("GlycemicGPT", ".github/workflows/auto-merge-renovate.yml"),
     ("android-unofficial", ".github/workflows/auto-merge-renovate.yml"),
@@ -864,6 +867,28 @@ def self_test() -> int:
             ],
         },
         set(),
+        warn_codes={"BYPASS-PENDING"},
+    )
+    # 12b. The pin downgrades only this file's BYPASS-PR mint -- a
+    # SECRETS-DUMP smuggled into the same pinned file still fails hard
+    # (the pin is not a whole-file skip).
+    expect(
+        "bypass-pinned-still-catches-dump",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "GlycemicGPT",
+                    workflows={
+                        ".github/workflows/auto-merge-renovate.yml": (
+                            bypass_wf("on:\n  pull_request:")
+                            + "      - run: echo '${{ toJSON(secrets) }}'\n"
+                        )
+                    },
+                )
+            ],
+        },
+        {"SECRETS-DUMP"},
         warn_codes={"BYPASS-PENDING"},
     )
     # 13. Bypass credential in a push-only workflow is fine.

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""Org-wide secret-placement invariants and environment drift checks.
+
+Two standing invariants (mirrors the guard comment in the website repo's
+renovate-automerge.yml -- workflow_run executes the default-branch copy,
+so a PR cannot substitute its own steps into a job that mints a
+privileged token):
+
+  SA invariant      No 1Password service-account token may exist as a
+                    plain (non-environment) Actions secret on a repo that
+                    has -- or could gain -- a write actor. Either the
+                    token is environment-gated behind required reviewers,
+                    or the repo is proven latent-safe (zero non-admin
+                    write actors) and tripwired below.
+
+  Bypass invariant  No workflow that wields a ruleset-bypass credential
+                    (merge/release app key today; add any new bypass
+                    actor's secret to BYPASS_SECRET_RE) may carry a
+                    pull_request or pull_request_target trigger. Those
+                    events run PR-controlled code -- pull_request with the
+                    PR-head copy of the workflow, pull_request_target
+                    with secrets in scope of PR-labelled context -- which
+                    hands the bypass credential to anyone who can open a
+                    pull request.
+
+Two drift checks (scaffolding for the gated-environment migration; the
+EXPECTED_GATED_ENVIRONMENTS map is populated as each secret moves behind
+an approval-gated environment):
+
+  env-secrets drift  Each gated environment must hold exactly its
+                     expected secret list, and none of those secrets may
+                     reappear as a plain repo secret (plain-copy re-add).
+
+  reviewer drift     Every environment on every org repo must carry a
+                     required_reviewers protection rule with >= 1
+                     reviewer. Pre-existing ungated environments are
+                     pinned in UNGATED_ENV_BASELINE; any environment not
+                     in that baseline fails.
+
+Modes:
+  --self-test  Run the bundled red-team fixtures and assert every
+               violation class is caught (fail-closed proof). No network.
+               CI runs this before every live audit.
+  --live       Audit the real org via the GitHub API (gh CLI; needs
+               GH_TOKEN with: repo Secrets read, Environments read,
+               Administration read, Contents read; org Secrets read).
+
+Exit codes: 0 clean, 1 violations, 2 operational error (missing token or
+permissions -- the audit fails closed rather than skipping silently).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+import subprocess
+import sys
+
+ORG = "lumose-health"
+
+# A secret with this shape is a 1Password service-account token: the
+# credential that unlocks a vault. For PPE the attack is a read, so a
+# plain copy on a repo with a write actor is a standing exfil path.
+SA_SECRET_RE = re.compile(r"^[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT$")
+
+# Workflow-text reference to a ruleset-bypass credential. MERGE and
+# RELEASE are the two app identities with org-ruleset bypass; extend this
+# pattern in the same PR that grants any new actor bypass.
+BYPASS_REF_RE = re.compile(r"secrets\.(MERGE|RELEASE)_APP_(ID|PRIVATE_KEY)")
+
+# Workflow-text reference to any SA token (reference form of the SA
+# invariant -- existence is checked against the secrets API above).
+SA_REF_RE = re.compile(r"secrets\.[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT")
+
+# Matches the trigger key at line start (same shape as the grep guard in
+# workflow-lint.yml). `pull_request_target` is included deliberately.
+PR_TRIGGER_RE = re.compile(r"^\s*pull_request(_target)?\s*:", re.MULTILINE)
+
+# pull_request_target executes the BASE-ref copy of a workflow, so the
+# integration branch matters as much as the default branch.
+EXTRA_BRANCHES = ("develop",)
+
+# ---------------------------------------------------------------------
+# Pinned allowlists. These only ever ratchet DOWN: entries are removed as
+# migrations land, never added without the same scrutiny that created
+# this file. Every entry names its removal condition.
+# ---------------------------------------------------------------------
+
+# (repo, secret) -> reason
+#   "pending-migration": known violation, tracked by the gated-environment
+#       migration; surfaces as a warning so it is never invisible.
+#   "latent-safe": allowed only while the repo has zero non-admin write
+#       actors; the check itself is the tripwire and fails the moment a
+#       write actor appears.
+SA_ALLOWLIST: dict[tuple[str, str], str] = {
+    # Monorepo 1Password bootstrap token; moves behind an approval-gated
+    # environment with the crown-jewel migration. Remove with that PR.
+    ("GlycemicGPT", "BACKEND_ACTIONS_SERVICE_ACCOUNT"): "pending-migration",
+    # Android signing bootstrap; latent-safe while android-unofficial has
+    # no non-admin write actor. Tripwired -- do not convert to
+    # "pending-migration" to silence a trip; gate the environment instead.
+    ("android-unofficial", "ANDROID_ACTIONS_SERVICE_ACCOUNT"): "latent-safe",
+}
+
+# (repo, workflow path) entries that mint a bypass credential from a
+# pull_request/pull_request_target context today. Both are replaced by
+# the workflow_run + direct-REST merge redesign (the website
+# renovate-automerge.yml template); remove each entry in that PR.
+BYPASS_ALLOWLIST: set[tuple[str, str]] = {
+    ("GlycemicGPT", ".github/workflows/auto-merge-renovate.yml"),
+    ("android-unofficial", ".github/workflows/auto-merge-renovate.yml"),
+}
+
+# repo -> environment -> exact set of secret names the environment must
+# hold. Populated as secrets move behind gated environments; empty while
+# no gated environments exist yet.
+EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {}
+
+# Environments that predate the gating work and hold zero secrets. They
+# surface as warnings, not failures; the gating migration either gates or
+# removes them, deleting these pins.
+UNGATED_ENV_BASELINE: set[tuple[str, str]] = {
+    ("GlycemicGPT", "copilot"),
+    ("website", "github-pages"),
+}
+
+
+class OperationalError(Exception):
+    """The audit could not gather ground truth. Fail closed (exit 2)."""
+
+
+# ---------------------------------------------------------------------
+# Checks. Each takes the org-state model and returns (violations,
+# warnings) as lists of strings. The model shape:
+#
+# {
+#   "org_secrets": [name, ...],
+#   "repos": [
+#     {
+#       "name": str,
+#       "secrets": [name, ...],              # plain repo-level secrets
+#       "write_actors": [login, ...],        # non-admin push/maintain
+#       "workflows": {path: text, ...},      # default + EXTRA_BRANCHES
+#       "environments": [
+#         {"name": str, "required_reviewers": int, "secrets": [name, ...]}
+#       ],
+#     }
+#   ],
+# }
+# ---------------------------------------------------------------------
+
+
+def check_sa_invariant(state: dict) -> tuple[list[str], list[str]]:
+    violations, warnings = [], []
+    for name in state["org_secrets"]:
+        if SA_SECRET_RE.match(name):
+            violations.append(
+                f"SA-ORG: org secret {name} is a service-account token "
+                f"visible to every repo; SA tokens must be per-repo and "
+                f"environment-gated"
+            )
+    for repo in state["repos"]:
+        for name in repo["secrets"]:
+            if not SA_SECRET_RE.match(name):
+                continue
+            reason = SA_ALLOWLIST.get((repo["name"], name))
+            if reason is None:
+                violations.append(
+                    f"SA-PLAIN: {repo['name']}/{name} is a plain repo "
+                    f"secret; gate it behind a required-reviewer "
+                    f"environment or pin it here with a removal condition"
+                )
+            elif reason == "latent-safe":
+                if repo["write_actors"]:
+                    violations.append(
+                        f"SA-TRIPWIRE: {repo['name']}/{name} was pinned "
+                        f"latent-safe but the repo now has write actors "
+                        f"({', '.join(sorted(repo['write_actors']))}); "
+                        f"gate the token before granting write"
+                    )
+            elif reason == "pending-migration":
+                warnings.append(
+                    f"SA-PENDING: {repo['name']}/{name} is a known plain "
+                    f"copy awaiting the gated-environment migration"
+                )
+    return violations, warnings
+
+
+def check_bypass_invariant(state: dict) -> tuple[list[str], list[str]]:
+    violations, warnings = [], []
+    for repo in state["repos"]:
+        for path, text in repo["workflows"].items():
+            has_pr_trigger = bool(PR_TRIGGER_RE.search(text))
+            if not has_pr_trigger:
+                continue
+            if BYPASS_REF_RE.search(text):
+                if (repo["name"], path) in BYPASS_ALLOWLIST:
+                    warnings.append(
+                        f"BYPASS-PENDING: {repo['name']}/{path} mints a "
+                        f"bypass credential from a pull_request context; "
+                        f"pinned until the workflow_run redesign lands"
+                    )
+                else:
+                    violations.append(
+                        f"BYPASS-PR: {repo['name']}/{path} references a "
+                        f"ruleset-bypass credential and carries a "
+                        f"pull_request/pull_request_target trigger; use "
+                        f"workflow_run (see website renovate-automerge.yml)"
+                    )
+            if SA_REF_RE.search(text):
+                violations.append(
+                    f"SA-REF-PR: {repo['name']}/{path} references a "
+                    f"service-account token in a workflow with a "
+                    f"pull_request/pull_request_target trigger; a poisoned "
+                    f"PR could read the vault credential"
+                )
+    return violations, warnings
+
+
+def check_env_secrets_drift(state: dict) -> tuple[list[str], list[str]]:
+    violations: list[str] = []
+    repos_by_name = {r["name"]: r for r in state["repos"]}
+    for repo_name, envs in EXPECTED_GATED_ENVIRONMENTS.items():
+        repo = repos_by_name.get(repo_name)
+        if repo is None:
+            violations.append(f"ENV-DRIFT: expected gated repo {repo_name} not found")
+            continue
+        actual_envs = {e["name"]: e for e in repo["environments"]}
+        for env_name, expected_secrets in envs.items():
+            env = actual_envs.get(env_name)
+            if env is None:
+                violations.append(
+                    f"ENV-DRIFT: {repo_name} is missing gated environment {env_name}"
+                )
+                continue
+            actual = set(env["secrets"])
+            if actual != expected_secrets:
+                missing = expected_secrets - actual
+                extra = actual - expected_secrets
+                detail = []
+                if missing:
+                    detail.append(f"missing: {', '.join(sorted(missing))}")
+                if extra:
+                    detail.append(f"unexpected: {', '.join(sorted(extra))}")
+                violations.append(
+                    f"ENV-DRIFT: {repo_name}/{env_name} secret list "
+                    f"deviates ({'; '.join(detail)})"
+                )
+            readded = expected_secrets & set(repo["secrets"])
+            if readded:
+                violations.append(
+                    f"ENV-READD: {repo_name} holds plain copies of gated "
+                    f"secrets: {', '.join(sorted(readded))}"
+                )
+    return violations, []
+
+
+def check_reviewer_drift(state: dict) -> tuple[list[str], list[str]]:
+    violations, warnings = [], []
+    for repo in state["repos"]:
+        for env in repo["environments"]:
+            if env["required_reviewers"] >= 1:
+                continue
+            key = (repo["name"], env["name"])
+            if key in UNGATED_ENV_BASELINE:
+                warnings.append(
+                    f"ENV-BASELINE: {repo['name']}/{env['name']} predates "
+                    f"gating and has no required reviewers; resolve with "
+                    f"the gated-environment migration"
+                )
+            else:
+                violations.append(
+                    f"ENV-UNGATED: {repo['name']}/{env['name']} has no "
+                    f"required_reviewers rule; every environment must "
+                    f"require >= 1 reviewer"
+                )
+    return violations, warnings
+
+
+CHECKS = (
+    check_sa_invariant,
+    check_bypass_invariant,
+    check_env_secrets_drift,
+    check_reviewer_drift,
+)
+
+
+def run_checks(state: dict) -> tuple[list[str], list[str]]:
+    violations: list[str] = []
+    warnings: list[str] = []
+    for check in CHECKS:
+        v, w = check(state)
+        violations.extend(v)
+        warnings.extend(w)
+    return violations, warnings
+
+
+# ---------------------------------------------------------------------
+# Live collection via the gh CLI.
+# ---------------------------------------------------------------------
+
+
+def gh_api(path: str, *, paginate: bool = False) -> object:
+    cmd = ["gh", "api", path]
+    if paginate:
+        cmd.append("--paginate")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        if "HTTP 404" in stderr:
+            return None
+        raise OperationalError(
+            f"gh api {path} failed: {stderr or 'unknown error'}. If this "
+            f"is HTTP 403, the token lacks a required permission (repo: "
+            f"Secrets/Environments/Administration/Contents read; org: "
+            f"Secrets read)."
+        )
+    if not paginate:
+        return json.loads(proc.stdout)
+    # --paginate emits one JSON document per page, back to back; decode
+    # them all rather than depending on gh's newer --slurp flag.
+    merged: list = []
+    decoder = json.JSONDecoder()
+    idx, text = 0, proc.stdout.strip()
+    while idx < len(text):
+        page, end = decoder.raw_decode(text, idx)
+        merged.extend(page if isinstance(page, list) else [page])
+        idx = end
+        while idx < len(text) and text[idx] in " \n\r\t":
+            idx += 1
+    return merged
+
+
+def collect_live_state() -> dict:
+    org_secrets = gh_api(f"/orgs/{ORG}/actions/secrets")
+    if org_secrets is None:
+        raise OperationalError("org secrets endpoint returned 404")
+    repo_names = [
+        r["name"] for r in gh_api(f"/orgs/{ORG}/repos?per_page=100", paginate=True)
+    ]
+    repos = []
+    for name in sorted(repo_names):
+        secrets_resp = gh_api(f"/repos/{ORG}/{name}/actions/secrets")
+        secrets = [s["name"] for s in (secrets_resp or {}).get("secrets", [])]
+
+        collaborators = (
+            gh_api(
+                f"/repos/{ORG}/{name}/collaborators?affiliation=all&per_page=100",
+                paginate=True,
+            )
+            or []
+        )
+        write_actors = [
+            c["login"]
+            for c in collaborators
+            if c["permissions"].get("push") and not c["permissions"].get("admin")
+        ]
+
+        default_branch = gh_api(f"/repos/{ORG}/{name}")["default_branch"]
+        workflows: dict[str, str] = {}
+        for branch in dict.fromkeys((default_branch, *EXTRA_BRANCHES)):
+            listing = gh_api(
+                f"/repos/{ORG}/{name}/contents/.github/workflows?ref={branch}"
+            )
+            if listing is None:
+                continue
+            for entry in listing:
+                if not entry["name"].endswith((".yml", ".yaml")):
+                    continue
+                if entry["path"] in workflows:
+                    continue
+                blob = gh_api(f"/repos/{ORG}/{name}/git/blobs/{entry['sha']}")
+                workflows[entry["path"]] = base64.b64decode(blob["content"]).decode(
+                    "utf-8", errors="replace"
+                )
+
+        envs_resp = gh_api(f"/repos/{ORG}/{name}/environments")
+        environments = []
+        for env in (envs_resp or {}).get("environments", []):
+            reviewer_rules = [
+                r
+                for r in env.get("protection_rules", [])
+                if r.get("type") == "required_reviewers"
+            ]
+            reviewer_count = sum(len(r.get("reviewers", [])) for r in reviewer_rules)
+            env_secrets_resp = gh_api(
+                f"/repos/{ORG}/{name}/environments/{env['name']}/secrets"
+            )
+            environments.append(
+                {
+                    "name": env["name"],
+                    "required_reviewers": reviewer_count,
+                    "secrets": [
+                        s["name"] for s in (env_secrets_resp or {}).get("secrets", [])
+                    ],
+                }
+            )
+
+        repos.append(
+            {
+                "name": name,
+                "secrets": secrets,
+                "write_actors": write_actors,
+                "workflows": workflows,
+                "environments": environments,
+            }
+        )
+    return {
+        "org_secrets": [s["name"] for s in org_secrets.get("secrets", [])],
+        "repos": repos,
+    }
+
+
+# ---------------------------------------------------------------------
+# Red-team self-test. Every violation class must be caught, and every
+# allowlisted shape must NOT fail. This runs in CI before the live audit;
+# if a refactor breaks a check, the audit goes red before it can go blind.
+# ---------------------------------------------------------------------
+
+
+def _repo(name: str, **overrides: object) -> dict:
+    base: dict = {
+        "name": name,
+        "secrets": [],
+        "write_actors": [],
+        "workflows": {},
+        "environments": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def expect(label: str, state: dict, codes: set[str], *, clean: bool = False):
+        violations, _ = run_checks(state)
+        got = {v.split(":", 1)[0] for v in violations}
+        if clean and violations:
+            failures.append(f"{label}: expected clean, got {violations}")
+        elif not clean and not codes <= got:
+            failures.append(f"{label}: expected codes {codes}, got {got or 'none'}")
+
+    pr_bypass_wf = (
+        "on:\n  pull_request:\njobs:\n  j:\n    steps:\n"
+        "      - uses: actions/create-github-app-token@sha\n"
+        "        with:\n          app-id: ${{ secrets.MERGE_APP_ID }}\n"
+        "          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}\n"
+    )
+    prt_bypass_wf = pr_bypass_wf.replace("pull_request:", "pull_request_target:")
+    sa_ref_wf = (
+        "on:\n  pull_request:\njobs:\n  j:\n    steps:\n"
+        "      - run: op read op://x\n        env:\n"
+        "          OP_SERVICE_ACCOUNT_TOKEN: "
+        "${{ secrets.EVIL_ACTIONS_SERVICE_ACCOUNT }}\n"
+    )
+    push_bypass_wf = pr_bypass_wf.replace("pull_request:", "push:")
+
+    empty = {"org_secrets": [], "repos": []}
+
+    # 1. SA token as an unpinned plain repo secret -> SA-PLAIN.
+    expect(
+        "sa-plain",
+        {
+            "org_secrets": [],
+            "repos": [_repo("evil-repo", secrets=["EVIL_ACTIONS_SERVICE_ACCOUNT"])],
+        },
+        {"SA-PLAIN"},
+    )
+    # 2. Latent-safe pin trips when the repo gains a write actor.
+    expect(
+        "sa-tripwire",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "android-unofficial",
+                    secrets=["ANDROID_ACTIONS_SERVICE_ACCOUNT"],
+                    write_actors=["mallory"],
+                )
+            ],
+        },
+        {"SA-TRIPWIRE"},
+    )
+    # 3. Pending-migration pin warns but does not fail.
+    expect(
+        "sa-pending-clean",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo("GlycemicGPT", secrets=["BACKEND_ACTIONS_SERVICE_ACCOUNT"])
+            ],
+        },
+        set(),
+        clean=True,
+    )
+    # 4. SA token as an org-wide secret -> SA-ORG.
+    expect(
+        "sa-org",
+        {"org_secrets": ["ROGUE_ACTIONS_SERVICE_ACCOUNT"], "repos": []},
+        {"SA-ORG"},
+    )
+    # 5. Bypass credential in a pull_request workflow -> BYPASS-PR.
+    expect(
+        "bypass-pr",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo("evil-repo", workflows={".github/workflows/x.yml": pr_bypass_wf})
+            ],
+        },
+        {"BYPASS-PR"},
+    )
+    # 6. Same via pull_request_target -> BYPASS-PR.
+    expect(
+        "bypass-prt",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo("evil-repo", workflows={".github/workflows/x.yml": prt_bypass_wf})
+            ],
+        },
+        {"BYPASS-PR"},
+    )
+    # 7. Allowlisted bypass workflow does not fail (warns only).
+    expect(
+        "bypass-pinned-clean",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "GlycemicGPT",
+                    workflows={
+                        ".github/workflows/auto-merge-renovate.yml": pr_bypass_wf
+                    },
+                )
+            ],
+        },
+        set(),
+        clean=True,
+    )
+    # 8. Bypass credential in a push workflow is fine.
+    expect(
+        "bypass-push-clean",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo("any", workflows={".github/workflows/x.yml": push_bypass_wf})
+            ],
+        },
+        set(),
+        clean=True,
+    )
+    # 9. SA token referenced from a pull_request workflow -> SA-REF-PR.
+    expect(
+        "sa-ref-pr",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo("evil-repo", workflows={".github/workflows/x.yml": sa_ref_wf})
+            ],
+        },
+        {"SA-REF-PR"},
+    )
+    # 10. New environment without required reviewers -> ENV-UNGATED.
+    expect(
+        "env-ungated",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "evil-repo",
+                    environments=[
+                        {"name": "prod", "required_reviewers": 0, "secrets": []}
+                    ],
+                )
+            ],
+        },
+        {"ENV-UNGATED"},
+    )
+    # 11. Baseline-pinned environment warns but does not fail.
+    expect(
+        "env-baseline-clean",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "GlycemicGPT",
+                    environments=[
+                        {"name": "copilot", "required_reviewers": 0, "secrets": []}
+                    ],
+                )
+            ],
+        },
+        set(),
+        clean=True,
+    )
+    # 12. Gated environment drift: exercised against a temporary
+    # expectation map (missing env, wrong secret set, plain re-add).
+    global EXPECTED_GATED_ENVIRONMENTS
+    saved = EXPECTED_GATED_ENVIRONMENTS
+    EXPECTED_GATED_ENVIRONMENTS = {"GlycemicGPT": {"secrets-merge": {"MERGE_SA_TOKEN"}}}
+    try:
+        expect(
+            "env-drift-missing",
+            {"org_secrets": [], "repos": [_repo("GlycemicGPT")]},
+            {"ENV-DRIFT"},
+        )
+        expect(
+            "env-drift-set",
+            {
+                "org_secrets": [],
+                "repos": [
+                    _repo(
+                        "GlycemicGPT",
+                        environments=[
+                            {
+                                "name": "secrets-merge",
+                                "required_reviewers": 1,
+                                "secrets": ["WRONG_TOKEN"],
+                            }
+                        ],
+                    )
+                ],
+            },
+            {"ENV-DRIFT"},
+        )
+        expect(
+            "env-readd",
+            {
+                "org_secrets": [],
+                "repos": [
+                    _repo(
+                        "GlycemicGPT",
+                        secrets=["MERGE_SA_TOKEN"],
+                        environments=[
+                            {
+                                "name": "secrets-merge",
+                                "required_reviewers": 1,
+                                "secrets": ["MERGE_SA_TOKEN"],
+                            }
+                        ],
+                    )
+                ],
+            },
+            {"ENV-READD"},
+        )
+    finally:
+        EXPECTED_GATED_ENVIRONMENTS = saved
+
+    # 13. Fully clean state passes.
+    expect("clean", empty, set(), clean=True)
+
+    if failures:
+        for f in failures:
+            print(f"SELF-TEST FAIL {f}", file=sys.stderr)
+        return 1
+    print(f"self-test: all {13} red-team fixtures behaved as expected")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--self-test", action="store_true")
+    mode.add_argument("--live", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        state = collect_live_state()
+    except OperationalError as exc:
+        print(f"::error::secrets audit could not run: {exc}")
+        return 2
+
+    violations, warnings = run_checks(state)
+    for w in warnings:
+        print(f"::warning::{w}")
+    for v in violations:
+        print(f"::error::{v}")
+    if violations:
+        print(f"secrets audit: {len(violations)} violation(s)")
+        return 1
+    print(
+        f"secrets audit: clean ({len(state['repos'])} repos, "
+        f"{len(warnings)} pinned warning(s))"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -380,7 +380,12 @@ def gh_api(path: str, *, paginate: bool = False, allow_404: bool = False) -> Any
     cmd = ["gh", "api", path]
     if paginate:
         cmd.append("--paginate")
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        # Bounded so a stalled CLI or hung request fails closed (exit 2)
+        # rather than hanging the audit forever.
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except subprocess.TimeoutExpired as exc:
+        raise OperationalError(f"gh api {path} timed out after 120s") from exc
     if proc.returncode != 0:
         stderr = proc.stderr.strip()
         if "HTTP 404" in stderr:
@@ -448,11 +453,12 @@ def collect_live_state() -> dict:
     repo_names = [r["name"] for r in gh_api_list(f"/orgs/{ORG}/repos")]
     repos = []
     for name in sorted(repo_names):
-        repo_meta = gh_api(f"/repos/{ORG}/{name}", allow_404=True)
-        if repo_meta is None:
-            # Deleted or renamed between the org listing and this fetch.
-            print(f"::warning::repo {name} vanished mid-audit; skipping")
-            continue
+        # A 404 here means the repo was renamed or deleted between the org
+        # listing and this fetch. A renamed repo is still active, so
+        # silently skipping it would report "clean" while a live repo went
+        # unaudited. Fail closed (exit 2); the next run sees consistent
+        # state.
+        repo_meta = gh_api(f"/repos/{ORG}/{name}")
 
         secrets = [
             s["name"]

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -15,7 +15,7 @@ privileged token):
 
   Bypass invariant  No workflow that wields a ruleset-bypass credential
                     (merge/release app key today; add any new bypass
-                    actor's secret to BYPASS_SECRET_RE) may carry a
+                    actor's secret to BYPASS_REF_RE) may carry a
                     pull_request or pull_request_target trigger. Those
                     events run PR-controlled code -- pull_request with the
                     PR-head copy of the workflow, pull_request_target
@@ -38,15 +38,34 @@ an approval-gated environment):
                      in that baseline fails.
 
 Modes:
-  --self-test  Run the bundled red-team fixtures and assert every
-               violation class is caught (fail-closed proof). No network.
-               CI runs this before every live audit.
-  --live       Audit the real org via the GitHub API (gh CLI; needs
-               GH_TOKEN with: repo Secrets read, Environments read,
-               Administration read, Contents read; org Secrets read).
+  --self-test        Run the bundled red-team fixtures and assert every
+                     violation class is caught, including the evasive
+                     trigger/accessor syntax variants (fail-closed
+                     proof). No network. CI runs this before every live
+                     audit.
+  --repo-local DIR   Run the bypass/SA reference invariants against a
+                     local workflow directory (used by workflow-lint on
+                     every PR; no network, no token). Requires
+                     --repo-name so allowlist pins resolve.
+  --live             Audit the real org via the GitHub API (gh CLI;
+                     needs GH_TOKEN with: repo Secrets read,
+                     Environments read, Administration read, Contents
+                     read; org Secrets read).
 
-Exit codes: 0 clean, 1 violations, 2 operational error (missing token or
-permissions -- the audit fails closed rather than skipping silently).
+Trigger detection parses the workflow YAML (all documented `on:` shapes:
+mapping, string, flow/block sequence, quoted keys). A workflow that
+references a guarded secret but does not parse as YAML is treated as
+violating -- fail closed, not blind.
+
+Static limits, stated honestly: an attacker with write access can still
+obfuscate an accessor beyond static reach (e.g. `secrets[format(...)]`).
+These checks are tripwires for the direct forms; the org ruleset, review
+requirements, and this scheduled audit of trusted-branch copies are the
+controls for deliberate evasion.
+
+Exit codes: 0 clean, 1 violations, 2 operational error (missing token,
+missing permissions, truncated API listing -- the audit fails closed
+rather than skipping silently).
 """
 
 from __future__ import annotations
@@ -54,9 +73,12 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import pathlib
 import re
 import subprocess
 import sys
+import urllib.parse
+from typing import Any
 
 ORG = "lumose-health"
 
@@ -65,18 +87,23 @@ ORG = "lumose-health"
 # plain copy on a repo with a write actor is a standing exfil path.
 SA_SECRET_RE = re.compile(r"^[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT$")
 
-# Workflow-text reference to a ruleset-bypass credential. MERGE and
-# RELEASE are the two app identities with org-ruleset bypass; extend this
-# pattern in the same PR that grants any new actor bypass.
-BYPASS_REF_RE = re.compile(r"secrets\.(MERGE|RELEASE)_APP_(ID|PRIVATE_KEY)")
+# Workflow-text reference to a ruleset-bypass credential, in either
+# documented accessor form: `secrets.NAME` or `secrets['NAME']` /
+# `secrets["NAME"]`. MERGE and RELEASE are the two app identities with
+# org-ruleset bypass; extend this pattern in the same PR that grants any
+# new actor bypass.
+BYPASS_REF_RE = re.compile(
+    r"secrets\s*(?:\.|\[\s*['\"])(MERGE|RELEASE)_APP_(ID|PRIVATE_KEY)\b"
+)
 
-# Workflow-text reference to any SA token (reference form of the SA
-# invariant -- existence is checked against the secrets API above).
-SA_REF_RE = re.compile(r"secrets\.[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT")
+# Workflow-text reference to any SA token, both accessor forms (the
+# reference form of the SA invariant -- existence is checked against the
+# secrets API above).
+SA_REF_RE = re.compile(
+    r"secrets\s*(?:\.|\[\s*['\"])[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT\b"
+)
 
-# Matches the trigger key at line start (same shape as the grep guard in
-# workflow-lint.yml). `pull_request_target` is included deliberately.
-PR_TRIGGER_RE = re.compile(r"^\s*pull_request(_target)?\s*:", re.MULTILINE)
+PR_TRIGGERS = frozenset({"pull_request", "pull_request_target"})
 
 # pull_request_target executes the BASE-ref copy of a workflow, so the
 # integration branch matters as much as the default branch.
@@ -108,6 +135,9 @@ SA_ALLOWLIST: dict[tuple[str, str], str] = {
 # pull_request/pull_request_target context today. Both are replaced by
 # the workflow_run + direct-REST merge redesign (the website
 # renovate-automerge.yml template); remove each entry in that PR.
+# NOTE: a pin skips the whole file, so the pinned file is a blind spot
+# for ADDITIONAL bypass misuse until its entry is removed -- another
+# reason these pins must be short-lived.
 BYPASS_ALLOWLIST: set[tuple[str, str]] = {
     ("GlycemicGPT", ".github/workflows/auto-merge-renovate.yml"),
     ("android-unofficial", ".github/workflows/auto-merge-renovate.yml"),
@@ -131,6 +161,43 @@ class OperationalError(Exception):
     """The audit could not gather ground truth. Fail closed (exit 2)."""
 
 
+def workflow_has_pr_trigger(text: str) -> bool:
+    """True when the workflow's `on:` includes a pull_request trigger.
+
+    Parses the YAML rather than grepping, so every documented trigger
+    shape is recognized: `on: pull_request`, `on: [push, pull_request]`,
+    `on: {pull_request: ...}`, block mappings, and quoted keys. A
+    workflow that does not parse is treated as HAVING the trigger: this
+    function is only consulted for workflows that reference a guarded
+    secret, and an unparseable one must fail the audit, not slip past it.
+    """
+    try:
+        import yaml
+    except ImportError as exc:  # fail closed, never skip silently
+        raise OperationalError(
+            "PyYAML is required for trigger parsing (pip install pyyaml)"
+        ) from exc
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return True
+    if not isinstance(doc, dict):
+        return False
+    # YAML 1.1 parses an unquoted `on` key as boolean True.
+    triggers = doc.get(True, doc.get("on"))
+    if triggers is None:
+        return False
+    if isinstance(triggers, str):
+        names: set[Any] = {triggers}
+    elif isinstance(triggers, list):
+        names = set(triggers)
+    elif isinstance(triggers, dict):
+        names = set(triggers.keys())
+    else:
+        return False
+    return bool(names & PR_TRIGGERS)
+
+
 # ---------------------------------------------------------------------
 # Checks. Each takes the org-state model and returns (violations,
 # warnings) as lists of strings. The model shape:
@@ -142,7 +209,7 @@ class OperationalError(Exception):
 #       "name": str,
 #       "secrets": [name, ...],              # plain repo-level secrets
 #       "write_actors": [login, ...],        # non-admin push/maintain
-#       "workflows": {path: text, ...},      # default + EXTRA_BRANCHES
+#       "workflows": {path: {branch: text}}, # default + EXTRA_BRANCHES
 #       "environments": [
 #         {"name": str, "required_reviewers": int, "secrets": [name, ...]}
 #       ],
@@ -191,31 +258,38 @@ def check_sa_invariant(state: dict) -> tuple[list[str], list[str]]:
 def check_bypass_invariant(state: dict) -> tuple[list[str], list[str]]:
     violations, warnings = [], []
     for repo in state["repos"]:
-        for path, text in repo["workflows"].items():
-            has_pr_trigger = bool(PR_TRIGGER_RE.search(text))
-            if not has_pr_trigger:
-                continue
-            if BYPASS_REF_RE.search(text):
-                if (repo["name"], path) in BYPASS_ALLOWLIST:
-                    warnings.append(
-                        f"BYPASS-PENDING: {repo['name']}/{path} mints a "
-                        f"bypass credential from a pull_request context; "
-                        f"pinned until the workflow_run redesign lands"
-                    )
-                else:
+        for path, by_branch in repo["workflows"].items():
+            pinned = (repo["name"], path) in BYPASS_ALLOWLIST
+            for branch, text in by_branch.items():
+                where = f"{repo['name']}/{path}@{branch}"
+                has_bypass_ref = bool(BYPASS_REF_RE.search(text))
+                has_sa_ref = bool(SA_REF_RE.search(text))
+                if not (has_bypass_ref or has_sa_ref):
+                    continue
+                if not workflow_has_pr_trigger(text):
+                    continue
+                if has_bypass_ref:
+                    if pinned:
+                        warnings.append(
+                            f"BYPASS-PENDING: {where} mints a bypass "
+                            f"credential from a pull_request context; "
+                            f"pinned until the workflow_run redesign lands"
+                        )
+                    else:
+                        violations.append(
+                            f"BYPASS-PR: {where} references a "
+                            f"ruleset-bypass credential and carries a "
+                            f"pull_request/pull_request_target trigger; "
+                            f"use workflow_run (see website "
+                            f"renovate-automerge.yml)"
+                        )
+                if has_sa_ref:
                     violations.append(
-                        f"BYPASS-PR: {repo['name']}/{path} references a "
-                        f"ruleset-bypass credential and carries a "
-                        f"pull_request/pull_request_target trigger; use "
-                        f"workflow_run (see website renovate-automerge.yml)"
+                        f"SA-REF-PR: {where} references a service-account "
+                        f"token in a workflow with a pull_request/"
+                        f"pull_request_target trigger; a poisoned PR "
+                        f"could read the vault credential"
                     )
-            if SA_REF_RE.search(text):
-                violations.append(
-                    f"SA-REF-PR: {repo['name']}/{path} references a "
-                    f"service-account token in a workflow with a "
-                    f"pull_request/pull_request_target trigger; a poisoned "
-                    f"PR could read the vault credential"
-                )
     return violations, warnings
 
 
@@ -302,7 +376,7 @@ def run_checks(state: dict) -> tuple[list[str], list[str]]:
 # ---------------------------------------------------------------------
 
 
-def gh_api(path: str, *, paginate: bool = False) -> object:
+def gh_api(path: str, *, paginate: bool = False, allow_404: bool = False) -> Any:
     cmd = ["gh", "api", path]
     if paginate:
         cmd.append("--paginate")
@@ -310,7 +384,9 @@ def gh_api(path: str, *, paginate: bool = False) -> object:
     if proc.returncode != 0:
         stderr = proc.stderr.strip()
         if "HTTP 404" in stderr:
-            return None
+            if allow_404:
+                return None
+            raise OperationalError(f"gh api {path} unexpectedly returned 404")
         raise OperationalError(
             f"gh api {path} failed: {stderr or 'unknown error'}. If this "
             f"is HTTP 403, the token lacks a required permission (repo: "
@@ -321,80 +397,116 @@ def gh_api(path: str, *, paginate: bool = False) -> object:
         return json.loads(proc.stdout)
     # --paginate emits one JSON document per page, back to back; decode
     # them all rather than depending on gh's newer --slurp flag.
-    merged: list = []
+    pages: list[Any] = []
     decoder = json.JSONDecoder()
     idx, text = 0, proc.stdout.strip()
     while idx < len(text):
         page, end = decoder.raw_decode(text, idx)
-        merged.extend(page if isinstance(page, list) else [page])
+        pages.append(page)
         idx = end
         while idx < len(text) and text[idx] in " \n\r\t":
             idx += 1
+    return pages
+
+
+def gh_api_list(path: str) -> list:
+    """Fetch a paginated array endpoint, merged across pages."""
+    sep = "&" if "?" in path else "?"
+    merged: list = []
+    for page in gh_api(f"{path}{sep}per_page=100", paginate=True):
+        merged.extend(page)
     return merged
 
 
+def gh_api_items(path: str, key: str, *, allow_404: bool = False) -> list:
+    """Fetch a paginated `{total_count, <key>: [...]}` collection endpoint.
+
+    Verifies the merged item count against total_count: a mismatch means
+    the listing was truncated, and a truncated security audit must fail
+    rather than report a hollow "clean".
+    """
+    sep = "&" if "?" in path else "?"
+    pages = gh_api(f"{path}{sep}per_page=100", paginate=True, allow_404=allow_404)
+    if pages is None:
+        return []
+    items: list = []
+    for page in pages:
+        items.extend(page.get(key, []))
+    total = pages[0].get("total_count") if pages else 0
+    if total is not None and total != len(items):
+        raise OperationalError(
+            f"gh api {path} returned {len(items)} of {total} items; "
+            f"refusing to audit a truncated listing"
+        )
+    return items
+
+
 def collect_live_state() -> dict:
-    org_secrets = gh_api(f"/orgs/{ORG}/actions/secrets")
-    if org_secrets is None:
-        raise OperationalError("org secrets endpoint returned 404")
-    repo_names = [
-        r["name"] for r in gh_api(f"/orgs/{ORG}/repos?per_page=100", paginate=True)
+    org_secret_names = [
+        s["name"] for s in gh_api_items(f"/orgs/{ORG}/actions/secrets", "secrets")
     ]
+    repo_names = [r["name"] for r in gh_api_list(f"/orgs/{ORG}/repos")]
     repos = []
     for name in sorted(repo_names):
-        secrets_resp = gh_api(f"/repos/{ORG}/{name}/actions/secrets")
-        secrets = [s["name"] for s in (secrets_resp or {}).get("secrets", [])]
+        repo_meta = gh_api(f"/repos/{ORG}/{name}", allow_404=True)
+        if repo_meta is None:
+            # Deleted or renamed between the org listing and this fetch.
+            print(f"::warning::repo {name} vanished mid-audit; skipping")
+            continue
 
-        collaborators = (
-            gh_api(
-                f"/repos/{ORG}/{name}/collaborators?affiliation=all&per_page=100",
-                paginate=True,
-            )
-            or []
-        )
-        write_actors = [
-            c["login"]
-            for c in collaborators
-            if c["permissions"].get("push") and not c["permissions"].get("admin")
+        secrets = [
+            s["name"]
+            for s in gh_api_items(f"/repos/{ORG}/{name}/actions/secrets", "secrets")
         ]
 
-        default_branch = gh_api(f"/repos/{ORG}/{name}")["default_branch"]
-        workflows: dict[str, str] = {}
-        for branch in dict.fromkeys((default_branch, *EXTRA_BRANCHES)):
+        write_actors = [
+            c["login"]
+            for c in gh_api_list(f"/repos/{ORG}/{name}/collaborators?affiliation=all")
+            if c.get("permissions", {}).get("push")
+            and not c.get("permissions", {}).get("admin")
+        ]
+
+        # Scan every branch copy separately: pull_request_target runs the
+        # base-ref copy, so a develop-only edit to a workflow that also
+        # exists on main must not be shadowed by main's clean copy.
+        workflows: dict[str, dict[str, str]] = {}
+        branches = dict.fromkeys((repo_meta["default_branch"], *EXTRA_BRANCHES))
+        for branch in branches:
             listing = gh_api(
-                f"/repos/{ORG}/{name}/contents/.github/workflows?ref={branch}"
+                f"/repos/{ORG}/{name}/contents/.github/workflows?ref={branch}",
+                allow_404=True,
             )
             if listing is None:
                 continue
             for entry in listing:
                 if not entry["name"].endswith((".yml", ".yaml")):
                     continue
-                if entry["path"] in workflows:
-                    continue
                 blob = gh_api(f"/repos/{ORG}/{name}/git/blobs/{entry['sha']}")
-                workflows[entry["path"]] = base64.b64decode(blob["content"]).decode(
+                text = base64.b64decode(blob["content"]).decode(
                     "utf-8", errors="replace"
                 )
+                workflows.setdefault(entry["path"], {})[branch] = text
 
-        envs_resp = gh_api(f"/repos/{ORG}/{name}/environments")
         environments = []
-        for env in (envs_resp or {}).get("environments", []):
-            reviewer_rules = [
-                r
+        for env in gh_api_items(
+            f"/repos/{ORG}/{name}/environments", "environments", allow_404=True
+        ):
+            reviewer_count = sum(
+                len(r.get("reviewers", []))
                 for r in env.get("protection_rules", [])
                 if r.get("type") == "required_reviewers"
-            ]
-            reviewer_count = sum(len(r.get("reviewers", [])) for r in reviewer_rules)
-            env_secrets_resp = gh_api(
-                f"/repos/{ORG}/{name}/environments/{env['name']}/secrets"
+            )
+            env_path = urllib.parse.quote(env["name"], safe="")
+            env_secrets = gh_api_items(
+                f"/repos/{ORG}/{name}/environments/{env_path}/secrets",
+                "secrets",
+                allow_404=True,
             )
             environments.append(
                 {
                     "name": env["name"],
                     "required_reviewers": reviewer_count,
-                    "secrets": [
-                        s["name"] for s in (env_secrets_resp or {}).get("secrets", [])
-                    ],
+                    "secrets": [s["name"] for s in env_secrets],
                 }
             )
 
@@ -407,20 +519,51 @@ def collect_live_state() -> dict:
                 "environments": environments,
             }
         )
+    return {"org_secrets": org_secret_names, "repos": repos}
+
+
+def collect_local_state(workflow_dir: str, repo_name: str) -> dict:
+    """Model a single repo from a local workflow directory.
+
+    Used by workflow-lint on every PR so the bypass/SA reference
+    invariants have one implementation instead of a hand-synced grep
+    copy. Secrets/environments checks trivially pass on the empty model;
+    the scheduled --live audit covers those.
+    """
+    root = pathlib.Path(workflow_dir)
+    if not root.is_dir():
+        raise OperationalError(f"{workflow_dir} is not a directory")
+    workflows: dict[str, dict[str, str]] = {}
+    for f in sorted(root.iterdir()):
+        if f.suffix not in (".yml", ".yaml") or not f.is_file():
+            continue
+        workflows[f".github/workflows/{f.name}"] = {
+            "local": f.read_text(encoding="utf-8", errors="replace")
+        }
     return {
-        "org_secrets": [s["name"] for s in org_secrets.get("secrets", [])],
-        "repos": repos,
+        "org_secrets": [],
+        "repos": [
+            {
+                "name": repo_name,
+                "secrets": [],
+                "write_actors": [],
+                "workflows": workflows,
+                "environments": [],
+            }
+        ],
     }
 
 
 # ---------------------------------------------------------------------
-# Red-team self-test. Every violation class must be caught, and every
-# allowlisted shape must NOT fail. This runs in CI before the live audit;
-# if a refactor breaks a check, the audit goes red before it can go blind.
+# Red-team self-test. Every violation class must be caught -- including
+# the evasive trigger/accessor syntax variants -- and every allowlisted
+# shape must produce its warning and nothing more. This runs in CI before
+# the live audit; if a refactor breaks a check, the audit goes red before
+# it can go blind.
 # ---------------------------------------------------------------------
 
 
-def _repo(name: str, **overrides: object) -> dict:
+def _repo(name: str, **overrides: Any) -> dict:
     base: dict = {
         "name": name,
         "secrets": [],
@@ -429,36 +572,58 @@ def _repo(name: str, **overrides: object) -> dict:
         "environments": [],
     }
     base.update(overrides)
+    # Fixture convenience: allow {path: text} and wrap to {path: {branch:}}.
+    base["workflows"] = {
+        path: (text if isinstance(text, dict) else {"main": text})
+        for path, text in base["workflows"].items()
+    }
     return base
 
 
 def self_test() -> int:
     failures: list[str] = []
+    fixture_count = 0
 
-    def expect(label: str, state: dict, codes: set[str], *, clean: bool = False):
-        violations, _ = run_checks(state)
+    def expect(
+        label: str,
+        state: dict,
+        codes: set[str],
+        warn_codes: set[str] | None = None,
+    ) -> None:
+        nonlocal fixture_count
+        fixture_count += 1
+        violations, warnings = run_checks(state)
         got = {v.split(":", 1)[0] for v in violations}
-        if clean and violations:
-            failures.append(f"{label}: expected clean, got {violations}")
-        elif not clean and not codes <= got:
-            failures.append(f"{label}: expected codes {codes}, got {got or 'none'}")
+        gotw = {w.split(":", 1)[0] for w in warnings}
+        # Exact match both ways: a check that fires spuriously is as
+        # broken as one that never fires.
+        if got != codes:
+            failures.append(
+                f"{label}: expected codes {codes or '{}'}, got {got or '{}'}"
+            )
+        if gotw != (warn_codes or set()):
+            failures.append(
+                f"{label}: expected warnings {warn_codes or '{}'}, got {gotw or '{}'}"
+            )
 
-    pr_bypass_wf = (
-        "on:\n  pull_request:\njobs:\n  j:\n    steps:\n"
-        "      - uses: actions/create-github-app-token@sha\n"
-        "        with:\n          app-id: ${{ secrets.MERGE_APP_ID }}\n"
-        "          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}\n"
-    )
-    prt_bypass_wf = pr_bypass_wf.replace("pull_request:", "pull_request_target:")
+    def bypass_wf(trigger_block: str, accessor: str = "dot") -> str:
+        ref = (
+            "${{ secrets.MERGE_APP_ID }}"
+            if accessor == "dot"
+            else "${{ secrets['MERGE_APP_ID'] }}"
+        )
+        return (
+            f"{trigger_block}\njobs:\n  j:\n    steps:\n"
+            f"      - uses: actions/create-github-app-token@sha\n"
+            f"        with:\n          app-id: {ref}\n"
+        )
+
     sa_ref_wf = (
         "on:\n  pull_request:\njobs:\n  j:\n    steps:\n"
         "      - run: op read op://x\n        env:\n"
         "          OP_SERVICE_ACCOUNT_TOKEN: "
         "${{ secrets.EVIL_ACTIONS_SERVICE_ACCOUNT }}\n"
     )
-    push_bypass_wf = pr_bypass_wf.replace("pull_request:", "push:")
-
-    empty = {"org_secrets": [], "repos": []}
 
     # 1. SA token as an unpinned plain repo secret -> SA-PLAIN.
     expect(
@@ -484,9 +649,9 @@ def self_test() -> int:
         },
         {"SA-TRIPWIRE"},
     )
-    # 3. Pending-migration pin warns but does not fail.
+    # 3. Pending-migration pin warns, and only warns.
     expect(
-        "sa-pending-clean",
+        "sa-pending-warns",
         {
             "org_secrets": [],
             "repos": [
@@ -494,7 +659,7 @@ def self_test() -> int:
             ],
         },
         set(),
-        clean=True,
+        warn_codes={"SA-PENDING"},
     )
     # 4. SA token as an org-wide secret -> SA-ORG.
     expect(
@@ -502,58 +667,96 @@ def self_test() -> int:
         {"org_secrets": ["ROGUE_ACTIONS_SERVICE_ACCOUNT"], "repos": []},
         {"SA-ORG"},
     )
-    # 5. Bypass credential in a pull_request workflow -> BYPASS-PR.
+    # 5-9. Bypass credential reachable from every documented trigger
+    # shape and both accessor forms -> BYPASS-PR each time.
+    for label, wf in (
+        ("bypass-block-mapping", bypass_wf("on:\n  pull_request:")),
+        ("bypass-flow-sequence", bypass_wf("on: [push, pull_request]")),
+        ("bypass-bare-string", bypass_wf("on: pull_request_target")),
+        ("bypass-quoted-key", bypass_wf('on:\n  "pull_request":')),
+        ("bypass-bracket-accessor", bypass_wf("on: [pull_request]", "bracket")),
+    ):
+        expect(
+            label,
+            {
+                "org_secrets": [],
+                "repos": [
+                    _repo("evil-repo", workflows={".github/workflows/x.yml": wf})
+                ],
+            },
+            {"BYPASS-PR"},
+        )
+    # 10. Unparseable YAML that references a bypass credential fails
+    # closed rather than slipping past the trigger parse.
     expect(
-        "bypass-pr",
+        "bypass-unparseable",
         {
             "org_secrets": [],
             "repos": [
-                _repo("evil-repo", workflows={".github/workflows/x.yml": pr_bypass_wf})
+                _repo(
+                    "evil-repo",
+                    workflows={
+                        ".github/workflows/x.yml": (
+                            "on: [pull_request\n  ${{ secrets.MERGE_APP_ID }}"
+                        )
+                    },
+                )
             ],
         },
         {"BYPASS-PR"},
     )
-    # 6. Same via pull_request_target -> BYPASS-PR.
+    # 11. A develop-only edit is caught even when main's copy is clean.
     expect(
-        "bypass-prt",
+        "bypass-develop-only",
         {
             "org_secrets": [],
             "repos": [
-                _repo("evil-repo", workflows={".github/workflows/x.yml": prt_bypass_wf})
+                _repo(
+                    "evil-repo",
+                    workflows={
+                        ".github/workflows/x.yml": {
+                            "main": bypass_wf("on: push"),
+                            "develop": bypass_wf("on: [pull_request]"),
+                        }
+                    },
+                )
             ],
         },
         {"BYPASS-PR"},
     )
-    # 7. Allowlisted bypass workflow does not fail (warns only).
+    # 12. Allowlisted bypass workflow warns, and only warns.
     expect(
-        "bypass-pinned-clean",
+        "bypass-pinned-warns",
         {
             "org_secrets": [],
             "repos": [
                 _repo(
                     "GlycemicGPT",
                     workflows={
-                        ".github/workflows/auto-merge-renovate.yml": pr_bypass_wf
+                        ".github/workflows/auto-merge-renovate.yml": bypass_wf(
+                            "on:\n  pull_request:"
+                        )
                     },
                 )
             ],
         },
         set(),
-        clean=True,
+        warn_codes={"BYPASS-PENDING"},
     )
-    # 8. Bypass credential in a push workflow is fine.
+    # 13. Bypass credential in a push-only workflow is fine.
     expect(
         "bypass-push-clean",
         {
             "org_secrets": [],
             "repos": [
-                _repo("any", workflows={".github/workflows/x.yml": push_bypass_wf})
+                _repo(
+                    "any", workflows={".github/workflows/x.yml": bypass_wf("on: push")}
+                )
             ],
         },
         set(),
-        clean=True,
     )
-    # 9. SA token referenced from a pull_request workflow -> SA-REF-PR.
+    # 14. SA token referenced from a pull_request workflow -> SA-REF-PR.
     expect(
         "sa-ref-pr",
         {
@@ -564,7 +767,7 @@ def self_test() -> int:
         },
         {"SA-REF-PR"},
     )
-    # 10. New environment without required reviewers -> ENV-UNGATED.
+    # 15. New environment without required reviewers -> ENV-UNGATED.
     expect(
         "env-ungated",
         {
@@ -580,9 +783,9 @@ def self_test() -> int:
         },
         {"ENV-UNGATED"},
     )
-    # 11. Baseline-pinned environment warns but does not fail.
+    # 16. Baseline-pinned environment warns, and only warns.
     expect(
-        "env-baseline-clean",
+        "env-baseline-warns",
         {
             "org_secrets": [],
             "repos": [
@@ -595,9 +798,9 @@ def self_test() -> int:
             ],
         },
         set(),
-        clean=True,
+        warn_codes={"ENV-BASELINE"},
     )
-    # 12. Gated environment drift: exercised against a temporary
+    # 17-19. Gated environment drift, exercised against a temporary
     # expectation map (missing env, wrong secret set, plain re-add).
     global EXPECTED_GATED_ENVIRONMENTS
     saved = EXPECTED_GATED_ENVIRONMENTS
@@ -650,46 +853,69 @@ def self_test() -> int:
     finally:
         EXPECTED_GATED_ENVIRONMENTS = saved
 
-    # 13. Fully clean state passes.
-    expect("clean", empty, set(), clean=True)
+    # 20. Fully clean state passes with no violations and no warnings.
+    expect("clean", {"org_secrets": [], "repos": []}, set())
 
     if failures:
         for f in failures:
             print(f"SELF-TEST FAIL {f}", file=sys.stderr)
         return 1
-    print(f"self-test: all {13} red-team fixtures behaved as expected")
+    print(f"self-test: all {fixture_count} red-team fixtures behaved as expected")
+    return 0
+
+
+def report(violations: list[str], warnings: list[str], scope: str) -> int:
+    for w in warnings:
+        print(f"::warning::{w}")
+    for v in violations:
+        print(f"::error::{v}")
+    if violations:
+        print(f"secrets audit ({scope}): {len(violations)} violation(s)")
+        return 1
+    print(f"secrets audit ({scope}): clean ({len(warnings)} pinned warning(s))")
     return 0
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--self-test", action="store_true")
     mode.add_argument("--live", action="store_true")
+    mode.add_argument(
+        "--repo-local",
+        metavar="DIR",
+        help="workflow directory to check (bypass/SA reference invariants)",
+    )
+    parser.add_argument(
+        "--repo-name",
+        help="repo name for allowlist resolution (required with --repo-local)",
+    )
     args = parser.parse_args()
 
     if args.self_test:
         return self_test()
 
     try:
-        state = collect_live_state()
+        if args.repo_local:
+            if not args.repo_name:
+                parser.error("--repo-local requires --repo-name")
+            state = collect_local_state(args.repo_local, args.repo_name)
+            scope = f"repo-local {args.repo_name}"
+        else:
+            state = collect_live_state()
+            scope = f"org {ORG}"
+        violations, warnings = run_checks(state)
     except OperationalError as exc:
         print(f"::error::secrets audit could not run: {exc}")
         return 2
+    except Exception as exc:  # noqa: BLE001 -- fail closed, exit 2 not 1
+        print(f"::error::secrets audit crashed: {exc!r}")
+        return 2
 
-    violations, warnings = run_checks(state)
-    for w in warnings:
-        print(f"::warning::{w}")
-    for v in violations:
-        print(f"::error::{v}")
-    if violations:
-        print(f"secrets audit: {len(violations)} violation(s)")
-        return 1
-    print(
-        f"secrets audit: clean ({len(state['repos'])} repos, "
-        f"{len(warnings)} pinned warning(s))"
-    )
-    return 0
+    return report(violations, warnings, scope)
 
 
 if __name__ == "__main__":

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -57,11 +57,22 @@ mapping, string, flow/block sequence, quoted keys). A workflow that
 references a guarded secret but does not parse as YAML is treated as
 violating -- fail closed, not blind.
 
-Static limits, stated honestly: an attacker with write access can still
-obfuscate an accessor beyond static reach (e.g. `secrets[format(...)]`).
-These checks are tripwires for the direct forms; the org ruleset, review
-requirements, and this scheduled audit of trusted-branch copies are the
-controls for deliberate evasion.
+Static limits, stated honestly. These checks are tripwires for the
+direct forms; the org ruleset, review requirements, and this scheduled
+audit of trusted-branch copies are the controls for deliberate evasion.
+Known gaps, tracked rather than hidden:
+  - Trigger scope is pull_request/pull_request_target only. Comment- and
+    review-driven triggers (issue_comment, pull_request_review,
+    pull_request_review_comment) share the base-copy-with-secrets trust
+    shape; a bypass-credential mint on those is not yet flagged. (Extend
+    PR_TRIGGERS once a concrete need appears -- doing so blindly risks
+    false-positives on legitimate comment-ops workflows.)
+  - Branch coverage is the default branch plus develop; a poisoned
+    workflow parked on another long-lived branch is unaudited (planting
+    it already requires write access).
+  - The latent-safe write-actor tripwire reads the collaborators
+    endpoint, which does not enumerate GitHub App installations holding
+    contents:write -- such an app is a write actor the tripwire misses.
 
 Exit codes: 0 clean, 1 violations, 2 operational error (missing token,
 missing permissions, truncated API listing -- the audit fails closed
@@ -89,18 +100,37 @@ SA_SECRET_RE = re.compile(r"^[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT$")
 
 # Workflow-text reference to a ruleset-bypass credential, in either
 # documented accessor form: `secrets.NAME` or `secrets['NAME']` /
-# `secrets["NAME"]`. MERGE and RELEASE are the two app identities with
-# org-ruleset bypass; extend this pattern in the same PR that grants any
-# new actor bypass.
+# `secrets["NAME"]`, with optional whitespace around the dot. MERGE and
+# RELEASE are the two app identities with org-ruleset bypass; extend this
+# pattern in the same PR that grants any new actor bypass.
+#
+# IGNORECASE is load-bearing, not cosmetic: GitHub secret names and
+# expression property dereference are case-insensitive, so
+# `secrets.merge_app_id` mints the real MERGE token. A case-sensitive
+# pattern would pass a fully functional exfil workflow as clean.
 BYPASS_REF_RE = re.compile(
-    r"secrets\s*(?:\.|\[\s*['\"])(MERGE|RELEASE)_APP_(ID|PRIVATE_KEY)\b"
+    r"secrets\s*(?:\.\s*|\[\s*['\"])(MERGE|RELEASE)_APP_(ID|PRIVATE_KEY)\b",
+    re.IGNORECASE,
 )
 
 # Workflow-text reference to any SA token, both accessor forms (the
 # reference form of the SA invariant -- existence is checked against the
-# secrets API above).
+# secrets API above). IGNORECASE for the same reason as BYPASS_REF_RE.
 SA_REF_RE = re.compile(
-    r"secrets\s*(?:\.|\[\s*['\"])[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT\b"
+    r"secrets\s*(?:\.\s*|\[\s*['\"])[A-Z0-9_]*_ACTIONS_SERVICE_ACCOUNT\b",
+    re.IGNORECASE,
+)
+
+# Opaque secret access that exfiltrates the WHOLE secret context without
+# naming any single secret, so the name regexes above cannot see it:
+# `toJSON(secrets)` dumps every secret, and a dynamic index
+# `secrets[<expr>]` (anything not opening with a quote) resolves a name
+# the checker cannot predict. On a repo where the org-wide MERGE/RELEASE
+# keys are in scope (they are, visibility=all today), either form in a
+# PR-triggered workflow leaks the bypass credentials. Fail closed.
+OPAQUE_SECRET_RE = re.compile(
+    r"toJSON\s*\(\s*secrets\s*\)|secrets\s*\[\s*(?!['\"])",
+    re.IGNORECASE,
 )
 
 PR_TRIGGERS = frozenset({"pull_request", "pull_request_target"})
@@ -264,10 +294,21 @@ def check_bypass_invariant(state: dict) -> tuple[list[str], list[str]]:
                 where = f"{repo['name']}/{path}@{branch}"
                 has_bypass_ref = bool(BYPASS_REF_RE.search(text))
                 has_sa_ref = bool(SA_REF_RE.search(text))
-                if not (has_bypass_ref or has_sa_ref):
+                has_opaque = bool(OPAQUE_SECRET_RE.search(text))
+                if not (has_bypass_ref or has_sa_ref or has_opaque):
                     continue
                 if not workflow_has_pr_trigger(text):
                     continue
+                if has_opaque:
+                    violations.append(
+                        f"SECRETS-DUMP: {where} reads the whole secret "
+                        f"context (toJSON(secrets) or a dynamic "
+                        f"secrets[...] index) in a pull_request/"
+                        f"pull_request_target workflow; this exfiltrates "
+                        f"the org-wide MERGE/RELEASE keys without naming "
+                        f"them -- reference only the specific non-bypass "
+                        f"secret you need"
+                    )
                 if has_bypass_ref:
                     if pinned:
                         warnings.append(
@@ -451,6 +492,21 @@ def collect_live_state() -> dict:
         s["name"] for s in gh_api_items(f"/orgs/{ORG}/actions/secrets", "secrets")
     ]
     repo_names = [r["name"] for r in gh_api_list(f"/orgs/{ORG}/repos")]
+    # A token whose App installation is scoped to "selected repositories"
+    # enumerates only those repos, so an unaudited repo would go unseen
+    # and the run would still report "clean" -- the same hollow-clean
+    # class the pagination guard closes. Cross-check the enumerated count
+    # against the org's own repo totals and fail closed on a shortfall.
+    org_meta = gh_api(f"/orgs/{ORG}")
+    expected_repos = org_meta.get("public_repos", 0) + org_meta.get(
+        "total_private_repos", 0
+    )
+    if expected_repos and len(repo_names) < expected_repos:
+        raise OperationalError(
+            f"enumerated {len(repo_names)} repos but org reports "
+            f"{expected_repos}; the audit token's installation is scoped "
+            f"to a subset -- refusing to report clean over unaudited repos"
+        )
     repos = []
     for name in sorted(repo_names):
         # A 404 here means the repo was renamed or deleted between the org
@@ -478,8 +534,9 @@ def collect_live_state() -> dict:
         workflows: dict[str, dict[str, str]] = {}
         branches = dict.fromkeys((repo_meta["default_branch"], *EXTRA_BRANCHES))
         for branch in branches:
+            ref = urllib.parse.quote(branch, safe="")
             listing = gh_api(
-                f"/repos/{ORG}/{name}/contents/.github/workflows?ref={branch}",
+                f"/repos/{ORG}/{name}/contents/.github/workflows?ref={ref}",
                 allow_404=True,
             )
             if listing is None:
@@ -612,17 +669,23 @@ def self_test() -> int:
                 f"{label}: expected warnings {warn_codes or '{}'}, got {gotw or '{}'}"
             )
 
+    ACCESSORS = {
+        "dot": "${{ secrets.MERGE_APP_ID }}",
+        "bracket": "${{ secrets['MERGE_APP_ID'] }}",
+        # GitHub resolves this to MERGE_APP_ID (case-insensitive lookup).
+        "lowercase": "${{ secrets.merge_app_id }}",
+        "spaced-dot": "${{ secrets . MERGE_APP_ID }}",
+    }
+
     def bypass_wf(trigger_block: str, accessor: str = "dot") -> str:
-        ref = (
-            "${{ secrets.MERGE_APP_ID }}"
-            if accessor == "dot"
-            else "${{ secrets['MERGE_APP_ID'] }}"
-        )
         return (
             f"{trigger_block}\njobs:\n  j:\n    steps:\n"
             f"      - uses: actions/create-github-app-token@sha\n"
-            f"        with:\n          app-id: {ref}\n"
+            f"        with:\n          app-id: {ACCESSORS[accessor]}\n"
         )
+
+    def opaque_wf(trigger_block: str, expr: str) -> str:
+        return f"{trigger_block}\njobs:\n  j:\n    steps:\n      - run: echo '{expr}'\n"
 
     sa_ref_wf = (
         "on:\n  pull_request:\njobs:\n  j:\n    steps:\n"
@@ -673,14 +736,18 @@ def self_test() -> int:
         {"org_secrets": ["ROGUE_ACTIONS_SERVICE_ACCOUNT"], "repos": []},
         {"SA-ORG"},
     )
-    # 5-9. Bypass credential reachable from every documented trigger
-    # shape and both accessor forms -> BYPASS-PR each time.
+    # 5-11. Bypass credential reachable from every documented trigger
+    # shape and every accessor form -> BYPASS-PR each time. The lowercase
+    # and spaced-dot accessors are the case-insensitive-lookup evasions
+    # the security review found; they resolve the real token.
     for label, wf in (
         ("bypass-block-mapping", bypass_wf("on:\n  pull_request:")),
         ("bypass-flow-sequence", bypass_wf("on: [push, pull_request]")),
         ("bypass-bare-string", bypass_wf("on: pull_request_target")),
         ("bypass-quoted-key", bypass_wf('on:\n  "pull_request":')),
         ("bypass-bracket-accessor", bypass_wf("on: [pull_request]", "bracket")),
+        ("bypass-lowercase-accessor", bypass_wf("on: [pull_request]", "lowercase")),
+        ("bypass-spaced-dot-accessor", bypass_wf("on: [pull_request]", "spaced-dot")),
     ):
         expect(
             label,
@@ -692,6 +759,46 @@ def self_test() -> int:
             },
             {"BYPASS-PR"},
         )
+    # 12-13. Whole-context dumps that never name a secret -> SECRETS-DUMP.
+    for label, expr in (
+        ("dump-tojson", "${{ toJSON(secrets) }}"),
+        ("dump-dynamic-index", "${{ secrets[matrix.key] }}"),
+    ):
+        expect(
+            label,
+            {
+                "org_secrets": [],
+                "repos": [
+                    _repo(
+                        "evil-repo",
+                        workflows={
+                            ".github/workflows/x.yml": opaque_wf(
+                                "on:\n  pull_request:", expr
+                            )
+                        },
+                    )
+                ],
+            },
+            {"SECRETS-DUMP"},
+        )
+    # 14. A dump in a push-only workflow is fine (no PR trust boundary).
+    expect(
+        "dump-push-clean",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "safe-repo",
+                    workflows={
+                        ".github/workflows/x.yml": opaque_wf(
+                            "on: push", "${{ toJSON(secrets) }}"
+                        )
+                    },
+                )
+            ],
+        },
+        set(),
+    )
     # 10. Unparseable YAML that references a bypass credential fails
     # closed rather than slipping past the trigger parse.
     expect(

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -50,7 +50,8 @@ Modes:
   --live             Audit the real org via the GitHub API (gh CLI;
                      needs GH_TOKEN with: repo Secrets read,
                      Environments read, Administration read, Contents
-                     read; org Secrets read).
+                     read; org Secrets read and org Plan read -- the
+                     latter for the installation-scope repo-count guard).
 
 Trigger detection parses the workflow YAML (all documented `on:` shapes:
 mapping, string, flow/block sequence, quoted keys). A workflow that
@@ -497,10 +498,19 @@ def collect_live_state() -> dict:
     # and the run would still report "clean" -- the same hollow-clean
     # class the pagination guard closes. Cross-check the enumerated count
     # against the org's own repo totals and fail closed on a shortfall.
+    #
+    # total_private_repos is only present with Organization-plan read; if
+    # it is absent, expected_repos would silently collapse to the public
+    # count and the check would pass a private-repo shortfall. Require the
+    # field rather than degrade the guard -- this org has private repos.
     org_meta = gh_api(f"/orgs/{ORG}")
-    expected_repos = org_meta.get("public_repos", 0) + org_meta.get(
-        "total_private_repos", 0
-    )
+    if "total_private_repos" not in org_meta:
+        raise OperationalError(
+            "org metadata is missing total_private_repos; the audit token "
+            "needs Organization-plan (read) so the installation-scope "
+            "check cannot silently degrade to the public-repo count"
+        )
+    expected_repos = org_meta.get("public_repos", 0) + org_meta["total_private_repos"]
     if expected_repos and len(repo_names) < expected_repos:
         raise OperationalError(
             f"enumerated {len(repo_names)} repos but org reports "


### PR DESCRIPTION
## Summary

Adds standing CI enforcement for two secret-placement invariants and scaffolds two environment drift checks, as defence-in-depth hygiene independent of the crown-jewel secret migration. Part of the GLY-56.24 Phase 2 hygiene batch.

New files:
- `scripts/security/check-secret-invariants.py` — org-wide auditor with a red-team self-test (25 fixtures), a per-PR `--repo-local` mode, and a `--live` org mode.
- `.github/workflows/secrets-hygiene.yml` — weekly (+ on-change) org-wide audit; runs the self-test before minting a token, then the live audit.

Extended:
- `.github/workflows/workflow-lint.yml` — the per-PR drift guard now calls the same auditor in `--repo-local` mode (one source of truth, no hand-synced grep copy).

## Invariants

**Bypass invariant** — no workflow referencing a ruleset-bypass credential (MERGE/RELEASE app keys) may carry a `pull_request`/`pull_request_target` trigger; those run PR-controlled code and would hand the merge-anything credential to anyone who can open a PR. `workflow_run` is the safe replacement (mirrors the website repo's `renovate-automerge.yml`). `auto-merge-renovate.yml` is pinned as a known offender until its `workflow_run` redesign lands.

**SA invariant** — no 1Password service-account token may exist as a plain secret on a repo with a write actor, nor be referenced from a PR-triggerable workflow. Latent-safe pins are tripwired: the audit fails the moment a pinned repo gains a write actor.

## Drift checks (scaffold)

Gated environments must hold exactly their expected secret lists (catching plain-copy re-adds), and every environment on every repo must require ≥1 reviewer. Populated as the gated-environment migration lands in later handoffs; pre-existing ungated environments (`copilot`, `github-pages`) are pinned as warnings.

## Rigor

Trigger detection parses workflow YAML (all documented `on:` shapes, not just block mappings); secret accessors are matched case-insensitively and in both `.` and `['...']` forms; `toJSON(secrets)` and dynamic `secrets[...]` dumps are flagged; the live audit paginates and refuses to report clean over a truncated or installation-scoped listing. Adversarial, senior-quality, and security reviews were run and their HIGH/MEDIUM findings fixed; the self-test carries a regression fixture for each.

The live audit's `--live` mode needs the `glycemicgpt-security` app granted repo Secrets/Environments/Administration read and org Secrets read; until then it fails closed with an actionable 403 rather than reporting a hollow clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Secrets Hygiene Audit” GitHub Actions workflow with weekly runs and manual execution.
  * Introduced automated secret-placement and workflow-trigger invariant checks, including gated-environment secret drift and reviewer protection validation.
  * Added offline self-tests and local workflow scanning alongside live org auditing.

* **Bug Fixes**
  * Strengthened CI enforcement with an explicit workflow invariants gate and reliable workflow YAML parsing, failing on prohibited secret/trigger configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->