### PR TITLE
Ci/gly 236 limit security scan gate

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,7 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    branches: [main, develop]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,7 +381,7 @@ The CLI auto-detects the project's `.coderabbit.yaml` configuration, so your loc
 
 ### Required CI Checks
 
-Every PR must pass these checks before it can be merged:
+Every PR must pass the checks required for its target branch before it can be merged:
 
 | Check | What It Validates |
 |-------|-------------------|
@@ -392,7 +392,7 @@ Every PR must pass these checks before it can be merged:
 | Sidecar Tests | Vitest for AI proxy |
 | Attribution Check | No prohibited attribution lines |
 | GitGuardian | Secret/credential scanning |
-| Security Scan Gate | SAST + DAST security testing (see below) |
+| Security Scan Gate | SAST + DAST security testing for PRs targeting `main` (see below) |
 
 ### How CI handles fork PRs
 
@@ -401,14 +401,14 @@ If you opened this PR from your own fork (the normal contributor flow), every re
 A few details on how that works, in case you're auditing:
 
 - **Labels and the attribution sticky comment** are posted by workflows running under `pull_request_target`. They inspect your PR's metadata (title, body, file list) and the text of your commits and diff -- they never install dependencies from your branch or execute any of your code. The attribution workflow fetches your commits as a remote-only ref so the working tree stays as the base.
-- **The Security Scan Gate** generates a throwaway password at job runtime to register ephemeral users in the CI database. The Docker stack lives and dies inside the same job, so the value protects nothing and isn't a repo secret -- the gate runs identically for forks and branch PRs.
+- **The Security Scan Gate** generates a throwaway password at job runtime to register ephemeral users in the CI database. The Docker stack lives and dies inside the same job, so the value protects nothing and isn't a repo secret. For PRs targeting `main`, the gate runs identically for forks and branch PRs.
 - **CodeRabbit** has its own review queue. If you push faster than it can catch up you may see stale state on the PR until it does -- not a CI failure. Comment `@coderabbitai review` to re-trigger if needed.
 
 If a check fails for what looks like an environmental reason rather than a problem in your code, ping a maintainer in the PR and we'll investigate.
 
 ### 🔒 Security Scan (Smart Targeting)
 
-This is a medical platform. We take security seriously. The Security Scan Gate runs **targeted security tests based on what your PR actually changes** -- it won't waste 25 minutes scanning the API if you only changed the web frontend.
+This is a medical platform. We take security seriously. For PRs targeting `main`, the Security Scan Gate runs **targeted security tests based on what your PR actually changes**. It won't waste 25 minutes scanning the API if you only changed the web frontend. Feature PRs targeting `develop` are covered by the full security suite after they merge.
 
 | If you changed... | What runs |
 |-------------------|-----------|

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1483,9 +1483,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9892,9 +9892,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -11678,9 +11678,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/docs/dev/security-testing.md
+++ b/docs/dev/security-testing.md
@@ -29,11 +29,13 @@ Runs on every PR targeting `main` and every push to `main` or `develop`. Uses **
 
 | Component | Paths Monitored | What Runs |
 |-----------|----------------|-----------|
-| API | `apps/api/**` | Semgrep Python, auth tests, IDOR, SSRF, fuzzer, nuclei API, ZAP API, ZAP Unauth API |
-| Web | `apps/web/**` | Semgrep TypeScript, nuclei Web, ZAP Web baseline, ZAP Unauth Web |
+| API | `apps/api/**` | Semgrep Python, auth tests, IDOR, SSRF, fuzzer, nuclei API, ZAP API |
+| Web | `apps/web/**` | Semgrep TypeScript, nuclei Web, ZAP Web baseline |
 | Sidecar | `sidecar/**` | Semgrep TypeScript |
 | Infra | `docker-compose*.yml`, `**/Dockerfile*` | Everything (config changes affect all services) |
 | Security | `scripts/security/**`, `.github/workflows/security-scan*` | Everything |
