### PR TITLE
fix(mobile): phone updater can install the Wear/WatchFace APK over the phone app

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
@@ -96,8 +96,11 @@ class AppUpdateChecker @Inject constructor(
                     val release = adapter.fromJson(body)
                         ?: return@withContext UpdateCheckResult.Error("Failed to parse release")
 
-                    val apkAsset = selectPhoneApkAsset(release.assets, channel)
-                        ?: return@withContext UpdateCheckResult.Error("No APK found in release")
+                    val apkAsset = if (channel == "dev") {
+                        selectPhoneApkAsset(release.assets, channel)
+                    } else {
+                        selectPhoneApkAsset(release.assets, channel, release.tagName.removePrefix("v"))
+                    } ?: return@withContext UpdateCheckResult.Error("No APK found in release")
 
                     if (channel == "dev") {
                         val remoteRunNumber = parseDevRunNumber(apkAsset.name)
@@ -231,8 +234,8 @@ class AppUpdateChecker @Inject constructor(
         // future filename-format change in those workflows makes it match *no* APK (surfaced as
         // "No APK found in release") rather than silently accepting a near-miss -- update this
         // regex in lockstep with the workflow steps above.
-        private val STABLE_PHONE_APK_REGEX = Regex("""^GlycemicGPT-\d+\.\d+\.\d+-release\.apk$""")
-        private val DEV_PHONE_APK_REGEX = Regex("""^GlycemicGPT-\d+\.\d+\.\d+-dev\.\d+-debug\.apk$""")
+        private val STABLE_PHONE_APK_REGEX = Regex("""^GlycemicGPT-(\d+\.\d+\.\d+)-release\.apk$""")
+        private val DEV_PHONE_APK_REGEX = Regex("""^GlycemicGPT-(\d+\.\d+\.\d+)-dev\.\d+-debug\.apk$""")
 
         fun isAllowedDownloadHost(url: String): Boolean {
             val host = try {
@@ -266,10 +269,25 @@ class AppUpdateChecker @Inject constructor(
          * order-dependent selector can return the Wear or WatchFace APK instead. Those share the
          * phone app's signing key and applicationId, so installing one over the phone app is a
          * silent in-place replacement rather than an install failure.
+         *
+         * When [expectedVersion] is given (the stable channel, from `release.tagName`), a
+         * shape match whose embedded version doesn't equal it is rejected -- otherwise a stale
+         * asset left over from a different release (e.g. `GlycemicGPT-1.2.2-release.apk`
+         * attached to a v1.2.3 release) would be installed under the version reported to the
+         * user. Fails closed on ambiguity too: if more than one asset matches, null is
+         * returned rather than picking one via [List.firstOrNull] order.
          */
-        fun selectPhoneApkAsset(assets: List<GitHubAsset>, channel: String): GitHubAsset? {
+        fun selectPhoneApkAsset(
+            assets: List<GitHubAsset>,
+            channel: String,
+            expectedVersion: String? = null,
+        ): GitHubAsset? {
             val regex = if (channel == "dev") DEV_PHONE_APK_REGEX else STABLE_PHONE_APK_REGEX
-            return assets.firstOrNull { regex.matches(it.name) }
+            val matches = assets.filter { asset ->
+                val match = regex.find(asset.name) ?: return@filter false
+                expectedVersion == null || match.groupValues[1] == expectedVersion
+            }
+            return matches.singleOrNull()
         }
 
         fun sanitizeFileName(name: String): String {

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
@@ -71,7 +71,6 @@ class AppUpdateChecker @Inject constructor(
             try {
                 val channel = BuildConfig.UPDATE_CHANNEL
                 val releasesUrl = if (channel == "dev") DEV_RELEASES_URL else STABLE_RELEASES_URL
-                val apkSuffix = if (channel == "dev") "-debug.apk" else "-release.apk"
 
                 val request = Request.Builder()
                     .url(releasesUrl)
@@ -97,9 +96,8 @@ class AppUpdateChecker @Inject constructor(
                     val release = adapter.fromJson(body)
                         ?: return@withContext UpdateCheckResult.Error("Failed to parse release")
 
-                    val apkAsset = release.assets.firstOrNull {
-                        it.name.startsWith(APK_PREFIX) && it.name.endsWith(apkSuffix)
-                    } ?: return@withContext UpdateCheckResult.Error("No APK found in release")
+                    val apkAsset = selectPhoneApkAsset(release.assets, channel)
+                        ?: return@withContext UpdateCheckResult.Error("No APK found in release")
 
                     if (channel == "dev") {
                         val remoteRunNumber = parseDevRunNumber(apkAsset.name)
@@ -214,7 +212,6 @@ class AppUpdateChecker @Inject constructor(
             "https://api.github.com/repos/GlycemicGPT/GlycemicGPT/releases/latest"
         private const val DEV_RELEASES_URL =
             "https://api.github.com/repos/GlycemicGPT/GlycemicGPT/releases/tags/dev-latest"
-        private const val APK_PREFIX = "GlycemicGPT-"
         private const val APK_SUBDIR = "apk_updates"
 
         private val ALLOWED_DOWNLOAD_HOSTS = setOf(
@@ -223,6 +220,19 @@ class AppUpdateChecker @Inject constructor(
         )
 
         private val DEV_RUN_NUMBER_REGEX = Regex("""-dev\.(\d+)-""")
+
+        // Anchored to the phone APK's exact release-asset shape so it can never match a Wear or
+        // WatchFace asset, regardless of asset order in the GitHub API response. Mirrors the
+        // "Rename APKs with version" step in .github/workflows/release.yml
+        // (`GlycemicGPT-${VERSION}-release.apk`, VERSION always MAJOR.MINOR.PATCH) and the
+        // "Rename dev APKs" step in .github/workflows/dev-pre-release.yml
+        // (`GlycemicGPT-${VERSION}-dev.${RUN}-debug.apk`, RUN = github.run_number). A positive
+        // anchored match trades tolerance for precision: it never matches a *wrong* APK, but a
+        // future filename-format change in those workflows makes it match *no* APK (surfaced as
+        // "No APK found in release") rather than silently accepting a near-miss -- update this
+        // regex in lockstep with the workflow steps above.
+        private val STABLE_PHONE_APK_REGEX = Regex("""^GlycemicGPT-\d+\.\d+\.\d+-release\.apk$""")
+        private val DEV_PHONE_APK_REGEX = Regex("""^GlycemicGPT-\d+\.\d+\.\d+-dev\.\d+-debug\.apk$""")
 
         fun isAllowedDownloadHost(url: String): Boolean {
             val host = try {
@@ -247,6 +257,19 @@ class AppUpdateChecker @Inject constructor(
             } catch (_: Exception) {
                 false
             }
+        }
+
+        /**
+         * Picks the phone APK out of a release's assets by matching its exact filename shape,
+         * never by asset order. GitHub does not guarantee upload order for a release's assets,
+         * and the phone APK -- being the largest -- tends to finish uploading LAST, so an
+         * order-dependent selector can return the Wear or WatchFace APK instead. Those share the
+         * phone app's signing key and applicationId, so installing one over the phone app is a
+         * silent in-place replacement rather than an install failure.
+         */
+        fun selectPhoneApkAsset(assets: List<GitHubAsset>, channel: String): GitHubAsset? {
+            val regex = if (channel == "dev") DEV_PHONE_APK_REGEX else STABLE_PHONE_APK_REGEX
+            return assets.firstOrNull { regex.matches(it.name) }
         }
 
         fun sanitizeFileName(name: String): String {

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -187,5 +188,100 @@ class AppUpdateCheckerTest {
     @Test
     fun `parseDevRunNumber rejects loose match without hyphens`() {
         assertEquals(0, AppUpdateChecker.parseDevRunNumber("some-devtools.5thing.apk"))
+    }
+
+    // selectPhoneApkAsset tests -- GLY-170: a stable release attaches four assets (phone, Wear,
+    // WatchFace Digital, WatchFace Analog) and GitHub does not guarantee upload order. The phone
+    // APK is the largest and tends to finish uploading LAST, so these fixtures deliberately put
+    // Wear/WatchFace FIRST to reproduce the real failure -- a phone-first-only fixture would not
+    // catch a selector that just trusts asset order.
+
+    private fun asset(name: String) = GitHubAsset(name, "https://github.com/example/$name", 1_000L)
+
+    @Test
+    fun `selectPhoneApkAsset picks the stable phone APK when Wear is listed first`() {
+        val assets = listOf(
+            asset("GlycemicGPT-Wear-1.2.3-release.apk"),
+            asset("GlycemicGPT-WatchFace-Digital-1.2.3-release.apk"),
+            asset("GlycemicGPT-WatchFace-Analog-1.2.3-release.apk"),
+            asset("GlycemicGPT-1.2.3-release.apk"),
+        )
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable")
+        assertEquals("GlycemicGPT-1.2.3-release.apk", selected?.name)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset picks the dev phone APK when Wear is listed first`() {
+        val assets = listOf(
+            asset("GlycemicGPT-Wear-1.2.3-dev.42-debug.apk"),
+            asset("GlycemicGPT-1.2.3-dev.42-debug.apk"),
+        )
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "dev")
+        assertEquals("GlycemicGPT-1.2.3-dev.42-debug.apk", selected?.name)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset picks the stable phone APK when it is already first`() {
+        val assets = listOf(
+            asset("GlycemicGPT-1.2.3-release.apk"),
+            asset("GlycemicGPT-Wear-1.2.3-release.apk"),
+        )
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable")
+        assertEquals("GlycemicGPT-1.2.3-release.apk", selected?.name)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset never returns a Wear or WatchFace asset for the stable channel`() {
+        val assets = listOf(
+            asset("GlycemicGPT-Wear-1.2.3-release.apk"),
+            asset("GlycemicGPT-WatchFace-Digital-1.2.3-release.apk"),
+            asset("GlycemicGPT-WatchFace-Analog-1.2.3-release.apk"),
+        )
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable")
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset never returns a Wear or WatchFace asset for the dev channel`() {
+        val assets = listOf(
+            asset("GlycemicGPT-Wear-1.2.3-dev.42-debug.apk"),
+            asset("GlycemicGPT-WatchFace-Digital-1.2.3-dev.42-debug.apk"),
+            asset("GlycemicGPT-WatchFace-Analog-1.2.3-dev.42-debug.apk"),
+        )
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "dev")
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset does not cross channels`() {
+        val assets = listOf(asset("GlycemicGPT-1.2.3-release.apk"))
+        assertNull(AppUpdateChecker.selectPhoneApkAsset(assets, channel = "dev"))
+
+        val devAssets = listOf(asset("GlycemicGPT-1.2.3-dev.42-debug.apk"))
+        assertNull(AppUpdateChecker.selectPhoneApkAsset(devAssets, channel = "stable"))
+    }
+
+    @Test
+    fun `selectPhoneApkAsset ignores an unrelated asset name`() {
+        // GitHub auto-attaches "Source code (zip)"/(tar.gz) to every release; neither of those,
+        // nor any other unrelated artifact, should ever satisfy the phone-APK shape.
+        val assets = listOf(
+            asset("SomeOtherApp-1.2.3-release.apk"),
+            asset("v1.2.3.zip"),
+            asset("GlycemicGPT-1.2.3-release.apk.sha256"),
+        )
+        assertNull(AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable"))
+    }
+
+    @Test
+    fun `selectPhoneApkAsset handles multi-digit version segments`() {
+        val assets = listOf(asset("GlycemicGPT-10.20.130-release.apk"))
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable")
+        assertEquals("GlycemicGPT-10.20.130-release.apk", selected?.name)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset returns null for an empty asset list`() {
+        assertNull(AppUpdateChecker.selectPhoneApkAsset(emptyList(), channel = "stable"))
     }
 }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
@@ -284,4 +284,43 @@ class AppUpdateCheckerTest {
     fun `selectPhoneApkAsset returns null for an empty asset list`() {
         assertNull(AppUpdateChecker.selectPhoneApkAsset(emptyList(), channel = "stable"))
     }
+
+    // expectedVersion pinning tests -- a release's assets should never be trusted purely by
+    // filename shape when a stronger source of truth (the release's own tag) is available; a
+    // stale asset left over from a different release must not be installed under the wrong
+    // reported version.
+
+    @Test
+    fun `selectPhoneApkAsset accepts a phone APK whose version matches expectedVersion`() {
+        val assets = listOf(asset("GlycemicGPT-1.2.3-release.apk"))
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable", expectedVersion = "1.2.3")
+        assertEquals("GlycemicGPT-1.2.3-release.apk", selected?.name)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset rejects a stale asset whose version does not match expectedVersion`() {
+        // A v1.2.3 release carrying a leftover GlycemicGPT-1.2.2-release.apk asset must not be
+        // installed and reported to the user as version 1.2.3.
+        val assets = listOf(asset("GlycemicGPT-1.2.2-release.apk"))
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable", expectedVersion = "1.2.3")
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset ignores expectedVersion when null`() {
+        val assets = listOf(asset("GlycemicGPT-1.2.3-release.apk"))
+        val selected = AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable", expectedVersion = null)
+        assertEquals("GlycemicGPT-1.2.3-release.apk", selected?.name)
+    }
+
+    @Test
+    fun `selectPhoneApkAsset fails closed when two phone-shaped assets are both present`() {
+        // Should never happen for a well-formed release, but the selector must not silently
+        // pick one via firstOrNull order if it does.
+        val assets = listOf(
+            asset("GlycemicGPT-1.2.3-release.apk"),
+            asset("GlycemicGPT-1.2.4-release.apk"),
+        )
+        assertNull(AppUpdateChecker.selectPhoneApkAsset(assets, channel = "stable"))
+    }
 }


### PR DESCRIPTION
## Summary

The phone app's GitHub self-updater could install the Wear or WatchFace APK in place of the phone app.

`AppUpdateChecker.check()` selected the phone APK from a release's assets with:

```kotlin
release.assets.firstOrNull { it.name.startsWith("GlycemicGPT-") && it.name.endsWith(apkSuffix) }
```

A stable release attaches four assets that all satisfy this prefix/suffix check: the phone APK, the Wear APK, and both WatchFace APKs. GitHub does not guarantee asset upload order, and the phone APK -- being the largest -- tends to finish uploading last, so `firstOrNull` could return a Wear or WatchFace asset instead. Those share the phone app's `applicationId` and signing key, so Android installs the wrong asset as a silent in-place update over the phone app rather than failing.

## Fix

- Replaced the prefix/suffix check with anchored regexes matching the phone APK's exact filename shape per channel (`^GlycemicGPT-(\d+\.\d+\.\d+)-release\.apk$` / `^GlycemicGPT-(\d+\.\d+\.\d+)-dev\.\d+-debug\.apk$`), so a Wear/WatchFace asset can never match regardless of asset order.
- Pinned the stable-channel selection to the release's own version (`release.tagName`), rejecting a shape-matching asset whose embedded version doesn't match -- closes a follow-up finding from CodeRabbit (below) where a stale asset left over from a different release could otherwise be installed under the wrong reported version.
- Fails closed on ambiguity: if more than one asset matches the expected shape, the selector returns `null` instead of picking one by list order.
- `WearAppUpdateChecker.kt` was confirmed unaffected -- its own prefix (`GlycemicGPT-Wear-`) is unambiguous and not shared by any other asset -- and was intentionally left untouched.

## Review

- Adversarial + senior-engineer review: no HIGH/MEDIUM findings; a few LOW-severity test-coverage and documentation gaps were addressed (added negative-case tests for unrelated asset names, multi-digit versions, empty asset lists; added traceability comments linking the regexes to the CI steps that generate the filenames).
- CodeRabbit CLI: one MAJOR finding on the first pass (the version-pinning/ambiguity gap described above) -- fixed and re-reviewed clean.
- Independent security review: no findings (no secrets, no ReDoS in the new regexes, no injection/SSRF/path-traversal introduced; version-pin comparison has no bypass).

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "...AppUpdateCheckerTest"` -- new tests reproduce the actual failure mode (Wear/WatchFace listed before the phone asset), plus version-pin and ambiguity cases.
- [x] `./gradlew :app:lintDebug`
- [x] `./gradlew :app:assembleDebug`
- Pure selector-logic change; no UI surface, so no emulator/device verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app update detection to reliably select the correct phone APK.
  * Prevented Wear, WatchFace, unrelated, mismatched-version, or ambiguous files from being offered as phone updates.
  * Added stable-release version validation to avoid installing outdated APKs.

* **Tests**
  * Added coverage for stable and development update channels, version matching, asset ordering, and ambiguous release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->