### PR TITLE
ci: fix docs-update dispatch broken by the org rename

### DIFF
--- a/.github/workflows/notify-docs-update.yml
+++ b/.github/workflows/notify-docs-update.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/notify-docs-update.yml'
+  # Allow maintainers to manually re-fire the dispatch (e.g. to force a website
+  # rebuild if a previous run failed).
+  workflow_dispatch:
 
 permissions: {}
 
@@ -20,14 +23,16 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-          owner: GlycemicGPT
+          # Use the running repo's owner so this keeps working across org renames
+          # (the GitHub App installation lookup does not follow org-rename redirects).
+          owner: ${{ github.repository_owner }}
           repositories: website
 
       - name: Fire docs-updated dispatch
         env:
           GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
         run: |
-          gh api repos/GlycemicGPT/website/dispatches \
+          gh api repos/${{ github.repository_owner }}/website/dispatches \
             -f event_type=docs-updated \
             -F client_payload[source]="${{ github.repository }}" \
             -F client_payload[sha]="${{ github.sha }}"


### PR DESCRIPTION
## Summary

This repo's `docs/` changes stopped auto-rebuilding the website after the org was renamed to `lumose-health`. The `notify-docs-update` workflow's `create-github-app-token` step looked up the App installation for a hardcoded `owner: GlycemicGPT`; that installation lookup does **not** follow GitHub's org-rename redirect, so the step 404'd and the `docs-updated` dispatch never reached the website.

## Fix

- Use `${{ github.repository_owner }}` for both the app-token `owner` and the `gh api .../dispatches` target, so it tracks the repo's actual owner and survives future renames.
- Add a `workflow_dispatch` trigger so a maintainer can manually re-fire the dispatch without pushing a docs change.

Same fix is going up in the org `.github` repo and android-unofficial, which have the identical workflow and bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the ability to manually trigger documentation update notifications.
  * Improved automated documentation updates to continue working when the repository owner changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->