+
+Whenever API, Web, Sidecar, infrastructure, or security changes trigger the DAST job, both unauthenticated ZAP scans run against the complete API and Web surfaces. Manual dispatch also runs both scans.
 
 Key optimization: **mobile-only PRs skip the Docker stack entirely** (~2 min vs ~25 min). Feature PRs targeting `develop` do not run this workflow before merge. The targeted scan and full suite scan the resulting `develop` head after each merge.
 
@@ -97,8 +99,8 @@ In the full suite workflow, SARIF results are uploaded to the GitHub Security ta
 5. **Nuclei DAST** -- Known vulnerability templates against API and Web surfaces.
 6. **ZAP API active scan** (`zap-api-plan.yaml`) -- Authenticated, OpenAPI-driven injection testing (SQLi, XSS, SSTI, CRLF, path traversal). Auto-discovers all endpoints.
 7. **ZAP Web scan** (`zap-web-plan.yaml`) -- Pre-seeds all known page URLs + standard spider + passive/active scanning on the web frontend. Tests security headers, cookie flags, CSP, and injection through the proxy path.
-8. **ZAP Unauthenticated API pentest** (`zap-unauth-api-plan.yaml`) -- Full attacker-perspective scan of the **entire API surface** without credentials. Discovers all endpoints from `/openapi.json` and probes every one -- public and authenticated alike. Tests injection, info disclosure in error responses, security headers, Host header injection, and what leaks when authenticated endpoints return 401/403. Runs on every PR targeting `main` regardless of which component changed.
-9. **ZAP Unauthenticated Web pentest** (`zap-unauth-web-plan.yaml`) -- Full attacker-perspective scan of the **entire web application** without credentials. Probes all pages including protected `/dashboard/*` routes to test redirect behavior, auth enforcement, and info leakage. Includes error handling probes (invalid invitation tokens, nonexistent pages). Runs on every PR targeting `main` regardless of which component changed.
+8. **ZAP Unauthenticated API pentest** (`zap-unauth-api-plan.yaml`) -- Full attacker-perspective scan of the **entire API surface** without credentials. Discovers all endpoints from `/openapi.json` and probes every one -- public and authenticated alike. Tests injection, info disclosure in error responses, security headers, Host header injection, and what leaks when authenticated endpoints return 401/403. Runs when API, Web, Sidecar, infrastructure, or security changes trigger DAST, and on manual dispatch.
+9. **ZAP Unauthenticated Web pentest** (`zap-unauth-web-plan.yaml`) -- Full attacker-perspective scan of the **entire web application** without credentials. Probes all pages including protected `/dashboard/*` routes to test redirect behavior, auth enforcement, and info leakage. Includes error handling probes (invalid invitation tokens, nonexistent pages). Runs when API, Web, Sidecar, infrastructure, or security changes trigger DAST, and on manual dispatch.
 
 ### Auto-discovery
 
@@ -106,7 +108,7 @@ Tests 2, 4, 6, and 8 read `/openapi.json` from the live API to discover endpoint
 
 Test 7 pre-seeds all known page URLs from the Next.js app structure and uses the standard spider to discover additional linked pages. (AJAX Spider with headless Firefox was evaluated but risks OOM on standard GitHub runners with 7GB RAM.)
 
-Tests 8 and 9 simulate a real external attacker. They run without session cookies or CSRF tokens, probe the **entire** application surface (not just public endpoints), and run on **every PR** regardless of which component changed. An attacker doesn't care which files you modified -- they probe everything. Protected endpoints are intentionally tested to verify auth enforcement and catch info leakage in error responses. Findings are tracked as separate issues from the authenticated scans (distinct fingerprints: `zap-unauth-api:*` and `zap-unauth-web:*`).
+Tests 8 and 9 simulate a real external attacker. They run without session cookies or CSRF tokens and probe the **entire** application surface, not just public endpoints, whenever a relevant change triggers DAST. An attacker probes the complete deployed surface regardless of which relevant component triggered the job. Protected endpoints are intentionally tested to verify auth enforcement and catch info leakage in error responses. Findings are tracked as separate issues from the authenticated scans (distinct fingerprints: `zap-unauth-api:*` and `zap-unauth-web:*`).
 
 ### Evaluation scripts
 

