### PR TITLE
chore: drop retired android keystore entries from secrets-hygiene invariants

### DIFF
--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -347,10 +347,6 @@ EXPECTED_GATED_ENVIRONMENTS: dict[str, dict[str, set[str]]] = {
         "release-gated": {
             "RELEASE_APP_ID",
             "RELEASE_APP_PRIVATE_KEY",
-            "RELEASE_KEYSTORE_BASE64",
-            "RELEASE_KEYSTORE_PASSWORD",
-            "RELEASE_KEY_ALIAS",
-            "RELEASE_KEY_PASSWORD",
             "MERGE_APP_ID",
             "MERGE_APP_PRIVATE_KEY",
         },
@@ -1940,20 +1936,12 @@ def self_test() -> int:
     EXPECTED_GATED_ENVIRONMENTS = _production_map
 
     RELEASE_KEY_SECRETS = ["RELEASE_APP_ID", "RELEASE_APP_PRIVATE_KEY"]
-    KEYSTORE_SECRETS = [
-        "RELEASE_KEYSTORE_BASE64",
-        "RELEASE_KEYSTORE_PASSWORD",
-        "RELEASE_KEY_ALIAS",
-        "RELEASE_KEY_PASSWORD",
-    ]
     MERGE_KEY_SECRETS = ["MERGE_APP_ID", "MERGE_APP_PRIVATE_KEY"]
 
     def _migrated_repos(
         *,
         plain_backend: bool = False,
         drop_backend_from_env: bool = False,
-        drop_keystore_from_env: bool = False,
-        plain_keystore: bool = False,
         drop_merge_from_env: bool = False,
         drop_android_merge: bool = False,
         plain_merge: bool = False,
@@ -1985,15 +1973,9 @@ def self_test() -> int:
         android_merge_env = (
             [] if (drop_merge_from_env or drop_android_merge) else MERGE_KEY_SECRETS
         )
-        gly_release_secrets = (
-            RELEASE_KEY_SECRETS
-            + ([] if drop_keystore_from_env else KEYSTORE_SECRETS)
-            + merge_env
-        )
-        gly_plain = (
-            (["BACKEND_ACTIONS_SERVICE_ACCOUNT"] if plain_backend else [])
-            + (KEYSTORE_SECRETS if plain_keystore else [])
-            + (MERGE_KEY_SECRETS if plain_merge else [])
+        gly_release_secrets = RELEASE_KEY_SECRETS + merge_env
+        gly_plain = (["BACKEND_ACTIONS_SERVICE_ACCOUNT"] if plain_backend else []) + (
+            MERGE_KEY_SECRETS if plain_merge else []
         )
         # Live posture on every reviewer-bearing gated env (verified
         # 2026-07-18, typed 2026-07-19): reviewer User:jlengelbrecht,
@@ -2119,23 +2101,10 @@ def self_test() -> int:
         {"SA-PLAIN", "ENV-READD"},
         warn_codes={"ENV-REVIEWERLESS"},
     )
-    # 24-27. The release-gated failure modes this migration must never let
-    # regress silently: keystore dropped from the environment, keystore
-    # re-added as plain repo secrets, the RELEASE key re-added at org level
-    # (its pre-migration home), and the reviewerless discord pin tripping
-    # the moment that repo gains a write actor.
-    expect(
-        "release-keystore-removed-from-env",
-        {"org_secrets": [], "repos": _migrated_repos(drop_keystore_from_env=True)},
-        {"ENV-DRIFT"},
-        warn_codes={"ENV-REVIEWERLESS"},
-    )
-    expect(
-        "release-keystore-plain-readd",
-        {"org_secrets": [], "repos": _migrated_repos(plain_keystore=True)},
-        {"ENV-READD"},
-        warn_codes={"ENV-REVIEWERLESS"},
-    )
+    # 24-25. The release-gated failure modes this migration must never let
+    # regress silently: the RELEASE key re-added at org level (its
+    # pre-migration home), and the reviewerless discord pin tripping the
+    # moment that repo gains a write actor.
     expect(
         "release-key-org-readd",
         {


### PR DESCRIPTION
## Summary
- Removes the four retired Android release-signing secret names (`RELEASE_KEYSTORE_BASE64`, `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`) from `EXPECTED_GATED_ENVIRONMENTS["GlycemicGPT"]["release-gated"]` in `scripts/security/check-secret-invariants.py`
- The monorepo no longer builds or signs APKs, so these secrets are dead weight in this repo's release-gated environment expectation; the keys continue to live in `android-unofficial` and 1Password
- Updates the paired self-test fixtures (`KEYSTORE_SECRETS`, `drop_keystore_from_env`, `plain_keystore`, and their two `expect()` cases) so they no longer exercise removed coverage

## Scope
- Code-only change. This PR does not delete any GitHub secrets — the four `RELEASE_KEYSTORE_*`/`RELEASE_KEY_*` secrets in the `release-gated` environment are removed as a coordinated follow-up immediately after this merges, so the weekly secrets-hygiene run doesn't trip `ENV-DRIFT`
- Untouched: `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `MERGE_APP_ID`, `MERGE_APP_PRIVATE_KEY`, and every other repo's expectations (website, ios-unofficial, android-unofficial)

## Test plan
- [x] `python3 -m py_compile scripts/security/check-secret-invariants.py`
- [x] `python3 scripts/security/check-secret-invariants.py --self-test` — 61/61 red-team fixtures pass
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` (apps/api) — clean; not applicable to this file's actual CI gate (`workflow-lint.yml`'s `--self-test` invocation)
- [x] `coderabbit review --committed --base develop` — no findings
- [x] Grep confirms zero remaining `RELEASE_KEYSTORE_BASE64`/`RELEASE_KEYSTORE_PASSWORD`/`RELEASE_KEY_ALIAS`/`RELEASE_KEY_PASSWORD` occurrences in the file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security validation to remove obsolete release keystore requirements.
  * Streamlined release-gated checks to focus on current app and merge credentials.
  * Adjusted self-test coverage and numbering to reflect the updated validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->