### PR TITLE
ci(security): gate RELEASE app key and release keystore behind release-gated environment

### DIFF
--- a/.github/workflows/changelog-pr.yml
+++ b/.github/workflows/changelog-pr.yml
@@ -14,6 +14,10 @@ jobs:
     name: Update CHANGELOG.md
     runs-on: ubuntu-latest
     permissions: {}
+    # The RELEASE app key exists only as a secret in this approval-gated
+    # environment (no plain org/repo copy). Runs pause for reviewer
+    # approval before the key is in scope.
+    environment: release-gated
     outputs:
       pr_number: ${{ steps.create-pr.outputs.pr_number }}
       has_changes: ${{ steps.changelog.outputs.has_changes }}

--- a/.github/workflows/release-signing-smoke.yml
+++ b/.github/workflows/release-signing-smoke.yml
@@ -145,12 +145,21 @@ jobs:
             COUNT=0
             while IFS= read -r APK; do
               COUNT=$((COUNT + 1))
-              ACTUAL=$("$APKSIGNER" verify --print-certs "$APK" \
-                | grep -oP 'SHA-256 digest: \K[0-9a-f]+' | head -1)
-              if [ "$ACTUAL" != "$EXPECTED_SHA256" ]; then
-                echo "::error::$APK is signed with certificate $ACTUAL, expected $EXPECTED_SHA256 -- the release signing identity CHANGED"
+              # Every signer's certificate digest must match -- an APK
+              # carrying an extra/unexpected signer fails, so no digest is
+              # skipped the way a first-match-only check would.
+              DIGESTS=$("$APKSIGNER" verify --print-certs "$APK" \
+                | grep -oP 'certificate SHA-256 digest: \K[0-9a-f]+')
+              if [ -z "$DIGESTS" ]; then
+                echo "::error::$APK has no signer certificate digest (unsigned or unreadable)"
                 exit 1
               fi
+              while IFS= read -r DIGEST; do
+                if [ "$DIGEST" != "$EXPECTED_SHA256" ]; then
+                  echo "::error::$APK carries signer certificate $DIGEST, expected $EXPECTED_SHA256 -- the release signing identity CHANGED"
+                  exit 1
+                fi
+              done <<< "$DIGESTS"
               echo "cert OK: $(basename "$APK")"
             done < <(find "$ROOT" -name '*.apk' ! -name '*unsigned*' | sort)
             if [ "$COUNT" -eq 0 ]; then

--- a/.github/workflows/release-signing-smoke.yml
+++ b/.github/workflows/release-signing-smoke.yml
@@ -123,32 +123,43 @@ jobs:
           # the frozen signing identity changed and in-place upgrades would
           # break for every installed user: hard stop.
           EXPECTED_SHA256="55f0d0cdabf20b398ad30a0ce3e998e3192666e5c15e6d378b86e1c8de342990"
+          if [ -z "${ANDROID_HOME:-}" ]; then
+            echo "::error::ANDROID_HOME is not set on this runner"
+            exit 1
+          fi
           APKSIGNER=$(find "$ANDROID_HOME"/build-tools -name apksigner -type f | sort -V | tail -1)
           if [ -z "$APKSIGNER" ]; then
             echo "::error::apksigner not found under ANDROID_HOME/build-tools"
             exit 1
           fi
-          FOUND=0
-          while IFS= read -r APK; do
-            FOUND=$((FOUND + 1))
-            ACTUAL=$("$APKSIGNER" verify --print-certs "$APK" \
-              | grep -oP 'SHA-256 digest: \K[0-9a-f]+' | head -1)
-            if [ "$ACTUAL" != "$EXPECTED_SHA256" ]; then
-              echo "::error::$APK is signed with certificate $ACTUAL, expected $EXPECTED_SHA256 -- the release signing identity CHANGED"
-              exit 1
-            fi
-            echo "cert OK: $(basename "$APK")"
-          done < <(find \
+          # Coverage is asserted PER MODULE (not a total count) so one
+          # module silently producing nothing cannot be masked by another
+          # module's extra flavor APKs. watchface is searched from its
+          # apk/ root because its flavors nest as apk/<flavor>/release/,
+          # unlike app and wear.
+          TOTAL=0
+          for ROOT in \
             apps/mobile/app/build/outputs/apk/release \
             apps/mobile/wear-device/build/outputs/apk/release \
-            apps/mobile/watchface/build/outputs/apk \
-            -name '*.apk' ! -name '*unsigned*' | sort)
-          # phone + wear + two watchface flavors
-          if [ "$FOUND" -lt 4 ]; then
-            echo "::error::expected at least 4 signed release APKs, found $FOUND"
-            exit 1
-          fi
-          echo "signing identity verified on $FOUND APKs"
+            apps/mobile/watchface/build/outputs/apk; do
+            COUNT=0
+            while IFS= read -r APK; do
+              COUNT=$((COUNT + 1))
+              ACTUAL=$("$APKSIGNER" verify --print-certs "$APK" \
+                | grep -oP 'SHA-256 digest: \K[0-9a-f]+' | head -1)
+              if [ "$ACTUAL" != "$EXPECTED_SHA256" ]; then
+                echo "::error::$APK is signed with certificate $ACTUAL, expected $EXPECTED_SHA256 -- the release signing identity CHANGED"
+                exit 1
+              fi
+              echo "cert OK: $(basename "$APK")"
+            done < <(find "$ROOT" -name '*.apk' ! -name '*unsigned*' | sort)
+            if [ "$COUNT" -eq 0 ]; then
+              echo "::error::no signed release APK found under $ROOT"
+              exit 1
+            fi
+            TOTAL=$((TOTAL + COUNT))
+          done
+          echo "signing identity verified on $TOTAL APKs across 3 modules"
 
   no_environment:
     name: Negative control (no environment -> secrets must be empty)
@@ -174,14 +185,18 @@ jobs:
                       P_RELEASE_KEYSTORE_BASE64 P_RELEASE_KEYSTORE_PASSWORD \
                       P_RELEASE_KEY_ALIAS P_RELEASE_KEY_PASSWORD; do
             # ${#...} is a byte length, not the value -- safe to print.
-            len=$(eval "echo \${#$name}")
+            val="${!name}"
+            len="${#val}"
             echo "no-environment ${name#P_} len=$len"
             if [ "$len" -ne 0 ]; then
               leaked=1
             fi
           done
           if [ "$leaked" -ne 0 ]; then
-            if [ "$ENFORCE" = "true" ]; then
+            # Fail-safe: anything other than the literal "false" enforces,
+            # so an empty/missing input can never silently downgrade this
+            # to a warning.
+            if [ "$ENFORCE" != "false" ]; then
               echo "::error::a RELEASE/keystore secret resolved non-empty in a job with no environment -- a plain org/repo copy still exists outside the release-gated environment (single-source-of-truth violated)"
               exit 1
             fi

--- a/.github/workflows/release-signing-smoke.yml
+++ b/.github/workflows/release-signing-smoke.yml
@@ -10,8 +10,13 @@ name: Release Signing Smoke
 #                   required reviewer, mints a RELEASE app token from the
 #                   environment secrets, decodes the keystore, builds
 #                   :app / :wear-device / :watchface assembleRelease, and
