### PR TITLE
chore(governance): align main CODEOWNERS with the lead-only model

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,19 +16,15 @@
 /apps/mobile/ @jlengelbrecht
 /plugins/ @jlengelbrecht
 
-# Web / frontend: web maintainers own this area. The project lead is
-# co-listed so code-owner review can be satisfied regardless of which
-# party authors the PR.
-/apps/web/ @lumose-health/web @jlengelbrecht
-
-# AI / evals / benchmarks: AI maintainers own this area (BYOAI
-# benchmark harness, eval scenarios, sidecar AI-provider layer, and
-# benchmarking docs). Project lead co-listed as above.
-/apps/api/benchmarks/ @lumose-health/ai @jlengelbrecht
-/apps/api/tests/benchmarks/ @lumose-health/ai @jlengelbrecht
-/evals/ @lumose-health/ai @jlengelbrecht
-/sidecar/ @lumose-health/ai @jlengelbrecht
-/docs/benchmarking/ @lumose-health/ai @jlengelbrecht
+# Web / frontend and AI / evals / benchmarks: project lead.
+# Code owners must hold Write; only the lead does (see GOVERNANCE.md,
+# repository access policy), so area ownership cannot be a team here.
+/apps/web/ @jlengelbrecht
+/apps/api/benchmarks/ @jlengelbrecht
+/apps/api/tests/benchmarks/ @jlengelbrecht
+/evals/ @jlengelbrecht
+/sidecar/ @jlengelbrecht
+/docs/benchmarking/ @jlengelbrecht
 
 # Governance & project policy: project lead only.
 /.github/CODEOWNERS @jlengelbrecht
@@ -42,6 +38,7 @@
 # or careless workflow change can compromise the release pipeline.
 /scripts/security/ @jlengelbrecht
 /.github/workflows/ @jlengelbrecht
+/.github/actions/ @jlengelbrecht
 /.github/renovate.json5 @jlengelbrecht
 /docs/dev/security-testing.md @jlengelbrecht
 


### PR DESCRIPTION
## Problem

Main and develop have diverged on `.github/CODEOWNERS`: #899 applied the team-based rescope directly to main, and develop subsequently moved to the lead-only ownership model. It is the only content conflict blocking the develop-to-main promotion (#923) -- verified with `git merge-tree`: exactly one "changed in both" path.

The team-based rules on main are also six live CODEOWNERS errors: `gh api repos/lumose-health/GlycemicGPT/codeowners/errors` reports "Unknown owner" for every `@lumose-health/web` / `@lumose-health/ai` entry, because code owners must hold Write and those teams hold triage. GitHub has been discarding them, so no review requirement actually changes -- the lead was already co-listed on every line and is the `*` fallback.

## Change

Copy develop's CODEOWNERS to main verbatim (byte-identical to `origin/develop`). With both branches identical on this file, the promotion merge computes clean; a simulated merge on top of this commit reports zero conflicts and a tree identical to develop's.

The same-content model also means the file cannot re-diverge on the next promotion.

## Notes for merging

- This targets main directly (same shape as #899) because develop's ruleset is squash-only with required linear history -- an ancestry-preserving sync merge into develop is not possible, and develop already has the desired content.
- Merging to main triggers a release-please run that pauses on the release-gated environment; cancel or leave it -- a `chore` commit mints nothing.

Closes the GLY-202 AC1 reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository review ownership rules for web, benchmarking, evaluation, sidecar, documentation, and GitHub Actions areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->