### PR TITLE
fix(security): correct web-merge app slug to lumose-web-merge

### DIFF
--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -228,7 +228,7 @@ PR_TRIGGERS = frozenset({"pull_request", "pull_request_target"})
 # ---------------------------------------------------------------------
 WEB_MERGE_SECRETS = frozenset({"WEB_MERGE_APP_ID", "WEB_MERGE_APP_PRIVATE_KEY"})
 WEB_MERGE_HOME_REPO = "website"
-WEB_MERGE_APP_SLUG = "glycemicgpt-web-merge"
+WEB_MERGE_APP_SLUG = "lumose-web-merge"
 # metadata:read is implicitly granted to every GitHub App and is excluded
 # from the comparison (an explicit metadata:WRITE would still fail it).
 WEB_MERGE_EXPECTED_PERMISSIONS = {"contents": "write", "pull_requests": "write"}


### PR DESCRIPTION
One-line constant fix: the web-merge confinement check pinned the expected app slug as `glycemicgpt-web-merge`, but the app was created as `lumose-web-merge`. The mismatch made the installation invisible to the check, so it fired `WEB-MERGE-UNVERIFIED` (fail-closed, as designed) once the website secrets existed.

Verified before opening this PR:
- Local `--live` run with the fix: the error clears and the check degrades to the documented `WEB-MERGE-REPOS-UNVERIFIED` warning; selection/permissions/placement legs verify green.
- `--self-test`: all 63 fixtures pass (fixtures use synthetic slugs; only the live-expectation constant changed).
- Remaining live errors are exactly the two expected `ENV-READD-ORG` findings that clear at the org-secret delete.