### PR TITLE
fix(GLY-220): stop glucose lines at latest reading

### DIFF
--- a/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.test.tsx
+++ b/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.test.tsx
@@ -366,7 +366,7 @@ describe("Dashboard GlucoseTrendChart", () => {
     );
   });
 
-  it("extends the latest visible glucose reading to the plot boundary", async () => {
+  it("ends the glucose line at the latest actual reading", async () => {
     const reading = makeReading(120, 5);
     const timestampSeconds = new Date(reading.reading_timestamp).getTime() / 1000;
     mockHookReturn.readings = [reading];
@@ -409,8 +409,59 @@ describe("Dashboard GlucoseTrendChart", () => {
       },
     });
 
-    expect(context.moveTo).toHaveBeenCalledWith(120, 60);
-    expect(context.lineTo).toHaveBeenCalledWith(200, 60);
+    expect(context.moveTo).not.toHaveBeenCalledWith(120, 60);
+    expect(context.lineTo).not.toHaveBeenCalledWith(200, 60);
+  });
+
+  it("does not extend a stale glucose reading to the plot boundary", async () => {
+    const reading = makeReading(120, 120);
+    const timestampSeconds = new Date(reading.reading_timestamp).getTime() / 1000;
+    mockHookReturn.readings = [reading];
+
+    render(<GlucoseTrendChart />);
+
+    await waitFor(() => expect(mockUPlot).toHaveBeenCalled());
+    const glucoseCall = mockUPlot.mock.calls.find(
+      ([options]) => options.axes[1].scale !== "insulin",
+    );
+    expect(glucoseCall).toBeDefined();
+    const [options] = glucoseCall as [{
+      hooks: { draw: Array<(chart: unknown) => void> };
+    }];
+    const context = {
+      arc: jest.fn(),
+      beginPath: jest.fn(),
+      fill: jest.fn(),
+      fillRect: jest.fn(),
+      fillStyle: "",
+      globalAlpha: 1,
+      lineCap: "butt",
+      lineJoin: "miter",
+      lineTo: jest.fn(),
+      lineWidth: 1,
+      moveTo: jest.fn(),
+      restore: jest.fn(),
+      save: jest.fn(),
+      setLineDash: jest.fn(),
+      stroke: jest.fn(),
+      strokeStyle: "",
+    };
+
+    options.hooks.draw[0]({
+      bbox: { height: 200, left: 36, top: 0, width: 164 },
+      ctx: context,
+      data: [[timestampSeconds], [120]],
+      scales: {
+        x: { min: timestampSeconds - 600, max: timestampSeconds + 7200 },
+      },
+      valToPos: (value: number, scale: string) => {
+        if (scale === "x") return 120;
+        return value === 120 ? 60 : value;
+      },
+    });
+
+    expect(context.moveTo).not.toHaveBeenCalledWith(120, 60);
+    expect(context.lineTo).not.toHaveBeenCalledWith(200, 60);
   });
 
   it("renders the reusable section separator only in the embedded dashboard chart", () => {

--- a/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.tsx
+++ b/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.tsx
@@ -501,67 +501,6 @@ function drawGlucoseLineSegments(
   chart.ctx.restore();
 }
 
-function drawLatestGlucoseExtension(
-  chart: uPlot,
-  points: ChartPoint[],
-  thresholds: {
-    urgentLow: number;
-    low: number;
-    high: number;
-    urgentHigh: number;
-  },
-  palette: ChartPalette,
-): void {
-  const scaleMin = chart.scales.x.min;
-  const scaleMax = chart.scales.x.max;
-
-  if (scaleMin == null || scaleMax == null) {
-    return;
-  }
-
-  let point: ChartPoint | undefined;
-
-  for (let index = points.length - 1; index >= 0; index -= 1) {
-    const candidate = points[index];
-    const timestamp = candidate.timestamp / 1000;
-
-    if (timestamp >= scaleMin && timestamp <= scaleMax) {
-      point = candidate;
-      break;
-    }
-  }
-
-  if (!point) {
-    return;
-  }
-
-  const pixelRatio =
-    typeof window === "undefined" ? 1 : window.devicePixelRatio || 1;
-  const plotRight = chart.bbox.left + chart.bbox.width;
-  const pointX = Math.max(
-    chart.bbox.left,
-    Math.min(plotRight, chart.valToPos(point.timestamp / 1000, "x", true)),
-  );
-  const pointY = chart.valToPos(point.value, "y", true);
-
-  if (
-    ![pointX, pointY, plotRight].every(Number.isFinite) ||
-    pointX >= plotRight
-  ) {
-    return;
-  }
-
-  chart.ctx.save();
-  chart.ctx.lineCap = "round";
-  chart.ctx.lineWidth = LINE_WIDTH * pixelRatio;
-  chart.ctx.strokeStyle = getPointCanvasColor(point.value, thresholds, palette);
-  chart.ctx.beginPath();
-  chart.ctx.moveTo(pointX, pointY);
-  chart.ctx.lineTo(plotRight, pointY);
-  chart.ctx.stroke();
-  chart.ctx.restore();
-}
-
 function drawReadingPoints(
   chart: uPlot,
   points: ChartPoint[],
@@ -892,14 +831,6 @@ function UplotGlucoseTrend({
           (chart) => {
             drawTargetRange(chart, lowThreshold, highThreshold, palette);
             drawGlucoseLineSegments(chart, lineSegments, thresholds, palette);
-            if (forecastPoints.length === 0) {
-              drawLatestGlucoseExtension(
-                chart,
-                dataRef.current,
-                thresholds,
-                palette,
-              );
-            }
             drawForecastLine(chart, forecastPoints, palette);
             drawThresholdLines(chart, lowThreshold, highThreshold, palette);
             drawReadingPoints(

--- a/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.test.tsx
+++ b/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.test.tsx
@@ -287,6 +287,59 @@ describe("MergedGlucoseTrendChart", () => {
     expect(desktopValues({} as uPlot, [70, 180])).toEqual(["3.9", "10.0"]);
   });
 
+  it("does not extend a stale mobile glucose reading to the plot boundary", () => {
+    const domainEndMs = 3 * 60 * 60 * 1000;
+    const staleTimestampMs = domainEndMs - 2 * 60 * 60 * 1000;
+
+    render(
+      <MobileMergedGlucoseTrendChart
+        model={model({
+          fullDomain: [0, domainEndMs],
+          points: [
+            {
+              timestampMs: staleTimestampMs,
+              trend: "Stable",
+              valueMgDl: 120,
+            },
+          ],
+        })}
+      />,
+    );
+
+    const options = mockUPlot.mock.calls[0]?.[0] as {
+      hooks: { draw: Array<(chart: unknown) => void> };
+    };
+    const context = {
+      arc: jest.fn(),
+      beginPath: jest.fn(),
+      fill: jest.fn(),
+      fillStyle: "",
+      globalAlpha: 1,
+      lineCap: "butt",
+      lineJoin: "miter",
+      lineTo: jest.fn(),
+      lineWidth: 1,
+      moveTo: jest.fn(),
+      restore: jest.fn(),
+      save: jest.fn(),
+      setLineDash: jest.fn(),
+      stroke: jest.fn(),
+      strokeStyle: "",
+    };
+
+    options.hooks.draw[0]({
+      bbox: { height: 200, left: 36, top: 0, width: 164 },
+      ctx: context,
+      valToPos: (value: number, scale: string) => {
+        if (scale === "x") return 120;
+        return value === 120 ? 60 : value;
+      },
+    });
+
+    expect(context.moveTo).not.toHaveBeenCalledWith(120, 60);
+    expect(context.lineTo).not.toHaveBeenCalledWith(200, 60);
+  });
+
   it("shows a compact mobile explanation legend with dynamic categories", () => {
     render(
       <MobileMergedGlucoseTrendChart


### PR DESCRIPTION
Remove the synthetic V2 chart extension so glucose traces end at real CGM samples. Cover recent and stale readings across the standard and mobile merged chart renderers.

## 📋 Summary

<!-- Brief description of what this PR does -->

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

-
-

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [ ] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Glucose trend charts no longer extend the latest or stale glucose reading as a horizontal line to the chart boundary when forecast data is unavailable.
  * Improved chart behavior on mobile and in cases involving outdated readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->