-#                   asserts every APK's signing cert SHA-256 matches the
-#                   shipped release cert (frozen signing identity).
+#                   asserts every phone/wear APK's signing cert SHA-256
+#                   matches the shipped release cert (frozen signing
+#                   identity). :watchface builds but is excluded from the
+#                   cert assertion: its release build type deliberately
+#                   uses the debug signing config (see
+#                   apps/mobile/watchface/build.gradle.kts) and has never
+#                   carried the release identity.
 #   no_environment  declares no environment; asserts the RELEASE key and all
 #                   four keystore secrets resolve empty (len=0), proving no
 #                   plain org/repo copy survives outside the gate. Set
@@ -134,14 +139,17 @@ jobs:
           fi
           # Coverage is asserted PER MODULE (not a total count) so one
           # module silently producing nothing cannot be masked by another
-          # module's extra flavor APKs. watchface is searched from its
-          # apk/ root because its flavors nest as apk/<flavor>/release/,
-          # unlike app and wear.
+          # module's extra APKs. :watchface is deliberately NOT here: its
+          # release build type signs with the debug config by design
+          # (apps/mobile/watchface/build.gradle.kts -- "a dedicated
+          # release keystore will be added when production distribution
+          # is set up"), so the release identity does not apply to it;
+          # its assembleRelease step above still hard-fails if the module
+          # stops building.
           TOTAL=0
           for ROOT in \
             apps/mobile/app/build/outputs/apk/release \
-            apps/mobile/wear-device/build/outputs/apk/release \
-            apps/mobile/watchface/build/outputs/apk; do
+            apps/mobile/wear-device/build/outputs/apk/release; do
             COUNT=0
             while IFS= read -r APK; do
               COUNT=$((COUNT + 1))