--- a/docs/dev/security-testing.md
+++ b/docs/dev/security-testing.md
@@ -15,17 +15,17 @@ Security testing has five pillars:
 2. **DAST & Auth Pentests** (`security-scan.yml`, `security-full-suite.yml`) -- behavior-based tests that spin up the Docker stack and attack it: auth flow penetration tests, IDOR prevention, SSRF blocking, OpenAPI-driven API fuzzing, nuclei vulnerability scanning, and OWASP ZAP active injection scanning.
 3. **Dependency Vulnerability Scanning** (`dependency-scan.yml`) -- OSV-Scanner checks all lockfiles against the OSV database for known CVEs. Runs on every dependency change and weekly on a schedule.
 4. **Static Analysis** (CodeRabbit) -- automated PR reviews that check for hardcoded secrets, medical safety violations, BLE protocol issues, and code quality. Configured in `.coderabbit.yaml`.
-5. **Full Suite Pentests** (`security-full-suite.yml`) -- comprehensive security scan of the entire platform. Runs on merges to main/develop and manual dispatch. Status badge in README.
+5. **Full Suite Pentests** (`security-full-suite.yml`) -- comprehensive security scan of the entire platform. Runs after merges to main or develop and by manual dispatch. Status badge in README.
 
 ### Medical Device Context
 
-GlycemicGPT handles glucose data, insulin pump telemetry, and AI-driven diabetes insights. Security failures in this context can have health consequences. The CI gates enforce a baseline: every PR must pass security checks before merging.
+GlycemicGPT handles glucose data, insulin pump telemetry, and AI-driven diabetes insights. Security failures in this context can have health consequences. PRs targeting `main` must pass the Security Scan Gate before merging. Feature PRs targeting `develop` receive full suite coverage after merge.
 
 ## Two-Workflow Architecture
 
 ### PR-Scoped Smart Testing (`security-scan.yml`)
 
-Runs on every PR and push to main/develop. Uses **granular change detection** to only test what actually changed:
+Runs on every PR targeting `main` and every push to `main` or `develop`. Uses **granular change detection** to only test what actually changed:
 
 | Component | Paths Monitored | What Runs |
 |-----------|----------------|-----------|
@@ -35,7 +35,7 @@ Runs on every PR and push to main/develop. Uses **granular change detection** to
 | Infra | `docker-compose*.yml`, `**/Dockerfile*` | Everything (config changes affect all services) |
 | Security | `scripts/security/**`, `.github/workflows/security-scan*` | Everything |
 
-Key optimization: **mobile-only PRs skip the Docker stack entirely** (~2 min vs ~25 min).
+Key optimization: **mobile-only PRs skip the Docker stack entirely** (~2 min vs ~25 min). Feature PRs targeting `develop` do not run this workflow before merge. The targeted scan and full suite scan the resulting `develop` head after each merge.
 
 ### Full Suite Pentests (`security-full-suite.yml`)
 
@@ -58,7 +58,7 @@ Checks 1-7 run unconditionally on every push/PR from `ci.yml`. Checks 8-9 use a 
 | 5 | Attribution Check | `ci.yml` | Every push/PR |
 | 6 | Sidecar Tests | `ci.yml` | Every push/PR |
 | 7 | GitGuardian | External | Every push/PR |
-| 8 | Security Scan Gate | `security-scan.yml` | Component-specific (see table above) |
+| 8 | Security Scan Gate | `security-scan.yml` | PRs targeting `main`; component-specific (see table above) |
 | 9 | Dependency Scan Gate | `dependency-scan.yml` | Dependency file changes + weekly schedule |
 
 Additionally, the **Security Full Suite** badge on the README reflects the pass/fail status of comprehensive pentests on main.
