### PR TITLE
chore: delegate web and ai area code ownership to their teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,15 +12,19 @@
 # rule below. Unowned paths fail safe to the lead.
 * @jlengelbrecht
 
-# Web / frontend and AI / evals / benchmarks: project lead.
-# Code owners must hold Write; only the lead does (see GOVERNANCE.md,
-# repository access policy), so area ownership cannot be a team here.
-/apps/web/ @jlengelbrecht
-/apps/api/benchmarks/ @jlengelbrecht
-/apps/api/tests/benchmarks/ @jlengelbrecht
-/evals/ @jlengelbrecht
-/sidecar/ @jlengelbrecht
-/docs/benchmarking/ @jlengelbrecht
+# Web / frontend: co-owned by the web area team and the project lead.
+# Either satisfies the code-owner review requirement. Authors can
+# never approve their own PRs, so a PR by the sole area maintainer
+# still falls to the lead for review.
+/apps/web/ @lumose-health/web @jlengelbrecht
+
+# AI / sidecar / evals / benchmarks: co-owned by the ai area team
+# and the project lead, same model as the web area above.
+/apps/api/benchmarks/ @lumose-health/ai @jlengelbrecht
+/apps/api/tests/benchmarks/ @lumose-health/ai @jlengelbrecht
+/evals/ @lumose-health/ai @jlengelbrecht
+/sidecar/ @lumose-health/ai @jlengelbrecht
+/docs/benchmarking/ @lumose-health/ai @jlengelbrecht
 
 # Governance & project policy: project lead only.
 /.github/CODEOWNERS @jlengelbrecht


### PR DESCRIPTION
## Summary

The `web` and `ai` teams now hold Write on this repository (org setting changed today). This PR completes the delegation by making them code owners of their areas:

- `/apps/web/` is co-owned by `@lumose-health/web` and the project lead
- `/sidecar/`, `/evals/`, `/apps/api/benchmarks/`, `/apps/api/tests/benchmarks/`, `/docs/benchmarking/` are co-owned by `@lumose-health/ai` and the project lead

Co-listing the lead on each delegated path keeps a counting code-owner review available when the sole area maintainer authors the PR (authors cannot approve their own PRs).

Unchanged and still owned by the project lead alone: the default catch-all, governance and policy files, GitHub Actions workflows and security infrastructure, bootstrap clinical knowledge, and the insulin/dosing safety surface (last-match rules).

## Effect after merge

- Area maintainers can approve and merge PRs in their areas (review by any listed owner satisfies the code-owner requirement; the 1-approval write-access rule is met by either party).
- Self-authored PRs still require review by the other listed owner.
- No change to branch protection rules themselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments for web, AI, benchmarking, evaluation, sidecar, and benchmarking documentation areas.
  * Added project leadership alongside relevant area teams for review responsibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->