--- a/.github/workflows/release-signing-smoke.yml
+++ b/.github/workflows/release-signing-smoke.yml
@@ -1,0 +1,191 @@
+name: Release Signing Smoke
+
+# Manually-dispatched smoke test for the release-gated environment: proves
+# the RELEASE app key mints and the relocated android release keystore still
+# signs every release module with the UNCHANGED release certificate, without
+# cutting a release. Companion to secrets-plumbing-check.yml, which covers
+# the op-github-gated environment. Rationale in docs/dev/gated-environments.md.
+#
+#   gated_signing   declares `environment: release-gated`, pauses on the
+#                   required reviewer, mints a RELEASE app token from the
+#                   environment secrets, decodes the keystore, builds
+#                   :app / :wear-device / :watchface assembleRelease, and
+#                   asserts every APK's signing cert SHA-256 matches the
+#                   shipped release cert (frozen signing identity).
+#   no_environment  declares no environment; asserts the RELEASE key and all
+#                   four keystore secrets resolve empty (len=0), proving no
+#                   plain org/repo copy survives outside the gate. Set
+#                   `enforce-no-plain-copies: false` only mid-MOVE, before
+#                   the plain copies are deleted, to report without failing.
+#
+# workflow_dispatch only: it references the RELEASE app key, so a
+# pull_request trigger would be a check-secret-invariants.py BYPASS-PR
+# violation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      enforce-no-plain-copies:
+        description: >-
+          Fail if RELEASE/keystore secrets resolve outside the gated
+          environment (disable only mid-MOVE, before plain copies are
+          deleted)
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # Not cancel-in-progress: a second dispatch must not cancel a run that is
+  # paused waiting for the environment approval.
+  group: release-signing-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  gated_signing:
+    name: Sign release APKs from gated keystore
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # JOB-level environment: the required-reviewer gate. The job pauses
+    # pre-step-execution, so neither the RELEASE key nor the keystore is in
+    # scope before approval.
+    environment: release-gated
+    steps:
+      # Succeeding at all proves the environment-held app id + private key
+      # are valid; the token itself is never used further.
+      - name: Mint RELEASE app token from environment secrets
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
+      - name: Decode signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          # Unlike release.yml this is NOT optional: an empty secret here
+          # means the environment is misconfigured and the smoke must fail,
+          # not silently build unsigned.
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 did not resolve from the release-gated environment"
+            exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 -d > /tmp/release-keystore.jks
+          echo "RELEASE_KEYSTORE_FILE=/tmp/release-keystore.jks" >> "$GITHUB_ENV"
+
+      # All three builds are hard requirements (no continue-on-error, unlike
+      # release.yml): the smoke exists to prove every module still signs.
+      - name: Build phone release APK
+        working-directory: apps/mobile
+        run: ./gradlew :app:assembleRelease
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+      - name: Build wear release APK
+        working-directory: apps/mobile
+        run: ./gradlew :wear-device:assembleRelease
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+      - name: Build watchface release APKs
+        working-directory: apps/mobile
+        run: ./gradlew :watchface:assembleRelease
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+      - name: Assert signing identity unchanged
+        run: |
+          set -euo pipefail
+          # SHA-256 of the shipped release signing certificate (public --
+          # printed by `apksigner verify --print-certs` on any published
+          # APK, e.g. the v0.13.0 release assets). If this ever mismatches,
+          # the frozen signing identity changed and in-place upgrades would
+          # break for every installed user: hard stop.
+          EXPECTED_SHA256="55f0d0cdabf20b398ad30a0ce3e998e3192666e5c15e6d378b86e1c8de342990"
+          APKSIGNER=$(find "$ANDROID_HOME"/build-tools -name apksigner -type f | sort -V | tail -1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "::error::apksigner not found under ANDROID_HOME/build-tools"
+            exit 1
+          fi
+          FOUND=0
+          while IFS= read -r APK; do
+            FOUND=$((FOUND + 1))
+            ACTUAL=$("$APKSIGNER" verify --print-certs "$APK" \
+              | grep -oP 'SHA-256 digest: \K[0-9a-f]+' | head -1)
+            if [ "$ACTUAL" != "$EXPECTED_SHA256" ]; then
+              echo "::error::$APK is signed with certificate $ACTUAL, expected $EXPECTED_SHA256 -- the release signing identity CHANGED"
+              exit 1
+            fi
+            echo "cert OK: $(basename "$APK")"
+          done < <(find \
+            apps/mobile/app/build/outputs/apk/release \
+            apps/mobile/wear-device/build/outputs/apk/release \
+            apps/mobile/watchface/build/outputs/apk \
+            -name '*.apk' ! -name '*unsigned*' | sort)
+          # phone + wear + two watchface flavors
+          if [ "$FOUND" -lt 4 ]; then
+            echo "::error::expected at least 4 signed release APKs, found $FOUND"
+            exit 1
+          fi
+          echo "signing identity verified on $FOUND APKs"
+
+  no_environment:
+    name: Negative control (no environment -> secrets must be empty)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Deliberately no `environment:`: environment secrets must not reach a
+    # job that does not declare the environment, and after the MOVE no
+    # plain org/repo copy may resolve here either.
+    env:
+      P_RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      P_RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      P_RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      P_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      P_RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      P_RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+      ENFORCE: ${{ inputs.enforce-no-plain-copies }}
+    steps:
+      - name: Assert secrets unresolvable outside the gate (lengths only)
+        run: |
+          set -euo pipefail
+          leaked=0
+          for name in P_RELEASE_APP_ID P_RELEASE_APP_PRIVATE_KEY \
+                      P_RELEASE_KEYSTORE_BASE64 P_RELEASE_KEYSTORE_PASSWORD \
+                      P_RELEASE_KEY_ALIAS P_RELEASE_KEY_PASSWORD; do
+            # ${#...} is a byte length, not the value -- safe to print.
+            len=$(eval "echo \${#$name}")
+            echo "no-environment ${name#P_} len=$len"
+            if [ "$len" -ne 0 ]; then
+              leaked=1
+            fi
+          done
+          if [ "$leaked" -ne 0 ]; then
+            if [ "$ENFORCE" = "true" ]; then
+              echo "::error::a RELEASE/keystore secret resolved non-empty in a job with no environment -- a plain org/repo copy still exists outside the release-gated environment (single-source-of-truth violated)"
+              exit 1
+            fi
+            echo "::warning::plain copies still resolve outside the gate (expected mid-MOVE; enforce-no-plain-copies=false)"
+          else
+            echo "single-source-of-truth OK: all six secrets resolve empty outside the gated environment"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    # The RELEASE app key and android release keystore exist only as
+    # secrets in this approval-gated environment (no plain org/repo
+    # copies). Every job that mints the RELEASE token or signs with the
+    # keystore declares it and pauses for reviewer approval.
+    environment: release-gated
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -116,6 +121,7 @@ jobs:
   fallback-release:
     name: Fallback Patch Release
     runs-on: ubuntu-latest
+    environment: release-gated
     needs: [release-please, detect-deployable-changes]
     if: >-
       needs.release-please.outputs.release_created != 'true' &&
@@ -310,6 +316,7 @@ jobs:
   release-android-apk:
     name: Build & Upload Release APK
     runs-on: ubuntu-latest
+    environment: release-gated
     needs: [release-please, fallback-release]
     if: >-
       always() && !cancelled() &&
@@ -446,6 +453,7 @@ jobs:
   update-release-body:
     name: Update Release with Contributor Credits
     runs-on: ubuntu-latest
+    environment: release-gated
     needs: [release-please, fallback-release]
     if: >-
       always() && !cancelled() &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,10 +356,15 @@ jobs:
         env:
           KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
         run: |
-          if [ -n "$KEYSTORE_BASE64" ]; then
-            echo "$KEYSTORE_BASE64" | base64 -d > /tmp/release-keystore.jks
-            echo "RELEASE_KEYSTORE_FILE=/tmp/release-keystore.jks" >> "$GITHUB_ENV"
+          # Fail closed: with the keystore now environment-scoped, an empty
+          # value means this job lost access to the release-gated
+          # environment -- refusing here beats releasing an unsigned APK.
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 did not resolve; refusing to build an unsigned release APK"
+            exit 1
           fi
+          echo "$KEYSTORE_BASE64" | base64 -d > /tmp/release-keystore.jks
+          echo "RELEASE_KEYSTORE_FILE=/tmp/release-keystore.jks" >> "$GITHUB_ENV"
 
       - name: Build phone release APK
         working-directory: apps/mobile

--- a/docs/dev/gated-environments.md
+++ b/docs/dev/gated-environments.md
@@ -61,23 +61,32 @@ directly.
 Consumers are every RELEASE-minting job: `changelog-pr.yml` (`changelog`) and
 `release.yml` (`release-please`, `fallback-release`, `release-android-apk`,
 `update-release-body`), and the equivalent jobs on the sibling repos. All are
-`push: main` / `workflow_dispatch` jobs (Class A, pause-tolerant). Each
+`push: main` / `workflow_dispatch` jobs (Class A, pause-tolerant). On the
+reviewer-protected repos (monorepo, `website`, `android-unofficial`) each
 gated job pauses for reviewer approval before the key is in scope, so a
 single release run prompts **more than once** as successive jobs start
 (release-please first, then the APK/release-body jobs); an unapproved job
 strands that run, and downstream jobs that need `release_created` skip
-rather than hang if `release-please` is rejected.
+rather than hang if `release-please` is rejected. On the reviewerless
+`glycemicgpt-discord-bot` exception (below) jobs do **not** pause -- its
+secrets are environment-scoped, not approval-gated.
 
 Configuration differs from `op-github-gated` in two deliberate ways:
 
 - **`prevent_self_review = false`.** The release trigger is already
   lead-only: pushes to `main` are restricted to promotion merges the lead
-  performs, so the dispatcher and the only sensible approver are the same
-  person. With a single-maintainer topology, `prevent_self_review = true`
-  would deadlock every release on a second human without excluding any
-  realistic attacker (an attacker who can trigger `push: main` already has
-  lead credentials). All other conditions -- `can_admins_bypass = false`,
-  custom additive branch policy, no auto-approver apps -- are unchanged.
+  performs, `workflow_dispatch` requires write access and the lead is the
+  only write-capable collaborator, so the dispatcher and the only sensible
+  approver are the same person. Approval authority itself never widens:
+  whoever triggers a run, only the required reviewer (the lead) can
+  approve it -- `prevent_self_review = false` merely stops the lead's own
+  dispatches from deadlocking on a second human. With a single-maintainer
+  topology, `prevent_self_review = true` would stall every release without
+  excluding any realistic attacker (an attacker who can trigger
+  `push: main` or dispatch already has lead credentials). All other
+  conditions -- `can_admins_bypass = false`, custom additive branch
+  policy, no auto-approver apps -- are unchanged. Revisit this setting if
+  the monorepo ever gains a second write-capable collaborator.
 - **`glycemicgpt-discord-bot` carries no reviewer rule at all.** The repo is
   private, and on the org's current plan the required-reviewer rule is
   rejected for private repos (empirically: the API returns HTTP 422

--- a/docs/dev/gated-environments.md
+++ b/docs/dev/gated-environments.md
@@ -10,8 +10,11 @@ signing material -- live behind approval-gated GitHub Environments so that a
 poisoned same-repo workflow cannot read them. This is the native remediation
 for the pipeline-privilege-escalation (PPE) class: a required-reviewer gate
 binds to the job that declares `environment:`, and a job that does **not**
-declare it resolves the secret to the empty string. There is no way to read a
-gated secret without a human approval.
+declare it resolves the secret to the empty string. On a reviewer-protected
+environment there is no way to read a gated secret without a human approval.
+(One documented exception exists: the reviewerless `release-gated`
+environment on the private `glycemicgpt-discord-bot` repo is
+environment-*scoped* but not approval-gated -- see its section below.)
 
 This page describes `op-github-gated`, the reference environment, and how to
 add a consumer without weakening the gate.
@@ -100,10 +103,15 @@ Configuration differs from `op-github-gated` in two deliberate ways:
 
 `release-signing-smoke.yml` (`workflow_dispatch`) proves the monorepo
 plumbing without cutting a release: the gated job mints a RELEASE app token,
-signs `:app` / `:wear-device` / `:watchface` from the environment-held
-keystore, and asserts the signing certificate SHA-256 still matches the
-shipped release cert (the frozen signing identity); the no-environment job
-asserts all six secrets resolve `len=0` outside the gate.
+builds `:app` / `:wear-device` / `:watchface` `assembleRelease` with the
+environment-held keystore, and asserts the phone and wear APKs' signing
+certificate SHA-256 still matches the shipped release cert (the frozen
+signing identity). `:watchface` must build but is excluded from the cert
+assertion -- its release build type deliberately signs with the debug
+config until production watchface distribution is set up
+(`apps/mobile/watchface/build.gradle.kts`), so it has never carried the
+release identity. The no-environment job asserts all six secrets resolve
+`len=0` outside the gate.
 
 ## The `op-load-secrets` composite
 

--- a/docs/dev/gated-environments.md
+++ b/docs/dev/gated-environments.md
@@ -61,8 +61,12 @@ directly.
 Consumers are every RELEASE-minting job: `changelog-pr.yml` (`changelog`) and
 `release.yml` (`release-please`, `fallback-release`, `release-android-apk`,
 `update-release-body`), and the equivalent jobs on the sibling repos. All are
-`push: main` / `workflow_dispatch` jobs (Class A, pause-tolerant): each run
-now pauses for one reviewer approval before the key is in scope.
+`push: main` / `workflow_dispatch` jobs (Class A, pause-tolerant). Each
+gated job pauses for reviewer approval before the key is in scope, so a
+single release run prompts **more than once** as successive jobs start
+(release-please first, then the APK/release-body jobs); an unapproved job
+strands that run, and downstream jobs that need `release_created` skip
+rather than hang if `release-please` is rejected.
 
 Configuration differs from `op-github-gated` in two deliberate ways:
 
@@ -75,11 +79,15 @@ Configuration differs from `op-github-gated` in two deliberate ways:
   lead credentials). All other conditions -- `can_admins_bypass = false`,
   custom additive branch policy, no auto-approver apps -- are unchanged.
 - **`glycemicgpt-discord-bot` carries no reviewer rule at all.** The repo is
-  private and the org plan only supports environment protection rules on
-  public repos. Compensating controls: a `main`-only custom branch policy and
-  zero non-admin write actors, both drift-checked (`ENV-REVIEWERLESS` /
-  `ENV-REVIEWERLESS-TRIPWIRE` in `check-secret-invariants.py`). Add the
-  reviewer rule if that repo ever goes public.
+  private, and on the org's current plan the required-reviewer rule is
+  rejected for private repos (empirically: the API returns HTTP 422
+  "billing plan" for the reviewer rule, while custom deployment branch
+  policies on the same environment are accepted and live -- they are not
+  the same plan gate). Compensating controls, both **verified** by the
+  drift audit rather than assumed: a `main`-only custom branch policy
+  (`ENV-REVIEWERLESS-POLICY` fires if removed or widened) and zero
+  non-admin write actors (`ENV-REVIEWERLESS-TRIPWIRE` fires when one
+  appears). Add the reviewer rule if that repo ever goes public.
 
 `release-signing-smoke.yml` (`workflow_dispatch`) proves the monorepo
 plumbing without cutting a release: the gated job mints a RELEASE app token,

--- a/docs/dev/gated-environments.md
+++ b/docs/dev/gated-environments.md
@@ -47,6 +47,47 @@ non-environment jobs). The scheduled `secrets-hygiene.yml` audit
 `required_reviewers >= 1`, and a gated secret must not reappear as a plain
 copy.
 
