### PR TITLE
fix(GLY-223): validate vendor CGM alert thresholds

### DIFF
--- a/apps/api/src/services/tandem_sync.py
+++ b/apps/api/src/services/tandem_sync.py
@@ -5,6 +5,7 @@ including Control-IQ activity parsing.
 """
 
 import asyncio
+import math
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -37,6 +38,8 @@ logger = get_logger(__name__)
 # Retry configuration
 MAX_RETRIES = 3
 RETRY_DELAY = 2  # seconds
+_CGM_ALERT_MIN_MGDL = 20
+_CGM_ALERT_MAX_MGDL = 500
 
 
 class TandemSyncError(Exception):
@@ -179,6 +182,47 @@ def calculate_basal_adjustment(event_data: dict) -> float | None:
         return round(adjustment, 1)
 
     return None
+
+
+def _bound_cgm_alert_threshold(
+    value: object,
+    *,
+    threshold: str,
+    user_id: uuid.UUID,
+) -> int | None:
+    """Return an integer CGM alert threshold within the platform bounds."""
+    if value is None:
+        return None
+
+    try:
+        numeric_value = (
+            float(value) if isinstance(value, (str, int, float)) else math.nan
+        )
+    except (ValueError, OverflowError):
+        numeric_value = math.nan
+
+    if not math.isfinite(numeric_value) or not numeric_value.is_integer():
+        logger.warning(
+            "Discarded invalid Tandem CGM alert threshold",
+            user_id=str(user_id),
+            threshold=threshold,
+            raw_value=repr(value),
+            reason="non_numeric",
+        )
+        return None
+
+    bounded_value = int(numeric_value)
+    if not _CGM_ALERT_MIN_MGDL <= bounded_value <= _CGM_ALERT_MAX_MGDL:
+        logger.warning(
+            "Discarded invalid Tandem CGM alert threshold",
+            user_id=str(user_id),
+            threshold=threshold,
+            raw_value=repr(value),
+            reason="out_of_range",
+        )
+        return None
+
+    return bounded_value
 
 
 def map_event_type(event_data: dict) -> tuple[PumpEventType, bool, str | None]:
@@ -802,22 +846,49 @@ async def _store_pump_settings(
     """
     from tconnectsync.domain.tandemsource.pump_settings import PumpSettings
 
-    pump_settings = PumpSettings.from_dict(raw_settings)
+    raw_cgm_settings = raw_settings.get("cgmSettings")
+    cgm_high = None
+    cgm_low = None
+    settings_to_parse = raw_settings
+    if isinstance(raw_cgm_settings, dict):
+        cgm_high = _bound_cgm_alert_threshold(
+            raw_cgm_settings.get("highGlucoseAlertMgPerDl"),
+            threshold="high",
+            user_id=user_id,
+        )
+        cgm_low = _bound_cgm_alert_threshold(
+            raw_cgm_settings.get("lowGlucoseAlertMgPerDl"),
+            threshold="low",
+            user_id=user_id,
+        )
+
+        if cgm_high is not None and cgm_low is not None and cgm_low >= cgm_high:
+            logger.warning(
+                "Discarded inverted Tandem CGM alert thresholds",
+                user_id=str(user_id),
+                cgm_high=cgm_high,
+                cgm_low=cgm_low,
+            )
+            cgm_high = None
+            cgm_low = None
+
+        # PumpSettings requires integer CGM fields. Feed it harmless placeholders
+        # for rejected values while retaining the validated values for persistence.
+        settings_to_parse = {
+            **raw_settings,
+            "cgmSettings": {
+                **raw_cgm_settings,
+                "highGlucoseAlertMgPerDl": cgm_high or 0,
+                "lowGlucoseAlertMgPerDl": cgm_low or 0,
+            },
+        }
+
+    pump_settings = PumpSettings.from_dict(settings_to_parse)
     now = datetime.now(UTC)
     profiles_stored = 0
 
     active_idp = getattr(pump_settings.profiles, "activeIdp", None)
     profile_list = getattr(pump_settings.profiles, "profile", None) or []
-
-    # Extract CGM alert thresholds
-    cgm_high = None
-    cgm_low = None
-    try:
-        cgm = pump_settings.cgmSettings
-        cgm_high = cgm.highGlucoseAlertMgPerDl
-        cgm_low = cgm.lowGlucoseAlertMgPerDl
-    except (AttributeError, TypeError):
-        pass
 
     skipped = 0
     for profile in profile_list:

--- a/apps/api/tests/test_tandem_sync.py
+++ b/apps/api/tests/test_tandem_sync.py
@@ -1209,8 +1209,8 @@ class TestControlIQActivityEndpoint:
 def _make_raw_settings(
     profiles: list[dict] | None = None,
     active_idp: int = 1,
-    cgm_high: int = 240,
-    cgm_low: int = 70,
+    cgm_high: object = 240,
+    cgm_low: object = 70,
 ) -> dict:
     """Build a raw settings dict matching the structure of Tandem metadata."""
     if profiles is None:
