### PR TITLE
fix: repoint stale GHCR image references from the retired org namespace

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -41,7 +41,7 @@ LABEL org.opencontainers.image.description="FastAPI backend for GlycemicGPT diab
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 LABEL org.opencontainers.image.revision="${GIT_SHA}"
-LABEL org.opencontainers.image.source="https://github.com/GlycemicGPT/GlycemicGPT"
+LABEL org.opencontainers.image.source="https://github.com/lumose-health/GlycemicGPT"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Surface the build commit to the runtime so Sentry can tag the release.

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.description="Next.js frontend for GlycemicGPT dia
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 LABEL org.opencontainers.image.revision="${GIT_SHA}"
-LABEL org.opencontainers.image.source="https://github.com/GlycemicGPT/GlycemicGPT"
+LABEL org.opencontainers.image.source="https://github.com/lumose-health/GlycemicGPT"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Install dependencies only when needed

--- a/deploy/examples/README.md
+++ b/deploy/examples/README.md
@@ -73,7 +73,7 @@ CORS_ORIGINS=["https://glycemicgpt.example.com"]
 
 These examples target Docker Compose. For Kubernetes:
 
-- Use the container images directly (`ghcr.io/glycemicgpt/glycemicgpt-{api,web,sidecar}`)
+- Use the container images directly (`ghcr.io/lumose-health/glycemicgpt-{api,web,sidecar}`)
 - Point `REDIS_URL` at your cluster's Redis/Valkey service
 - Use Kubernetes Secrets for `SECRET_KEY`, `POSTGRES_PASSWORD`, etc.
 - Add an Ingress resource with TLS termination (cert-manager, etc.)

--- a/deploy/examples/cloudflare-tunnel/docker-compose.yml
+++ b/deploy/examples/cloudflare-tunnel/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       retries: 5
 
   ai-sidecar:
-    image: ghcr.io/glycemicgpt/glycemicgpt-sidecar:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-sidecar:${IMAGE_TAG:-latest}
     restart: unless-stopped
     volumes:
       - sidecar_auth:/home/sidecar/.config
@@ -65,7 +65,7 @@ services:
       start_period: 10s
 
   api:
-    image: ghcr.io/glycemicgpt/glycemicgpt-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-api:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # No ports exposed -- cloudflared tunnel handles ingress
     environment:
@@ -92,7 +92,7 @@ services:
       start_period: 40s
 
   web:
-    image: ghcr.io/glycemicgpt/glycemicgpt-web:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-web:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # No ports exposed -- cloudflared tunnel handles ingress
     environment:

--- a/deploy/examples/external-redis/docker-compose.yml
+++ b/deploy/examples/external-redis/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       retries: 5
 
   ai-sidecar:
-    image: ghcr.io/glycemicgpt/glycemicgpt-sidecar:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-sidecar:${IMAGE_TAG:-latest}
     restart: unless-stopped
     volumes:
       - sidecar_auth:/home/sidecar/.config
@@ -43,7 +43,7 @@ services:
       start_period: 10s
 
   api:
-    image: ghcr.io/glycemicgpt/glycemicgpt-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-api:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # WARNING: Ports exposed directly. Add a reverse proxy (Caddy, Nginx,
     # Cloudflare Tunnel) for TLS in production -- see other examples.
@@ -71,7 +71,7 @@ services:
       start_period: 40s
 
   web:
-    image: ghcr.io/glycemicgpt/glycemicgpt-web:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-web:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # WARNING: Ports exposed directly. See note on api service above.
     ports:

--- a/deploy/examples/prod-caddy/docker-compose.yml
+++ b/deploy/examples/prod-caddy/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       retries: 5
 
   ai-sidecar:
-    image: ghcr.io/glycemicgpt/glycemicgpt-sidecar:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-sidecar:${IMAGE_TAG:-latest}
     restart: unless-stopped
     volumes:
       - sidecar_auth:/home/sidecar/.config
@@ -70,7 +70,7 @@ services:
       start_period: 10s
 
   api:
-    image: ghcr.io/glycemicgpt/glycemicgpt-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-api:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # No ports exposed -- Caddy proxies via internal network
     environment:
@@ -97,7 +97,7 @@ services:
       start_period: 40s
 
   web:
-    image: ghcr.io/glycemicgpt/glycemicgpt-web:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-web:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # No ports exposed -- Caddy proxies via internal network
     environment:

--- a/deploy/examples/public-cloud/docker-compose.yml
+++ b/deploy/examples/public-cloud/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       retries: 5
 
   ai-sidecar:
-    image: ghcr.io/glycemicgpt/glycemicgpt-sidecar:latest
+    image: ghcr.io/lumose-health/glycemicgpt-sidecar:latest
     restart: unless-stopped
     volumes:
       - sidecar_auth:/home/sidecar/.config
@@ -81,7 +81,7 @@ services:
       start_period: 10s
 
   api:
-    image: ghcr.io/glycemicgpt/glycemicgpt-api:latest
+    image: ghcr.io/lumose-health/glycemicgpt-api:latest
     restart: unless-stopped
     # No ports exposed -- Caddy proxies via internal network
     environment:
@@ -109,7 +109,7 @@ services:
       start_period: 40s
 
   web:
-    image: ghcr.io/glycemicgpt/glycemicgpt-web:latest
+    image: ghcr.io/lumose-health/glycemicgpt-web:latest
     restart: unless-stopped
     # No ports exposed -- Caddy proxies via internal network
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,9 +2,9 @@
 # Usage: docker compose -f docker-compose.prod.yml up -d
 #
 # Pull latest images:
-#   docker pull ghcr.io/glycemicgpt/glycemicgpt-api:latest
-#   docker pull ghcr.io/glycemicgpt/glycemicgpt-web:latest
-#   docker pull ghcr.io/glycemicgpt/glycemicgpt-sidecar:latest
+#   docker pull ghcr.io/lumose-health/glycemicgpt-api:latest
+#   docker pull ghcr.io/lumose-health/glycemicgpt-web:latest
+#   docker pull ghcr.io/lumose-health/glycemicgpt-sidecar:latest
 #
 # Or use a specific version:
 #   IMAGE_TAG=0.1.2 docker compose -f docker-compose.prod.yml up -d
@@ -43,7 +43,7 @@ services:
       retries: 5
 
   ai-sidecar:
-    image: ghcr.io/glycemicgpt/glycemicgpt-sidecar:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-sidecar:${IMAGE_TAG:-latest}
     restart: unless-stopped
     volumes:
       - sidecar_auth:/home/sidecar/.config
@@ -65,7 +65,7 @@ services:
       start_period: 10s
 
   api:
-    image: ghcr.io/glycemicgpt/glycemicgpt-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-api:${IMAGE_TAG:-latest}
     restart: unless-stopped
     ports:
       - "${API_PORT:-8000}:8000"
@@ -97,7 +97,7 @@ services:
       start_period: 40s
 
   web:
-    image: ghcr.io/glycemicgpt/glycemicgpt-web:${IMAGE_TAG:-latest}
+    image: ghcr.io/lumose-health/glycemicgpt-web:${IMAGE_TAG:-latest}
     restart: unless-stopped
     ports:
       - "${WEB_PORT:-3000}:3000"

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -18,13 +18,13 @@ labels:
 # Override `newName` if you build and push to your own registry instead.
 images:
   - name: glycemicgpt-api
-    newName: ghcr.io/glycemicgpt/glycemicgpt-api
+    newName: ghcr.io/lumose-health/glycemicgpt-api
     newTag: latest
   - name: glycemicgpt-web
-    newName: ghcr.io/glycemicgpt/glycemicgpt-web
+    newName: ghcr.io/lumose-health/glycemicgpt-web
     newTag: latest
   - name: glycemicgpt-sidecar
-    newName: ghcr.io/glycemicgpt/glycemicgpt-sidecar
+    newName: ghcr.io/lumose-health/glycemicgpt-sidecar
     newTag: latest
 
 patches:


### PR DESCRIPTION
## Summary

Container images have been published under `ghcr.io/lumose-health/glycemicgpt-*` since the GitHub org rename, and CI (`container-build.yml`) already resolves the correct namespace dynamically via `github.repository_owner`. Several deploy-time configs, however, still hardcoded the retired `ghcr.io/glycemicgpt/*` namespace, which no longer exists (verified directly against the GHCR API: the old namespace returns no such package).

This meant every documented self-hosted "always-on deployment" path -- Cloudflare Tunnel, public-cloud VPS, prod-Caddy, external-redis, and Kubernetes -- was pulling from a dead registry path.

## Changes

- `docker-compose.prod.yml` and all four `deploy/examples/*/docker-compose.yml` files: `image:` references repointed.
- `deploy/examples/README.md`: doc reference repointed.
- `k8s/overlays/prod/kustomization.yaml`: `newName` fields repointed (the Kubernetes deploy path).
- `apps/api/Dockerfile` / `apps/web/Dockerfile`: `org.opencontainers.image.source` label repointed. Note: CI already sets the correct label dynamically via `docker/metadata-action`, which takes precedence over the Dockerfile's static `LABEL` at build time -- so this specifically corrects local/manual `docker build` introspection, not the CI-published images (those were already correct).

No application code changed; this is a registry-path and Kubernetes-manifest correction only.

## Test plan

- [x] Verified via the GHCR API that `ghcr.io/lumose-health/glycemicgpt-{api,web,sidecar}` resolves and the old `ghcr.io/glycemicgpt/*` namespace does not.
- [x] `docker compose config` validated on all touched compose files (pre-existing, unrelated `${VAR:?message}` parse quirk on `public-cloud/docker-compose.yml` confirmed present on `develop` before this change too -- not introduced here).
- [x] Full-repo grep confirms no remaining `ghcr.io/glycemicgpt` references outside of two doc files fixed in a parallel docs branch (GLY-169).
- [x] Adversarial review performed; follow-up finding (missing k8s overlay) addressed in a second commit on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Updated production and example deployment configurations to pull API, web, and sidecar images from the new container registry namespace.
  * Updated Kubernetes and Docker Compose deployment guidance accordingly.
  * Production image tags remain unchanged.

* **Documentation**
  * Updated container image source metadata and deployment instructions to reference the relocated repository and registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->