+## `release-gated`
+
+**Label: release credentials / live consumers.** Exists on the monorepo,
+`website`, `android-unofficial`, and `glycemicgpt-discord-bot`. It holds the
+`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` GitHub App key (formerly an
+org-wide secret) on every repo, plus -- on the monorepo only -- the four
+android release-signing keystore secrets (`RELEASE_KEYSTORE_BASE64`,
+`RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`).
+The 1Password items remain escrow only; CI reads the environment secrets
+directly.
+
+Consumers are every RELEASE-minting job: `changelog-pr.yml` (`changelog`) and
+`release.yml` (`release-please`, `fallback-release`, `release-android-apk`,
+`update-release-body`), and the equivalent jobs on the sibling repos. All are
+`push: main` / `workflow_dispatch` jobs (Class A, pause-tolerant): each run
+now pauses for one reviewer approval before the key is in scope.
+
+Configuration differs from `op-github-gated` in two deliberate ways:
+
+- **`prevent_self_review = false`.** The release trigger is already
+  lead-only: pushes to `main` are restricted to promotion merges the lead
+  performs, so the dispatcher and the only sensible approver are the same
+  person. With a single-maintainer topology, `prevent_self_review = true`
+  would deadlock every release on a second human without excluding any
+  realistic attacker (an attacker who can trigger `push: main` already has
+  lead credentials). All other conditions -- `can_admins_bypass = false`,
+  custom additive branch policy, no auto-approver apps -- are unchanged.
+- **`glycemicgpt-discord-bot` carries no reviewer rule at all.** The repo is
+  private and the org plan only supports environment protection rules on
+  public repos. Compensating controls: a `main`-only custom branch policy and
+  zero non-admin write actors, both drift-checked (`ENV-REVIEWERLESS` /
+  `ENV-REVIEWERLESS-TRIPWIRE` in `check-secret-invariants.py`). Add the
+  reviewer rule if that repo ever goes public.
+
+`release-signing-smoke.yml` (`workflow_dispatch`) proves the monorepo
+plumbing without cutting a release: the gated job mints a RELEASE app token,
+signs `:app` / `:wear-device` / `:watchface` from the environment-held
+keystore, and asserts the signing certificate SHA-256 still matches the
+shipped release cert (the frozen signing identity); the no-environment job
+asserts all six secrets resolve `len=0` outside the gate.
+
 ## The `op-load-secrets` composite
 
 `.github/actions/op-load-secrets/action.yml` is the reference composite for

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -29,13 +29,20 @@ an approval-gated environment):
 
   env-secrets drift  Each gated environment must hold exactly its
                      expected secret list, and none of those secrets may
