### PR TITLE
ci(security): fix develop scan self-cancellation and URL-embedded push token

### DIFF
--- a/.github/workflows/regen-gradle-lockfiles-push.yml
+++ b/.github/workflows/regen-gradle-lockfiles-push.yml
@@ -143,6 +143,7 @@ jobs:
         env:
           PUSH_TOKEN: ${{ steps.generate-token.outputs.token }}
           HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
           git config core.hooksPath /dev/null
@@ -154,7 +155,21 @@ jobs:
             exit 0
           fi
           git commit -m "chore(deps): refresh gradle lockfiles"
-          # Non-force push pinned to the built-from head: if Renovate advanced
-          # the branch after the build, this is rejected as non-fast-forward
-          # instead of committing lockfiles that no longer match the build files.
-          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${HEAD_REF}"
+          # The token rides in a host-scoped HTTP header instead of the remote
+          # URL: the user:token@host shape in source is exactly what secret
+          # scanners (GitGuardian) flag, and passing the config via GIT_CONFIG_*
+          # keeps the credential off argv and out of .git/config. Mask the
+          # derived base64 form -- only the raw app token is auto-registered
+          # as a secret, not values computed from it.
+          AUTH_B64=$(printf 'x-access-token:%s' "${PUSH_TOKEN}" | base64 | tr -d '\n')
+          echo "::add-mask::${AUTH_B64}"
+          # Push leased on the built-from head: if the branch moved at all
+          # after the build -- advanced by Renovate, or reset to an ancestor
+          # (which a plain non-fast-forward check would wave through) -- the
+          # push is rejected instead of committing lockfiles that no longer
+          # match the build files.
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${AUTH_B64}" \
+            git push --force-with-lease="refs/heads/${HEAD_REF}:${HEAD_SHA}" \
+            origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,7 +22,16 @@ permissions:
 # CONTRIBUTING.md "How CI handles fork PRs".
 
 concurrency:
-  group: security-scan-${{ github.ref }}
+  # The event name must be part of the group: `closed` pull_request events
+  # resolve github.ref to the BASE branch (the merge ref is gone once the PR
+  # closes), so a merged PR's closed run raced the push run for that very
+  # merge in one shared group -- whenever the closed run registered second,
+  # cancel-in-progress killed the push scan ("higher priority waiting
+  # request"). The race is as old as the `closed` trigger and recently lost
+  # on nearly every develop merge, leaving develop heads unscanned.
+  # Keying pull_request runs by PR number (same idiom as attribution-check)
+  # also stops two closed PRs from cancelling each other's cleanup job.
+  group: security-scan-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

Four of the six red checks on the promotion PR #923 (SAST, DAST & Auth Penetration Tests, Security Scan Gate, Detect Security-Relevant Changes) come from a single cancelled Security Scan push run on develop. Every recent merge to develop kills its own security scan: the merged PR's `closed`-event run resolves `github.ref` to the base branch (the merge ref is gone once the PR closes), lands in the same concurrency group as the push run for that very merge, and `cancel-in-progress` cancels it. GitHub's annotation on every cancelled run: "Canceling since a higher priority waiting request for security-scan-refs/heads/develop exists". The gate job then fails on the missing `sast-results`/`dast-results` artifacts. Net effect: develop heads were getting no completed security scan.

Separately, GitGuardian flags the `x-access-token:${PUSH_TOKEN}@github.com` URL shape in `regen-gradle-lockfiles-push.yml` (the "1 secret uncovered" check failure on #923). The value is a workflow expression, not a literal secret, but the pattern is what secret scanners key on and a URL-embedded credential is the weaker form regardless.

## Changes

- `security-scan.yml`: concurrency group now keys on event name, and pull_request runs key on PR number (same idiom as `attribution-check.yml`). Push scans and closed-event runs can no longer collide, and two closed PRs can no longer cancel each other's cleanup job.
- `regen-gradle-lockfiles-push.yml`: the push token rides in a host-scoped HTTP extraheader passed via `GIT_CONFIG_*` environment variables (off argv, never written to `.git/config`), the derived base64 value is `add-mask`'d, and the push is leased on the built-from head (`--force-with-lease=ref:sha`) so a branch reset to an ancestor is rejected rather than waved through by the plain non-fast-forward check.

## Verification

- actionlint clean on both workflows.
- Cancellation mechanism confirmed from run annotations and the run history (pattern: every develop merge produces a same-second skipped closed-run + cancelled push-run pair).
- Note for after merge: the GitGuardian incident on #923 also needs a dashboard resolution (mark as false positive) -- the flagged pattern lives in develop's immutable history, so no commit can retract it; this PR stops it recurring.

Fixes the infra half of the GLY-202 gate failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated lockfile updates with safer authenticated pushes and protection against overwriting newer changes.
  * Improved security scan workflow concurrency handling, including more reliable behavior when pull requests are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->