### PR TITLE
fix(GLY-222): keep isolated CGM readings visible

### DIFF
--- a/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.test.tsx
+++ b/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.test.tsx
@@ -137,6 +137,22 @@ function makeReading(value: number, minutesAgo: number): (typeof mockHookReturn.
   };
 }
 
+function makeReadingAt(
+  value: number,
+  timestampMs: number,
+): (typeof mockHookReturn.readings)[0] {
+  const timestamp = new Date(timestampMs).toISOString();
+
+  return {
+    value,
+    reading_timestamp: timestamp,
+    trend: "flat",
+    trend_rate: null,
+    received_at: timestamp,
+    source: "dexcom",
+  };
+}
+
 function makeForecast(startMs: number): ForecastReadResponse {
   return {
     source_preference: "auto",
@@ -411,6 +427,68 @@ describe("Dashboard GlucoseTrendChart", () => {
 
     expect(context.moveTo).not.toHaveBeenCalledWith(120, 60);
     expect(context.lineTo).not.toHaveBeenCalledWith(200, 60);
+  });
+
+  it("renders an isolated reading as a point in line mode", async () => {
+    const minuteMs = 60_000;
+    const startMs = Date.now() - 170 * minuteMs;
+    const beforeGap = Array.from({ length: 65 }, (_, index) =>
+      makeReadingAt(100, startMs + index * minuteMs),
+    );
+    const isolatedTimestampMs = startMs + 84 * minuteMs;
+    const isolatedReading = makeReadingAt(222, isolatedTimestampMs);
+    const afterGap = Array.from({ length: 65 }, (_, index) =>
+      makeReadingAt(120, startMs + (104 + index) * minuteMs),
+    );
+    mockHookReturn.readings = [
+      ...beforeGap,
+      isolatedReading,
+      ...afterGap,
+    ];
+
+    render(<GlucoseTrendChart />);
+
+    await waitFor(() => expect(mockUPlot).toHaveBeenCalled());
+    const glucoseCall = mockUPlot.mock.calls.find(
+      ([options]) => options.axes[1].scale !== "insulin",
+    );
+    expect(glucoseCall).toBeDefined();
+    const [options] = glucoseCall as [{
+      hooks: { draw: Array<(chart: unknown) => void> };
+    }];
+    const context = {
+      arc: jest.fn(),
+      beginPath: jest.fn(),
+      fill: jest.fn(),
+      fillRect: jest.fn(),
+      fillStyle: "",
+      globalAlpha: 1,
+      lineCap: "butt",
+      lineJoin: "miter",
+      lineTo: jest.fn(),
+      lineWidth: 1,
+      moveTo: jest.fn(),
+      restore: jest.fn(),
+      save: jest.fn(),
+      setLineDash: jest.fn(),
+      stroke: jest.fn(),
+      strokeStyle: "",
+    };
+
+    options.hooks.draw[0]({
+      bbox: { height: 200, left: 36, top: 0, width: 640 },
+      ctx: context,
+      valToPos: (value: number) => value,
+    });
+
+    expect(context.arc).toHaveBeenCalledTimes(1);
+    expect(context.arc).toHaveBeenCalledWith(
+      isolatedTimestampMs / 1000,
+      222,
+      3,
+      0,
+      Math.PI * 2,
+    );
   });
 
   it("does not extend a stale glucose reading to the plot boundary", async () => {

--- a/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.tsx
+++ b/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.tsx
@@ -42,7 +42,10 @@ import {
   formatSharedTimeTick,
   getSharedTimeSplits,
 } from "@/lib/charts/chart-axis";
-import { getContinuousGlucosePairs } from "@/lib/charts/glucose-continuity";
+import {
+  getContinuousGlucosePairs,
+  getIsolatedGlucosePoints,
+} from "@/lib/charts/glucose-continuity";
 import {
   resolveChartPalette,
   type ChartPalette,
@@ -503,8 +506,7 @@ function drawGlucoseLineSegments(
 
 function drawReadingPoints(
   chart: uPlot,
-  points: ChartPoint[],
-  mode: "all" | "none",
+  points: readonly ChartPoint[],
   thresholds: {
     urgentLow: number;
     low: number;
@@ -513,30 +515,24 @@ function drawReadingPoints(
   },
   palette: ChartPalette,
 ): void {
-  if (mode === "none") {
-    return;
-  }
-
   const pixelRatio =
     typeof window === "undefined" ? 1 : window.devicePixelRatio || 1;
-  const xs = chart.data[0];
-  const ys = chart.data[1];
 
   chart.ctx.save();
 
-  for (let index = 0; index < xs.length; index += 1) {
-    const yValue = ys[index];
+  for (const point of points) {
+    const x = chart.valToPos(point.timestamp / 1000, "x", true);
+    const y = chart.valToPos(point.value, "y", true);
 
-    if (yValue == null) {
+    if (![x, y].every(Number.isFinite)) {
       continue;
     }
 
-    const x = chart.valToPos(xs[index], "x", true);
-    const y = chart.valToPos(yValue, "y", true);
-
-    chart.ctx.fillStyle = points[index]
-      ? getPointCanvasColor(points[index].value, thresholds, palette)
-      : palette.target;
+    chart.ctx.fillStyle = getPointCanvasColor(
+      point.value,
+      thresholds,
+      palette,
+    );
     chart.ctx.beginPath();
     chart.ctx.arc(x, y, POINT_RADIUS * pixelRatio, 0, Math.PI * 2);
     chart.ctx.fill();
@@ -754,6 +750,10 @@ function UplotGlucoseTrend({
       data.length,
       dimensions.width,
     );
+    const readingPoints =
+      effectiveRenderMode === "points"
+        ? data
+        : getIsolatedGlucosePoints(data, (point) => point.timestamp);
     const palette = resolveChartPalette(element);
     const thresholds = {
       urgentLow: urgentLowThreshold,
@@ -835,8 +835,7 @@ function UplotGlucoseTrend({
             drawThresholdLines(chart, lowThreshold, highThreshold, palette);
             drawReadingPoints(
               chart,
-              dataRef.current,
-              effectiveRenderMode === "points" ? "all" : "none",
+              readingPoints,
               thresholds,
               palette,
             );

--- a/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.test.tsx
+++ b/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.test.tsx
@@ -408,6 +408,52 @@ describe("MergedGlucoseTrendChart", () => {
     );
   });
 
+  it("skips reading points with non-finite canvas coordinates", () => {
+    const timestampMs = 30 * 60 * 1000;
+
+    render(
+      <MergedGlucoseTrendSurface
+        heightClassName="h-80"
+        interactive
+        model={model({
+          points: [{ timestampMs, trend: "Stable", valueMgDl: 120 }],
+        })}
+        xDomain={[0, 60 * 60 * 1000]}
+      />,
+    );
+
+    const options = mockUPlot.mock.calls.at(-1)?.[0] as {
+      hooks: { draw: Array<(chart: unknown) => void> };
+    };
+    const context = {
+      arc: jest.fn(),
+      beginPath: jest.fn(),
+      fill: jest.fn(),
+      fillRect: jest.fn(),
+      fillStyle: "",
+      globalAlpha: 1,
+      lineCap: "butt",
+      lineJoin: "miter",
+      lineTo: jest.fn(),
+      lineWidth: 1,
+      moveTo: jest.fn(),
+      restore: jest.fn(),
+      save: jest.fn(),
+      setLineDash: jest.fn(),
+      stroke: jest.fn(),
+      strokeStyle: "",
+    };
+
+    options.hooks.draw[0]({
+      bbox: { height: 200, left: 36, top: 0, width: 640 },
+      ctx: context,
+      valToPos: (_value: number, scale: string) =>
+        scale === "x" ? Number.NaN : 120,
+    });
+
+    expect(context.arc).not.toHaveBeenCalled();
+  });
+
   it("shows a compact mobile explanation legend with dynamic categories", () => {
     render(
       <MobileMergedGlucoseTrendChart

--- a/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.test.tsx
+++ b/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.test.tsx
@@ -340,6 +340,74 @@ describe("MergedGlucoseTrendChart", () => {
     expect(context.lineTo).not.toHaveBeenCalledWith(200, 60);
   });
 
+  it("renders an isolated reading as a point in line mode", () => {
+    const minuteMs = 60_000;
+    const startMs = Date.now() - 170 * minuteMs;
+    const beforeGap = Array.from({ length: 65 }, (_, index) => ({
+      timestampMs: startMs + index * minuteMs,
+      trend: "Stable" as const,
+      valueMgDl: 100,
+    }));
+    const isolatedPoint = {
+      timestampMs: startMs + 84 * minuteMs,
+      trend: "Stable" as const,
+      valueMgDl: 222,
+    };
+    const afterGap = Array.from({ length: 65 }, (_, index) => ({
+      timestampMs: startMs + (104 + index) * minuteMs,
+      trend: "Stable" as const,
+      valueMgDl: 120,
+    }));
+    const points = [...beforeGap, isolatedPoint, ...afterGap];
+    const xDomain: [number, number] = [startMs, startMs + 170 * minuteMs];
+
+    render(
+      <MergedGlucoseTrendSurface
+        heightClassName="h-80"
+        interactive
+        model={model({ fullDomain: xDomain, points })}
+        xDomain={xDomain}
+      />,
+    );
+
+    const options = mockUPlot.mock.calls.at(-1)?.[0] as {
+      hooks: { draw: Array<(chart: unknown) => void> };
+    };
+    const context = {
+      arc: jest.fn(),
+      beginPath: jest.fn(),
+      fill: jest.fn(),
+      fillRect: jest.fn(),
+      fillStyle: "",
+      globalAlpha: 1,
+      lineCap: "butt",
+      lineJoin: "miter",
+      lineTo: jest.fn(),
+      lineWidth: 1,
+      moveTo: jest.fn(),
+      restore: jest.fn(),
+      save: jest.fn(),
+      setLineDash: jest.fn(),
+      stroke: jest.fn(),
+      strokeStyle: "",
+    };
+
+    options.hooks.draw[0]({
+      bbox: { height: 200, left: 36, top: 0, width: 640 },
+      ctx: context,
+      valToPos: (value: number) => value,
+    });
+
+    expect(context.arc).toHaveBeenCalledTimes(1);
+    expect(context.arc).toHaveBeenCalledWith(
+      isolatedPoint.timestampMs / 1000,
+      isolatedPoint.valueMgDl,
+      3,
+      0,
+      Math.PI * 2,
+    );
+  });
+
   it("shows a compact mobile explanation legend with dynamic categories", () => {
     render(
       <MobileMergedGlucoseTrendChart

--- a/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendSurface.tsx
+++ b/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendSurface.tsx
@@ -283,6 +283,10 @@ function drawGlucose(
     const x = chart.valToPos(point.timestampMs / 1000, "x", true);
     const y = chart.valToPos(point.valueMgDl, "glucose", true);
 
+    if (![x, y].every(Number.isFinite)) {
+      continue;
+    }
+
     chart.ctx.fillStyle = glucoseColor(point.valueMgDl, model.thresholds, palette);
     chart.ctx.beginPath();
     chart.ctx.arc(x, y, GLUCOSE_POINT_RADIUS_PX * pixelRatio, 0, Math.PI * 2);

--- a/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendSurface.tsx
+++ b/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendSurface.tsx
@@ -11,7 +11,10 @@ import {
   formatSharedTimeTick,
   getSharedTimeSplits,
 } from "@/lib/charts/chart-axis";
-import { getContinuousGlucosePairs } from "@/lib/charts/glucose-continuity";
+import {
+  getContinuousGlucosePairs,
+  getIsolatedGlucosePoints,
+} from "@/lib/charts/glucose-continuity";
 import {
   resolveChartPalette,
   type ChartPalette,
@@ -243,6 +246,9 @@ function drawGlucose(
 
   const pixelRatio = typeof window === "undefined" ? 1 : window.devicePixelRatio || 1;
   const showPoints = points.length <= Math.max(1, Math.floor(chart.bbox.width / pixelRatio / 5));
+  const readingPoints = showPoints
+    ? points
+    : getIsolatedGlucosePoints(points, (point) => point.timestampMs);
 
   chart.ctx.save();
   chart.ctx.lineCap = "round";
@@ -273,16 +279,14 @@ function drawGlucose(
     chart.ctx.stroke();
   }
 
-  if (showPoints) {
-    for (const point of points) {
-      const x = chart.valToPos(point.timestampMs / 1000, "x", true);
-      const y = chart.valToPos(point.valueMgDl, "glucose", true);
+  for (const point of readingPoints) {
+    const x = chart.valToPos(point.timestampMs / 1000, "x", true);
+    const y = chart.valToPos(point.valueMgDl, "glucose", true);
 
-      chart.ctx.fillStyle = glucoseColor(point.valueMgDl, model.thresholds, palette);
-      chart.ctx.beginPath();
-      chart.ctx.arc(x, y, GLUCOSE_POINT_RADIUS_PX * pixelRatio, 0, Math.PI * 2);
-      chart.ctx.fill();
-    }
+    chart.ctx.fillStyle = glucoseColor(point.valueMgDl, model.thresholds, palette);
+    chart.ctx.beginPath();
+    chart.ctx.arc(x, y, GLUCOSE_POINT_RADIUS_PX * pixelRatio, 0, Math.PI * 2);
+    chart.ctx.fill();
   }
 
   chart.ctx.restore();

--- a/apps/web/src/lib/charts/glucose-continuity.test.ts
+++ b/apps/web/src/lib/charts/glucose-continuity.test.ts
@@ -1,5 +1,6 @@
 import {
   getContinuousGlucosePairs,
+  getIsolatedGlucosePoints,
   MAX_CONTINUOUS_GLUCOSE_INTERVAL_MS,
 } from "./glucose-continuity";
 
@@ -17,6 +18,15 @@ describe("getContinuousGlucosePairs", () => {
   it("keeps adjacent readings within the continuity interval", () => {
     const first = point(0, 100);
     const second = point(MAX_CONTINUOUS_GLUCOSE_INTERVAL_MS, 110);
+
+    expect(
+      getContinuousGlucosePairs([first, second], (item) => item.timestampMs),
+    ).toEqual([[first, second]]);
+  });
+
+  it("tolerates timestamp jitter around a 15 minute reading cadence", () => {
+    const first = point(0, 100);
+    const second = point(15 * 60 * 1000 + 30 * 1000, 110);
 
     expect(
       getContinuousGlucosePairs([first, second], (item) => item.timestampMs),
@@ -49,5 +59,38 @@ describe("getContinuousGlucosePairs", () => {
         (item) => item.timestampMs,
       ),
     ).toEqual([[afterGap, nextReading]]);
+  });
+});
+
+describe("getIsolatedGlucosePoints", () => {
+  const point = (timestampMs: number, value: number): TestPoint => ({
+    timestampMs,
+    value,
+  });
+
+  it("returns a reading with continuity gaps on both sides", () => {
+    const first = point(0, 100);
+    const isolated = point(40 * 60 * 1000, 140);
+    const last = point(80 * 60 * 1000, 120);
+
+    expect(
+      getIsolatedGlucosePoints(
+        [first, isolated, last],
+        (item) => item.timestampMs,
+      ),
+    ).toEqual([first, isolated, last]);
+  });
+
+  it("excludes readings that connect to either neighbor", () => {
+    const beforeGap = point(0, 100);
+    const afterGap = point(40 * 60 * 1000, 140);
+    const connected = point(45 * 60 * 1000, 145);
+
+    expect(
+      getIsolatedGlucosePoints(
+        [beforeGap, afterGap, connected],
+        (item) => item.timestampMs,
+      ),
+    ).toEqual([beforeGap]);
   });
 });

--- a/apps/web/src/lib/charts/glucose-continuity.ts
+++ b/apps/web/src/lib/charts/glucose-continuity.ts
@@ -1,4 +1,12 @@
-export const MAX_CONTINUOUS_GLUCOSE_INTERVAL_MS = 15 * 60 * 1000;
+export const MAX_CONTINUOUS_GLUCOSE_INTERVAL_MS = 16 * 60 * 1000;
+
+function isContinuousGlucoseInterval(intervalMs: number): boolean {
+  return (
+    Number.isFinite(intervalMs) &&
+    intervalMs >= 0 &&
+    intervalMs <= MAX_CONTINUOUS_GLUCOSE_INTERVAL_MS
+  );
+}
 
 export function getContinuousGlucosePairs<T>(
   points: readonly T[],
@@ -11,14 +19,30 @@ export function getContinuousGlucosePairs<T>(
     const current = points[index];
     const intervalMs = getTimestampMs(current) - getTimestampMs(previous);
 
-    if (
-      Number.isFinite(intervalMs) &&
-      intervalMs >= 0 &&
-      intervalMs <= MAX_CONTINUOUS_GLUCOSE_INTERVAL_MS
-    ) {
+    if (isContinuousGlucoseInterval(intervalMs)) {
       pairs.push([previous, current]);
     }
   }
 
   return pairs;
+}
+
+export function getIsolatedGlucosePoints<T>(
+  points: readonly T[],
+  getTimestampMs: (point: T) => number,
+): T[] {
+  return points.filter((point, index) => {
+    const timestampMs = getTimestampMs(point);
+    const previousIntervalMs =
+      index > 0 ? timestampMs - getTimestampMs(points[index - 1]) : NaN;
+    const nextIntervalMs =
+      index < points.length - 1
+        ? getTimestampMs(points[index + 1]) - timestampMs
+        : NaN;
+
+    return (
+      !isContinuousGlucoseInterval(previousIntervalMs) &&
+      !isContinuousGlucoseInterval(nextIntervalMs)
+    );
+  });
 }


### PR DESCRIPTION
Render continuity-orphaned readings as points in line mode on both glucose chart surfaces. Allow one minute of jitter around a 15 minute CGM cadence and cover both behaviors with regression tests.

## 📋 Summary

<!-- Brief description of what this PR does -->

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

-
-

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [ ] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Isolated glucose readings now appear as individual points in line charts instead of being incorrectly connected.
  * Glucose readings with brief timestamp variations remain correctly connected.
  * Chart rendering now handles telemetry gaps more accurately.
  * Invalid chart coordinates are safely excluded from rendering.

* **Tests**
  * Added coverage for isolated readings, telemetry gaps, invalid coordinates, and timestamp continuity across glucose trend charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->