-                     reappear as a plain repo secret (plain-copy re-add).
+                     reappear as a plain repo secret (plain-copy re-add)
+                     or as an org-wide secret (org-level re-add -- the
+                     RELEASE key's pre-migration home).
 
   reviewer drift     Every environment on every org repo must carry a
                      required_reviewers protection rule with >= 1
                      reviewer. Pre-existing ungated environments are
-                     pinned in UNGATED_ENV_BASELINE; any environment not
-                     in that baseline fails.
+                     pinned in UNGATED_ENV_BASELINE; environments that
+                     cannot carry a reviewer rule (private repo on the
+                     current org plan) are pinned in
+                     REVIEWERLESS_ENV_BASELINE, warn while both verified
+                     compensations hold (main-only custom branch policy,
+                     zero write actors), and fail the moment either
+                     breaks; any environment in neither baseline fails.
 
 Modes:
   --self-test        Run the bundled red-team fixtures and assert every
@@ -209,12 +216,15 @@ EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {
 }
 
 # Environments that hold gated secrets but cannot carry a required-reviewer
-# rule: the repo is private and the org plan only supports environment
-# protection rules on public repos. Compensating controls: custom deployment
-# branch policy (main only) plus zero non-admin write actors -- the write
-# actor check is a tripwire, not advice. Remove the pin (and add the
-# reviewer) if the repo goes public or the org plan gains private-repo
-# environment protection.
+# rule: the repo is private, and on the org's current plan the reviewer rule
+# is rejected for private repos (empirically HTTP 422 "billing plan"), while
+# custom deployment branch policies ARE accepted and live. Compensating
+# controls, both VERIFIED by check_reviewer_drift rather than assumed: a
+# main-only custom deployment branch policy (ENV-REVIEWERLESS-POLICY fires
+# if it is removed or widened) and zero non-admin write actors
+# (ENV-REVIEWERLESS-TRIPWIRE fires the moment one appears). Remove the pin
+# (and add the reviewer) if the repo goes public or the plan gains
+# private-repo required reviewers.
 REVIEWERLESS_ENV_BASELINE: set[tuple[str, str]] = {
     ("glycemicgpt-discord-bot", "release-gated"),
 }
@@ -282,7 +292,8 @@ def workflow_has_pr_trigger(text: str) -> bool:
 #       "write_actors": [login, ...],        # non-admin push/maintain
 #       "workflows": {path: {branch: text}}, # default + EXTRA_BRANCHES
 #       "environments": [
-#         {"name": str, "required_reviewers": int, "secrets": [name, ...]}
+#         {"name": str, "required_reviewers": int, "secrets": [name, ...],
+#          "branch_policy_branches": [name, ...] | None}  # custom policy
 #       ],
 #     }
 #   ],
@@ -411,9 +422,10 @@ def check_env_secrets_drift(state: dict) -> tuple[list[str], list[str]]:
                     f"secrets: {', '.join(sorted(readded))}"
                 )
     # Org-level re-add: an org secret is delivered ungated to every repo's
