### PR TITLE
fix(security): track ios repo rename to ios-unofficial

### DIFF
--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -260,7 +260,7 @@ GATED_ENV_PROTECTION_BASELINE: dict[tuple[str, str], dict[str, Any]] = {
         "can_admins_bypass": False,
         "reviewers": {"User:jlengelbrecht"},
     },
-    ("glycemicgpt-ios-unofficial", "op-github-gated"): {
+    ("ios-unofficial", "op-github-gated"): {
         "prevent_self_review": True,
         "can_admins_bypass": False,
         "reviewers": {"User:jlengelbrecht"},
@@ -355,7 +355,7 @@ EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {
             "MERGE_APP_PRIVATE_KEY",
         },
     },
-    "glycemicgpt-ios-unofficial": {"op-github-gated": {"IOS_ACTIONS_SERVICE_ACCOUNT"}},
+    "ios-unofficial": {"op-github-gated": {"IOS_ACTIONS_SERVICE_ACCOUNT"}},
     "website": {
         "release-gated": {
             "RELEASE_APP_ID",
@@ -2034,7 +2034,7 @@ def self_test() -> int:
                 ],
             ),
             _repo(
-                "glycemicgpt-ios-unofficial",
+                "ios-unofficial",
                 environments=[
                     {
                         "name": "op-github-gated",


### PR DESCRIPTION
The ios repo was renamed (`glycemicgpt-ios-unofficial` → `ios-unofficial`). The audit pins gated-env expectations by repo name, so it failed closed on the stale name — correct fail-closed behavior, stale pin.

Verified: `--self-test` 63/63; local `--live` with the fix reports zero errors (standing warnings only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gated-environment audit expectations to recognize the iOS repository under its standardized name.
  * Ensured protection and drift checks consistently validate the correct repository identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->