### PR TITLE
fix(mobile): repoint in-app updater to the standalone android repository

### DIFF
--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/AppUpdateChecker.kt
@@ -211,10 +211,13 @@ class AppUpdateChecker @Inject constructor(
     }
 
     companion object {
-        private const val STABLE_RELEASES_URL =
-            "https://api.github.com/repos/GlycemicGPT/GlycemicGPT/releases/latest"
-        private const val DEV_RELEASES_URL =
-            "https://api.github.com/repos/GlycemicGPT/GlycemicGPT/releases/tags/dev-latest"
+        // Self-update source: the standalone Android repository, which owns the
+        // signed release and `dev-latest` pipelines this app polls. `internal`
+        // (not `private`) so AppUpdateCheckerTest can assert the target repo.
+        internal const val STABLE_RELEASES_URL =
+            "https://api.github.com/repos/lumose-health/android-unofficial/releases/latest"
+        internal const val DEV_RELEASES_URL =
+            "https://api.github.com/repos/lumose-health/android-unofficial/releases/tags/dev-latest"
         private const val APK_SUBDIR = "apk_updates"
 
         private val ALLOWED_DOWNLOAD_HOSTS = setOf(
@@ -226,14 +229,16 @@ class AppUpdateChecker @Inject constructor(
 
         // Anchored to the phone APK's exact release-asset shape so it can never match a Wear or
         // WatchFace asset, regardless of asset order in the GitHub API response. Mirrors the
-        // "Rename APKs with version" step in .github/workflows/release.yml
+        // "Rename APKs with version" step in lumose-health/android-unofficial's release.yml
         // (`GlycemicGPT-${VERSION}-release.apk`, VERSION always MAJOR.MINOR.PATCH) and the
-        // "Rename dev APKs" step in .github/workflows/dev-pre-release.yml
-        // (`GlycemicGPT-${VERSION}-dev.${RUN}-debug.apk`, RUN = github.run_number). A positive
+        // dev-APK rename step in its dev-pre-release.yml
+        // (`GlycemicGPT-${VERSION}-dev.${RUN}-debug.apk`, RUN = github.run_number plus that
+        // repo's PERMANENT +500 offset, which keeps its run numbers above this monorepo
+        // cohort's so migrated dev-channel installs still see updates). A positive
         // anchored match trades tolerance for precision: it never matches a *wrong* APK, but a
         // future filename-format change in those workflows makes it match *no* APK (surfaced as
         // "No APK found in release") rather than silently accepting a near-miss -- update this
-        // regex in lockstep with the workflow steps above.
+        // regex in lockstep with the workflow steps in that repo.
         private val STABLE_PHONE_APK_REGEX = Regex("""^GlycemicGPT-(\d+\.\d+\.\d+)-release\.apk$""")
         private val DEV_PHONE_APK_REGEX = Regex("""^GlycemicGPT-(\d+\.\d+\.\d+)-dev\.\d+-debug\.apk$""")
 

--- a/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/WearAppUpdateChecker.kt
+++ b/apps/mobile/app/src/main/java/com/glycemicgpt/mobile/data/update/WearAppUpdateChecker.kt
@@ -44,7 +44,6 @@ class WearAppUpdateChecker @Inject constructor(
     ): UpdateCheckResult = withContext(Dispatchers.IO) {
         try {
             val releasesUrl = if (watchChannel == "dev") DEV_RELEASES_URL else STABLE_RELEASES_URL
-            val apkSuffix = if (watchChannel == "dev") "-debug.apk" else "-release.apk"
 
             val request = Request.Builder()
                 .url(releasesUrl)
@@ -69,8 +68,10 @@ class WearAppUpdateChecker @Inject constructor(
                 val release = adapter.fromJson(body)
                     ?: return@withContext UpdateCheckResult.Error("Failed to parse release")
 
-                val apkAsset = release.assets.firstOrNull {
-                    it.name.startsWith(WEAR_APK_PREFIX) && it.name.endsWith(apkSuffix)
+                val apkAsset = if (watchChannel == "dev") {
+                    selectWearApkAsset(release.assets, watchChannel)
+                } else {
+                    selectWearApkAsset(release.assets, watchChannel, release.tagName.removePrefix("v"))
                 } ?: return@withContext UpdateCheckResult.Error("No wear APK found in release")
 
                 if (watchChannel == "dev") {
@@ -190,12 +191,44 @@ class WearAppUpdateChecker @Inject constructor(
     }
 
     companion object {
-        private const val STABLE_RELEASES_URL =
-            "https://api.github.com/repos/GlycemicGPT/GlycemicGPT/releases/latest"
-        private const val DEV_RELEASES_URL =
-            "https://api.github.com/repos/GlycemicGPT/GlycemicGPT/releases/tags/dev-latest"
-        private const val WEAR_APK_PREFIX = "GlycemicGPT-Wear-"
+        // Self-update source: the standalone Android repository, which owns the
+        // signed release and `dev-latest` pipelines this app polls. `internal`
+        // (not `private`) so WearAppUpdateCheckerTest can assert the target repo.
+        internal const val STABLE_RELEASES_URL =
+            "https://api.github.com/repos/lumose-health/android-unofficial/releases/latest"
+        internal const val DEV_RELEASES_URL =
+            "https://api.github.com/repos/lumose-health/android-unofficial/releases/tags/dev-latest"
         private const val WEAR_APK_SUBDIR = "wear_apk_updates"
+
+        // Anchored to the Wear APK's exact release-asset shape for the same reason as the
+        // phone selector in [AppUpdateChecker]: a positive anchored match can never pick a
+        // phone or WatchFace asset, regardless of asset order in the GitHub API response,
+        // and a filename-format change in the release pipeline surfaces as "No wear APK
+        // found in release" rather than a silent near-miss install.
+        private val STABLE_WEAR_APK_REGEX =
+            Regex("""^GlycemicGPT-Wear-(\d+\.\d+\.\d+)-release\.apk$""")
+        private val DEV_WEAR_APK_REGEX =
+            Regex("""^GlycemicGPT-Wear-(\d+\.\d+\.\d+)-dev\.\d+-debug\.apk$""")
+
+        /**
+         * Picks the Wear APK out of a release's assets by matching its exact filename shape,
+         * never by asset order. Same contract as [AppUpdateChecker.selectPhoneApkAsset]:
+         * when [expectedVersion] is given (the stable channel, from `release.tagName`), a
+         * shape match whose embedded version doesn't equal it is rejected, and ambiguity
+         * (more than one match) fails closed to null.
+         */
+        fun selectWearApkAsset(
+            assets: List<GitHubAsset>,
+            channel: String,
+            expectedVersion: String? = null,
+        ): GitHubAsset? {
+            val regex = if (channel == "dev") DEV_WEAR_APK_REGEX else STABLE_WEAR_APK_REGEX
+            val matches = assets.filter { asset ->
+                val match = regex.find(asset.name) ?: return@filter false
+                expectedVersion == null || match.groupValues[1] == expectedVersion
+            }
+            return matches.singleOrNull()
+        }
         /** Max download size: 100 MB to prevent disk exhaustion */
         private const val MAX_DOWNLOAD_SIZE_BYTES = 100L * 1024 * 1024
     }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/AppUpdateCheckerTest.kt
@@ -13,6 +13,33 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class AppUpdateCheckerTest {
 
+    // Self-update targets the standalone Android repository, not the monorepo.
+
+    @Test
+    fun `release URLs target the android-only repository`() {
+        assertTrue(AppUpdateChecker.STABLE_RELEASES_URL.startsWith("https://api.github.com/"))
+        assertTrue(AppUpdateChecker.DEV_RELEASES_URL.startsWith("https://api.github.com/"))
+        assertTrue(
+            AppUpdateChecker.STABLE_RELEASES_URL
+                .contains("/repos/lumose-health/android-unofficial/"),
+        )
+        assertTrue(
+            AppUpdateChecker.DEV_RELEASES_URL
+                .contains("/repos/lumose-health/android-unofficial/"),
+        )
+        // Never regress to a legacy owner/repo slug.
+        assertFalse(AppUpdateChecker.STABLE_RELEASES_URL.contains("/GlycemicGPT/GlycemicGPT/"))
+        assertFalse(AppUpdateChecker.DEV_RELEASES_URL.contains("/GlycemicGPT/GlycemicGPT/"))
+        assertFalse(
+            AppUpdateChecker.STABLE_RELEASES_URL
+                .contains("/GlycemicGPT/glycemicgpt-android-unofficial/"),
+        )
+        assertFalse(
+            AppUpdateChecker.DEV_RELEASES_URL
+                .contains("/GlycemicGPT/glycemicgpt-android-unofficial/"),
+        )
+    }
+
     @Test
     fun `parseVersionCode for simple version`() {
         assertEquals(1_000_000, AppUpdateChecker.parseVersionCode("1.0.0"))
@@ -110,7 +137,7 @@ class AppUpdateCheckerTest {
 
     @Test
     fun `an https URL to an allowed host passes both download guards`() {
-        val url = "https://github.com/GlycemicGPT/GlycemicGPT/releases/download/v1.0/app.apk"
+        val url = "https://github.com/lumose-health/android-unofficial/releases/download/v1.0/app.apk"
         assertTrue(AppUpdateChecker.isHttpsUrl(url))
         assertTrue(AppUpdateChecker.isAllowedDownloadHost(url))
     }

--- a/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/WearAppUpdateCheckerTest.kt
+++ b/apps/mobile/app/src/test/java/com/glycemicgpt/mobile/data/update/WearAppUpdateCheckerTest.kt
@@ -5,11 +5,40 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WearAppUpdateCheckerTest {
+
+    // The wear checker self-updates from the standalone Android repository.
+
+    @Test
+    fun `wear release URLs target the android-only repository`() {
+        assertTrue(WearAppUpdateChecker.STABLE_RELEASES_URL.startsWith("https://api.github.com/"))
+        assertTrue(WearAppUpdateChecker.DEV_RELEASES_URL.startsWith("https://api.github.com/"))
+        assertTrue(
+            WearAppUpdateChecker.STABLE_RELEASES_URL
+                .contains("/repos/lumose-health/android-unofficial/"),
+        )
+        assertTrue(
+            WearAppUpdateChecker.DEV_RELEASES_URL
+                .contains("/repos/lumose-health/android-unofficial/"),
+        )
+        // Never regress to a legacy owner/repo slug.
+        assertFalse(WearAppUpdateChecker.STABLE_RELEASES_URL.contains("/GlycemicGPT/GlycemicGPT/"))
+        assertFalse(WearAppUpdateChecker.DEV_RELEASES_URL.contains("/GlycemicGPT/GlycemicGPT/"))
+        assertFalse(
+            WearAppUpdateChecker.STABLE_RELEASES_URL
+                .contains("/GlycemicGPT/glycemicgpt-android-unofficial/"),
+        )
+        assertFalse(
+            WearAppUpdateChecker.DEV_RELEASES_URL
+                .contains("/GlycemicGPT/glycemicgpt-android-unofficial/"),
+        )
+    }
 
     @Test
     fun `parseDevRunNumber extracts number from wear APK filename`() {
@@ -34,7 +63,7 @@ class WearAppUpdateCheckerTest {
     fun `isAllowedDownloadHost accepts github domains`() {
         assertTrue(
             AppUpdateChecker.isAllowedDownloadHost(
-                "https://github.com/GlycemicGPT/GlycemicGPT/releases/download/v1.0.0/test.apk",
+                "https://github.com/lumose-health/android-unofficial/releases/download/v1.0.0/test.apk",
             ),
         )
         assertTrue(
@@ -53,7 +82,7 @@ class WearAppUpdateCheckerTest {
 
     @Test
     fun `an https URL to an allowed host passes both wear download guards`() {
-        val url = "https://github.com/GlycemicGPT/GlycemicGPT/releases/download/v1.0/wear.apk"
+        val url = "https://github.com/lumose-health/android-unofficial/releases/download/v1.0/wear.apk"
         assertTrue(AppUpdateChecker.isHttpsUrl(url))
         assertTrue(AppUpdateChecker.isAllowedDownloadHost(url))
     }
@@ -86,24 +115,66 @@ class WearAppUpdateCheckerTest {
         )
     }
 
+    private fun asset(name: String) = GitHubAsset(
+        name = name,
+        browserDownloadUrl =
+            "https://github.com/lumose-health/android-unofficial/releases/download/v0.14.0/$name",
+        size = 1L,
+    )
+
+    // selectWearApkAsset tests -- same failure class as the phone selector (GLY-170): a
+    // release attaches four assets and GitHub does not guarantee order, so the fixtures put
+    // the wrong assets first to catch a selector that trusts asset order.
+
     @Test
-    fun `wear APK prefix matching picks correct asset`() {
-        val wearPrefix = "GlycemicGPT-Wear-"
-        val phonePrefix = "GlycemicGPT-"
+    fun `selectWearApkAsset picks the stable wear APK among all four release assets`() {
         val assets = listOf(
-            "GlycemicGPT-0.1.99-dev.42-debug.apk",
-            "GlycemicGPT-Wear-0.1.99-dev.42-debug.apk",
+            asset("GlycemicGPT-0.14.0-release.apk"),
+            asset("GlycemicGPT-WatchFace-Digital-0.14.0-release.apk"),
+            asset("GlycemicGPT-WatchFace-Analog-0.14.0-release.apk"),
+            asset("GlycemicGPT-Wear-0.14.0-release.apk"),
         )
+        val selected = WearAppUpdateChecker.selectWearApkAsset(assets, channel = "stable")
+        assertEquals("GlycemicGPT-Wear-0.14.0-release.apk", selected?.name)
+    }
 
-        val wearAsset = assets.firstOrNull {
-            it.startsWith(wearPrefix) && it.endsWith("-debug.apk")
-        }
-        val phoneAsset = assets.firstOrNull {
-            it.startsWith(phonePrefix) && !it.startsWith(wearPrefix) && it.endsWith("-debug.apk")
-        }
+    @Test
+    fun `selectWearApkAsset picks the dev wear APK and never the phone dev APK`() {
+        val assets = listOf(
+            asset("GlycemicGPT-0.14.0-dev.42-debug.apk"),
+            asset("GlycemicGPT-Wear-0.14.0-dev.42-debug.apk"),
+        )
+        val selected = WearAppUpdateChecker.selectWearApkAsset(assets, channel = "dev")
+        assertEquals("GlycemicGPT-Wear-0.14.0-dev.42-debug.apk", selected?.name)
+    }
 
-        assertEquals("GlycemicGPT-Wear-0.1.99-dev.42-debug.apk", wearAsset)
-        assertEquals("GlycemicGPT-0.1.99-dev.42-debug.apk", phoneAsset)
+    @Test
+    fun `selectWearApkAsset does not cross channels`() {
+        val stableAssets = listOf(asset("GlycemicGPT-Wear-0.14.0-release.apk"))
+        assertNull(WearAppUpdateChecker.selectWearApkAsset(stableAssets, channel = "dev"))
+
+        val devAssets = listOf(asset("GlycemicGPT-Wear-0.14.0-dev.42-debug.apk"))
+        assertNull(WearAppUpdateChecker.selectWearApkAsset(devAssets, channel = "stable"))
+    }
+
+    @Test
+    fun `selectWearApkAsset rejects a stale asset whose version does not match expectedVersion`() {
+        val assets = listOf(asset("GlycemicGPT-Wear-0.13.0-release.apk"))
+        val selected = WearAppUpdateChecker.selectWearApkAsset(
+            assets,
+            channel = "stable",
+            expectedVersion = "0.14.0",
+        )
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectWearApkAsset fails closed when two wear-shaped assets are both present`() {
+        val assets = listOf(
+            asset("GlycemicGPT-Wear-0.14.0-release.apk"),
+            asset("GlycemicGPT-Wear-0.14.1-release.apk"),
+        )
+        assertNull(WearAppUpdateChecker.selectWearApkAsset(assets, channel = "stable"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

The phone and wear in-app update checkers now poll `lumose-health/android-unofficial` releases (stable `releases/latest` and the `dev-latest` prerelease) instead of this repository, which stops producing mobile releases after the next patch. Users who take a build carrying this change migrate to the standalone repository's releases on their next update check.

Also included:
- The wear APK asset selector is hardened to the same anchored-regex, fail-closed contract as the phone selector: exact filename-shape match (a phone or WatchFace asset can never match), expected-version cross-check against the release tag on the stable channel, and ambiguity returning null instead of trusting GitHub's asset order.
- The release URL slugs are pinned by tests (with anti-regression assertions on legacy slugs), so a silent repoint regression cannot pass the suite.
- The asset-regex lockstep comment now documents the standalone repository's actual pipeline, including the permanent +500 dev run-number offset that keeps its dev builds ordered above this repository's dev-channel installs.

## Verification

- Full mobile unit suite, lint, and debug build green; 45 phone + 17 wear updater tests pass, including new selector and URL-pinning tests.
- Verified live against the standalone repository's published releases on both channels: stable v0.14.0 assets match the anchored selectors exactly, and an emulator install of this build surfaced the standalone repo's dev build (0.14.0-dev.511) as an available update end to end.
- Version ordering confirmed: the standalone repository's stable versionCode (140000) exceeds this repository's current and next patch mobile versionCode, and its dev run numbers (offset +500) exceed this repository's dev-channel run numbers.

## Rollout notes

- This change must ship in the final mobile release cut from this repository (a patch, keeping versionCode below 140000) so installed users are carried over.
- Until the installed base has taken that release, older installs still poll the previous repository slug; the old slug's redirect must remain intact for the migration window before any repository parking or renaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic update detection for mobile and wearable apps.
  * Updates now use the correct Android release source.
  * Wearable app updates require an exact, uniquely matching APK and reject ambiguous or outdated files.
* **Tests**
  * Expanded coverage for release sources, channel-specific APK selection, version matching, and secure download URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->