-    # non-environment jobs, so a gated secret reappearing at org level (its
-    # pre-migration home for the RELEASE key) voids the gate org-wide.
-    # Checked once against the union of all expected names, not per repo.
+    # non-environment jobs, so ANY gated secret reappearing at org level
+    # voids its gate org-wide (the RELEASE key lived there pre-migration;
+    # an SA token re-added at org level trips SA-ORG as well). Checked
+    # once against the union of all expected names, not per repo.
     gated_names = {
         name
         for envs in EXPECTED_GATED_ENVIRONMENTS.values()
@@ -437,7 +449,11 @@ def check_reviewer_drift(state: dict) -> tuple[list[str], list[str]]:
                 continue
             key = (repo["name"], env["name"])
             if key in REVIEWERLESS_ENV_BASELINE:
+                # Both compensating controls are verified independently;
+                # the warning below only appears when both hold.
+                compensated = True
                 if repo["write_actors"]:
+                    compensated = False
                     violations.append(
                         f"ENV-REVIEWERLESS-TRIPWIRE: {repo['name']}/"
                         f"{env['name']} was pinned reviewerless (private-"
@@ -447,12 +463,24 @@ def check_reviewer_drift(state: dict) -> tuple[list[str], list[str]]:
                         f"holds -- gate the environment before granting "
                         f"write"
                     )
-                else:
+                if env.get("branch_policy_branches") != ["main"]:
+                    compensated = False
+                    actual = env.get("branch_policy_branches")
+                    violations.append(
+                        f"ENV-REVIEWERLESS-POLICY: {repo['name']}/"
+                        f"{env['name']} is pinned reviewerless on the "
+                        f"strength of a main-only custom deployment branch "
+                        f"policy, but the live policy is "
+                        f"{actual if actual is not None else 'absent'}; "
+                        f"restore the main-only policy"
+                    )
+                if compensated:
                     warnings.append(
                         f"ENV-REVIEWERLESS: {repo['name']}/{env['name']} "
                         f"holds gated secrets without a required reviewer "
-                        f"(private-repo plan limitation); compensated by a "
-                        f"main-only branch policy and zero write actors"
+                        f"(private-repo plan limitation); compensations "
+                        f"verified: main-only custom branch policy and "
+                        f"zero write actors"
                     )
             elif key in UNGATED_ENV_BASELINE:
                 warnings.append(
@@ -694,11 +722,27 @@ def collect_live_state() -> dict:
                 "secrets",
                 allow_404=True,
             )
+            # Custom deployment-branch-policy names, or None when the
+            # environment has no custom policy configured. Consumed by the
+            # REVIEWERLESS_ENV_BASELINE verification (a reviewerless pin is
+            # only sound while its main-only policy is live).
+            branch_policy_branches = None
+            if (env.get("deployment_branch_policy") or {}).get(
+                "custom_branch_policies"
+            ):
+                policies = gh_api_items(
+                    f"/repos/{ORG}/{name}/environments/{env_path}"
+                    f"/deployment-branch-policies",
+                    "branch_policies",
+                    allow_404=True,
+                )
+                branch_policy_branches = sorted(p["name"] for p in policies)
             environments.append(
                 {
                     "name": env["name"],
                     "required_reviewers": reviewer_count,
                     "secrets": [s["name"] for s in env_secrets],
+                    "branch_policy_branches": branch_policy_branches,
                 }
             )
 
@@ -1165,6 +1209,7 @@ def self_test() -> int:
         drop_keystore_from_env: bool = False,
         plain_keystore: bool = False,
         discord_write_actor: bool = False,
+        discord_policy_drift: bool = False,
     ) -> list[dict]:
         """Every gated repo in its post-migration shape, mutated per the
         failure mode under test. Mirrors EXPECTED_GATED_ENVIRONMENTS so a new
@@ -1227,7 +1272,9 @@ def self_test() -> int:
             ),
             # Private repo: no required-reviewer rule available on the org
             # plan; pinned in REVIEWERLESS_ENV_BASELINE, so the clean state
-            # carries a permanent ENV-REVIEWERLESS warning.
+            # carries a permanent ENV-REVIEWERLESS warning while both
+            # verified compensations (main-only policy, no write actors)
+            # hold.
             _repo(
                 "glycemicgpt-discord-bot",
                 write_actors=(["mallory"] if discord_write_actor else []),
@@ -1236,6 +1283,9 @@ def self_test() -> int:
                         "name": "release-gated",
                         "required_reviewers": 0,
                         "secrets": list(RELEASE_KEY_SECRETS),
+                        "branch_policy_branches": (
+                            None if discord_policy_drift else ["main"]
+                        ),
                     }
                 ],
             ),
@@ -1289,6 +1339,11 @@ def self_test() -> int:
         "reviewerless-env-write-actor-tripwire",
         {"org_secrets": [], "repos": _migrated_repos(discord_write_actor=True)},
         {"ENV-REVIEWERLESS-TRIPWIRE"},
+    )
+    expect(
+        "reviewerless-env-policy-drift",
+        {"org_secrets": [], "repos": _migrated_repos(discord_policy_drift=True)},
+        {"ENV-REVIEWERLESS-POLICY"},
     )
 
     if failures:

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -183,10 +183,40 @@ BYPASS_ALLOWLIST: set[tuple[str, str]] = {
 # asserts the environment holds exactly its expected secret list and that
 # none of those secrets reappears as a plain repo copy.
 EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {
-    "GlycemicGPT": {"op-github-gated": {"BACKEND_ACTIONS_SERVICE_ACCOUNT"}},
+    "GlycemicGPT": {
+        "op-github-gated": {"BACKEND_ACTIONS_SERVICE_ACCOUNT"},
+        "release-gated": {
+            "RELEASE_APP_ID",
+            "RELEASE_APP_PRIVATE_KEY",
+            "RELEASE_KEYSTORE_BASE64",
+            "RELEASE_KEYSTORE_PASSWORD",
+            "RELEASE_KEY_ALIAS",
+            "RELEASE_KEY_PASSWORD",
+        },
+    },
     "glycemicgpt-ios-unofficial": {
         "op-github-gated": {"IOS_ACTIONS_SERVICE_ACCOUNT"}
     },
+    "website": {
+        "release-gated": {"RELEASE_APP_ID", "RELEASE_APP_PRIVATE_KEY"}
+    },
+    "android-unofficial": {
+        "release-gated": {"RELEASE_APP_ID", "RELEASE_APP_PRIVATE_KEY"}
+    },
+    "glycemicgpt-discord-bot": {
+        "release-gated": {"RELEASE_APP_ID", "RELEASE_APP_PRIVATE_KEY"}
+    },
+}
+
+# Environments that hold gated secrets but cannot carry a required-reviewer
+# rule: the repo is private and the org plan only supports environment
+# protection rules on public repos. Compensating controls: custom deployment
+# branch policy (main only) plus zero non-admin write actors -- the write
+# actor check is a tripwire, not advice. Remove the pin (and add the
+# reviewer) if the repo goes public or the org plan gains private-repo
+# environment protection.
+REVIEWERLESS_ENV_BASELINE: set[tuple[str, str]] = {
+    ("glycemicgpt-discord-bot", "release-gated"),
 }
 
 # Environments that predate the gating work and hold zero secrets. They
@@ -380,6 +410,22 @@ def check_env_secrets_drift(state: dict) -> tuple[list[str], list[str]]:
                     f"ENV-READD: {repo_name} holds plain copies of gated "
                     f"secrets: {', '.join(sorted(readded))}"
                 )
+    # Org-level re-add: an org secret is delivered ungated to every repo's
+    # non-environment jobs, so a gated secret reappearing at org level (its
+    # pre-migration home for the RELEASE key) voids the gate org-wide.
+    # Checked once against the union of all expected names, not per repo.
+    gated_names = {
+        name
+        for envs in EXPECTED_GATED_ENVIRONMENTS.values()
+        for expected in envs.values()
+        for name in expected
+    }
+    for name in sorted(gated_names & set(state["org_secrets"])):
+        violations.append(
+            f"ENV-READD-ORG: {name} belongs only inside a gated "
+            f"environment but exists as an org-wide secret, readable by "
+            f"every repo's non-environment jobs"
+        )
     return violations, []
 
 
@@ -390,7 +436,25 @@ def check_reviewer_drift(state: dict) -> tuple[list[str], list[str]]:
             if env["required_reviewers"] >= 1:
                 continue
             key = (repo["name"], env["name"])
-            if key in UNGATED_ENV_BASELINE:
+            if key in REVIEWERLESS_ENV_BASELINE:
+                if repo["write_actors"]:
+                    violations.append(
+                        f"ENV-REVIEWERLESS-TRIPWIRE: {repo['name']}/"
+                        f"{env['name']} was pinned reviewerless (private-"
+                        f"repo plan limitation) but the repo now has write "
+                        f"actors ({', '.join(sorted(repo['write_actors']))}); "
+                        f"the branch-policy-only compensation no longer "
+                        f"holds -- gate the environment before granting "
+                        f"write"
+                    )
+                else:
+                    warnings.append(
+                        f"ENV-REVIEWERLESS: {repo['name']}/{env['name']} "
+                        f"holds gated secrets without a required reviewer "
+                        f"(private-repo plan limitation); compensated by a "
+                        f"main-only branch policy and zero write actors"
+                    )
+            elif key in UNGATED_ENV_BASELINE:
                 warnings.append(
                     f"ENV-BASELINE: {repo['name']}/{env['name']} predates "
                     f"gating and has no required reviewers; resolve with "
@@ -1086,27 +1150,49 @@ def self_test() -> int:
     # regress to a no-op. Restores the production map.
     EXPECTED_GATED_ENVIRONMENTS = _production_map
 
+    RELEASE_KEY_SECRETS = ["RELEASE_APP_ID", "RELEASE_APP_PRIVATE_KEY"]
+    KEYSTORE_SECRETS = [
+        "RELEASE_KEYSTORE_BASE64",
+        "RELEASE_KEYSTORE_PASSWORD",
+        "RELEASE_KEY_ALIAS",
+        "RELEASE_KEY_PASSWORD",
+    ]
+
     def _migrated_repos(
-        *, plain_backend: bool = False, drop_backend_from_env: bool = False
+        *,
+        plain_backend: bool = False,
+        drop_backend_from_env: bool = False,
+        drop_keystore_from_env: bool = False,
+        plain_keystore: bool = False,
+        discord_write_actor: bool = False,
     ) -> list[dict]:
-        """Both gated repos in their post-migration shape, mutated per the
+        """Every gated repo in its post-migration shape, mutated per the
         failure mode under test. Mirrors EXPECTED_GATED_ENVIRONMENTS so a new
         production entry that is not modelled here surfaces as a drift."""
-        gly_env_secrets = (
+        gly_op_secrets = (
             [] if drop_backend_from_env else ["BACKEND_ACTIONS_SERVICE_ACCOUNT"]
         )
+        gly_release_secrets = RELEASE_KEY_SECRETS + (
+            [] if drop_keystore_from_env else KEYSTORE_SECRETS
+        )
+        gly_plain = (
+            ["BACKEND_ACTIONS_SERVICE_ACCOUNT"] if plain_backend else []
+        ) + (KEYSTORE_SECRETS if plain_keystore else [])
         return [
             _repo(
                 "GlycemicGPT",
-                secrets=(
-                    ["BACKEND_ACTIONS_SERVICE_ACCOUNT"] if plain_backend else []
-                ),
+                secrets=gly_plain,
                 environments=[
                     {
                         "name": "op-github-gated",
                         "required_reviewers": 1,
-                        "secrets": gly_env_secrets,
-                    }
+                        "secrets": gly_op_secrets,
+                    },
+                    {
+                        "name": "release-gated",
+                        "required_reviewers": 1,
+                        "secrets": gly_release_secrets,
+                    },
                 ],
             ),
             _repo(
@@ -1119,22 +1205,90 @@ def self_test() -> int:
                     }
                 ],
             ),
