### PR TITLE
fix(GLY-221): preserve high forecast curves

### DIFF
--- a/apps/api/src/schemas/forecast.py
+++ b/apps/api/src/schemas/forecast.py
@@ -35,8 +35,12 @@ logger = logging.getLogger(__name__)
 # corrupting the response shape.
 _KNOWN_CURVE_KEYS = frozenset({"main", "IOB", "COB", "UAM", "ZT"})
 _MAX_CURVE_POINTS = 288
+# Keep these reader bounds aligned with `_FORECAST_VALUE_MIN_MGDL` and
+# `_FORECAST_VALUE_MAX_MGDL` in the Nightscout forecast mapper. Ingestion
+# deliberately allows prediction overshoot headroom through 800 mg/dL, so the
+# reader must accept every curve value that ingestion can persist.
 _MIN_GLUCOSE_MGDL = 20.0
-_MAX_GLUCOSE_MGDL = 500.0
+_MAX_GLUCOSE_MGDL = 800.0
 
 # Allow-list mirrors `forecast_settings.source` CHECK constraint (PR 3
 # migration 057) and adds 'auto' / 'none' for the picker. The

--- a/apps/api/src/services/integrations/nightscout/_forecast_mapper.py
+++ b/apps/api/src/services/integrations/nightscout/_forecast_mapper.py
@@ -53,7 +53,8 @@ _OPENAPS_DEFAULT_CURVE_PRIORITY = ("IOB", "COB", "UAM", "ZT")
 # it would poison both the chart overlay and the deferred scoring
 # job. Bounds match the entries-side gap rule (`SGV_MIN_VALID` /
 # `SGV_MAX_VALID` in `models.py`) plus a small headroom for forecast
-# extrapolation peaks.
+# extrapolation peaks. The defensive reader in `src.schemas.forecast`
+# intentionally mirrors these bounds so every persisted curve remains readable.
 _FORECAST_VALUE_MIN_MGDL = 20.0
 _FORECAST_VALUE_MAX_MGDL = 800.0
 

--- a/apps/api/tests/test_forecast_endpoints.py
+++ b/apps/api/tests/test_forecast_endpoints.py
@@ -63,6 +63,7 @@ async def _seed_snapshot(
     *,
     source_engine: str,
     issued_minutes_ago: int,
+    curves: dict[str, list[float]] | None = None,
 ) -> NightscoutConnection:
     """Insert one forecast snapshot for the user. Creates a connection
     on first call if needed."""
@@ -96,7 +97,9 @@ async def _seed_snapshot(
         start_at=issued,
         step_minutes=5,
         horizon_minutes=30,
-        curves_mgdl_json={"main": [120, 122, 125, 128, 130, 131]},
+        curves_mgdl_json=(
+            curves if curves is not None else {"main": [120, 122, 125, 128, 130, 131]}
+        ),
         default_curve_name="main",
         dedupe_key=f"test-{uuid.uuid4().hex}",
     )
@@ -240,6 +243,33 @@ async def test_get_auto_single_source_resolves_and_returns_forecast():
     assert data["forecast"]["curves_mgdl"]["main"] == [120, 122, 125, 128, 130, 131]
     # Happy path -> reason omitted (null).
     assert data["forecast_unavailable_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_returns_stored_forecast_with_value_above_500():
+    """Forecast overshoot headroom accepted during ingestion remains readable."""
+    curves = {"main": [480.0, 520.0, 490.0]}
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        cookie, user_id = await register_and_login(client)
+        async for db in get_db():
+            await _seed_snapshot(
+                db,
+                user_id,
+                source_engine="loop",
+                issued_minutes_ago=5,
+                curves=curves,
+            )
+            break
+
+        resp = await client.get(
+            "/api/integrations/forecast",
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["forecast"]["curves_mgdl"]["main"] == curves["main"]
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_forecast_schema.py
+++ b/apps/api/tests/test_forecast_schema.py
@@ -33,11 +33,11 @@ def test_curves_from_jsonb_handles_non_object_payload():
     }
 
 
-@pytest.mark.parametrize("value", [10**1000, 19, 501, float("inf"), float("-inf")])
+@pytest.mark.parametrize("value", [10**1000, 19, 801, float("inf"), float("-inf")])
 def test_curves_from_jsonb_rejects_unsafe_glucose_values(value):
     assert curves_from_jsonb({"main": [value]}).main is None
 
 
-@pytest.mark.parametrize("value", [20, 500])
+@pytest.mark.parametrize("value", [20, 800])
 def test_curves_from_jsonb_accepts_inclusive_glucose_boundaries(value):
     assert curves_from_jsonb({"main": [value]}).main == [float(value)]


### PR DESCRIPTION
Align forecast reader bounds with the 800 mg/dL ingestion ceiling so valid prediction overshoot does not discard entire stored curves. Cover schema boundaries and endpoint serialization for a stored 520 mg/dL point.

## 📋 Summary

<!-- Brief description of what this PR does -->

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

-
-

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [ ] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forecast data now supports glucose curve values up to 800 mg/dL.
  * Valid forecast values between 20 and 800 mg/dL are preserved and returned correctly.
  * Values below 20 mg/dL, above 800 mg/dL, or non-finite values remain rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->