### PR TITLE
fix: quiet benign bolus-started skip warnings and stop third-party JWT logging

### DIFF
--- a/apps/api/src/logging_config.py
+++ b/apps/api/src/logging_config.py
@@ -128,6 +128,19 @@ def setup_logging(
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
 
+    # tconnectsync.api.tandemsource narrates the Tandem login with the account
+    # attached to it: the decoded JWT (email, given/family name, accountId,
+    # pumperId) at INFO, and the raw id_token plus the OIDC token responses at
+    # DEBUG. Mute that module so those never reach our log stream or Sentry.
+    # Scoped to the module rather than the package root so the library's other
+    # diagnostics survive -- notably the eventparser's DEBUG dump of records it
+    # could not decode, which is what a pump-log parse failure is triaged with.
+    # Its own WARNING and above still propagate, which leaves two known gaps a
+    # level cannot close: one cached-credential warning names two account
+    # emails, and its ApiException text embeds the HTTP response body. Both
+    # need redaction or disabling the library's credential cache, not a level.
+    logging.getLogger("tconnectsync.api.tandemsource").setLevel(logging.WARNING)
+
 
 class StructuredLogger:
     """Logger wrapper that supports structured extra fields."""

--- a/apps/api/src/services/tandem_sync.py
+++ b/apps/api/src/services/tandem_sync.py
@@ -9,6 +9,7 @@ import math
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from enum import Enum, auto
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
@@ -346,18 +347,30 @@ _EVENT_ID_TYPE_MAP: dict[int, str] = {
 _AUTOMATED_BASAL_CHANGE_TYPES = {2, 3, 4, 5}
 
 
+class _SkipReason(Enum):
+    """Why a record was dropped deliberately rather than by failing to parse.
+
+    An Enum rather than a bare object() so `is` narrows the return union for
+    type checkers.
+    """
+
+    BY_DESIGN = auto()
+
+
 def _normalize_pump_event(
     event,
     _seen_ids: set[int] | None = None,
     *,
     raw_event: dict | None = None,
-) -> dict | None:
+) -> dict | _SkipReason | None:
     """Convert a tconnectsync event object into a dict for storage.
 
     Maps tconnectsync field names to the names expected by our parsing layer
     (map_event_type, parse_control_iq_event, and the storage loop).
 
-    Returns None for unsupported event types that should be skipped.
+    Returns None when the record could not be mapped or parsed, which the
+    caller logs as an anomaly. Returns _SkipReason.BY_DESIGN when a later
+    record supersedes this one, which the caller drops quietly.
     """
     try:
         d = event.todict()
@@ -372,7 +385,9 @@ def _normalize_pump_event(
         event_id = None
     event_type = _EVENT_ID_TYPE_MAP.get(event_id) if event_id is not None else None
     if not event_type:
-        # Track unmapped event IDs for the caller's summary log
+        # Track unmapped event IDs for the caller's summary log. fetch_with_retry
+        # already filters on _EVENT_ID_TYPE_MAP before calling us, so this branch
+        # cannot produce a spurious "no parsed event" warning there.
         if _seen_ids is not None and event_id is not None:
             _seen_ids.add(event_id)
         return None
@@ -450,7 +465,7 @@ def _normalize_pump_event(
         # to avoid duplicate records for the same physical bolus.
         delivery_status = _int("bolusDeliveryStatusRaw")
         if delivery_status == 1:
-            return None
+            return _SkipReason.BY_DESIGN
 
         delivered_mu = _int("deliveredTotal")
         if delivered_mu is not None:
@@ -705,6 +720,7 @@ def fetch_with_retry(
                 pump_events: list[dict] = []
                 seen_event_keys: set[tuple] = set()
                 raw_count = 0
+                skipped_by_design = 0
                 for window_start, window_end in _pump_log_windows(start_date, end_date):
                     response = api.get_pump_logs(
                         device_id,
@@ -780,6 +796,18 @@ def fetch_with_retry(
                                 error_type=type(e).__name__,
                             )
                             continue
+                        if normalized is _SkipReason.BY_DESIGN:
+                            # Hundreds per month-long import; warning on each
+                            # one buried the genuine parse failures below.
+                            skipped_by_design += 1
+                            logger.debug(
+                                "Pump log record skipped by design",
+                                device_id=device_id,
+                                event_id=event_id,
+                                sequence_group=raw_event.get("sequenceGroup"),
+                                sequence_number=raw_event.get("sequenceNumber"),
+                            )
+                            continue
                         if normalized is None:
                             logger.warning(
                                 "Pump log record produced no parsed event",
@@ -791,8 +819,7 @@ def fetch_with_retry(
                             continue
                         if event_key != (None, None):
                             seen_event_keys.add(event_key)
-                        if normalized:
-                            pump_events.append(normalized)
+                        pump_events.append(normalized)
 
                 pump_events = _apply_pump_activity_modes(pump_events)
                 all_events.extend(pump_events)
@@ -802,6 +829,7 @@ def fetch_with_retry(
                     device_id=device_id,
                     raw_events=raw_count,
                     normalized_events=len(pump_events),
+                    skipped_by_design=skipped_by_design,
                     skipped_event_ids=sorted(seen_ids - set(_EVENT_ID_TYPE_MAP.keys())),
                 )
                 break  # Success for this pump

--- a/apps/api/tests/test_logging.py
+++ b/apps/api/tests/test_logging.py
@@ -3,6 +3,8 @@
 import json
 import logging
 
+import pytest
+
 from src.logging_config import (
     JsonFormatter,
     TextFormatter,
@@ -10,6 +12,34 @@ from src.logging_config import (
     get_logger,
     setup_logging,
 )
+
+# Third-party loggers setup_logging turns down. Spelled out here rather than
+# imported so a rename in either place shows up as a test failure.
+_MUTED_THIRD_PARTY_LOGGERS = (
+    "uvicorn.access",
+    "sqlalchemy.engine",
+    "tconnectsync.api.tandemsource",
+)
+
+
+class _RecordCollector(logging.Handler):
+    """Collects records that survive the handler chain setup_logging installs.
+
+    caplog is no use for these assertions: setup_logging clears the root
+    handlers, taking pytest's capture handler with them, so caplog.records
+    would be empty whether or not the logger under test was muted.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    @property
+    def messages(self) -> list[str]:
+        return [record.getMessage() for record in self.records]
 
 
 class TestJsonFormatter:
@@ -201,6 +231,26 @@ class TestStructuredLogger:
 class TestSetupLogging:
     """Tests for logging setup function."""
 
+    @pytest.fixture(autouse=True)
+    def _restore_logging_state(self):
+        """setup_logging mutates process-wide logging; put it back afterwards.
+
+        Without this, the muted third-party level leaks into every later test
+        in the session and makes their log assertions order-dependent.
+        """
+        root = logging.getLogger()
+        muted = [logging.getLogger(name) for name in _MUTED_THIRD_PARTY_LOGGERS]
+        saved_handlers = root.handlers[:]
+        saved_root_level = root.level
+        saved_levels = [logger.level for logger in muted]
+        try:
+            yield
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_root_level)
+            for logger, level in zip(muted, saved_levels, strict=True):
+                logger.setLevel(level)
+
     def test_setup_json_logging(self):
         """Test setup_logging with JSON format."""
         setup_logging(log_format="json", log_level="DEBUG")
@@ -226,3 +276,49 @@ class TestSetupLogging:
         formatter = root.handlers[0].formatter
         assert isinstance(formatter, JsonFormatter)
         assert formatter.service_name == "custom-service"
+
+    @staticmethod
+    def _collect_configured_output() -> _RecordCollector:
+        """Attach a collector to the root logger setup_logging just configured."""
+        collector = _RecordCollector()
+        logging.getLogger().addHandler(collector)
+        return collector
+
+    def test_tandem_jwt_dump_is_not_logged(self):
+        """The library's decoded-JWT line must not reach our log stream.
+
+        tconnectsync.api.tandemsource logs the decoded JWT (email, name,
+        accountId, pumperId) at INFO and the raw id_token at DEBUG. Asserted by
+        emitting the real line shapes rather than by reading the level back, so
+        any equally-effective mute keeps passing.
+        """
+        setup_logging(log_format="json", log_level="DEBUG")
+        collected = self._collect_configured_output()
+        library_logger = logging.getLogger("tconnectsync.api.tandemsource")
+
+        library_logger.info(
+            'Decoded JWT: {"email": "someone@example.invalid", '
+            '"pumperId": "12345", "accountId": "67890"}'
+        )
+        library_logger.debug("6. extracting JWT from eyJhbGciOiJSUzI1NiJ9.fake")
+
+        assert collected.messages == []
+
+    def test_tconnectsync_signals_still_propagate(self):
+        """Muting is scoped to one module's noisy levels, not the whole library."""
+        setup_logging(log_format="json", log_level="DEBUG")
+        collected = self._collect_configured_output()
+
+        logging.getLogger("tconnectsync.api.tandemsource").warning(
+            "Received ApiException in TandemSourceApi"
+        )
+        # A sibling module keeps its DEBUG diagnostics -- that is what a
+        # pump-log parse failure is triaged with.
+        logging.getLogger("tconnectsync.eventparser.generic").debug(
+            "UNKNOWN_EVENT | id=999"
+        )
+
+        assert collected.messages == [
+            "Received ApiException in TandemSourceApi",
+            "UNKNOWN_EVENT | id=999",
+        ]

--- a/apps/api/tests/test_tandem_sync.py
+++ b/apps/api/tests/test_tandem_sync.py
@@ -1,6 +1,7 @@
 """Story 3.4, 3.5, & 15.8: Tests for Tandem pump data ingestion, Control-IQ parsing,
 and pump profile sync."""
 
+import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,6 +15,7 @@ from src.main import app
 from src.models.pump_data import PumpActivityMode, PumpEventType
 from src.services.tandem_sync import (
     _normalize_pump_event,
+    _SkipReason,
     _store_pump_settings,
     calculate_basal_adjustment,
     detect_pump_activity_mode,
@@ -821,12 +823,12 @@ class TestNormalizePumpEvent:
             }
         )
         result = _normalize_pump_event(event)
-        assert result is not None
+        assert isinstance(result, dict)
         assert result["type"] == "bolus"
         assert result["units"] == 3.0
 
     def test_event_id_280_started_is_skipped(self):
-        """Event ID 280 (LidBolusDelivery) Started should be skipped."""
+        """Event ID 280 (LidBolusDelivery) Started should be skipped by design."""
         import arrow
 
         event = self._make_event(
@@ -838,7 +840,7 @@ class TestNormalizePumpEvent:
             }
         )
         result = _normalize_pump_event(event)
-        assert result is None
+        assert result is _SkipReason.BY_DESIGN
 
     def test_manual_bolus_with_correction_component_stays_manual(self):
         """A correction component does not make a pump UI bolus automated."""
@@ -1712,7 +1714,7 @@ class TestFetchWithRetryReturnsSettings:
 
         assert events == []
 
-    def test_empty_event_generator_is_skipped(self):
+    def test_empty_event_generator_is_skipped(self, caplog):
         from src.services.tandem_sync import fetch_with_retry
 
         raw_event = self._raw_event(
@@ -1726,7 +1728,10 @@ class TestFetchWithRetryReturnsSettings:
         mock_api.get_pumper.return_value = {"pumps": [{"assignmentId": "device-123"}]}
         mock_api.get_pump_logs.return_value = {"events": [raw_event]}
 
-        with patch("src.services.tandem_sync.Events", return_value=iter(())):
+        with (
+            caplog.at_level(logging.WARNING, logger="src.services.tandem_sync"),
+            patch("src.services.tandem_sync.Events", return_value=iter(())),
+        ):
             events, _ = fetch_with_retry(
                 mock_api,
                 datetime(2026, 7, 30, tzinfo=UTC),
@@ -1734,6 +1739,82 @@ class TestFetchWithRetryReturnsSettings:
             )
 
         assert events == []
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "src.services.tandem_sync"
+            and record.levelno >= logging.WARNING
+        ]
+        assert "Pump log record produced no parsed event" in warnings
+
+    def test_bolus_started_is_skipped_without_warning(self, caplog):
+        """A Started/Completed pair yields one bolus and no warning.
+
+        This is the real shape of the reported problem: a healthy month-long
+        import contains hundreds of Started records, each superseded by its
+        Completed twin, and warning on every one of them buried the records
+        that genuinely failed to parse.
+        """
+        from src.services.tandem_sync import fetch_with_retry
+
+        started = self._raw_event(
+            280,
+            "2026-07-30T22:40:00",
+            "2026-07-30T20:40:00Z",
+            {
+                "bolusDeliveryStatus": 1,  # Started; the Completed record wins
+                "deliveredTotal": 3000,
+                "bolusSource": 1,
+                "correction": 0,
+            },
+            1,
+        )
+        completed = self._raw_event(
+            280,
+            "2026-07-30T22:40:30",
+            "2026-07-30T20:40:30Z",
+            {
+                "bolusDeliveryStatus": 0,
+                "deliveredTotal": 3000,
+                "bolusSource": 1,
+                "correction": 0,
+            },
+            2,
+        )
+        mock_api = MagicMock()
+        mock_api.get_pumper.return_value = {"pumps": [{"assignmentId": "device-123"}]}
+        mock_api.get_pump_logs.return_value = {"events": [started, completed]}
+
+        with caplog.at_level(logging.DEBUG, logger="src.services.tandem_sync"):
+            events, _ = fetch_with_retry(
+                mock_api,
+                datetime(2026, 7, 30, tzinfo=UTC),
+                datetime(2026, 7, 30, 23, 59, tzinfo=UTC),
+            )
+
+        # Only the Completed leg survives, with its units intact.
+        assert [event["type"] for event in events] == ["bolus"]
+        assert events[0]["units"] == 3.0
+
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "src.services.tandem_sync"
+            and record.levelno >= logging.WARNING
+        ]
+        assert warnings == [], f"by-design skip logged a warning: {warnings}"
+        assert "Pump log record skipped by design" in caplog.text
+
+        # The summary log still accounts for the dropped record, so the
+        # raw-vs-normalized gap stays explainable at production log level.
+        summary = next(
+            record
+            for record in caplog.records
+            if record.getMessage() == "Processed pump events"
+        )
+        assert summary.extra_fields["raw_events"] == 2
+        assert summary.extra_fields["normalized_events"] == 1
+        assert summary.extra_fields["skipped_by_design"] == 1
 
     def test_mixed_valid_and_invalid_records_preserve_valid_events(self):
         from src.services.tandem_sync import fetch_with_retry


### PR DESCRIPTION
Two logging-only fixes on the Tandem ingestion surface, found during US-region sync validation. Parsing, mapping, skip/keep decisions and stored rows are unchanged.

## Benign bolus-started warnings

Pump log records for event 280 with delivery status "Started" are skipped by design, because only the "Completed" record for the same physical bolus is stored. Each skip still emitted a `Pump log record produced no parsed event` WARNING -- 453 of them in a healthy one-month import -- which buried the records that genuinely failed to parse.

The mapper now returns a `_SkipReason.BY_DESIGN` sentinel for the deliberate drop, so the caller drops it at DEBUG and keeps the WARNING for records it could not parse. An `Enum` is used rather than a bare sentinel object so `is` narrows the return union for type checkers.

To avoid trading log noise for a blind spot, the dropped count is added to the existing `Processed pump events` summary, keeping the raw-vs-normalized gap explainable at production log level.

## Third-party JWT logging

`tconnectsync.api.tandemsource` logs the decoded JWT -- email, given and family name, `accountId`, `pumperId` -- at INFO, and the raw `id_token` plus the OIDC token responses at DEBUG. All of that reached our log stream and, with Sentry enabled, became breadcrumbs on any later error event from the same request.

That module is now turned down to WARNING in our logging setup. The fix is deliberately scoped to the module rather than the package root, so the library's other diagnostics survive -- notably the event parser's DEBUG dump of records it could not decode, which is exactly what a pump-log parse failure is triaged with.

Two known gaps a level cannot close are documented inline: one cached-credential warning names two account emails, and `ApiException` text embeds the HTTP response body. Both need redaction or disabling the library's credential cache, and are filed as follow-up rather than widened into this change.

## Verification

Behavioural proof is unit-test based; no live Tandem credentials exist.

- A Started/Completed pair through `fetch_with_retry` yields exactly one bolus at the correct units, emits no WARNING, and reports `skipped_by_design=1` in the summary.
- A genuinely unparseable record still emits the WARNING.
- The decoded-JWT INFO line and the raw `id_token` DEBUG line produce no output; a sibling module's diagnostics still do.
- Both fixes were mutation-tested: reverting either one fails its tests.
- Full API suite green on a clean stack. `ruff check` and `ruff format --check` clean. `mypy` error count on the touched file is unchanged from `develop`.
- Sentry-enabled boot plus golden-path smoke surfaced no new issues; the boot log contains no `tconnectsync` lines. A live Tandem sync is not achievable without credentials and is not required here, since the risk surface of a logging-config change is startup behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bolus synchronization so intentionally duplicated start records are skipped while completed bolus records are retained.
  * Malformed pump records now generate warnings without interrupting synchronization.
  * Processing summaries now report intentionally skipped records.

* **Improvements**
  * Reduced noisy credential-related diagnostic messages while preserving important warnings and errors.
  * Enhanced synchronization logging to distinguish expected skips from processing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->