+            _repo(
+                "website",
+                environments=[
+                    {
+                        "name": "release-gated",
+                        "required_reviewers": 1,
+                        "secrets": list(RELEASE_KEY_SECRETS),
+                    }
+                ],
+            ),
+            _repo(
+                "android-unofficial",
+                environments=[
+                    {
+                        "name": "release-gated",
+                        "required_reviewers": 1,
+                        "secrets": list(RELEASE_KEY_SECRETS),
+                    }
+                ],
+            ),
+            # Private repo: no required-reviewer rule available on the org
+            # plan; pinned in REVIEWERLESS_ENV_BASELINE, so the clean state
+            # carries a permanent ENV-REVIEWERLESS warning.
+            _repo(
+                "glycemicgpt-discord-bot",
+                write_actors=(["mallory"] if discord_write_actor else []),
+                environments=[
+                    {
+                        "name": "release-gated",
+                        "required_reviewers": 0,
+                        "secrets": list(RELEASE_KEY_SECRETS),
+                    }
+                ],
+            ),
         ]
 
     expect(
         "gated-tokens-migrated-clean",
         {"org_secrets": [], "repos": _migrated_repos()},
         set(),
+        warn_codes={"ENV-REVIEWERLESS"},
     )
     expect(
         "gated-token-removed-from-env",
         {"org_secrets": [], "repos": _migrated_repos(drop_backend_from_env=True)},
         {"ENV-DRIFT"},
+        warn_codes={"ENV-REVIEWERLESS"},
     )
     expect(
         "gated-token-plain-readd",
         {"org_secrets": [], "repos": _migrated_repos(plain_backend=True)},
         {"SA-PLAIN", "ENV-READD"},
+        warn_codes={"ENV-REVIEWERLESS"},
+    )
+    # 24-27. The release-gated failure modes this migration must never let
+    # regress silently: keystore dropped from the environment, keystore
+    # re-added as plain repo secrets, the RELEASE key re-added at org level
+    # (its pre-migration home), and the reviewerless discord pin tripping
+    # the moment that repo gains a write actor.
+    expect(
+        "release-keystore-removed-from-env",
+        {"org_secrets": [], "repos": _migrated_repos(drop_keystore_from_env=True)},
+        {"ENV-DRIFT"},
+        warn_codes={"ENV-REVIEWERLESS"},
+    )
+    expect(
+        "release-keystore-plain-readd",
+        {"org_secrets": [], "repos": _migrated_repos(plain_keystore=True)},
+        {"ENV-READD"},
+        warn_codes={"ENV-REVIEWERLESS"},
+    )
+    expect(
+        "release-key-org-readd",
+        {
+            "org_secrets": ["RELEASE_APP_ID", "RELEASE_APP_PRIVATE_KEY"],
+            "repos": _migrated_repos(),
+        },
+        {"ENV-READD-ORG"},
+        warn_codes={"ENV-REVIEWERLESS"},
+    )
+    expect(
+        "reviewerless-env-write-actor-tripwire",
+        {"org_secrets": [], "repos": _migrated_repos(discord_write_actor=True)},
+        {"ENV-REVIEWERLESS-TRIPWIRE"},
     )
 
     if failures:

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -39,10 +39,11 @@ an approval-gated environment):
                      pinned in UNGATED_ENV_BASELINE; environments that
                      cannot carry a reviewer rule (private repo on the
                      current org plan) are pinned in
-                     REVIEWERLESS_ENV_BASELINE, warn while both verified
-                     compensations hold (main-only custom branch policy,
-                     zero write actors), and fail the moment either
-                     breaks; any environment in neither baseline fails.
+                     REVIEWERLESS_ENV_BASELINE, warn while every verified
+                     leg of the contract holds (main-only custom branch
+                     policy, zero write actors, single admin, repo still
+                     private), and fail the moment any leg breaks; any
+                     environment in neither baseline fails.
 
 Modes:
   --self-test        Run the bundled red-team fixtures and assert every
@@ -218,13 +219,14 @@ EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {
 # Environments that hold gated secrets but cannot carry a required-reviewer
 # rule: the repo is private, and on the org's current plan the reviewer rule
 # is rejected for private repos (empirically HTTP 422 "billing plan"), while
-# custom deployment branch policies ARE accepted and live. Compensating
-# controls, both VERIFIED by check_reviewer_drift rather than assumed: a
-# main-only custom deployment branch policy (ENV-REVIEWERLESS-POLICY fires
-# if it is removed or widened) and zero non-admin write actors
-# (ENV-REVIEWERLESS-TRIPWIRE fires the moment one appears). Remove the pin
-# (and add the reviewer) if the repo goes public or the plan gains
-# private-repo required reviewers.
+# custom deployment branch policies ARE accepted and live. Every leg of the
+# compensating contract is VERIFIED by check_reviewer_drift rather than
+# assumed: a main-only custom deployment branch policy
+# (ENV-REVIEWERLESS-POLICY fires if it is removed or widened), zero
+# non-admin write actors (ENV-REVIEWERLESS-TRIPWIRE), a single admin
+# (ENV-REVIEWERLESS-ADMINS), and the repo staying private
+# (ENV-REVIEWERLESS-PUBLIC -- once public, add the reviewer and remove the
+# pin).
 REVIEWERLESS_ENV_BASELINE: set[tuple[str, str]] = {
     ("glycemicgpt-discord-bot", "release-gated"),
 }
@@ -290,6 +292,8 @@ def workflow_has_pr_trigger(text: str) -> bool:
 #       "name": str,
 #       "secrets": [name, ...],              # plain repo-level secrets
 #       "write_actors": [login, ...],        # non-admin push/maintain
+#       "admin_actors": [login, ...],        # admin collaborators
+#       "private": bool,                     # repo visibility
 #       "workflows": {path: {branch: text}}, # default + EXTRA_BRANCHES
 #       "environments": [
 #         {"name": str, "required_reviewers": int, "secrets": [name, ...],
@@ -449,9 +453,30 @@ def check_reviewer_drift(state: dict) -> tuple[list[str], list[str]]:
                 continue
             key = (repo["name"], env["name"])
             if key in REVIEWERLESS_ENV_BASELINE:
-                # Both compensating controls are verified independently;
-                # the warning below only appears when both hold.
+                # Every leg of the reviewerless contract is verified
+                # independently; the warning below only appears when all
+                # hold: no write actors, single admin, still private,
+                # main-only custom branch policy.
                 compensated = True
+                if not repo.get("private", True):
+                    compensated = False
+                    violations.append(
+                        f"ENV-REVIEWERLESS-PUBLIC: {repo['name']} is now "
+                        f"public, so the plan limitation that justified "
+                        f"the reviewerless pin on {env['name']} no longer "
+                        f"applies -- add the required reviewer and remove "
+                        f"the pin"
+                    )
+                admins = repo.get("admin_actors", [])
+                if len(admins) > 1:
+                    compensated = False
+                    violations.append(
+                        f"ENV-REVIEWERLESS-ADMINS: {repo['name']} now has "
+                        f"multiple admins ({', '.join(sorted(admins))}); "
+                        f"the reviewerless pin on {env['name']} assumed a "
+                        f"single-lead topology -- gate the environment or "
+                        f"shrink the admin set"
+                    )
                 if repo["write_actors"]:
                     compensated = False
                     violations.append(
@@ -678,11 +703,23 @@ def collect_live_state() -> dict:
             for s in gh_api_items(f"/repos/{ORG}/{name}/actions/secrets", "secrets")
         ]
 
+        collaborators = gh_api_list(
+            f"/repos/{ORG}/{name}/collaborators?affiliation=all"
+        )
         write_actors = [
             c["login"]
-            for c in gh_api_list(f"/repos/{ORG}/{name}/collaborators?affiliation=all")
+            for c in collaborators
             if c.get("permissions", {}).get("push")
             and not c.get("permissions", {}).get("admin")
+        ]
+        # Admins are tracked separately (they are excluded from
+        # write_actors so the latent-safe/tripwire semantics stay scoped
+        # to non-admin write grants); the reviewerless-environment check
+        # uses this to notice the single-lead topology growing.
+        admin_actors = [
+            c["login"]
+            for c in collaborators
+            if c.get("permissions", {}).get("admin")
         ]
 
         # Scan every branch copy separately: pull_request_target runs the
@@ -751,6 +788,8 @@ def collect_live_state() -> dict:
                 "name": name,
                 "secrets": secrets,
                 "write_actors": write_actors,
+                "admin_actors": admin_actors,
+                "private": bool(repo_meta.get("private")),
                 "workflows": workflows,
                 "environments": environments,
             }