@@ -97,8 +97,8 @@ In the full suite workflow, SARIF results are uploaded to the GitHub Security ta
 5. **Nuclei DAST** -- Known vulnerability templates against API and Web surfaces.
 6. **ZAP API active scan** (`zap-api-plan.yaml`) -- Authenticated, OpenAPI-driven injection testing (SQLi, XSS, SSTI, CRLF, path traversal). Auto-discovers all endpoints.
 7. **ZAP Web scan** (`zap-web-plan.yaml`) -- Pre-seeds all known page URLs + standard spider + passive/active scanning on the web frontend. Tests security headers, cookie flags, CSP, and injection through the proxy path.
-8. **ZAP Unauthenticated API pentest** (`zap-unauth-api-plan.yaml`) -- Full attacker-perspective scan of the **entire API surface** without credentials. Discovers all endpoints from `/openapi.json` and probes every one -- public and authenticated alike. Tests injection, info disclosure in error responses, security headers, Host header injection, and what leaks when authenticated endpoints return 401/403. Runs on every PR regardless of which component changed.
-9. **ZAP Unauthenticated Web pentest** (`zap-unauth-web-plan.yaml`) -- Full attacker-perspective scan of the **entire web application** without credentials. Probes all pages including protected `/dashboard/*` routes to test redirect behavior, auth enforcement, and info leakage. Includes error handling probes (invalid invitation tokens, nonexistent pages). Runs on every PR regardless of which component changed.
+8. **ZAP Unauthenticated API pentest** (`zap-unauth-api-plan.yaml`) -- Full attacker-perspective scan of the **entire API surface** without credentials. Discovers all endpoints from `/openapi.json` and probes every one -- public and authenticated alike. Tests injection, info disclosure in error responses, security headers, Host header injection, and what leaks when authenticated endpoints return 401/403. Runs on every PR targeting `main` regardless of which component changed.
+9. **ZAP Unauthenticated Web pentest** (`zap-unauth-web-plan.yaml`) -- Full attacker-perspective scan of the **entire web application** without credentials. Probes all pages including protected `/dashboard/*` routes to test redirect behavior, auth enforcement, and info leakage. Includes error handling probes (invalid invitation tokens, nonexistent pages). Runs on every PR targeting `main` regardless of which component changed.
 
 ### Auto-discovery
 

--- a/sidecar/package-lock.json
+++ b/sidecar/package-lock.json
@@ -2695,9 +2695,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 📋 Summary

[GLY-236](https://linear.app/lumose/issue/GLY-236/move-security-scan-gate-from-develop-prs-to-main-prs)

@jlengelbrecht I suggest removing the security scan on PRs to develop, simply because it takes so long to run, and it still runs on merge to `develop`, and both PRs and merge to `main`. I won't merge this without your approval, let me know what you think.

If this is okey, the Protect develop settings of the project needs to be changed - and I would need your help with that.

## 🔗 Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## 🏷️ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactoring / Code cleanup
- [ ] 📝 Documentation update
- [ ] 🔧 CI/CD / Infrastructure
- [ ] 📦 Dependencies

## 🔨 Changes Made

<!-- List the key changes -->

-
-

## 🧪 Test Plan

- [ ] Unit tests pass
- [ ] New tests added for new functionality
- [ ] Manual/visual testing performed
- [ ] Docker integration tested (if applicable)

## ✅ Checklist

- [ ] Self-review completed
- [ ] Code follows project style guidelines
- [ ] No hardcoded secrets, API keys, or credentials
- [ ] Changes generate no new warnings
- [ ] Documentation updated (if applicable)

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI/Workflow**
  - Security scans now run on pull requests targeting `main`; pull requests targeting `develop` receive the full security suite after merging.
  - Unauthenticated web scans now run only for relevant changes or when manually requested.

- **Documentation**
  - Updated contributor and security-testing documentation to clarify branch-specific security checks, scan coverage, and medical-device CI gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->