### PR TITLE
docs: point mobile contributions at android-unofficial during the split

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -713,6 +713,22 @@ The mobile app uses a capability-based plugin architecture. New device support (
 - Hilt DI registration pattern
 - The Tandem plugin as a reference implementation
 
+### Mobile Code During the Repository Split
+
+The Android/Wear OS code (`apps/mobile/`, `plugins/`) is moving to
+[android-unofficial](https://github.com/lumose-health/android-unofficial), and that is where
+mobile development now happens:
+
+- **Open mobile PRs against android-unofficial's `develop`.** It has the full Android CI gates,
+  and dev-channel APKs (the builds the app's auto-updater installs) are published from that
+  repository.
+- The mobile tree in this monorepo remains temporarily while the migration completes, but it is
+  winding down — new mobile PRs opened here will be redirected to android-unofficial.
+- If an in-flight mobile change does still land here during the wind-down, maintainers port it to
+  android-unofficial via `git cherry-pick -x`, which preserves the contributor's commit authorship
+  there. Ports are tracked in that repository's `docs/dev/monorepo-port-ledger.md`.
+- Backend, web, sidecar, and platform documentation contributions continue here as usual.
+
 ---
 
 ## 📦 Release Channels


### PR DESCRIPTION
Documents the contribution flow for the Android/Wear OS split: mobile development now happens in android-unofficial (full Android CI gates; dev-channel APKs that the auto-updater installs are published there), so mobile PRs should be opened against that repository's develop. The mobile tree here remains temporarily while the migration completes; any in-flight mobile change that still lands here is ported over via git cherry-pick -x with contributor authorship preserved, tracked in android-unofficial's docs/dev/monorepo-port-ledger.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new contributor guidance for the Android/Wear OS repository split.
  * Documented how to submit mobile PRs to the new repository’s `develop` branch while the monorepo’s mobile tree remains temporary.
  * Explained how to port any rare in-flight changes back via cherry-picking with contributor authorship, including where port tracking is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->