@@ -1460,6 +1460,71 @@ class TestStorePumpSettings:
         second_params = second_stmt.compile().params
         assert second_params["cgm_high_alert_mgdl"] is None
         assert second_params["cgm_low_alert_mgdl"] is None
+
+    @pytest.mark.parametrize(
+        ("cgm_high", "cgm_low", "expected_high", "expected_low"),
+        [
+            (501, 70, None, 70),
+            (240, 19, 240, None),
+        ],
+    )
+    async def test_discards_out_of_range_cgm_alert_thresholds(
+        self,
+        cgm_high,
+        cgm_low,
+        expected_high,
+        expected_low,
+    ):
+        raw_settings = _make_raw_settings(cgm_high=cgm_high, cgm_low=cgm_low)
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock(rowcount=1))
+
+        with patch("src.services.tandem_sync.logger") as mock_logger:
+            await _store_pump_settings(db, uuid.uuid4(), raw_settings)
+
+        params = db.execute.call_args.args[0].compile().params
+        assert params["cgm_high_alert_mgdl"] == expected_high
+        assert params["cgm_low_alert_mgdl"] == expected_low
+        mock_logger.warning.assert_called()
+
+    async def test_discards_inverted_cgm_alert_thresholds(self):
+        raw_settings = _make_raw_settings(cgm_high=70, cgm_low=70)
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock(rowcount=1))
+
+        with patch("src.services.tandem_sync.logger") as mock_logger:
+            await _store_pump_settings(db, uuid.uuid4(), raw_settings)
+
+        params = db.execute.call_args.args[0].compile().params
+        assert params["cgm_high_alert_mgdl"] is None
+        assert params["cgm_low_alert_mgdl"] is None
+        mock_logger.warning.assert_called()
+
+    @pytest.mark.parametrize(
+        ("cgm_high", "cgm_low", "expected_high", "expected_low"),
+        [
+            ("not-a-number", 70, None, 70),
+            (240, "not-a-number", 240, None),
+        ],
+    )
+    async def test_discards_non_numeric_cgm_alert_thresholds(
+        self,
+        cgm_high,
+        cgm_low,
+        expected_high,
+        expected_low,
+    ):
+        raw_settings = _make_raw_settings(cgm_high=cgm_high, cgm_low=cgm_low)
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock(rowcount=1))
+
+        with patch("src.services.tandem_sync.logger") as mock_logger:
+            await _store_pump_settings(db, uuid.uuid4(), raw_settings)
+
+        params = db.execute.call_args.args[0].compile().params
+        assert params["cgm_high_alert_mgdl"] == expected_high
+        assert params["cgm_low_alert_mgdl"] == expected_low
+        mock_logger.warning.assert_called()
 
 
 class TestFetchWithRetryReturnsSettings:

--- a/apps/api/tests/test_tandem_sync.py
+++ b/apps/api/tests/test_tandem_sync.py
@@ -1461,6 +1461,19 @@ class TestStorePumpSettings:
         assert second_params["cgm_high_alert_mgdl"] is None
         assert second_params["cgm_low_alert_mgdl"] is None
 
+    async def test_accepts_canonical_cgm_alert_bounds(self):
+        raw_settings = _make_raw_settings(cgm_high=500, cgm_low=20)
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock(rowcount=1))
+
+        with patch("src.services.tandem_sync.logger") as mock_logger:
+            await _store_pump_settings(db, uuid.uuid4(), raw_settings)
+
+        params = db.execute.call_args.args[0].compile().params
+        assert params["cgm_high_alert_mgdl"] == 500
+        assert params["cgm_low_alert_mgdl"] == 20
+        mock_logger.warning.assert_not_called()
+
     @pytest.mark.parametrize(
         ("cgm_high", "cgm_low", "expected_high", "expected_low"),
         [
@@ -1505,9 +1518,13 @@ class TestStorePumpSettings:
         [
             ("not-a-number", 70, None, 70),
             (240, "not-a-number", 240, None),
+            (240.5, 70, None, 70),
+            (240, 70.5, 240, None),
+            (float("nan"), 70, None, 70),
+            (240, float("inf"), 240, None),
         ],
     )
-    async def test_discards_non_numeric_cgm_alert_thresholds(
+    async def test_discards_invalid_cgm_alert_threshold_values(
         self,
         cgm_high,
         cgm_low,


### PR DESCRIPTION
Reject nonnumeric, clinically implausible, and inverted Tandem alert values before profile persistence so unsafe settings cannot enter AI prompt context. Preserve valid companion thresholds and log discarded vendor data.

## 📋 Summary

<!-- Brief description of what this PR does -->

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

-
-

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [ ] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Tandem CGM alert thresholds.
  * Invalid, non-numeric, fractional, infinite, out-of-range, or contradictory high/low values are now rejected.
  * Valid threshold settings are preserved for pump profiles.
  * Added warnings when invalid alert values are discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->