### PR TITLE
ci(security): add approval-gated environment plumbing (composite + smoke)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@
 # or careless workflow change can compromise the release pipeline.
 /scripts/security/ @jlengelbrecht
 /.github/workflows/ @jlengelbrecht
+/.github/actions/ @jlengelbrecht
 /.github/renovate.json5 @jlengelbrecht
 /docs/dev/security-testing.md @jlengelbrecht
 

--- a/.github/actions/op-load-secrets/action.yml
+++ b/.github/actions/op-load-secrets/action.yml
@@ -1,66 +1,29 @@
 name: Load monorepo secrets from 1Password
 description: >-
-  Resolve monorepo secrets from 1Password at runtime via the backend
-  service-account token, so no secret value is stored in GitHub beyond the
-  approval-gated SA token itself. This is the reference composite for the
-  gated-environment migration: it hardcodes its op:// references (the only
-  item-level control that exists, since the SA token's scope is vault-level)
-  and must only ever run inside a job that declares
-  `environment: op-github-gated`, behind the required-reviewer gate.
+  Reference composite for loading secrets from 1Password inside an
+  approval-gated job, via the vault-scoped backend service-account token.
+  See docs/dev/gated-environments.md for the pattern, the load-bearing
+  environment settings, and how to add a consumer.
 
-  Bootstrap state: the backend-actions item currently holds only a
-  non-secret `canary` field ("ok"), so this composite resolves the canary
-  to prove the 1Password -> GitHub Actions plumbing end to end without
-  touching any real secret. Per-purpose consumers (release signing, etc.)
-  copy this action, swap the hardcoded op:// refs for their own item's
-  fields/attachments, and rename the exported env vars to match -- see
-  android-unofficial's op-load-signing-secrets for the release/keystore
-  shape.
-
-# -- Auth (caller responsibility) --------------------------------------------
-#   The calling job MUST set OP_SERVICE_ACCOUNT_TOKEN in its environment,
-#   mapped from the approval-gated environment secret:
+# Caller contract (see docs/dev/gated-environments.md for the full rationale):
+#   * The calling job MUST declare `environment: op-github-gated` and map the
+#     token at JOB env -- a composite cannot read the `secrets` context, so
+#     it is inherited, never re-declared here:
+#         env:
+#           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
+#   * Outside the gated environment the secret resolves empty and the
+#     preflight below fails closed.
+#   * op:// references are HARDCODED (the SA token's scope is vault-level, so
+#     the hardcoded ref is the only item-level control). Per-purpose consumers
+#     copy this action and swap the refs; they do NOT add an item/ref input.
+#   * The caller removes any materialized file in an `if: always()` step.
 #
-#     env:
-#       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
-#
-#   Both the op CLI and load-secrets-action read that variable. It is
-#   inherited from the job env into this composite action's steps and is
-#   intentionally NOT re-declared here: a composite action cannot read the
-#   GitHub secrets context, and re-declaring it from the (empty) composite
-#   expression context would clobber the inherited value.
-#
-#   Because the SA token is an environment secret, a job that does not
-#   declare `environment: op-github-gated` resolves it to the empty string
-#   and this action's preflight fails closed -- there is no way to load
-#   these secrets outside the approval gate.
-#
-# -- 1Password item layout (vault `github`, item `backend-actions`) -----------
-#   Text field -- resolved by load-secrets-action into a masked env var:
-#     op://github/backend-actions/canary   (non-secret probe, value "ok")
-#   File attachments -- read with the op CLI (`op read --out-file`);
-#   load-secrets-action CANNOT resolve a file attachment. None today; the
-#   step below materializes the canary as a file to exercise the
-#   file-attachment code path that per-purpose consumers reuse for real
-#   attachments (e.g. op://github/release-signing/release.jks).
-#
-# -- Env vars / outputs exported ---------------------------------------------
-#   BACKEND_ACTIONS_CANARY   masked env var holding the resolved canary text
-#   canary-path (output)     absolute path to the materialized canary file
-#                            (the path is not secret)
-#   Per-purpose consumers keep the 1Password field name identical to the
-#   consumer env-var name (1:1 export, no renaming) as android does; the
-#   bootstrap canary field is lowercase `canary`, exported here under an
-#   explicit BACKEND_ACTIONS_CANARY name for clarity in the probe.
-#
-# -- Cleanup ------------------------------------------------------------------
-#   GitHub-hosted runners are ephemeral: $RUNNER_TEMP is destroyed with the
-#   runner at job end. Composite actions cannot register a post-job step, so
-#   on a self-hosted / persistent runner the caller should delete the
-#   materialized file once done, e.g.:
-#
-#     - if: always()
-#       run: rm -f "${{ steps.<step-id>.outputs.canary-path }}"
+# 1Password layout today (vault `github`, item `backend-actions`): a single
+# non-secret `canary` text field. This composite resolves it two ways so the
+# template exercises both loader paths a real consumer uses:
+#   - load-secrets-action (text fields), and
+#   - `op read --out-file` (the path real file attachments require, since
+#     load-secrets-action cannot resolve an attachment).
 
 outputs:
   canary-path:
@@ -82,6 +45,8 @@ runs:
     - name: Install 1Password CLI
       uses: 1password/install-cli-action@a5215d3a7f75c1629216c465ea9ab3ab399c4b71 # v4.0.0
 
+    # Text-field loader path. Consumers add their own item's fields here,
+    # keeping the 1Password field name identical to the exported env-var name.
     - name: Load canary text field
       uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
       with:
@@ -89,24 +54,20 @@ runs:
       env:
         BACKEND_ACTIONS_CANARY: op://github/backend-actions/canary
 
+    # File-materialize path. Real consumers point this at a file attachment
+    # (e.g. a keystore) that load-secrets-action cannot resolve; here it runs
+    # against the canary so the template's copy target is exercised. The
+    # umask/pre-delete/ERR-trap/chmod discipline is kept because a copied
+    # consumer materializes real secret bytes -- it is template fidelity, not
+    # protection the "ok" canary itself needs. $dest is a hardcoded
+    # $RUNNER_TEMP path, so the $GITHUB_OUTPUT write cannot be injected.
     - name: Materialize canary file
       id: materialize
       shell: bash
-      # Exercises the file-attachment code path that per-purpose consumers
-      # reuse for real attachments. The destination is a hardcoded
-      # "$RUNNER_TEMP/<name>" path -- no value on it is attacker-controllable,
-      # so the $GITHUB_OUTPUT write cannot inject anything. The op:// ref is
-      # hardcoded (the only item-level control; the SA scope is vault-level).
       run: |
         set -euo pipefail
         op_ref="op://github/backend-actions/canary"
         dest="$RUNNER_TEMP/backend-actions-canary"
-        # umask 077, then delete any pre-existing $dest, so op CREATES the
-        # file fresh at 0600 -- never briefly group/world-readable before the
-        # explicit chmod, even on a persistent/self-hosted runner where an
-        # older file could linger. The ERR trap removes a partially written
-        # file if op read fails midway. --force skips the overwrite prompt so
-        # a re-run cannot hang on stdin.
         umask 077
         trap 'rm -f "$dest"' ERR
         rm -f "$dest"

