### PR TITLE
fix(GLY-226): align caregiver glucose indicators

### DIFF
--- a/apps/web/src/components/CaregiverDashboard/CaregiverDashboard.test.tsx
+++ b/apps/web/src/components/CaregiverDashboard/CaregiverDashboard.test.tsx
@@ -1,4 +1,11 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { CaregiverDashboard } from "./CaregiverDashboard";
 import {
   getCaregiverPatientStatus,
@@ -38,15 +45,19 @@ const mockSendCaregiverChat = sendCaregiverChat as jest.MockedFunction<
 function makeStatus(
   patientId: string,
   patientEmail: string,
+  glucoseOverrides: Partial<
+    NonNullable<CaregiverPatientStatus["glucose"]>
+  > = {},
 ): CaregiverPatientStatus {
   return {
     glucose: {
       is_stale: false,
       minutes_ago: 1,
       reading_timestamp: "2026-08-02T10:00:00.000Z",
-      trend: "Flat",
+      trend: "flat",
       trend_rate: 0,
       value: patientId === "patient-a" ? 111 : 222,
+      ...glucoseOverrides,
     },
     glucose_unit: "mgdl",
     iob: null,
@@ -106,6 +117,100 @@ describe("CaregiverDashboard", () => {
     ).toBeVisible();
   });
 
+  it("uses one glucose classification for text and status dots at every default boundary", async () => {
+    const cases = [
+      [54, "text-signal-error-text", "bg-signal-error-fill"],
+      [55, "text-signal-warning-text", "bg-signal-warning-fill"],
+      [69, "text-signal-warning-text", "bg-signal-warning-fill"],
+      [70, "text-signal-check-text", "bg-signal-check-fill"],
+      [180, "text-signal-check-text", "bg-signal-check-fill"],
+      [181, "text-signal-warning-text", "bg-signal-warning-fill"],
+      [250, "text-signal-warning-text", "bg-signal-warning-fill"],
+      [251, "text-signal-error-text", "bg-signal-error-fill"],
+    ] as const;
+    const patients = cases.map(([value]) => ({
+      linked_at: "2026-08-01T00:00:00.000Z",
+      patient_email: `patient-${value}@example.com`,
+      patient_id: `patient-${value}`,
+    }));
+    const statuses = new Map<string, CaregiverPatientStatus>(
+      patients.map((patient, index) => [
+        patient.patient_id,
+        makeStatus(patient.patient_id, patient.patient_email, {
+          trend: "flat",
+          value: cases[index][0],
+        }),
+      ]),
+    );
+
+    mockListLinkedPatients.mockResolvedValue({
+      count: patients.length,
+      patients,
+    });
+    mockGetCaregiverPatientStatus.mockImplementation((patientId) =>
+      Promise.resolve(statuses.get(patientId)!),
+    );
+
+    render(<CaregiverDashboard />);
+
+    await waitFor(() => {
+      cases.forEach(([value, textClass, dotClass]) => {
+        const card = screen.getByRole("button", {
+          name: `View details for patient-${value}@example.com`,
+        });
+        expect(within(card).getByText(String(value))).toHaveClass(textClass);
+        expect(card.querySelector(".rounded-pill")).toHaveClass(dotClass);
+      });
+    });
+  });
+
+  it("renders labels for the backend snake_case trend enum", async () => {
+    const cases = [
+      ["double_up", "Rising quickly"],
+      ["single_up", "Rising"],
+      ["forty_five_up", "Slightly rising"],
+      ["flat", "Steady"],
+      ["forty_five_down", "Slightly falling"],
+      ["single_down", "Falling"],
+      ["double_down", "Falling quickly"],
+      ["not_computable", "Trend unavailable"],
+      ["rate_out_of_range", "Trend unavailable"],
+    ] as const;
+    const patients = cases.map(([trend]) => ({
+      linked_at: "2026-08-01T00:00:00.000Z",
+      patient_email: `${trend}@example.com`,
+      patient_id: trend,
+    }));
+    const statuses = new Map<string, CaregiverPatientStatus>(
+      patients.map((patient, index) => [
+        patient.patient_id,
+        makeStatus(patient.patient_id, patient.patient_email, {
+          trend: cases[index][0],
+          value: 120,
+        }),
+      ]),
+    );
+
+    mockListLinkedPatients.mockResolvedValue({
+      count: patients.length,
+      patients,
+    });
+    mockGetCaregiverPatientStatus.mockImplementation((patientId) =>
+      Promise.resolve(statuses.get(patientId)!),
+    );
+
+    render(<CaregiverDashboard />);
+
+    await waitFor(() => {
+      cases.forEach(([trend, label]) => {
+        const card = screen.getByRole("button", {
+          name: `View details for ${trend}@example.com`,
+        });
+        expect(within(card).getByText(`${label}, 1m ago`)).toBeVisible();
+      });
+    });
+  });
+
   it("does not apply a stale status response after switching patients", async () => {
     const statusA = makeStatus("patient-a", "a@example.com");
     const statusB = makeStatus("patient-b", "b@example.com");
@@ -121,7 +226,9 @@ describe("CaregiverDashboard", () => {
 
     render(<CaregiverDashboard />);
 
-    await screen.findByRole("button", { name: "View details for a@example.com" });
+    await screen.findByRole("button", {
+      name: "View details for a@example.com",
+    });
     await waitFor(() => {
       expect(mockGetCaregiverPatientStatus).toHaveBeenCalledTimes(2);
     });
@@ -139,7 +246,9 @@ describe("CaregiverDashboard", () => {
       screen.getByRole("button", { name: "View details for a@example.com" }),
     );
     await screen.findByRole("button", { name: "All patients" });
-    expect(screen.getByText("a@example.com", { selector: "span" })).toBeVisible();
+    expect(
+      screen.getByText("a@example.com", { selector: "span" }),
+    ).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh data" }));
     fireEvent.click(screen.getByRole("button", { name: "All patients" }));
@@ -148,20 +257,29 @@ describe("CaregiverDashboard", () => {
     );
 
     await screen.findByText("222");
-    expect(screen.getByText("b@example.com", { selector: "span" })).toBeVisible();
+    expect(
+      screen.getByText("b@example.com", { selector: "span" }),
+    ).toBeVisible();
 
     await act(async () => {
       resolveRefreshA!(statusA);
     });
 
-    expect(screen.getByText("b@example.com", { selector: "span" })).toBeVisible();
-    expect(screen.queryByText("a@example.com", { selector: "span" })).not.toBeInTheDocument();
+    expect(
+      screen.getByText("b@example.com", { selector: "span" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByText("a@example.com", { selector: "span" }),
+    ).not.toBeInTheDocument();
   });
 
   it("does not render a chat response after switching patients", async () => {
     const statusA = makeStatus("patient-a", "a@example.com");
     const statusB = makeStatus("patient-b", "b@example.com");
-    let resolveChatA: (response: { response: string; disclaimer: string }) => void;
+    let resolveChatA: (response: {
+      response: string;
+      disclaimer: string;
+    }) => void;
     const chatA = new Promise<{ response: string; disclaimer: string }>(
       (resolve) => {
         resolveChatA = resolve;
@@ -202,6 +320,8 @@ describe("CaregiverDashboard", () => {
     });
 
     expect(screen.queryByText("Patient A response")).not.toBeInTheDocument();
-    expect(screen.getByText("b@example.com", { selector: "span" })).toBeVisible();
+    expect(
+      screen.getByText("b@example.com", { selector: "span" }),
+    ).toBeVisible();
   });
 });

--- a/apps/web/src/components/CaregiverDashboard/CaregiverDashboard.test.tsx
+++ b/apps/web/src/components/CaregiverDashboard/CaregiverDashboard.test.tsx
@@ -164,6 +164,63 @@ describe("CaregiverDashboard", () => {
     });
   });
 
+  it("treats glucose values outside the canonical bounds as unavailable", async () => {
+    const values = [19, 501] as const;
+    const invalidPatients = values.map((value) => ({
+      linked_at: "2026-08-01T00:00:00.000Z",
+      patient_email: `patient-${value}@example.com`,
+      patient_id: `patient-${value}`,
+    }));
+    const controlPatient = {
+      linked_at: "2026-08-01T00:00:00.000Z",
+      patient_email: "control@example.com",
+      patient_id: "control",
+    };
+    const patients = [...invalidPatients, controlPatient];
+    const statuses = new Map<string, CaregiverPatientStatus>([
+      ...invalidPatients.map(
+        (patient, index) =>
+          [
+            patient.patient_id,
+            makeStatus(patient.patient_id, patient.patient_email, {
+              value: values[index],
+            }),
+          ] as const,
+      ),
+      [
+        controlPatient.patient_id,
+        makeStatus(controlPatient.patient_id, controlPatient.patient_email, {
+          value: 120,
+        }),
+      ],
+    ]);
+
+    mockListLinkedPatients.mockResolvedValue({
+      count: patients.length,
+      patients,
+    });
+    mockGetCaregiverPatientStatus.mockImplementation((patientId) =>
+      Promise.resolve(statuses.get(patientId)!),
+    );
+
+    render(<CaregiverDashboard />);
+
+    await screen.findByText("120");
+
+    values.forEach((value) => {
+      const card = screen.getByRole("button", {
+        name: `View details for patient-${value}@example.com`,
+      });
+      const statusDot = card.querySelector(".rounded-pill");
+
+      expect(within(card).getByText("No glucose data")).toBeVisible();
+      expect(within(card).queryByText(String(value))).not.toBeInTheDocument();
+      expect(statusDot).toHaveClass("bg-foreground-disabled");
+      expect(statusDot).not.toHaveClass("bg-signal-check-fill");
+      expect(statusDot).not.toHaveClass("bg-signal-error-fill");
+    });
+  });
+
   it("renders labels for the backend snake_case trend enum", async () => {
     const cases = [
       ["double_up", "Rising quickly"],

--- a/apps/web/src/components/CaregiverDashboard/CaregiverDashboard.tsx
+++ b/apps/web/src/components/CaregiverDashboard/CaregiverDashboard.tsx
@@ -42,6 +42,7 @@ import type {
 } from "./CaregiverDashboard.types";
 
 const DEFAULT_REFRESH_INTERVAL_MS = 60_000;
+const GLUCOSE_READING_BOUNDS_MGDL = { min: 20, max: 500 } as const;
 
 function patientUnit(status: CaregiverPatientStatus | null): GlucoseUnit {
   return status?.glucose_unit ?? "mgdl";
@@ -89,6 +90,14 @@ const GLUCOSE_RANGE_CLASSES: Record<
 };
 
 function glucoseRangeClasses(value: number | null) {
+  if (
+    value === null ||
+    !Number.isFinite(value) ||
+    value < GLUCOSE_READING_BOUNDS_MGDL.min ||
+    value > GLUCOSE_READING_BOUNDS_MGDL.max
+  ) {
+    return null;
+  }
   return GLUCOSE_RANGE_CLASSES[classifyGlucose(value)];
 }
 
@@ -115,7 +124,7 @@ function PatientOverviewCard({
           aria-hidden="true"
           className={twMerge(
             "h-2.5 w-2.5 shrink-0 rounded-pill",
-            !glucose
+            !glucose || !glucoseClasses
               ? "bg-foreground-disabled"
               : glucose.is_stale
                 ? "bg-signal-warning-fill"
@@ -126,7 +135,7 @@ function PatientOverviewCard({
           {patient.patient_email}
         </span>
       </span>
-      {glucose ? (
+      {glucose && glucoseClasses ? (
         <span className="block space-y-1">
           <span className="flex items-baseline gap-2">
             <span
@@ -389,6 +398,13 @@ export function CaregiverDashboard({
   }
 
   const unit = patientUnit(status);
+  const selectedGlucose =
+    status?.permissions.can_view_glucose && status.glucose
+      ? status.glucose
+      : null;
+  const selectedGlucoseClasses = glucoseRangeClasses(
+    selectedGlucose?.value ?? null,
+  );
   return (
     <div className="mx-auto max-w-5xl space-y-8">
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -459,32 +475,32 @@ export function CaregiverDashboard({
           </p>
           <div className="grid gap-6 lg:grid-cols-2">
             <Panel heading="Current Glucose">
-              {status.permissions.can_view_glucose && status.glucose ? (
+              {selectedGlucose && selectedGlucoseClasses ? (
                 <div className="space-y-2">
                   <p
                     className={twMerge(
                       "font_ui_mono_value",
-                      glucoseRangeClasses(status.glucose.value).text,
+                      selectedGlucoseClasses.text,
                     )}
                   >
-                    {formatGlucose(status.glucose.value, unit)}{" "}
+                    {formatGlucose(selectedGlucose.value, unit)}{" "}
                     <span className="font_metric_label text-foreground-secondary">
                       {unitLabel(unit)}
                     </span>
                   </p>
                   <p className="font_body_3 text-foreground-secondary">
-                    {trendLabel(status.glucose.trend)},{" "}
-                    {status.glucose.minutes_ago < 1
+                    {trendLabel(selectedGlucose.trend)},{" "}
+                    {selectedGlucose.minutes_ago < 1
                       ? "just now"
-                      : `${status.glucose.minutes_ago}m ago`}
+                      : `${selectedGlucose.minutes_ago}m ago`}
                   </p>
-                  {status.glucose.trend_rate !== null ? (
+                  {selectedGlucose.trend_rate !== null ? (
                     <p className="font_metric_caption text-foreground-secondary">
-                      {formatTrendRate(status.glucose.trend_rate, unit)}{" "}
+                      {formatTrendRate(selectedGlucose.trend_rate, unit)}{" "}
                       {unitLabel(unit)}/min
                     </p>
                   ) : null}
-                  {status.glucose.is_stale ? (
+                  {selectedGlucose.is_stale ? (
                     <FeedbackMessage
                       message="Glucose data may be stale"
                       variant="warning"

--- a/apps/web/src/components/CaregiverDashboard/CaregiverDashboard.tsx
+++ b/apps/web/src/components/CaregiverDashboard/CaregiverDashboard.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation";
 import { Button, Icon } from "@/base";
 import { EmptyState } from "@/components/EmptyState";
 import { FeedbackMessage } from "@/components/FeedbackMessage";
+import { classifyGlucose, type GlucoseRange } from "@/components/GlucoseHero";
 import { LoadingState } from "@/components/LoadingState";
 import { MarkdownContent } from "@/components/MarkdownContent";
 import { PageHeader } from "@/components/PageHeader";
@@ -48,32 +49,47 @@ function patientUnit(status: CaregiverPatientStatus | null): GlucoseUnit {
 
 function trendLabel(trend: string): string {
   const labels: Record<string, string> = {
-    Falling: "Falling",
-    FallingQuickly: "Falling quickly",
-    Flat: "Steady",
-    Rising: "Rising",
-    RisingQuickly: "Rising quickly",
-    SlightlyFalling: "Slightly falling",
-    SlightlyRising: "Slightly rising",
+    double_down: "Falling quickly",
+    double_up: "Rising quickly",
+    flat: "Steady",
+    forty_five_down: "Slightly falling",
+    forty_five_up: "Slightly rising",
+    not_computable: "Trend unavailable",
+    rate_out_of_range: "Trend unavailable",
+    single_down: "Falling",
+    single_up: "Rising",
   };
   return labels[trend] ?? "Trend unavailable";
 }
 
-function glucoseTextClass(value: number): string {
-  if (value < 70 || value > 250) return "text-signal-error-text";
-  if (value < 80 || value > 180) return "text-signal-warning-text";
-  return "text-signal-check-text";
-}
+const GLUCOSE_RANGE_CLASSES: Record<
+  GlucoseRange,
+  { dot: string; text: string }
+> = {
+  high: {
+    dot: "bg-signal-warning-fill",
+    text: "text-signal-warning-text",
+  },
+  inRange: {
+    dot: "bg-signal-check-fill",
+    text: "text-signal-check-text",
+  },
+  low: {
+    dot: "bg-signal-warning-fill",
+    text: "text-signal-warning-text",
+  },
+  urgentHigh: {
+    dot: "bg-signal-error-fill",
+    text: "text-signal-error-text",
+  },
+  urgentLow: {
+    dot: "bg-signal-error-fill",
+    text: "text-signal-error-text",
+  },
+};
 
-function glucoseDotClass(status: CaregiverPatientStatus | null): string {
-  if (!status?.glucose || !status.permissions.can_view_glucose) {
-    return "bg-foreground-disabled";
-  }
-  if (status.glucose.is_stale) return "bg-signal-warning-fill";
-  const value = status.glucose.value;
-  if (value < 55 || value > 250) return "bg-signal-error-fill";
-  if (value < 70 || value > 180) return "bg-signal-warning-fill";
-  return "bg-signal-check-fill";
+function glucoseRangeClasses(value: number | null) {
+  return GLUCOSE_RANGE_CLASSES[classifyGlucose(value)];
 }
 
 function PatientOverviewCard({
@@ -85,6 +101,7 @@ function PatientOverviewCard({
     status?.permissions.can_view_glucose && status.glucose
       ? status.glucose
       : null;
+  const glucoseClasses = glucoseRangeClasses(glucose?.value ?? null);
   const unit = patientUnit(status);
 
   return (
@@ -98,7 +115,11 @@ function PatientOverviewCard({
           aria-hidden="true"
           className={twMerge(
             "h-2.5 w-2.5 shrink-0 rounded-pill",
-            glucoseDotClass(status),
+            !glucose
+              ? "bg-foreground-disabled"
+              : glucose.is_stale
+                ? "bg-signal-warning-fill"
+                : glucoseClasses.dot,
           )}
         />
         <span className="min-w-0 truncate font_body_2 text-foreground-primary">
@@ -109,10 +130,7 @@ function PatientOverviewCard({
         <span className="block space-y-1">
           <span className="flex items-baseline gap-2">
             <span
-              className={twMerge(
-                "font_ui_mono_value",
-                glucoseTextClass(glucose.value),
-              )}
+              className={twMerge("font_ui_mono_value", glucoseClasses.text)}
             >
               {formatGlucose(glucose.value, unit)}
             </span>
@@ -446,7 +464,7 @@ export function CaregiverDashboard({
                   <p
                     className={twMerge(
                       "font_ui_mono_value",
-                      glucoseTextClass(status.glucose.value),
+                      glucoseRangeClasses(status.glucose.value).text,
                     )}
                   >
                     {formatGlucose(status.glucose.value, unit)}{" "}


### PR DESCRIPTION
Reuse the shared glucose classification for caregiver text and status dots. Map backend snake_case trends to readable labels and cover the thresholds and enum values with focused tests.

## 📋 Summary

<!-- Brief description of what this PR does -->

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

-
-

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [ ] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer glucose status classification across dashboard overview cards and detailed readings.
  * Added support for current glucose trend labels, including directional and unavailable states.
* **Bug Fixes**
  * Improved glucose boundary handling for more accurate status colors.
  * Preserved correct disabled and stale-data behavior during refreshes and chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->