### PR TITLE
ci: register signing smoke workflow and gate release jobs on main

### DIFF
--- a/.github/workflows/release-signing-smoke.yml
+++ b/.github/workflows/release-signing-smoke.yml
@@ -1,0 +1,223 @@
+name: Release Signing Smoke
+
+# Manually-dispatched smoke test for the release-gated environment: proves
+# the RELEASE app key mints and the relocated android release keystore still
+# signs every release module with the UNCHANGED release certificate, without
+# cutting a release. Companion to secrets-plumbing-check.yml, which covers
+# the op-github-gated environment. Rationale in docs/dev/gated-environments.md.
+#
+#   gated_signing   declares `environment: release-gated`, pauses on the
+#                   required reviewer, mints a RELEASE app token from the
+#                   environment secrets, decodes the keystore, builds
+#                   :app / :wear-device / :watchface assembleRelease, and
+#                   asserts every phone/wear APK's signing cert SHA-256
+#                   matches the shipped release cert (frozen signing
+#                   identity). :watchface builds but is excluded from the
+#                   cert assertion: its release build type deliberately
+#                   uses the debug signing config (see
+#                   apps/mobile/watchface/build.gradle.kts) and has never
+#                   carried the release identity.
+#   no_environment  declares no environment; asserts the RELEASE key and all
+#                   four keystore secrets resolve empty (len=0), proving no
+#                   plain org/repo copy survives outside the gate. Set
+#                   `enforce-no-plain-copies: false` only mid-MOVE, before
+#                   the plain copies are deleted, to report without failing.
+#
+# workflow_dispatch only: it references the RELEASE app key, so a
+# pull_request trigger would be a check-secret-invariants.py BYPASS-PR
+# violation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      enforce-no-plain-copies:
+        description: >-
+          Fail if RELEASE/keystore secrets resolve outside the gated
+          environment (disable only mid-MOVE, before plain copies are
+          deleted)
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # Not cancel-in-progress: a second dispatch must not cancel a run that is
+  # paused waiting for the environment approval.
+  group: release-signing-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  gated_signing:
+    name: Sign release APKs from gated keystore
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # JOB-level environment: the required-reviewer gate. The job pauses
+    # pre-step-execution, so neither the RELEASE key nor the keystore is in
+    # scope before approval.
+    environment: release-gated
+    steps:
+      # Succeeding at all proves the environment-held app id + private key
+      # are valid; the token itself is never used further.
+      - name: Mint RELEASE app token from environment secrets
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
+      - name: Decode signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          # Unlike release.yml this is NOT optional: an empty secret here
+          # means the environment is misconfigured and the smoke must fail,
+          # not silently build unsigned.
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 did not resolve from the release-gated environment"
+            exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 -d > /tmp/release-keystore.jks
+          echo "RELEASE_KEYSTORE_FILE=/tmp/release-keystore.jks" >> "$GITHUB_ENV"
+
+      # All three builds are hard requirements (no continue-on-error, unlike
+      # release.yml): the smoke exists to prove every module still signs.
+      - name: Build phone release APK
+        working-directory: apps/mobile
+        run: ./gradlew :app:assembleRelease
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+      - name: Build wear release APK
+        working-directory: apps/mobile
+        run: ./gradlew :wear-device:assembleRelease
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+      - name: Build watchface release APKs
+        working-directory: apps/mobile
+        run: ./gradlew :watchface:assembleRelease
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+      - name: Assert signing identity unchanged
+        run: |
+          set -euo pipefail
+          # SHA-256 of the shipped release signing certificate (public --
+          # printed by `apksigner verify --print-certs` on any published
+          # APK, e.g. the v0.13.0 release assets). If this ever mismatches,
+          # the frozen signing identity changed and in-place upgrades would
+          # break for every installed user: hard stop.
+          EXPECTED_SHA256="55f0d0cdabf20b398ad30a0ce3e998e3192666e5c15e6d378b86e1c8de342990"
+          if [ -z "${ANDROID_HOME:-}" ]; then
+            echo "::error::ANDROID_HOME is not set on this runner"
+            exit 1
+          fi
+          APKSIGNER=$(find "$ANDROID_HOME"/build-tools -name apksigner -type f | sort -V | tail -1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "::error::apksigner not found under ANDROID_HOME/build-tools"
+            exit 1
+          fi
+          # Coverage is asserted PER MODULE (not a total count) so one
+          # module silently producing nothing cannot be masked by another
+          # module's extra APKs. :watchface is deliberately NOT here: its
+          # release build type signs with the debug config by design
+          # (apps/mobile/watchface/build.gradle.kts -- "a dedicated
+          # release keystore will be added when production distribution
+          # is set up"), so the release identity does not apply to it;
+          # its assembleRelease step above still hard-fails if the module
+          # stops building.
+          TOTAL=0
+          for ROOT in \
+            apps/mobile/app/build/outputs/apk/release \
+            apps/mobile/wear-device/build/outputs/apk/release; do
+            COUNT=0
+            while IFS= read -r APK; do
+              COUNT=$((COUNT + 1))
+              # Every signer's certificate digest must match -- an APK
+              # carrying an extra/unexpected signer fails, so no digest is
+              # skipped the way a first-match-only check would.
+              DIGESTS=$("$APKSIGNER" verify --print-certs "$APK" \
+                | grep -oP 'certificate SHA-256 digest: \K[0-9a-f]+')
+              if [ -z "$DIGESTS" ]; then
+                echo "::error::$APK has no signer certificate digest (unsigned or unreadable)"
+                exit 1
+              fi
+              while IFS= read -r DIGEST; do
+                if [ "$DIGEST" != "$EXPECTED_SHA256" ]; then
+                  echo "::error::$APK carries signer certificate $DIGEST, expected $EXPECTED_SHA256 -- the release signing identity CHANGED"
+                  exit 1
+                fi
+              done <<< "$DIGESTS"
+              echo "cert OK: $(basename "$APK")"
+            done < <(find "$ROOT" -name '*.apk' ! -name '*unsigned*' | sort)
+            if [ "$COUNT" -eq 0 ]; then
+              echo "::error::no signed release APK found under $ROOT"
+              exit 1
+            fi
+            TOTAL=$((TOTAL + COUNT))
+          done
+          echo "signing identity verified on $TOTAL APKs across 3 modules"
+
+  no_environment:
+    name: Negative control (no environment -> secrets must be empty)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Deliberately no `environment:`: environment secrets must not reach a
+    # job that does not declare the environment, and after the MOVE no
+    # plain org/repo copy may resolve here either.
+    env:
+      P_RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      P_RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      P_RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      P_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      P_RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      P_RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+      ENFORCE: ${{ inputs.enforce-no-plain-copies }}
+    steps:
+      - name: Assert secrets unresolvable outside the gate (lengths only)
+        run: |
+          set -euo pipefail
+          leaked=0
+          for name in P_RELEASE_APP_ID P_RELEASE_APP_PRIVATE_KEY \
+                      P_RELEASE_KEYSTORE_BASE64 P_RELEASE_KEYSTORE_PASSWORD \
+                      P_RELEASE_KEY_ALIAS P_RELEASE_KEY_PASSWORD; do
+            # ${#...} is a byte length, not the value -- safe to print.
+            val="${!name}"
+            len="${#val}"
+            echo "no-environment ${name#P_} len=$len"
+            if [ "$len" -ne 0 ]; then
+              leaked=1
+            fi
+          done
+          if [ "$leaked" -ne 0 ]; then
+            # Fail-safe: anything other than the literal "false" enforces,
+            # so an empty/missing input can never silently downgrade this
+            # to a warning.
+            if [ "$ENFORCE" != "false" ]; then
+              echo "::error::a RELEASE/keystore secret resolved non-empty in a job with no environment -- a plain org/repo copy still exists outside the release-gated environment (single-source-of-truth violated)"
+              exit 1
+            fi
+            echo "::warning::plain copies still resolve outside the gate (expected mid-MOVE; enforce-no-plain-copies=false)"
+          else
+            echo "single-source-of-truth OK: all six secrets resolve empty outside the gated environment"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    # The RELEASE app key and android release keystore exist only as
+    # secrets in this approval-gated environment (no plain org/repo
+    # copies). Every job that mints the RELEASE token or signs with the
+    # keystore declares it and pauses for reviewer approval.
+    environment: release-gated
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -116,6 +121,7 @@ jobs:
   fallback-release:
     name: Fallback Patch Release
     runs-on: ubuntu-latest
+    environment: release-gated
     needs: [release-please, detect-deployable-changes]
     if: >-
       needs.release-please.outputs.release_created != 'true' &&
@@ -310,6 +316,7 @@ jobs:
   release-android-apk:
     name: Build & Upload Release APK
     runs-on: ubuntu-latest
+    environment: release-gated
     needs: [release-please, fallback-release]
     if: >-
       always() && !cancelled() &&
@@ -349,10 +356,15 @@ jobs:
         env:
           KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
         run: |
-          if [ -n "$KEYSTORE_BASE64" ]; then
-            echo "$KEYSTORE_BASE64" | base64 -d > /tmp/release-keystore.jks
-            echo "RELEASE_KEYSTORE_FILE=/tmp/release-keystore.jks" >> "$GITHUB_ENV"
+          # Fail closed: with the keystore now environment-scoped, an empty
+          # value means this job lost access to the release-gated
+          # environment -- refusing here beats releasing an unsigned APK.
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 did not resolve; refusing to build an unsigned release APK"
+            exit 1
           fi
+          echo "$KEYSTORE_BASE64" | base64 -d > /tmp/release-keystore.jks
+          echo "RELEASE_KEYSTORE_FILE=/tmp/release-keystore.jks" >> "$GITHUB_ENV"
 
       - name: Build phone release APK
         working-directory: apps/mobile
@@ -446,6 +458,7 @@ jobs:
   update-release-body:
     name: Update Release with Contributor Credits
     runs-on: ubuntu-latest
+    environment: release-gated
     needs: [release-please, fallback-release]
     if: >-
       always() && !cancelled() &&


### PR DESCRIPTION
## Summary

Surgical carry of exactly two workflow files from develop to main, byte-identical to the reviewed develop versions (develop head 351d81a3):

- `.github/workflows/release-signing-smoke.yml` (new on main, blob d866fbe5): registers the workflow_dispatch-only signing smoke. GitHub builds the dispatchable-workflow registry from the default branch, so the smoke cannot be dispatched until this file exists on main.
- `.github/workflows/release.yml` (blob 5024ef35): the gated version. Every job that mints the RELEASE app token or signs with the release keystore declares `environment: release-gated`, and the keystore decode step fails closed on an empty `RELEASE_KEYSTORE_BASE64` instead of silently building an unsigned APK.

## Why now

The keystore secret relocation cannot safely proceed while main's release path treats an empty keystore as optional. This PR makes main's release path read the environment-scoped secrets and hard-stop on a missing keystore, and registers the smoke needed to prove the relocated keystore still signs with the unchanged release certificate before any plain copy is deleted.

## Non-release guarantees

- `ci:` commit type: release-please cuts no version PR.
- Not a promotion merge: the changelog workflow only fires on "promote develop to main" head-commit messages, which this squash merge does not produce.
- Merging triggers a `release.yml` run on main whose first job now pauses on the release-gated required-reviewer approval; on approval, release-please finds no releasable commits and exits without output.

## Verification

- `git diff origin/develop -- <both files>` on the branch head is empty (blobs d866fbe5 / 5024ef35 match develop exactly).
- The PR diff contains only these two files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release workflows now require gated access to release-related secrets.
  * Android release builds fail immediately when signing credentials are unavailable, preventing unsigned APKs.
  * Added smoke tests to verify release APK signing integrity across supported app modules.
  * Added checks to detect unexpectedly exposed release secrets outside the gated environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->