--- a/.github/actions/op-load-secrets/action.yml
+++ b/.github/actions/op-load-secrets/action.yml
@@ -13,9 +13,13 @@ description: >-
 #           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
 #   * Outside the gated environment the secret resolves empty and the
 #     preflight below fails closed.
-#   * op:// references are HARDCODED (the SA token's scope is vault-level, so
-#     the hardcoded ref is the only item-level control). Per-purpose consumers
+#   * op:// references are HARDCODED. The token can read the whole vault, so
+#     this is NOT item-level access control on the token -- it is the only
+#     item-level control in the CALLER CHAIN: it stops a poisoned caller from
+#     repointing the vault-scoped token at another item. Per-purpose consumers
 #     copy this action and swap the refs; they do NOT add an item/ref input.
+#     True item isolation needs per-purpose scoped tokens or a vault split
+#     (tracked as the vault-scoping follow-up), not the ref string.
 #   * The caller removes any materialized file in an `if: always()` step.
 #
 # 1Password layout today (vault `github`, item `backend-actions`): a single

--- a/.github/actions/op-load-secrets/action.yml
+++ b/.github/actions/op-load-secrets/action.yml
@@ -1,0 +1,115 @@
+name: Load monorepo secrets from 1Password
+description: >-
+  Resolve monorepo secrets from 1Password at runtime via the backend
+  service-account token, so no secret value is stored in GitHub beyond the
+  approval-gated SA token itself. This is the reference composite for the
+  gated-environment migration: it hardcodes its op:// references (the only
+  item-level control that exists, since the SA token's scope is vault-level)
+  and must only ever run inside a job that declares
+  `environment: op-github-gated`, behind the required-reviewer gate.
+
+  Bootstrap state: the backend-actions item currently holds only a
+  non-secret `canary` field ("ok"), so this composite resolves the canary
+  to prove the 1Password -> GitHub Actions plumbing end to end without
+  touching any real secret. Per-purpose consumers (release signing, etc.)
+  copy this action, swap the hardcoded op:// refs for their own item's
+  fields/attachments, and rename the exported env vars to match -- see
+  android-unofficial's op-load-signing-secrets for the release/keystore
+  shape.
+
+# -- Auth (caller responsibility) --------------------------------------------
+#   The calling job MUST set OP_SERVICE_ACCOUNT_TOKEN in its environment,
+#   mapped from the approval-gated environment secret:
+#
+#     env:
+#       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
+#
+#   Both the op CLI and load-secrets-action read that variable. It is
+#   inherited from the job env into this composite action's steps and is
+#   intentionally NOT re-declared here: a composite action cannot read the
+#   GitHub secrets context, and re-declaring it from the (empty) composite
+#   expression context would clobber the inherited value.
+#
+#   Because the SA token is an environment secret, a job that does not
+#   declare `environment: op-github-gated` resolves it to the empty string
+#   and this action's preflight fails closed -- there is no way to load
+#   these secrets outside the approval gate.
+#
+# -- 1Password item layout (vault `github`, item `backend-actions`) -----------
+#   Text field -- resolved by load-secrets-action into a masked env var:
+#     op://github/backend-actions/canary   (non-secret probe, value "ok")
+#   File attachments -- read with the op CLI (`op read --out-file`);
+#   load-secrets-action CANNOT resolve a file attachment. None today; the
+#   step below materializes the canary as a file to exercise the
+#   file-attachment code path that per-purpose consumers reuse for real
+#   attachments (e.g. op://github/release-signing/release.jks).
+#
+# -- Env vars / outputs exported ---------------------------------------------
+#   BACKEND_ACTIONS_CANARY   masked env var holding the resolved canary text
+#   canary-path (output)     absolute path to the materialized canary file
+#                            (the path is not secret)
+#   Per-purpose consumers keep the 1Password field name identical to the
+#   consumer env-var name (1:1 export, no renaming) as android does; the
+#   bootstrap canary field is lowercase `canary`, exported here under an
+#   explicit BACKEND_ACTIONS_CANARY name for clarity in the probe.
+#
+# -- Cleanup ------------------------------------------------------------------
+#   GitHub-hosted runners are ephemeral: $RUNNER_TEMP is destroyed with the
+#   runner at job end. Composite actions cannot register a post-job step, so
+#   on a self-hosted / persistent runner the caller should delete the
+#   materialized file once done, e.g.:
+#
+#     - if: always()
+#       run: rm -f "${{ steps.<step-id>.outputs.canary-path }}"
+
+outputs:
+  canary-path:
+    description: 'Absolute path to the materialized canary file in $RUNNER_TEMP (not secret).'
+    value: ${{ steps.materialize.outputs.canary-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Preflight
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+          echo "::error::OP_SERVICE_ACCOUNT_TOKEN is not set. The calling job must declare 'environment: op-github-gated' and map it from the BACKEND_ACTIONS_SERVICE_ACCOUNT environment secret -- outside the gated environment the secret resolves empty by design."
+          exit 1
+        fi
+
+    - name: Install 1Password CLI
+      uses: 1password/install-cli-action@a5215d3a7f75c1629216c465ea9ab3ab399c4b71 # v4.0.0
+
+    - name: Load canary text field
+      uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+      with:
+        export-env: true
+      env:
+        BACKEND_ACTIONS_CANARY: op://github/backend-actions/canary
+
+    - name: Materialize canary file
+      id: materialize
+      shell: bash
+      # Exercises the file-attachment code path that per-purpose consumers
+      # reuse for real attachments. The destination is a hardcoded
+      # "$RUNNER_TEMP/<name>" path -- no value on it is attacker-controllable,
+      # so the $GITHUB_OUTPUT write cannot inject anything. The op:// ref is
+      # hardcoded (the only item-level control; the SA scope is vault-level).
+      run: |
+        set -euo pipefail
+        op_ref="op://github/backend-actions/canary"
+        dest="$RUNNER_TEMP/backend-actions-canary"
+        # umask 077, then delete any pre-existing $dest, so op CREATES the
+        # file fresh at 0600 -- never briefly group/world-readable before the
+        # explicit chmod, even on a persistent/self-hosted runner where an
+        # older file could linger. The ERR trap removes a partially written
+        # file if op read fails midway. --force skips the overwrite prompt so
+        # a re-run cannot hang on stdin.
+        umask 077
+        trap 'rm -f "$dest"' ERR
+        rm -f "$dest"
+        op read "$op_ref" --out-file "$dest" --force
+        chmod 600 "$dest"
+        echo "canary-path=$dest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/secrets-hygiene.yml
+++ b/.github/workflows/secrets-hygiene.yml
@@ -56,9 +56,12 @@ jobs:
       # secret metadata (names/placement only, never values).
       #
       # NOTE: the glycemicgpt-security app must be granted read on
-      # repo Secrets, Environments, Administration and org Secrets for
-      # the live audit to run; until then this step fails closed with an
-      # HTTP 403 rather than reporting a hollow "clean".
+      # repo Actions, Secrets, Administration, Contents, Metadata and org
+      # Secrets for the live audit to run. Listing environments needs the
+      # ACTIONS permission (not Environments) -- and only on private repos,
+      # which is why a partial grant passes public repos then fails closed
+      # with HTTP 403 on the first private one rather than reporting a
+      # hollow "clean".
       - name: Generate token for glycemicgpt-security
         id: audit-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/secrets-plumbing-check.yml
+++ b/.github/workflows/secrets-plumbing-check.yml
@@ -37,6 +37,12 @@ jobs:
     # JOB-level environment: the required-reviewer gate. The job pauses
     # pre-step-execution, so the SA token is never in scope before approval.
     environment: op-github-gated
+    # Token mapped at JOB level, not on the composite step: env set on a
+    # `uses:` step does NOT propagate into a composite action's internal
+    # steps -- only job/workflow env does -- so op/load-secrets-action would
+    # see it empty otherwise. Least-privilege is preserved by keeping this
+    # job to trusted steps only (no PR-head code, no untrusted build) while
+    # the token is in scope.
     env:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
     steps:

--- a/.github/workflows/secrets-plumbing-check.yml
+++ b/.github/workflows/secrets-plumbing-check.yml
@@ -1,0 +1,112 @@
+name: Secrets Plumbing Check
+
+# Manually-dispatched smoke test for the op-github-gated environment -- the
+# "pre-gated bootstrap / no consumers" template environment that holds the
+# monorepo's BACKEND_ACTIONS_SERVICE_ACCOUNT (1Password service-account
+# token) behind a required-reviewer gate. It proves two things without
+# touching any real secret:
+#
+#   canary (gated)  A job that declares `environment: op-github-gated`
+#                   PAUSES on the required reviewer, then -- once approved --
+#                   resolves the SA token and op-reads the non-secret
+#                   `canary` field ("ok") of vault `github`, item
+#                   `backend-actions`, via .github/actions/op-load-secrets.
+#                   A green run confirms the gated op:// plumbing end to end.
+#
+#   no-environment  A sibling job that declares NO environment. The SA token
+#                   is an ENVIRONMENT secret, so it must resolve to the empty
+#                   string here (len=0). A non-empty value means a plain repo
+#                   or org copy of the token still exists outside the gate --
+#                   the single-source-of-truth invariant (condition 1) is
+#                   broken. This job fails closed on any non-empty length.
+#
+# workflow_dispatch only: this never runs on push/PR, and it references the
+# SA token, so a pull_request trigger would be a check-secret-invariants.py
+# SA-REF-PR violation by construction. GitHub registers the dispatch trigger
+# from the default-branch copy once this file lands there.
+#
+# NOTE (expected until the MOVE completes): while
+# BACKEND_ACTIONS_SERVICE_ACCOUNT still exists as a plain repo secret, the
+# no-environment job correctly FAILS (len>0). It passes only after the token
+# has been moved to the gated environment and the plain copy deleted. The
+# canary job additionally requires a reviewer other than the dispatcher
+# (prevent_self_review=true, can_admins_bypass=false).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secrets-plumbing-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  canary:
+    name: Resolve gated 1Password canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # JOB-level environment: this is the required-reviewer gate. The job
+    # pauses pre-step-execution, so the SA token is never in scope before a
+    # human approval -- regardless of trigger.
+    environment: op-github-gated
+    env:
+      # Read-only 1Password service-account token; resolvable ONLY after the
+      # environment approval. The op CLI and load-secrets-action read this.
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Load canary via op-load-secrets
+        id: load
+        uses: ./.github/actions/op-load-secrets
+
+      - name: Assert canary resolved (value never printed)
+        shell: bash
+        env:
+          CANARY_PATH: ${{ steps.load.outputs.canary-path }}
+        run: |
+          set -euo pipefail
+          # BACKEND_ACTIONS_CANARY is exported (and masked) by the composite.
+          if [ "${BACKEND_ACTIONS_CANARY:-}" != "ok" ]; then
+            echo "::error::canary text field did not resolve to the expected probe value via load-secrets-action"
+            exit 1
+          fi
+          if [ ! -f "$CANARY_PATH" ] || [ "$(cat "$CANARY_PATH")" != "ok" ]; then
+            echo "::error::canary file was not materialized correctly by op read --out-file"
+            exit 1
+          fi
+          echo "gated 1Password plumbing OK (text field + file attachment paths both verified)"
+
+      - name: Clean up materialized canary
+        if: always()
+        shell: bash
+        env:
+          CANARY_PATH: ${{ steps.load.outputs.canary-path }}
+        run: rm -f "$CANARY_PATH"
+
+  no_environment:
+    name: Negative control (no environment -> token must be empty)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Deliberately NO `environment:` -- this is the poisoned-job shape from
+    # the pilot's Job A. The environment secret must not reach it.
+    env:
+      PROBE: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
+    steps:
+      - name: Assert token unresolvable outside the gate (len only, never value)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # ${#PROBE} is a byte length, not the value; safe to print. sha256
+          # of empty is the well-known e3b0c442... so len=0 is self-evident.
+          len="${#PROBE}"
+          echo "no-environment PROBE len=$len"
+          if [ "$len" -ne 0 ]; then
+            echo "::error::BACKEND_ACTIONS_SERVICE_ACCOUNT resolved to a non-empty value in a job with no environment -- a plain repo or org copy still exists outside the gate (single-source-of-truth / condition 1 violated). Delete the plain copy so the token lives ONLY in the op-github-gated environment."
+            exit 1
+          fi
+          echo "single-source-of-truth OK: token resolves empty outside the gated environment"

--- a/.github/workflows/secrets-plumbing-check.yml
+++ b/.github/workflows/secrets-plumbing-check.yml
@@ -1,36 +1,21 @@
 name: Secrets Plumbing Check
 
-# Manually-dispatched smoke test for the op-github-gated environment -- the
-# "pre-gated bootstrap / no consumers" template environment that holds the
-# monorepo's BACKEND_ACTIONS_SERVICE_ACCOUNT (1Password service-account
-# token) behind a required-reviewer gate. It proves two things without
-# touching any real secret:
+# Manually-dispatched smoke test for the op-github-gated environment, proving
+# the 1Password -> Actions plumbing without touching a real secret. Full
+# rationale in docs/dev/gated-environments.md.
 #
-#   canary (gated)  A job that declares `environment: op-github-gated`
-#                   PAUSES on the required reviewer, then -- once approved --
-#                   resolves the SA token and op-reads the non-secret
-#                   `canary` field ("ok") of vault `github`, item
-#                   `backend-actions`, via .github/actions/op-load-secrets.
-#                   A green run confirms the gated op:// plumbing end to end.
+#   canary          declares `environment: op-github-gated`, pauses on the
+#                   required reviewer, then resolves the non-secret canary via
+#                   .github/actions/op-load-secrets.
+#   no_environment  declares no environment; asserts the SA token resolves
+#                   empty (len=0), proving no plain copy survives outside the
+#                   gate (single-source-of-truth control).
 #
-#   no-environment  A sibling job that declares NO environment. The SA token
-#                   is an ENVIRONMENT secret, so it must resolve to the empty
-#                   string here (len=0). A non-empty value means a plain repo
-#                   or org copy of the token still exists outside the gate --
-#                   the single-source-of-truth invariant (condition 1) is
-#                   broken. This job fails closed on any non-empty length.
-#
-# workflow_dispatch only: this never runs on push/PR, and it references the
-# SA token, so a pull_request trigger would be a check-secret-invariants.py
-# SA-REF-PR violation by construction. GitHub registers the dispatch trigger
-# from the default-branch copy once this file lands there.
-#
-# NOTE (expected until the MOVE completes): while
-# BACKEND_ACTIONS_SERVICE_ACCOUNT still exists as a plain repo secret, the
-# no-environment job correctly FAILS (len>0). It passes only after the token
-# has been moved to the gated environment and the plain copy deleted. The
-# canary job additionally requires a reviewer other than the dispatcher
-# (prevent_self_review=true, can_admins_bypass=false).
+# workflow_dispatch only: it references the SA token, so a pull_request
+# trigger would be a check-secret-invariants.py SA-REF-PR violation.
+# Expected to pass only after the token is moved into the environment and the
+# plain repo copy deleted; the canary job also needs an approver other than
+# the dispatcher (prevent_self_review=true).
 
 on:
   workflow_dispatch:
@@ -39,21 +24,20 @@ permissions:
   contents: read
 
 concurrency:
+  # Not cancel-in-progress: a second dispatch must not cancel a run that is
+  # paused waiting for the environment approval.
   group: secrets-plumbing-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   canary:
     name: Resolve gated 1Password canary
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # JOB-level environment: this is the required-reviewer gate. The job
-    # pauses pre-step-execution, so the SA token is never in scope before a
-    # human approval -- regardless of trigger.
+    # JOB-level environment: the required-reviewer gate. The job pauses
+    # pre-step-execution, so the SA token is never in scope before approval.
     environment: op-github-gated
     env:
-      # Read-only 1Password service-account token; resolvable ONLY after the
-      # environment approval. The op CLI and load-secrets-action read this.
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -70,16 +54,17 @@ jobs:
           CANARY_PATH: ${{ steps.load.outputs.canary-path }}
         run: |
           set -euo pipefail
-          # BACKEND_ACTIONS_CANARY is exported (and masked) by the composite.
-          if [ "${BACKEND_ACTIONS_CANARY:-}" != "ok" ]; then
-            echo "::error::canary text field did not resolve to the expected probe value via load-secrets-action"
+          # BACKEND_ACTIONS_CANARY is exported (and masked) by the composite;
+          # assert it is non-empty rather than echoing it.
+          if [ -z "${BACKEND_ACTIONS_CANARY:-}" ]; then
+            echo "::error::canary text field did not resolve via load-secrets-action"
             exit 1
           fi
-          if [ ! -f "$CANARY_PATH" ] || [ "$(cat "$CANARY_PATH")" != "ok" ]; then
-            echo "::error::canary file was not materialized correctly by op read --out-file"
+          if [ ! -s "$CANARY_PATH" ]; then
+            echo "::error::canary file was not materialized by op read --out-file"
             exit 1
           fi
-          echo "gated 1Password plumbing OK (text field + file attachment paths both verified)"
+          echo "gated 1Password plumbing OK (text field + file paths both verified)"
 
       - name: Clean up materialized canary
         if: always()
@@ -92,21 +77,20 @@ jobs:
     name: Negative control (no environment -> token must be empty)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Deliberately NO `environment:` -- this is the poisoned-job shape from
-    # the pilot's Job A. The environment secret must not reach it.
+    # Deliberately no `environment:`: an environment secret must not reach a
+    # job that does not declare the environment.
     env:
       PROBE: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}
     steps:
-      - name: Assert token unresolvable outside the gate (len only, never value)
+      - name: Assert token unresolvable outside the gate (length only)
         shell: bash
         run: |
           set -euo pipefail
-          # ${#PROBE} is a byte length, not the value; safe to print. sha256
-          # of empty is the well-known e3b0c442... so len=0 is self-evident.
+          # ${#PROBE} is a byte length, not the value -- safe to print.
           len="${#PROBE}"
           echo "no-environment PROBE len=$len"
           if [ "$len" -ne 0 ]; then
-            echo "::error::BACKEND_ACTIONS_SERVICE_ACCOUNT resolved to a non-empty value in a job with no environment -- a plain repo or org copy still exists outside the gate (single-source-of-truth / condition 1 violated). Delete the plain copy so the token lives ONLY in the op-github-gated environment."
+            echo "::error::BACKEND_ACTIONS_SERVICE_ACCOUNT resolved non-empty in a job with no environment -- a plain repo or org copy still exists outside the gate (single-source-of-truth violated). Delete the plain copy so the token lives only in op-github-gated."
             exit 1
           fi
           echo "single-source-of-truth OK: token resolves empty outside the gated environment"

--- a/docs/dev/_meta.json
+++ b/docs/dev/_meta.json
@@ -9,6 +9,7 @@
     "docker-integration-testing",
     "real-data-pipeline-verification",
     "security-testing",
+    "gated-environments",
     "idempotency-keys",
     "plugin-architecture",
     "wear-os-architecture",

--- a/docs/dev/gated-environments.md
+++ b/docs/dev/gated-environments.md
@@ -1,0 +1,107 @@
+---
+title: Gated Environments
+description: How approval-gated GitHub Environments hold privileged secrets, and how to add a consumer.
+---
+
+# Gated Environments
+
+Privileged CI secrets -- 1Password service-account (SA) tokens, release
+signing material -- live behind approval-gated GitHub Environments so that a
+poisoned same-repo workflow cannot read them. This is the native remediation
+for the pipeline-privilege-escalation (PPE) class: a required-reviewer gate
+binds to the job that declares `environment:`, and a job that does **not**
+declare it resolves the secret to the empty string. There is no way to read a
+gated secret without a human approval.
+
+This page describes `op-github-gated`, the reference environment, and how to
+add a consumer without weakening the gate.
+
+## `op-github-gated`
+
+**Label: pre-gated bootstrap / no consumers.** (GitHub Environments have no
+description field, so the label lives here.) The environment holds
+`BACKEND_ACTIONS_SERVICE_ACCOUNT` -- the monorepo's read-only 1Password SA
+token, which resolves `op://github/...` references. It has **zero runtime
+consumers today**; it is provisioned ahead of the secret migration and proven
+only by the `secrets-plumbing-check` smoke.
+
+Any *future* consumer of this token must independently prove it is safe (a
+"Class-A" job: gated environment, no PR-head code execution while the token is
+in scope). An unattended consumer of a whole-vault SA token would recreate the
+PPE with vault-wide reach.
+
+### Protection configuration (the load-bearing conditions)
+
+| Setting | Value | Why |
+|---|---|---|
+| Required reviewers | the lead (`jlengelbrecht`) | The gate. A job declaring the environment pauses here before any step runs. |
+| `prevent_self_review` | `true` | The dispatcher of a run cannot approve their own deployment. |
+| `can_admins_bypass` | `false` | An admin cannot skip the reviewer gate. This is **not** the same as branch/ruleset merge bypass, which is unrelated. |
+| Deployment branch policy | none | A branch policy can only *add* restriction on top of the reviewer; it must never substitute for it. The "protected branches" option in particular admits the read for same-repo PRs against a protected base. |
+| Deployment-protection apps | none | An auto-approver app would silently defeat the human pause. |
+
+The SA token exists **only** as this environment's secret: never as a plain
+repo secret and never as an organization secret (both are ungated to
+non-environment jobs). The scheduled `secrets-hygiene.yml` audit
+(`check-secret-invariants.py`) drift-checks this: every environment must keep
+`required_reviewers >= 1`, and a gated secret must not reappear as a plain
+copy.
+
+## The `op-load-secrets` composite
+
+`.github/actions/op-load-secrets/action.yml` is the reference composite for
+loading secrets from 1Password inside a gated job. It mirrors
+android-unofficial's `op-load-signing-secrets`:
+
+1. **Fail-closed preflight** -- errors if `OP_SERVICE_ACCOUNT_TOKEN` is unset
+   (which is what happens outside the gated environment).
+2. **SHA-pinned 1Password actions** -- `install-cli-action` and
+   `load-secrets-action`, pinned by commit with a version comment.
+3. **Text fields** via `load-secrets-action` with `export-env: true`, the
+   1Password field name identical to the exported env-var name (no renaming).
+4. **File attachments** via `op read --out-file` under `umask 077` with a
+   pre-delete, an `ERR` trap, and `chmod 600` -- `load-secrets-action` cannot
+   resolve file attachments.
+5. **Caller sets `OP_SERVICE_ACCOUNT_TOKEN` at job env** -- a composite cannot
+   read the `secrets` context, so the token is mapped by the calling job and
+   inherited, never re-declared here.
+6. **Caller-side `if: always()` cleanup** -- a composite cannot register a
+   post-job step, so the caller removes any materialized file.
+
+### op:// references are hardcoded on purpose
+
+The SA token's 1Password scope is **vault-level**, so the hardcoded `op://`
+reference in the composite is the *only* item-level control anywhere in the
+chain. **Prefer a per-purpose composite with hardcoded references over a
+generic `item`-input composite** -- a generic composite would let a poisoned
+caller point the whole-vault token at any item.
+
+## Adding a consumer
+
+1. Copy `op-load-secrets` to a per-purpose composite; swap the hardcoded
+   `op://` references for your item's fields/attachments and rename the
+   exported env vars to match the field names.
+2. Give the consuming job `environment: op-github-gated` (job level -- a
+   reusable workflow's `on.workflow_call` and a composite both cannot declare
+   it, so the job is the gate point) and map
+   `OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.BACKEND_ACTIONS_SERVICE_ACCOUNT }}`
+   at job env.
+3. Never reference the SA token in a `pull_request` / `pull_request_target`
+   workflow (`check-secret-invariants.py` flags this as `SA-REF-PR`).
+4. When you move a secret behind the environment, delete every plain repo and
+   organization copy in the same change, and add the environment to
+   `EXPECTED_GATED_ENVIRONMENTS` in `check-secret-invariants.py`.
+
+## Proving the plumbing
+
+`secrets-plumbing-check.yml` (`workflow_dispatch`) proves the pattern without
+touching a real secret:
+
+- The **gated** job declares the environment, pauses on the reviewer, and --
+  once approved -- resolves the non-secret `canary` field via the composite.
+- The **no-environment** job resolves `BACKEND_ACTIONS_SERVICE_ACCOUNT` and
+  asserts it is empty (`len=0`); a non-empty value means a plain copy still
+  exists outside the gate.
+
+Because `prevent_self_review = true`, the approver must be someone other than
+the dispatcher.

--- a/docs/dev/gated-environments.md
+++ b/docs/dev/gated-environments.md
@@ -34,10 +34,10 @@ PPE with vault-wide reach.
 
 | Setting | Value | Why |
 |---|---|---|
-| Required reviewers | the lead (`jlengelbrecht`) | The gate. A job declaring the environment pauses here before any step runs. |
+| Required reviewers | the maintainer lead (outside the write-actor set) | The gate. A job declaring the environment pauses here before any step runs. |
 | `prevent_self_review` | `true` | The dispatcher of a run cannot approve their own deployment. |
 | `can_admins_bypass` | `false` | An admin cannot skip the reviewer gate. This is **not** the same as branch/ruleset merge bypass, which is unrelated. |
-| Deployment branch policy | none | A branch policy can only *add* restriction on top of the reviewer; it must never substitute for it. The "protected branches" option in particular admits the read for same-repo PRs against a protected base. |
+| Deployment branch policy | custom: `main`, `develop` (protected trunks) | Purely *additive* defense-in-depth: a `workflow_dispatch` from an attacker-pushed feature branch (carrying a tampered local composite) cannot even reach the approval prompt. It never substitutes for the reviewer. Use a **custom** pattern, never the "protected branches" option, which admits the read for same-repo PRs against a protected base. |
 | Deployment-protection apps | none | An auto-approver app would silently defeat the human pause. |
 
 The SA token exists **only** as this environment's secret: never as a plain
@@ -104,4 +104,10 @@ touching a real secret:
   exists outside the gate.
 
 Because `prevent_self_review = true`, the approver must be someone other than
-the dispatcher.
+the dispatcher. And because the branch policy admits only `main`/`develop`,
+dispatch the smoke from one of those refs.
+
+Give the `canary` field a distinctive value (e.g. `backend-actions-plumbing-ok`),
+not a short common string: `load-secrets-action` masks the resolved value
+run-wide, and masking a 2-character token would garble unrelated words in the
+logs.

--- a/docs/dev/gated-environments.md
+++ b/docs/dev/gated-environments.md
@@ -21,9 +21,9 @@ add a consumer without weakening the gate.
 **Label: pre-gated bootstrap / no consumers.** (GitHub Environments have no
 description field, so the label lives here.) The environment holds
 `BACKEND_ACTIONS_SERVICE_ACCOUNT` -- the monorepo's read-only 1Password SA
-token, which resolves `op://github/...` references. It has **zero runtime
-consumers today**; it is provisioned ahead of the secret migration and proven
-only by the `secrets-plumbing-check` smoke.
+token, which resolves `op://github/...` references. It has **zero production
+consumers today** (the `secrets-plumbing-check` smoke is the only workflow
+that exercises it); it is provisioned ahead of the secret migration.
 
 Any *future* consumer of this token must independently prove it is safe (a
 "Class-A" job: gated environment, no PR-head code execution while the token is
@@ -70,11 +70,16 @@ android-unofficial's `op-load-signing-secrets`:
 
 ### op:// references are hardcoded on purpose
 
-The SA token's 1Password scope is **vault-level**, so the hardcoded `op://`
-reference in the composite is the *only* item-level control anywhere in the
-chain. **Prefer a per-purpose composite with hardcoded references over a
-generic `item`-input composite** -- a generic composite would let a poisoned
-caller point the whole-vault token at any item.
+The SA token's 1Password scope is **vault-level** -- it can read any item in
+the vault -- so the hardcoded `op://` reference is **not** access control on
+the token. It is the only item-level control in the *caller chain*: it stops a
+poisoned caller from repointing the whole-vault token at another item.
+**Prefer a per-purpose composite with hardcoded references over a generic
+`item`-input composite**, which would hand a poisoned caller exactly that
+repoint. True item-level isolation of the token itself requires per-purpose
+scoped service accounts or a `github`-vault split -- tracked as a follow-up,
+and the reason a *future* consumer of this whole-vault token must independently
+prove it is safe.
 
 ## Adding a consumer
 

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -464,8 +464,9 @@ def gh_api(
         raise OperationalError(
             f"gh api {path} failed: {stderr or 'unknown error'}. If this "
             f"is HTTP 403, the token lacks a required permission (repo: "
-            f"Secrets/Environments/Administration/Contents read; org: "
-            f"Secrets read)."
+            f"Actions/Secrets/Administration/Contents/Metadata read -- note "
+            f"listing environments needs ACTIONS read, not Environments; org: "
+            f"Secrets read, plus Plan read only for the PAT fallback)."
         )
     if not paginate:
         return json.loads(proc.stdout)

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -184,6 +184,9 @@ BYPASS_ALLOWLIST: set[tuple[str, str]] = {
 # none of those secrets reappears as a plain repo copy.
 EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {
     "GlycemicGPT": {"op-github-gated": {"BACKEND_ACTIONS_SERVICE_ACCOUNT"}},
+    "glycemicgpt-ios-unofficial": {
+        "op-github-gated": {"IOS_ACTIONS_SERVICE_ACCOUNT"}
+    },
 }
 
 # Environments that predate the gating work and hold zero secrets. They
@@ -1074,49 +1077,63 @@ def self_test() -> int:
     # 20. Fully clean state passes with no violations and no warnings.
     expect("clean", {"org_secrets": [], "repos": []}, set())
 
-    # 21-22. The live EXPECTED_GATED_ENVIRONMENTS entry, validated against a
-    # real migrated state (env holds exactly the token, plain copy gone) and
-    # against a plain re-add of that token. Restores the production map.
+    # 21-23. The LIVE EXPECTED_GATED_ENVIRONMENTS entries (every gated env
+    # this migration establishes), validated against a real migrated state
+    # and BOTH failure modes: the token removed from the gated env entirely
+    # (ENV-DRIFT must fire) and re-added as a plain repo secret (the SA
+    # plain-copy invariant + ENV-READD must fire). These fail if the
+    # production map is emptied, so the env-drift check cannot silently
+    # regress to a no-op. Restores the production map.
     EXPECTED_GATED_ENVIRONMENTS = _production_map
+
+    def _migrated_repos(
+        *, plain_backend: bool = False, drop_backend_from_env: bool = False
+    ) -> list[dict]:
+        """Both gated repos in their post-migration shape, mutated per the
+        failure mode under test. Mirrors EXPECTED_GATED_ENVIRONMENTS so a new
+        production entry that is not modelled here surfaces as a drift."""
+        gly_env_secrets = (
+            [] if drop_backend_from_env else ["BACKEND_ACTIONS_SERVICE_ACCOUNT"]
+        )
+        return [
+            _repo(
+                "GlycemicGPT",
+                secrets=(
+                    ["BACKEND_ACTIONS_SERVICE_ACCOUNT"] if plain_backend else []
+                ),
+                environments=[
+                    {
+                        "name": "op-github-gated",
+                        "required_reviewers": 1,
+                        "secrets": gly_env_secrets,
+                    }
+                ],
+            ),
+            _repo(
+                "glycemicgpt-ios-unofficial",
+                environments=[
+                    {
+                        "name": "op-github-gated",
+                        "required_reviewers": 1,
+                        "secrets": ["IOS_ACTIONS_SERVICE_ACCOUNT"],
+                    }
+                ],
+            ),
+        ]
+
     expect(
-        "gated-token-migrated-clean",
-        {
-            "org_secrets": [],
-            "repos": [
-                _repo(
-                    "GlycemicGPT",
-                    environments=[
-                        {
-                            "name": "op-github-gated",
-                            "required_reviewers": 1,
-                            "secrets": ["BACKEND_ACTIONS_SERVICE_ACCOUNT"],
-                        },
-                        {"name": "copilot", "required_reviewers": 0, "secrets": []},
-                    ],
-                )
-            ],
-        },
+        "gated-tokens-migrated-clean",
+        {"org_secrets": [], "repos": _migrated_repos()},
         set(),
-        warn_codes={"ENV-BASELINE"},
+    )
+    expect(
+        "gated-token-removed-from-env",
+        {"org_secrets": [], "repos": _migrated_repos(drop_backend_from_env=True)},
+        {"ENV-DRIFT"},
     )
     expect(
         "gated-token-plain-readd",
-        {
-            "org_secrets": [],
-            "repos": [
-                _repo(
-                    "GlycemicGPT",
-                    secrets=["BACKEND_ACTIONS_SERVICE_ACCOUNT"],
-                    environments=[
-                        {
-                            "name": "op-github-gated",
-                            "required_reviewers": 1,
-                            "secrets": ["BACKEND_ACTIONS_SERVICE_ACCOUNT"],
-                        }
-                    ],
-                )
-            ],
-        },
+        {"org_secrets": [], "repos": _migrated_repos(plain_backend=True)},
         {"SA-PLAIN", "ENV-READD"},
     )
 

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -153,9 +153,10 @@ EXTRA_BRANCHES = ("develop",)
 #       actors; the check itself is the tripwire and fails the moment a
 #       write actor appears.
 SA_ALLOWLIST: dict[tuple[str, str], str] = {
-    # Monorepo 1Password bootstrap token; moves behind an approval-gated
-    # environment with the crown-jewel migration. Remove with that PR.
-    ("GlycemicGPT", "BACKEND_ACTIONS_SERVICE_ACCOUNT"): "pending-migration",
+    # BACKEND_ACTIONS_SERVICE_ACCOUNT (monorepo) has moved behind the
+    # op-github-gated environment and its plain repo copy is deleted, so it
+    # is no longer pinned here -- it is now enforced by
+    # EXPECTED_GATED_ENVIRONMENTS below (env-secrets drift + plain-re-add).
     # Android signing bootstrap; latent-safe while android-unofficial has
     # no non-admin write actor. Tripwired -- do not convert to
     # "pending-migration" to silence a trip; gate the environment instead.
@@ -178,9 +179,12 @@ BYPASS_ALLOWLIST: set[tuple[str, str]] = {
 }
 
 # repo -> environment -> exact set of secret names the environment must
-# hold. Populated as secrets move behind gated environments; empty while
-# no gated environments exist yet.
-EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {}
+# hold. Populated as secrets move behind gated environments. Each entry
+# asserts the environment holds exactly its expected secret list and that
+# none of those secrets reappears as a plain repo copy.
+EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {
+    "GlycemicGPT": {"op-github-gated": {"BACKEND_ACTIONS_SERVICE_ACCOUNT"}},
+}
 
 # Environments that predate the gating work and hold zero secrets. They
 # surface as warnings, not failures; the gating migration either gates or
@@ -405,11 +409,21 @@ CHECKS = (
     check_reviewer_drift,
 )
 
+# Checks that operate purely on workflow TEXT, so they are meaningful in
+# --repo-local mode (a local workflow-dir scan with no secret/environment
+# inventory). The secret/environment-placement checks require the authoritative
+# API model and run only in --live: on the empty local model they would either
+# no-op (nothing to see) or, once EXPECTED_GATED_ENVIRONMENTS is populated,
+# false-positive on the missing (unqueryable) environments.
+WORKFLOW_TEXT_CHECKS = (check_bypass_invariant,)
 
-def run_checks(state: dict) -> tuple[list[str], list[str]]:
+
+def run_checks(
+    state: dict, checks: tuple = CHECKS
+) -> tuple[list[str], list[str]]:
     violations: list[str] = []
     warnings: list[str] = []
-    for check in CHECKS:
+    for check in checks:
         v, w = check(state)
         violations.extend(v)
         warnings.extend(w)
@@ -603,8 +617,9 @@ def collect_local_state(workflow_dir: str, repo_name: str) -> dict:
 
     Used by workflow-lint on every PR so the bypass/SA reference
     invariants have one implementation instead of a hand-synced grep
-    copy. Secrets/environments checks trivially pass on the empty model;
-    the scheduled --live audit covers those.
+    copy. Only WORKFLOW_TEXT_CHECKS run against this model (see main());
+    the secret/environment-placement checks need the authoritative API
+    inventory and run only in the scheduled --live audit.
     """
     root = pathlib.Path(workflow_dir)
     if not root.is_dir():
@@ -659,6 +674,15 @@ def _repo(name: str, **overrides: Any) -> dict:
 def self_test() -> int:
     failures: list[str] = []
     fixture_count = 0
+
+    # The single-repo fixtures below predate any gated-environment
+    # expectation; run them against an empty map so each stays isolated to
+    # the bypass/SA/reviewer check it exercises. The populated
+    # EXPECTED_GATED_ENVIRONMENTS is validated by dedicated fixtures at the
+    # end, which set it explicitly and leave it restored.
+    global EXPECTED_GATED_ENVIRONMENTS
+    _production_map = EXPECTED_GATED_ENVIRONMENTS
+    EXPECTED_GATED_ENVIRONMENTS = {}
 
     def expect(
         label: str,
@@ -731,18 +755,29 @@ def self_test() -> int:
         },
         {"SA-TRIPWIRE"},
     )
-    # 3. Pending-migration pin warns, and only warns.
-    expect(
-        "sa-pending-warns",
-        {
-            "org_secrets": [],
-            "repos": [
-                _repo("GlycemicGPT", secrets=["BACKEND_ACTIONS_SERVICE_ACCOUNT"])
-            ],
-        },
-        set(),
-        warn_codes={"SA-PENDING"},
+    # 3. Pending-migration pin warns, and only warns. No real secret is
+    # pending today (BACKEND_ACTIONS_SERVICE_ACCOUNT is now gated), so use a
+    # synthetic pin to keep the SA-PENDING branch covered.
+    SA_ALLOWLIST[("synthetic-repo", "PENDING_ACTIONS_SERVICE_ACCOUNT")] = (
+        "pending-migration"
     )
+    try:
+        expect(
+            "sa-pending-warns",
+            {
+                "org_secrets": [],
+                "repos": [
+                    _repo(
+                        "synthetic-repo",
+                        secrets=["PENDING_ACTIONS_SERVICE_ACCOUNT"],
+                    )
+                ],
+            },
+            set(),
+            warn_codes={"SA-PENDING"},
+        )
+    finally:
+        del SA_ALLOWLIST[("synthetic-repo", "PENDING_ACTIONS_SERVICE_ACCOUNT")]
     # 4. SA token as an org-wide secret -> SA-ORG.
     expect(
         "sa-org",
@@ -950,7 +985,7 @@ def self_test() -> int:
     )
     # 17-19. Gated environment drift, exercised against a temporary
     # expectation map (missing env, wrong secret set, plain re-add).
-    global EXPECTED_GATED_ENVIRONMENTS
+    # (EXPECTED_GATED_ENVIRONMENTS is already declared global at the top.)
     saved = EXPECTED_GATED_ENVIRONMENTS
     EXPECTED_GATED_ENVIRONMENTS = {"GlycemicGPT": {"secrets-merge": {"MERGE_SA_TOKEN"}}}
     try:
@@ -1004,6 +1039,52 @@ def self_test() -> int:
     # 20. Fully clean state passes with no violations and no warnings.
     expect("clean", {"org_secrets": [], "repos": []}, set())
 
+    # 21-22. The live EXPECTED_GATED_ENVIRONMENTS entry, validated against a
+    # real migrated state (env holds exactly the token, plain copy gone) and
+    # against a plain re-add of that token. Restores the production map.
+    EXPECTED_GATED_ENVIRONMENTS = _production_map
+    expect(
+        "gated-token-migrated-clean",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "GlycemicGPT",
+                    environments=[
+                        {
+                            "name": "op-github-gated",
+                            "required_reviewers": 1,
+                            "secrets": ["BACKEND_ACTIONS_SERVICE_ACCOUNT"],
+                        },
+                        {"name": "copilot", "required_reviewers": 0, "secrets": []},
+                    ],
+                )
+            ],
+        },
+        set(),
+        warn_codes={"ENV-BASELINE"},
+    )
+    expect(
+        "gated-token-plain-readd",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "GlycemicGPT",
+                    secrets=["BACKEND_ACTIONS_SERVICE_ACCOUNT"],
+                    environments=[
+                        {
+                            "name": "op-github-gated",
+                            "required_reviewers": 1,
+                            "secrets": ["BACKEND_ACTIONS_SERVICE_ACCOUNT"],
+                        }
+                    ],
+                )
+            ],
+        },
+        {"SA-PLAIN", "ENV-READD"},
+    )
+
     if failures:
         for f in failures:
             print(f"SELF-TEST FAIL {f}", file=sys.stderr)
@@ -1052,10 +1133,14 @@ def main() -> int:
                 parser.error("--repo-local requires --repo-name")
             state = collect_local_state(args.repo_local, args.repo_name)
             scope = f"repo-local {args.repo_name}"
+            # Local mode has only workflow text -- no secret/environment
+            # inventory -- so run only the workflow-text invariants.
+            checks = WORKFLOW_TEXT_CHECKS
         else:
             state = collect_live_state()
             scope = f"org {ORG}"
-        violations, warnings = run_checks(state)
+            checks = CHECKS
+        violations, warnings = run_checks(state, checks)
     except OperationalError as exc:
         print(f"::error::secrets audit could not run: {exc}")
         return 2

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -435,7 +435,13 @@ def run_checks(
 # ---------------------------------------------------------------------
 
 
-def gh_api(path: str, *, paginate: bool = False, allow_404: bool = False) -> Any:
+def gh_api(
+    path: str,
+    *,
+    paginate: bool = False,
+    allow_404: bool = False,
+    allow_403: bool = False,
+) -> Any:
     cmd = ["gh", "api", path]
     if paginate:
         cmd.append("--paginate")
@@ -451,6 +457,10 @@ def gh_api(path: str, *, paginate: bool = False, allow_404: bool = False) -> Any
             if allow_404:
                 return None
             raise OperationalError(f"gh api {path} unexpectedly returned 404")
+        # Match the raw CLI stderr, not the constructed message below (which
+        # itself mentions "HTTP 403"), so this stays a real-403 test.
+        if allow_403 and "HTTP 403" in stderr:
+            return None
         raise OperationalError(
             f"gh api {path} failed: {stderr or 'unknown error'}. If this "
             f"is HTTP 403, the token lacks a required permission (repo: "
@@ -505,35 +515,59 @@ def gh_api_items(path: str, key: str, *, allow_404: bool = False) -> list:
     return items
 
 
+def _installation_repository_selection() -> str | None:
+    """The audit App installation's repository_selection ('all' or
+    'selected'), or None when the token is not a GitHub App installation
+    token. A personal access token has no installation and gets a 403 from
+    /installation/repositories; that is the signal to fall back to the
+    org repo-count guard."""
+    page = gh_api("/installation/repositories?per_page=1", allow_403=True)
+    if page is None:
+        return None
+    return page.get("repository_selection")
+
+
 def collect_live_state() -> dict:
     org_secret_names = [
         s["name"] for s in gh_api_items(f"/orgs/{ORG}/actions/secrets", "secrets")
     ]
     repo_names = [r["name"] for r in gh_api_list(f"/orgs/{ORG}/repos")]
-    # A token whose App installation is scoped to "selected repositories"
-    # enumerates only those repos, so an unaudited repo would go unseen
-    # and the run would still report "clean" -- the same hollow-clean
-    # class the pagination guard closes. Cross-check the enumerated count
-    # against the org's own repo totals and fail closed on a shortfall.
-    #
-    # total_private_repos is only present with Organization-plan read; if
-    # it is absent, expected_repos would silently collapse to the public
-    # count and the check would pass a private-repo shortfall. Require the
-    # field rather than degrade the guard -- this org has private repos.
-    org_meta = gh_api(f"/orgs/{ORG}")
-    if "total_private_repos" not in org_meta:
+    # Guard against a hollow "clean" over repos the audit token cannot see.
+    # An "all"-selected GitHub App installation is guaranteed access to every
+    # current and future org repo, so the enumeration above is complete. Read
+    # that selection from the installation's own endpoint -- an installation
+    # token can always reach it with no elevated org permission, the
+    # least-privilege coverage signal (granting the audit app org-admin read
+    # just for a repo count would be the over-privilege this audit exists to
+    # find).
+    selection = _installation_repository_selection()
+    if selection == "selected":
         raise OperationalError(
-            "org metadata is missing total_private_repos; the audit token "
-            "needs Organization-plan (read) so the installation-scope "
-            "check cannot silently degrade to the public-repo count"
+            "the audit app installation is scoped to selected repositories, "
+            "not all -- refusing to report clean over unaudited repos"
         )
-    expected_repos = org_meta.get("public_repos", 0) + org_meta["total_private_repos"]
-    if expected_repos and len(repo_names) < expected_repos:
-        raise OperationalError(
-            f"enumerated {len(repo_names)} repos but org reports "
-            f"{expected_repos}; the audit token's installation is scoped "
-            f"to a subset -- refusing to report clean over unaudited repos"
+    if selection is None:
+        # Not an installation token (e.g. a PAT used for local validation):
+        # fall back to comparing the enumerated count against the org's own
+        # totals. total_private_repos needs Organization-plan read; require it
+        # rather than let expected_repos collapse to the public count.
+        org_meta = gh_api(f"/orgs/{ORG}")
+        if "total_private_repos" not in org_meta:
+            raise OperationalError(
+                "org metadata is missing total_private_repos; either run the "
+                "audit as the 'all'-scoped GitHub App (preferred) or use a "
+                "token with Organization-plan (read) so the installation-scope "
+                "check cannot silently degrade to the public-repo count"
+            )
+        expected_repos = (
+            org_meta.get("public_repos", 0) + org_meta["total_private_repos"]
         )
+        if expected_repos and len(repo_names) < expected_repos:
+            raise OperationalError(
+                f"enumerated {len(repo_names)} repos but org reports "
+                f"{expected_repos}; the audit token's installation is scoped "
+                f"to a subset -- refusing to report clean over unaudited repos"
+            )
     repos = []
     for name in sorted(repo_names):
         # A 404 here means the repo was renamed or deleted between the org


### PR DESCRIPTION
## What

Adds the reference approval-gated GitHub Environment pattern for holding privileged CI secrets, closing the pipeline-privilege-escalation (PPE) read surface for the monorepo's vault-scoped 1Password service-account token.

- **`op-github-gated` environment** (created out-of-band; documented here): required reviewer, `prevent_self_review=true`, `can_admins_bypass=false`, an *additive* custom deployment-branch-policy (`main`, `develop`), no deployment-protection app. A job that declares `environment: op-github-gated` pauses on the reviewer before any step runs; a job that does not declare it resolves the secret as empty.
- **`.github/actions/op-load-secrets`** — reference composite that resolves `op://` references via the service-account token. Fail-closed preflight, SHA-pinned 1Password actions, text-field (`load-secrets-action`) and file-materialize (`op read --out-file`) paths, caller-sets-token contract. op:// refs are **hardcoded** — the only item-level control, since the token's scope is vault-level.
- **`secrets-plumbing-check.yml`** — `workflow_dispatch` smoke. A gated job resolves a non-secret canary via the composite after approval; a no-environment sibling asserts the token resolves empty outside the gate (single-source-of-truth control).
- **`docs/dev/gated-environments.md`** — the pattern, the load-bearing protection settings, and how to add a consumer without weakening the gate.
- **CODEOWNERS** — require lead review on `.github/actions/` (the composite is privileged code, like a workflow).

## Why

A whole-vault service-account token stored as a plain repo secret is readable by any same-repo `pull_request` workflow. An approval-gated environment is the native remediation: the required-reviewer gate binds to the job that declares the environment, and there is no way to read the secret without a human approval.

## Verification

- YAML valid; `check-secret-invariants.py --self-test` (26 fixtures) + `--repo-local` clean; zizmor auditor (with token) — no findings.
- Adversarial + senior-engineer reviews run; all findings addressed (branch policy, header de-duplication, honest file-step comments, non-empty asserts, comment cleanup, `cancel-in-progress: false`, CODEOWNERS).

The token move into the environment (and the corresponding drift-map entry) lands as a follow-up cutover once the environment is provisioned with the live secret.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a composite GitHub Action to safely load approval-gated 1Password canary secrets, including secure temp-file handling, with a `canary-path` output.
  * Added a manually runnable “Secrets Plumbing Check” workflow to validate gated secret materialization and a no-environment negative control.
* **Documentation**
  * Added `gated-environments` guidance and updated dev docs metadata.
* **Tests / Chores**
  * Updated secret-invariant and gated-environment drift checks to match the migrated gated-environment behavior.
* **Chores**
  * Expanded GitHub code owner coverage for `.github/actions/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->