### PR TITLE
fix(GLY-225): render empty AGP hours as gaps

### DIFF
--- a/apps/web/src/components/AgpChart/AgpChart.test.tsx
+++ b/apps/web/src/components/AgpChart/AgpChart.test.tsx
@@ -63,6 +63,12 @@ function makeReadings() {
   ).flat();
 }
 
+function makeReadingsWithEmptyHour(emptyHour: number) {
+  return makeReadings().filter(
+    (reading) => new Date(reading.reading_timestamp).getUTCHours() !== emptyHour,
+  );
+}
+
 beforeAll(() => {
   Object.defineProperty(HTMLElement.prototype, "clientWidth", {
     configurable: true,
@@ -161,6 +167,33 @@ describe("Dashboard AgpChart", () => {
     expect(values[3][0]).toBe(105);
     expect(values[6]).toEqual(Array(24).fill(70));
     expect(values[7]).toEqual(Array(24).fill(180));
+  });
+
+  it("plots null percentile values for an hour with no readings", async () => {
+    mockHookReturn.readings = makeReadingsWithEmptyHour(6);
+
+    render(<AgpChart />);
+
+    await waitFor(() => expect(mockUPlot).toHaveBeenCalledTimes(1));
+    const [, values] = mockUPlot.mock.calls[0] as [
+      unknown,
+      Array<Array<number | null>>,
+    ];
+
+    expect(values.slice(1, 6).map((series) => series[6])).toEqual([
+      null,
+      null,
+      null,
+      null,
+      null,
+    ]);
+    expect(values.slice(1, 6).map((series) => series[5])).toEqual([
+      76,
+      85,
+      110,
+      140,
+      164,
+    ]);
   });
 
   it("uses custom target thresholds and shows percentile details on hover", async () => {

--- a/apps/web/src/components/AgpChart/AgpChart.tsx
+++ b/apps/web/src/components/AgpChart/AgpChart.tsx
@@ -35,16 +35,46 @@ export function formatHour(hour: number): string {
 }
 
 export function transformBuckets(buckets: AGPBucket[]): AgpChartPoint[] {
-  return buckets.map((bucket) => ({
-    hour: bucket.hour,
-    label: formatHour(bucket.hour),
-    p10: clampMgdl(bucket.p10),
-    p25: clampMgdl(bucket.p25),
-    p50: clampMgdl(bucket.p50),
-    p75: clampMgdl(bucket.p75),
-    p90: clampMgdl(bucket.p90),
-    count: bucket.count,
-  }));
+  return buckets.map((bucket) => {
+    const percentiles =
+      bucket.count === 0
+        ? { p10: null, p25: null, p50: null, p75: null, p90: null }
+        : {
+            p10: clampMgdl(bucket.p10),
+            p25: clampMgdl(bucket.p25),
+            p50: clampMgdl(bucket.p50),
+            p75: clampMgdl(bucket.p75),
+            p90: clampMgdl(bucket.p90),
+          };
+
+    return {
+      hour: bucket.hour,
+      label: formatHour(bucket.hour),
+      ...percentiles,
+      count: bucket.count,
+    };
+  });
+}
+
+type AgpChartPointWithData = AgpChartPoint & {
+  p10: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  p90: number;
+};
+
+function hasPercentileData(
+  point: AgpChartPoint,
+): point is AgpChartPointWithData {
+  return (
+    point.count > 0 &&
+    point.p10 !== null &&
+    point.p25 !== null &&
+    point.p50 !== null &&
+    point.p75 !== null &&
+    point.p90 !== null
+  );
 }
 
 function percentile(values: number[], percentage: number): number {
@@ -131,6 +161,8 @@ function resolveYDomain(
   let max = Math.max(DEFAULT_Y_DOMAIN[1], ...thresholds);
 
   for (const point of points) {
+    if (!hasPercentileData(point)) continue;
+
     min = Math.min(min, point.p10);
     max = Math.max(max, point.p90);
   }
@@ -154,6 +186,7 @@ function AgpTooltip({
   unit: GlucoseUnit;
 }) {
   const label = unitLabel(unit);
+  const hasData = hasPercentileData(point);
 
   return (
     <div
@@ -161,7 +194,7 @@ function AgpTooltip({
       data-testid="agp-tooltip"
     >
       <p className="font_header_4 text-foreground-primary">{point.label}</p>
-      {point.count === 0 ? (
+      {!hasData ? (
         <p>No data for this hour</p>
       ) : (
         <>
@@ -183,7 +216,7 @@ function AgpTooltip({
 }
 
 function describeAgpPoint(point: AgpChartPoint, unit: GlucoseUnit): string {
-  if (point.count === 0) {
+  if (!hasPercentileData(point)) {
     return `${point.label}. No data for this hour.`;
   }
 

--- a/apps/web/src/components/AgpChart/AgpChart.types.ts
+++ b/apps/web/src/components/AgpChart/AgpChart.types.ts
@@ -14,10 +14,10 @@ export interface AgpChartProps {
 export interface AgpChartPoint {
   hour: number;
   label: string;
-  p10: number;
-  p25: number;
-  p50: number;
-  p75: number;
-  p90: number;
+  p10: number | null;
+  p25: number | null;
+  p50: number | null;
+  p75: number | null;
+  p90: number | null;
   count: number;
 }


### PR DESCRIPTION
Represent empty hourly percentiles as null so uPlot leaves gaps instead of clamping fabricated zero values. Keep populated tooltip and screen reader details unchanged and cover the plotted series.

## 📋 Summary

<!-- Brief description of what this PR does -->

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

-
-

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [ ] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AGP charts now accurately display gaps for hours without readings instead of showing misleading zero-value percentiles.
  * Tooltips, accessible descriptions, and chart scaling correctly treat missing data as unavailable.
* **Tests**
  * Added coverage to verify empty hours display gaps while neighboring populated hours retain their percentile values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->