### PR TITLE
ci: surface apksigner failures and correct signing-smoke module count

### DIFF
--- a/.github/workflows/release-signing-smoke.yml
+++ b/.github/workflows/release-signing-smoke.yml
@@ -156,8 +156,18 @@ jobs:
               # Every signer's certificate digest must match -- an APK
               # carrying an extra/unexpected signer fails, so no digest is
               # skipped the way a first-match-only check would.
-              DIGESTS=$("$APKSIGNER" verify --print-certs "$APK" \
-                | grep -oP 'certificate SHA-256 digest: \K[0-9a-f]+')
+              # Split the pipeline so each failure mode reports precisely:
+              # an apksigner failure hard-fails with its output, while a
+              # no-match grep falls through (`|| true`) to the explicit
+              # empty-digest diagnostic below instead of dying silently in
+              # the command substitution under `set -euo pipefail`.
+              if ! APKSIGNER_OUTPUT=$("$APKSIGNER" verify --print-certs "$APK" 2>&1); then
+                echo "::error::$APK failed apksigner verification"
+                printf '%s\n' "$APKSIGNER_OUTPUT" >&2
+                exit 1
+              fi
+              DIGESTS=$(printf '%s\n' "$APKSIGNER_OUTPUT" \
+                | grep -oP 'certificate SHA-256 digest: \K[0-9a-f]+' || true)
               if [ -z "$DIGESTS" ]; then
                 echo "::error::$APK has no signer certificate digest (unsigned or unreadable)"
                 exit 1
@@ -176,7 +186,7 @@ jobs:
             fi
             TOTAL=$((TOTAL + COUNT))
           done
-          echo "signing identity verified on $TOTAL APKs across 3 modules"
+          echo "signing identity verified on $TOTAL APKs across 2 modules (:watchface excluded by design)"
 
   no_environment:
     name: Negative control (no environment -> secrets must be empty)


### PR DESCRIPTION
Two small corrections to `release-signing-smoke.yml`, from the promotion PR review:

- The `DIGESTS` command substitution died inside `set -euo pipefail` when apksigner failed or grep matched nothing, so the explicit unsigned/unreadable diagnostic below it could never fire. The pipeline is now split: an apksigner failure hard-fails with its output attached, and a no-match grep falls through to the existing empty-digest diagnostic.
- The summary echo claimed 3 modules while the frozen-identity loop asserts exactly two (`:app` and `:wear-device`); `:watchface` is excluded by design and only build-checked. The echo now says so.

actionlint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release signing verification to provide clearer failure output when certificate validation fails.
  * Prevented misleading script termination when no signer certificate digest is found, allowing the appropriate error message to be shown.
  * Updated verification reporting to accurately reflect the two modules covered by signing identity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->