### PR TITLE
fix(GLY-224): preserve urgent alert redelivery

### DIFF
--- a/apps/web/src/compositions/NotificationsProvider/NotificationsProvider.test.tsx
+++ b/apps/web/src/compositions/NotificationsProvider/NotificationsProvider.test.tsx
@@ -370,6 +370,37 @@ describe("NotificationsProvider", () => {
     expect(showBrowserNotification).toHaveBeenCalledTimes(1);
   });
 
+  it("re-delivers an active urgent alert after its notification times out", () => {
+    jest.useFakeTimers();
+
+    render(
+      <NotificationsProvider>
+        <TriggerNotifications />
+      </NotificationsProvider>,
+    );
+
+    const alert = makeAlert({ id: "timed-out-urgent", severity: "urgent" });
+    act(() => {
+      mockAlertCallback?.(alert);
+    });
+
+    expect(screen.getByText("URGENT")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(screen.queryByText("URGENT")).not.toBeInTheDocument();
+    expect(sessionStorage.getItem("glycemicgpt-dismissed-alerts")).toBeNull();
+
+    act(() => {
+      mockAlertCallback?.(alert);
+    });
+
+    expect(screen.getByText("URGENT")).toBeInTheDocument();
+    expect(playAlertSound).toHaveBeenCalledTimes(2);
+  });
+
   it("persists alert dismissal and ignores a re-delivered alert", async () => {
     render(
       <NotificationsProvider>

--- a/apps/web/src/compositions/NotificationsProvider/NotificationsProvider.tsx
+++ b/apps/web/src/compositions/NotificationsProvider/NotificationsProvider.tsx
@@ -183,16 +183,20 @@ export function NotificationsProvider({
     savePreferences(nextPreferences);
   }, []);
 
-  const dismissNotification = useCallback(
-    (notificationId: string) => {
-      const dismissedItem = stateRef.current.visibleItems.find(
+  const removeNotification = useCallback(
+    (notificationId: string, reason: "timeout" | "user") => {
+      const removedItem = stateRef.current.visibleItems.find(
         (item) => item.id === notificationId,
       );
-      if (!dismissedItem) return;
+      if (!removedItem) return;
 
-      if (dismissedItem.sourceAlertId) {
-        addDismissedAlert(dismissedItem.sourceAlertId);
-        dismissedAlertsRef.current.add(dismissedItem.sourceAlertId);
+      if (removedItem.sourceAlertId) {
+        if (reason === "user") {
+          addDismissedAlert(removedItem.sourceAlertId);
+          dismissedAlertsRef.current.add(removedItem.sourceAlertId);
+        } else {
+          announcedAlertsRef.current.delete(removedItem.sourceAlertId);
+        }
       }
 
       const exitWindowEndsAt = Date.now() + exitDurationMs;
@@ -253,7 +257,7 @@ export function NotificationsProvider({
 
       return [
         window.setTimeout(
-          () => dismissNotification(item.id),
+          () => removeNotification(item.id, "timeout"),
           Math.max(0, item.dismissAt - Date.now()),
         ),
       ];
@@ -262,7 +266,7 @@ export function NotificationsProvider({
     return () => {
       timers.forEach((timer) => window.clearTimeout(timer));
     };
-  }, [dismissNotification, state.visibleItems]);
+  }, [removeNotification, state.visibleItems]);
 
   useEffect(() => {
     if (state.exitingCount === 0 || state.exitWindowEndsAt === null) return;
@@ -447,7 +451,7 @@ export function NotificationsProvider({
                       <Button
                         aria-label={`Close notification: ${item.title}`}
                         className="grid h-7 w-7 shrink-0 place-items-center rounded-button text-foreground-primary transition-colors hover:bg-surface-tertiary hover:text-foreground-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-border-active"
-                        onClick={() => dismissNotification(item.id)}
+                        onClick={() => removeNotification(item.id, "user")}
                       >
                         <Icon className="h-4 w-4" decorative icon="x" />
                       </Button>


### PR DESCRIPTION
Distinguish automatic notification timeouts from explicit user dismissals. Timed-out alerts no longer persist dismissal state and may be announced again while they remain active.

## 📋 Summary

<!-- Brief description of what this PR does -->

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

-
-

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [ ] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Urgent alerts now reappear after their notification timeout unless manually dismissed.
  * Manually closed alerts remain dismissed as expected.
  * Alert sounds play again when an urgent alert is shown again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->