@@ -1210,6 +1249,8 @@ def self_test() -> int:
         plain_keystore: bool = False,
         discord_write_actor: bool = False,
         discord_policy_drift: bool = False,
+        discord_public: bool = False,
+        discord_second_admin: bool = False,
     ) -> list[dict]:
         """Every gated repo in its post-migration shape, mutated per the
         failure mode under test. Mirrors EXPECTED_GATED_ENVIRONMENTS so a new
@@ -1278,6 +1319,12 @@ def self_test() -> int:
             _repo(
                 "glycemicgpt-discord-bot",
                 write_actors=(["mallory"] if discord_write_actor else []),
+                admin_actors=(
+                    ["jlengelbrecht", "mallory"]
+                    if discord_second_admin
+                    else ["jlengelbrecht"]
+                ),
+                private=not discord_public,
                 environments=[
                     {
                         "name": "release-gated",
@@ -1344,6 +1391,16 @@ def self_test() -> int:
         "reviewerless-env-policy-drift",
         {"org_secrets": [], "repos": _migrated_repos(discord_policy_drift=True)},
         {"ENV-REVIEWERLESS-POLICY"},
+    )
+    expect(
+        "reviewerless-env-goes-public",
+        {"org_secrets": [], "repos": _migrated_repos(discord_public=True)},
+        {"ENV-REVIEWERLESS-PUBLIC"},
+    )
+    expect(
+        "reviewerless-env-second-admin",
+        {"org_secrets": [], "repos": _migrated_repos(discord_second_admin=True)},
+        {"ENV-REVIEWERLESS-ADMINS"},
     )
 
     if failures:


### PR DESCRIPTION
## What

Moves the release identity behind an approval-gated GitHub environment (`release-gated`), closing the PR-readable exposure of the org-wide RELEASE app key and the plain-repo android release keystore.

- **`environment: release-gated`** on every RELEASE-minting job: `changelog` (changelog-pr.yml) and `release-please` / `fallback-release` / `release-android-apk` / `update-release-body` (release.yml). These run on `push: main` / `workflow_dispatch` (pause-tolerant); each pauses for reviewer approval before the key is in scope.
- **New `release-signing-smoke.yml`** (dispatch-only): the gated job mints a RELEASE app token from environment secrets, decodes the keystore, builds `:app`/`:wear-device`/`:watchface` `assembleRelease`, and asserts every signer certificate on every APK matches the shipped release cert SHA-256 (frozen signing identity), with per-module coverage. A no-environment job asserts all six secrets resolve `len=0` outside the gate (fail-safe enforce toggle for mid-migration runs).
- **`check-secret-invariants.py`**: `EXPECTED_GATED_ENVIRONMENTS` now expects `release-gated` on all four consuming repos (monorepo entry includes the four keystore secrets); new `ENV-READD-ORG` violation catches a gated secret reappearing as an org-wide secret (the key's pre-migration home); the private discord-bot repo -- where the org plan rejects required reviewers (HTTP 422) while branch policies work -- is pinned reviewerless with two *verified* compensations (`ENV-REVIEWERLESS-POLICY` if the main-only branch policy is removed/widened, `ENV-REVIEWERLESS-TRIPWIRE` if the repo gains a write actor). The live collector now records each environment's custom deployment-branch-policy names. 34 red-team self-test fixtures, all passing.
- **docs/dev/gated-environments.md**: documents `release-gated`, including the deliberate `prevent_self_review = false` rationale for the lead-only trigger surface and the discord-bot exception.

## Why

The RELEASE app key was an org-wide secret (`visibility=ALL`) readable by a poisoned `pull_request` workflow on any repo, and RELEASE is a mandatory-main-bypass credential; the keystore secrets were plain repo secrets guarding an irreplaceable signing identity. Environment scoping with a required reviewer is the native control (validated in the gate-validation review); this PR is the workflow/enforcement half. The operational secret MOVE (set env secrets, then delete the org/plain copies) follows after merge, and the drift audit turns red if it regresses.

## Verification

- `check-secret-invariants.py --self-test`: 34/34 fixtures.
- `--repo-local`: clean (1 pre-existing pinned warning).
- `--live` (pre-MOVE state): RED with exactly the 7 violations describing the not-yet-moved reality (missing env secrets, plain keystore copies, org-level key) -- proof the new entries enforce rather than no-op; goes clean when the MOVE completes.
- Cert-assert grep validated against the published v0.13.0 APK (`apksigner verify --print-certs`).
- zizmor: no findings on the new workflow.
- Adversarial, senior code-quality, CodeRabbit CLI, and security reviews run; all HIGH/MEDIUM findings fixed (per-module cert coverage, every-signer digest check, branch-policy verification, fail-safe enforce default, docs precision).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Added approval gating for multiple release automation jobs and strengthened release signing validation via a new manual “Release Signing Smoke” workflow.
  * Hardened signing behavior to fail when signing keystore access is missing.
  * Strengthened secret-exposure and environment drift checks, including stricter handling for reviewerless environments with compensating controls (actor and main-only branch policy requirements).
* **Documentation**
  * Documented the new `release-gated` environment, including its secrets, reviewer-gating behavior (including reviewerless exception), and the signing verification workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->