### PR TITLE
ci: close workflow_dispatch reachability of gated release environments

### DIFF
--- a/.github/workflows/changelog-pr.yml
+++ b/.github/workflows/changelog-pr.yml
@@ -1,9 +1,13 @@
 name: Changelog
 
+# push:main only -- no workflow_dispatch. A dispatch on ref=main yields
+# github.ref=refs/heads/main, which PASSES the release-gated environment's
+# main-scoped deployment branch policy (the policy binds the ref, not the
+# actor), letting any write actor start a changelog/merge run. MI-1 in
+# scripts/security/check-secret-invariants.py enforces this.
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 # Least privilege: no default GITHUB_TOKEN permissions.
 # All privileged operations use explicit GitHub App tokens.
@@ -24,12 +28,8 @@ jobs:
       today: ${{ steps.changelog.outputs.today }}
     # Only run on promotion merges (develop -> main), skip bot commits.
     # Promotion PRs use "chore: promote develop to main" title pattern.
-    # workflow_dispatch is allowed for manual reruns.
     if: >-
-      (
-        github.event_name == 'workflow_dispatch' ||
-        contains(github.event.head_commit.message, 'promote develop to main')
-      ) &&
+      contains(github.event.head_commit.message, 'promote develop to main') &&
       !contains(github.event.head_commit.message, '[Changelog]') &&
       !contains(github.event.head_commit.message, 'chore: release')
 
@@ -80,14 +80,12 @@ jobs:
           SINCE: ${{ steps.last-date.outputs.cutoff }}
           PUSH_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
         run: |
-          # Upper bound: use main's HEAD commit time to exclude PRs merged after this promotion
-          # For push events, PUSH_TIMESTAMP is available.
-          # For workflow_dispatch, fall back to main's latest commit time (not wall clock).
+          # Upper bound: the promotion push's commit time, so PRs merged after
+          # this promotion are excluded. Always set: the job's `if:` matches on
+          # head_commit.message, so head_commit (and its timestamp) exist.
           UNTIL="$PUSH_TIMESTAMP"
-          if [ -z "$UNTIL" ] || [ "$UNTIL" = "" ]; then
-            UNTIL=$(git log -1 --format=%cI origin/main)
-          fi
-          # Normalize to UTC (validator at line 54 only accepts Z or + suffixes)
+          # Normalize to UTC (the cutoff validator in the last-date step only
+          # accepts Z or + suffixes)
           NOW=$(date -u -d "$UNTIL" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "$UNTIL")
           # Derive TODAY from normalized UTC timestamp to avoid midnight timezone mismatch
           TODAY=$(echo "$NOW" | cut -dT -f1)

--- a/.github/workflows/changelog-pr.yml
+++ b/.github/workflows/changelog-pr.yml
@@ -1,12 +1,12 @@
 name: Changelog
 
-# push:main only -- no workflow_dispatch. A dispatch on any branch in the
-# release-gated environment's deployment branch policy PASSES that policy
-# (it binds the ref, not the actor), letting any write actor start a
-# changelog/merge run. MI-1 in scripts/security/check-secret-invariants.py
-# enforces this. Recovery for a lost gated run (rejected/expired approval,
-# run past retention): re-run the original push run from the Actions UI;
-# failing that, the lead lands the next promotion merge on main.
+# push:main only -- no workflow_dispatch: the deployment branch policy
+# binds the ref, not the actor, so a dispatch on a policy-listed branch
+# would pass it. Enforced by MI-1 (scripts/security/
+# check-secret-invariants.py); full rationale in
+# docs/dev/gated-environments.md. Recovery for a lost gated run: re-run
+# the original push run (it replays the original push payload); failing
+# that, the lead lands the next promotion merge on main.
 on:
   push:
     branches: [main]

--- a/.github/workflows/changelog-pr.yml
+++ b/.github/workflows/changelog-pr.yml
@@ -1,10 +1,12 @@
 name: Changelog
 
-# push:main only -- no workflow_dispatch. A dispatch on ref=main yields
-# github.ref=refs/heads/main, which PASSES the release-gated environment's
-# main-scoped deployment branch policy (the policy binds the ref, not the
-# actor), letting any write actor start a changelog/merge run. MI-1 in
-# scripts/security/check-secret-invariants.py enforces this.
+# push:main only -- no workflow_dispatch. A dispatch on any branch in the
+# release-gated environment's deployment branch policy PASSES that policy
+# (it binds the ref, not the actor), letting any write actor start a
+# changelog/merge run. MI-1 in scripts/security/check-secret-invariants.py
+# enforces this. Recovery for a lost gated run (rejected/expired approval,
+# run past retention): re-run the original push run from the Actions UI;
+# failing that, the lead lands the next promotion merge on main.
 on:
   push:
     branches: [main]
@@ -83,7 +85,13 @@ jobs:
           # Upper bound: the promotion push's commit time, so PRs merged after
           # this promotion are excluded. Always set: the job's `if:` matches on
           # head_commit.message, so head_commit (and its timestamp) exist.
+          # Fail closed rather than generate a changelog over a garbage window
+          # if that guarantee is ever broken.
           UNTIL="$PUSH_TIMESTAMP"
+          if [ -z "$UNTIL" ]; then
+            echo "::error::head_commit.timestamp missing from push event"
+            exit 1
+          fi
           # Normalize to UTC (the cutoff validator in the last-date step only
           # accepts Z or + suffixes)
           NOW=$(date -u -d "$UNTIL" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "$UNTIL")

--- a/.github/workflows/regen-gradle-lockfiles-push.yml
+++ b/.github/workflows/regen-gradle-lockfiles-push.yml
@@ -90,9 +90,10 @@ jobs:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           # Scope the token to exactly what the push needs; without this it
-          # inherits every permission of the app installation (which now
-          # includes the develop-ruleset bypass). pull-requests: read is for
-          # the same-repo Renovate PR guard below (gh pr list).
+          # inherits every permission of the app installation. RENOVATE holds
+          # no ruleset bypass (see the header note), so this is least-privilege
+          # hygiene, not bypass containment. pull-requests: read is for the
+          # same-repo Renovate PR guard below (gh pr list).
           permission-contents: write
           permission-pull-requests: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
 name: Release
 
-# push:main only -- no workflow_dispatch. A dispatch on any branch in the
-# release-gated environment's deployment branch policy PASSES that policy
-# (it binds the ref, not the actor), letting any write actor start a
-# release run. MI-1 in scripts/security/check-secret-invariants.py
-# enforces this. Recovery for a lost gated run (rejected/expired approval,
-# run past retention): re-run the original push run from the Actions UI;
-# failing that, the lead lands the next promotion merge on main.
+# push:main only -- no workflow_dispatch: the deployment branch policy
+# binds the ref, not the actor, so a dispatch on a policy-listed branch
+# would pass it. Enforced by MI-1 (scripts/security/
+# check-secret-invariants.py); full rationale in
+# docs/dev/gated-environments.md. Recovery for a lost gated run: re-run
+# the original push run; failing that, the lead lands the next promotion
+# merge on main.
 on:
   push:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: Release
 
-# push:main only -- no workflow_dispatch. A dispatch on ref=main yields
-# github.ref=refs/heads/main, which PASSES the release-gated environment's
-# main-scoped deployment branch policy (the policy binds the ref, not the
-# actor), letting any write actor start a release run. MI-1 in
-# scripts/security/check-secret-invariants.py enforces this.
+# push:main only -- no workflow_dispatch. A dispatch on any branch in the
+# release-gated environment's deployment branch policy PASSES that policy
+# (it binds the ref, not the actor), letting any write actor start a
+# release run. MI-1 in scripts/security/check-secret-invariants.py
+# enforces this. Recovery for a lost gated run (rejected/expired approval,
+# run past retention): re-run the original push run from the Actions UI;
+# failing that, the lead lands the next promotion merge on main.
 on:
   push:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Release
 
+# push:main only -- no workflow_dispatch. A dispatch on ref=main yields
+# github.ref=refs/heads/main, which PASSES the release-gated environment's
+# main-scoped deployment branch policy (the policy binds the ref, not the
+# actor), letting any write actor start a release run. MI-1 in
+# scripts/security/check-secret-invariants.py enforces this.
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}

--- a/.github/workflows/secrets-plumbing-check.yml
+++ b/.github/workflows/secrets-plumbing-check.yml
@@ -15,9 +15,14 @@ name: Secrets Plumbing Check
 # trigger would be a check-secret-invariants.py SA-REF-PR violation.
 # Dispatch reachability of the gated job is sanctioned by the MI-1 escape
 # hatch (check-secret-invariants.py): op-github-gated keeps
-# required_reviewers >= 1 permanently -- that reviewer, not the branch
-# policy, is the load-bearing control -- and the canary checkout pins
-# ref: main so dispatched runs execute lead-controlled code.
+# required_reviewers >= 1 permanently, and that reviewer is the ONLY
+# load-bearing control here -- a dispatched run executes the dispatched
+# ref's copy of this workflow, which neither the branch policy (it binds
+# the ref, not the actor) nor any checkout pin can change. The ref: main
+# pin below is defense in depth for the checked-out tree only, and it
+# means the canary always exercises main's op-load-secrets composite;
+# validate composite changes after they reach main, not by dispatching
+# from a feature ref.
 # Expected to pass only after the token is moved into the environment and the
 # plain repo copy deleted; the canary job also needs an approver other than
 # the dispatcher (prevent_self_review=true).
@@ -53,10 +58,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # MI-1 clause 4: the SA token is in scope for this job, so the
-          # repo-controlled code it runs (the op-load-secrets composite)
-          # must come from main -- the lead-controlled ref -- not from
-          # whatever ref the run was dispatched on.
+          # MI-1 clause 4 (defense in depth): the checked-out tree -- the
+          # op-load-secrets composite this job runs -- comes from main,
+          # the lead-controlled ref, not the dispatched ref. The workflow
+          # YAML itself still runs from the dispatched ref; the required
+          # reviewer is the control for that (see header).
           ref: main
           persist-credentials: false
 

--- a/.github/workflows/secrets-plumbing-check.yml
+++ b/.github/workflows/secrets-plumbing-check.yml
@@ -13,6 +13,11 @@ name: Secrets Plumbing Check
 #
 # workflow_dispatch only: it references the SA token, so a pull_request
 # trigger would be a check-secret-invariants.py SA-REF-PR violation.
+# Dispatch reachability of the gated job is sanctioned by the MI-1 escape
+# hatch (check-secret-invariants.py): op-github-gated keeps
+# required_reviewers >= 1 permanently -- that reviewer, not the branch
+# policy, is the load-bearing control -- and the canary checkout pins
+# ref: main so dispatched runs execute lead-controlled code.
 # Expected to pass only after the token is moved into the environment and the
 # plain repo copy deleted; the canary job also needs an approver other than
 # the dispatcher (prevent_self_review=true).
@@ -48,6 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          # MI-1 clause 4: the SA token is in scope for this job, so the
+          # repo-controlled code it runs (the op-load-secrets composite)
+          # must come from main -- the lead-controlled ref -- not from
+          # whatever ref the run was dispatched on.
+          ref: main
           persist-credentials: false
 
       - name: Load canary via op-load-secrets

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -144,6 +144,11 @@ jobs:
           #     workflow_run job that executes only trusted-branch code and
           #     consumes PR output via artifacts, never PR code (see
           #     regen-gradle-lockfiles-push.yml). Never pull_request_target.
+          # Enforcement scope, stated plainly: the grep below catches only
+          # the plain-pull_request case. The gated-environment rules are
+          # enforced by the Secret-placement invariants step (MI-1); the
+          # non-gated workflow_run shape is convention, reviewed not
+          # machine-checked.
           #
           # Grep-based check (no YAML parser dependency). The pattern
           # `^[[:space:]]*pull_request:` matches the literal trigger key

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -132,16 +132,18 @@ jobs:
 
           # 2. CI_APP_ID / CI_APP_PRIVATE_KEY must never appear in workflows
           # triggered by plain pull_request: fork PRs receive empty secrets,
-          # which crashes the token-generation step. Do NOT "fix" that by
-          # switching to pull_request_target or workflow_run -- those events
-          # run with a trusted-branch github.ref (the PR's base branch and
-          # the default branch respectively), which PASSES a main-scoped
-          # deployment branch policy, so they defeat environment gating
-          # entirely (MI-1 in scripts/security/check-secret-invariants.py).
-          # Mint app tokens only in push/schedule workflows on trusted
-          # branches; if a PR run must feed a privileged step, hand the data
-          # across via an artifact to a trusted-branch workflow that never
-          # executes PR code (see regen-gradle-lockfiles-push.yml).
+          # which crashes the token-generation step. The correct fix depends
+          # on whether the job declares a gated environment:
+          #   - Gated (environment:) jobs: reachable from push to a trusted
+          #     branch ONLY. pull_request_target and workflow_run are banned
+          #     outright -- they run with a trusted-branch github.ref (the
+          #     PR's base and the default branch respectively), which PASSES
+          #     the deployment branch policy and defeats the gate (MI-1 in
+          #     scripts/security/check-secret-invariants.py).
+          #   - Non-gated plain app secrets: the sanctioned shape is a
+          #     workflow_run job that executes only trusted-branch code and
+          #     consumes PR output via artifacts, never PR code (see
+          #     regen-gradle-lockfiles-push.yml). Never pull_request_target.
           #
           # Grep-based check (no YAML parser dependency). The pattern
           # `^[[:space:]]*pull_request:` matches the literal trigger key
@@ -153,7 +155,7 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             if grep -nE '^[[:space:]]*pull_request:' "$f" >/dev/null; then
-              echo "::error file=$f::CI App secret reference used in a workflow triggered by pull_request. Fork PRs do not receive secrets. Do NOT switch to pull_request_target or workflow_run -- both run with a trusted-branch github.ref and defeat deployment branch policies. Mint the token in a push/schedule workflow and pass PR-run data across via artifacts (see regen-gradle-lockfiles-push.yml)."
+              echo "::error file=$f::CI App secret reference used in a workflow triggered by pull_request. Fork PRs do not receive secrets. For a job declaring a gated environment, pull_request_target and workflow_run are banned too (both run with a trusted-branch github.ref and defeat deployment branch policies -- MI-1); gated jobs are push-to-trusted-branch only. For non-gated secrets, use a workflow_run job that executes only trusted-branch code and consumes PR output via artifacts (see regen-gradle-lockfiles-push.yml)."
               FAILED=1
             fi
           done <<< "$CANDIDATES"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -130,11 +130,18 @@ jobs:
             FAILED=1
           fi
 
-          # 2. CI_APP_ID / CI_APP_PRIVATE_KEY must only appear in workflows
-          # triggered by safe events (push, schedule, workflow_dispatch,
-          # workflow_run, or pull_request_target -- NEVER plain pull_request,
-          # which leaks an empty secret on fork PRs and crashes the token
-          # generation step).
+          # 2. CI_APP_ID / CI_APP_PRIVATE_KEY must never appear in workflows
+          # triggered by plain pull_request: fork PRs receive empty secrets,
+          # which crashes the token-generation step. Do NOT "fix" that by
+          # switching to pull_request_target or workflow_run -- those events
+          # run with a trusted-branch github.ref (the PR's base branch and
+          # the default branch respectively), which PASSES a main-scoped
+          # deployment branch policy, so they defeat environment gating
+          # entirely (MI-1 in scripts/security/check-secret-invariants.py).
+          # Mint app tokens only in push/schedule workflows on trusted
+          # branches; if a PR run must feed a privileged step, hand the data
+          # across via an artifact to a trusted-branch workflow that never
+          # executes PR code (see regen-gradle-lockfiles-push.yml).
           #
           # Grep-based check (no YAML parser dependency). The pattern
           # `^[[:space:]]*pull_request:` matches the literal trigger key
@@ -146,7 +153,7 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             if grep -nE '^[[:space:]]*pull_request:' "$f" >/dev/null; then
-              echo "::error file=$f::CI App secret reference used in a workflow triggered by pull_request. Fork PRs do not receive secrets -- use pull_request_target (with a safe checkout pattern) or workflow_run instead."
+              echo "::error file=$f::CI App secret reference used in a workflow triggered by pull_request. Fork PRs do not receive secrets. Do NOT switch to pull_request_target or workflow_run -- both run with a trusted-branch github.ref and defeat deployment branch policies. Mint the token in a push/schedule workflow and pass PR-run data across via artifacts (see regen-gradle-lockfiles-push.yml)."
               FAILED=1
             fi
           done <<< "$CANDIDATES"

--- a/docs/dev/gated-environments.md
+++ b/docs/dev/gated-environments.md
@@ -40,7 +40,7 @@ PPE with vault-wide reach.
 | Required reviewers | the maintainer lead (outside the write-actor set) | The gate. A job declaring the environment pauses here before any step runs. |
 | `prevent_self_review` | `true` | The dispatcher of a run cannot approve their own deployment. |
 | `can_admins_bypass` | `false` | An admin cannot skip the reviewer gate. This is **not** the same as branch/ruleset merge bypass, which is unrelated. |
-| Deployment branch policy | custom: `main`, `develop` (protected trunks) | Purely *additive* defense-in-depth: a `workflow_dispatch` from an attacker-pushed feature branch (carrying a tampered local composite) cannot even reach the approval prompt. It never substitutes for the reviewer. Use a **custom** pattern, never the "protected branches" option, which admits the read for same-repo PRs against a protected base. |
+| Deployment branch policy | custom: `main`, `develop` (protected trunks) | Purely *additive* defense-in-depth: a `workflow_dispatch` from an attacker-pushed feature branch (carrying a tampered local composite) cannot even reach the approval prompt. It never substitutes for the reviewer -- and the converse holds too: a ref that IS on the policy list always passes, whoever triggered the run (the policy binds the ref, not the actor), which is why workflows containing gated jobs must not carry `workflow_dispatch` at all unless the environment's reviewer is pinned as the load-bearing control (MI-1 in `check-secret-invariants.py`). Use a **custom** pattern, never the "protected branches" option, which admits the read for same-repo PRs against a protected base. |
 | Deployment-protection apps | none | An auto-approver app would silently defeat the human pause. |
 
 The SA token exists **only** as this environment's secret: never as a plain
@@ -65,8 +65,14 @@ environment secrets directly.
 
 Consumers are every RELEASE-minting job: `changelog-pr.yml` (`changelog`) and
 `release.yml` (`release-please`, `fallback-release`, `update-release-body`),
-and the equivalent jobs on the sibling repos. All are `push: main` /
-`workflow_dispatch` jobs (Class A, pause-tolerant). On the reviewer-protected
+and the equivalent jobs on the sibling repos. On the monorepo these are
+`push: main`-only jobs (Class A, pause-tolerant) -- MI-1 in
+`check-secret-invariants.py` forbids `workflow_dispatch` on any workflow
+containing a gated job, because a dispatch on a policy-listed trunk passes
+the deployment branch policy (the policy binds the ref, not the actor). The
+sibling repos' equivalent jobs still carry `workflow_dispatch` until each is
+ported to MI-1 per the release-gate porting checklist (the scheduled audit
+surfaces them as `MI1-PENDING` warnings). On the reviewer-protected
 repos (monorepo, `website`, `android-unofficial`) each gated job pauses for
 reviewer approval before the key is in scope, so a single release run can
 prompt **more than once** as successive jobs start; an unapproved job strands
@@ -77,20 +83,23 @@ secrets are environment-scoped, not approval-gated.
 
 Configuration differs from `op-github-gated` in two deliberate ways:
 
-- **`prevent_self_review = false`.** The release trigger is already
-  lead-only: pushes to `main` are restricted to promotion merges the lead
-  performs, `workflow_dispatch` requires write access and the lead is the
-  only write-capable collaborator, so the dispatcher and the only sensible
-  approver are the same person. Approval authority itself never widens:
+- **`prevent_self_review = false`.** The release trigger is lead-only:
+  pushes to `main` are restricted to promotion merges the lead performs,
+  and the monorepo's gated workflows carry no `workflow_dispatch` (MI-1) --
+  so the triggerer and the only sensible approver are the same person.
+  (The old form of this rationale leaned on "the lead is the only
+  write-capable collaborator"; that stopped being true with the area
+  write delegation, which is exactly why dispatch reachability had to go
+  rather than be reasoned away.) Approval authority itself never widens:
   whoever triggers a run, only the required reviewer (the lead) can
   approve it -- `prevent_self_review = false` merely stops the lead's own
-  dispatches from deadlocking on a second human. With a single-maintainer
-  topology, `prevent_self_review = true` would stall every release without
-  excluding any realistic attacker (an attacker who can trigger
-  `push: main` or dispatch already has lead credentials). All other
-  conditions -- `can_admins_bypass = false`, custom additive branch
-  policy, no auto-approver apps -- are unchanged. Revisit this setting if
-  the monorepo ever gains a second write-capable collaborator.
+  promotions from deadlocking on a second human. With a single-lead
+  reviewer set, `prevent_self_review = true` would stall every release
+  without excluding any realistic attacker (an attacker who can trigger
+  `push: main` already has lead credentials). All other conditions --
+  `can_admins_bypass = false`, custom additive branch policy, no
+  auto-approver apps -- are unchanged. Revisit this setting if the
+  reviewer set ever widens.
 - **`glycemicgpt-discord-bot` carries no reviewer rule at all.** The repo is
   private, and on the org's current plan the required-reviewer rule is
   rejected for private repos (empirically: the API returns HTTP 422

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -164,6 +164,13 @@ Known gaps, tracked rather than hidden:
     reusable workflow are invisible to the static scan. The clause-5
     reviewer remains the primary control for every dispatch-reachable
     shape.
+  - MI-1 does not evaluate a gated job whose workflow's only trigger is
+    plain pull_request: the custom branch policy rejects PR merge refs
+    at deploy time, and the bypass/SA reference invariants already fail
+    the crown-jewel secrets under PR triggers. The uncovered slice -- a
+    gated environment holding some other secret, reached from a
+    same-repo PR -- is caught by the scheduled --live audit's other
+    checks, not statically here.
 
 Exit codes: 0 clean, 1 violations, 2 operational error (missing token,
 missing permissions, truncated API listing -- the audit fails closed

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -41,6 +41,32 @@ enforcement of the web-merge design, not a recommendation):
                     org installation list fails closed rather than
                     reporting an unverified confinement as clean.
 
+One reachability invariant (the release-gate pattern; enforced per repo
+via MI1_ENFORCED_REPOS as the pattern is proven and ported):
+
+  MI-1              For every job J declaring environment E, the set of
+                    (event, ref) tuples that can cause J to resolve E
+                    must be a subset of {(push, b) : b in policy(E)} --
+                    the deployment branch policy binds the REF, not the
+                    ACTOR, so a workflow_dispatch on ref=main yields
+                    github.ref=refs/heads/main and PASSES a main-scoped
+                    policy, handing the gated secret's run to any write
+                    actor. Five clauses: (1) gated policies are custom,
+                    never protected_branches (a PR merge ref satisfies
+                    "protected"); (2) no workflow containing a gated job
+                    declares workflow_dispatch; (3) hard fail on
+                    pull_request_target / workflow_run /
+                    repository_dispatch / workflow_call / schedule
+                    reachability -- those events run with a base or
+                    default-branch github.ref, so the policy gives them
+                    zero isolation; (4) a dispatch-reachable gated job
+                    checks out a pinned trusted ref; (5) escape hatch --
+                    where reachability cannot be proven statically
+                    (dispatch-only canaries), the environment must keep
+                    required_reviewers >= 1 and is pinned in
+                    MI1_DISPATCH_SAFE_ENVS: the reviewer, not the branch
+                    policy, is then the load-bearing control.
+
 Three drift checks (scaffolding for the gated-environment migration; the
 EXPECTED_GATED_ENVIRONMENTS map is populated as each secret moves behind
 an approval-gated environment):
@@ -407,20 +433,62 @@ UNGATED_ENV_BASELINE: set[tuple[str, str]] = {
     ("website", "github-pages"),
 }
 
+# ---------------------------------------------------------------------
+# MI-1 -- gated-secret reachability (see the module docstring). Enforced
+# per repo, monorepo first; add a repo here only after its workflows have
+# been brought into compliance (the release-gate porting checklist).
+# ---------------------------------------------------------------------
+MI1_ENFORCED_REPOS = frozenset({"GlycemicGPT"})
+
+# Clause-5 pins: environments whose DESIGN posture keeps a required
+# reviewer permanently, which makes workflow_dispatch reachability of
+# their jobs compliant -- the reviewer, not the branch policy, is the
+# gate. An environment on the reviewer-removal track (release-gated ->
+# release-auto) must NEVER be pinned here: pinning it would let dispatch
+# reachability back in the moment its reviewer comes off. Every entry
+# must keep >= 1 reviewer pinned in GATED_ENV_PROTECTION_BASELINE
+# (check_mi1_reachability enforces the consistency statically; live
+# reviewer drift is caught by check_env_protection_drift).
+MI1_DISPATCH_SAFE_ENVS: dict[tuple[str, str], str] = {
+    ("GlycemicGPT", "op-github-gated"): (
+        "dispatch-only canary (secrets-plumbing-check.yml) proving the "
+        "gate works; its required reviewer is the load-bearing control"
+    ),
+}
+
+# Clause-3 events: they deliver secrets while github.ref is the PR's base
+# branch (pull_request_target), the default branch (workflow_run), or an
+# arbitrary trusted context (repository_dispatch, workflow_call,
+# schedule) -- every one of them passes a main-scoped deployment branch
+# policy, so a gated job reachable from any of these is a hard fail with
+# no escape hatch.
+MI1_FORBIDDEN_TRIGGERS = frozenset(
+    {
+        "pull_request_target",
+        "workflow_run",
+        "repository_dispatch",
+        "workflow_call",
+        "schedule",
+    }
+)
+
+# Clause-4 trusted checkout refs: the default branch (only the lead can
+# push it) or an immutable full commit SHA.
+MI1_TRUSTED_REF_RE = re.compile(r"^(main|[0-9a-f]{40})$")
+
 
 class OperationalError(Exception):
     """The audit could not gather ground truth. Fail closed (exit 2)."""
 
 
-def workflow_has_pr_trigger(text: str) -> bool:
-    """True when the workflow's `on:` includes a pull_request trigger.
+def _parse_workflow(text: str) -> tuple[set[Any], dict[str, Any]] | None:
+    """Parse workflow YAML into (trigger-name set, jobs mapping).
 
-    Parses the YAML rather than grepping, so every documented trigger
-    shape is recognized: `on: pull_request`, `on: [push, pull_request]`,
-    `on: {pull_request: ...}`, block mappings, and quoted keys. A
-    workflow that does not parse is treated as HAVING the trigger: this
-    function is only consulted for workflows that reference a guarded
-    secret, and an unparseable one must fail the audit, not slip past it.
+    Every documented `on:` shape is recognized: `on: pull_request`,
+    `on: [push, pull_request]`, `on: {pull_request: ...}`, block
+    mappings, and quoted keys (YAML 1.1 parses an unquoted `on` key as
+    boolean True). Returns None when the text does not parse as YAML;
+    each caller decides its own fail-closed behavior.
     """
     try:
         import yaml
@@ -431,22 +499,81 @@ def workflow_has_pr_trigger(text: str) -> bool:
     try:
         doc = yaml.safe_load(text)
     except yaml.YAMLError:
-        return True
+        return None
     if not isinstance(doc, dict):
-        return False
-    # YAML 1.1 parses an unquoted `on` key as boolean True.
+        return set(), {}
     triggers = doc.get(True, doc.get("on"))
     if triggers is None:
-        return False
-    if isinstance(triggers, str):
-        names: set[Any] = {triggers}
+        names: set[Any] = set()
+    elif isinstance(triggers, str):
+        names = {triggers}
     elif isinstance(triggers, list):
         names = set(triggers)
     elif isinstance(triggers, dict):
         names = set(triggers.keys())
     else:
-        return False
+        names = set()
+    jobs = doc.get("jobs")
+    return names, (jobs if isinstance(jobs, dict) else {})
+
+
+def workflow_has_pr_trigger(text: str) -> bool:
+    """True when the workflow's `on:` includes a pull_request trigger.
+
+    A workflow that does not parse is treated as HAVING the trigger:
+    this function is only consulted for workflows that reference a
+    guarded secret, and an unparseable one must fail the audit, not
+    slip past it.
+    """
+    parsed = _parse_workflow(text)
+    if parsed is None:
+        return True
+    names, _ = parsed
     return bool(names & PR_TRIGGERS)
+
+
+def _job_environment(job: Any) -> str | None:
+    """The environment name a job declares.
+
+    None when the job declares no environment; the sentinel "?" when the
+    declaration exists but the name cannot be statically resolved (an
+    expression, or a malformed mapping) -- callers treat "?" as gated
+    and fail closed.
+    """
+    if not isinstance(job, dict):
+        return None
+    env = job.get("environment")
+    if env is None:
+        return None
+    if isinstance(env, dict):
+        env = env.get("name")
+    if not isinstance(env, str) or "${{" in env:
+        return "?"
+    return env
+
+
+def _checkout_refs(job: dict) -> list[str | None]:
+    """The `ref:` of every actions/checkout step in a job.
+
+    None entries mean the step checks out the event's default ref (for
+    workflow_dispatch: the dispatched ref). A non-string ref (an
+    expression resolved at runtime) is normalized to its text so the
+    trusted-ref pattern rejects it.
+    """
+    refs: list[str | None] = []
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        return refs
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        uses = step.get("uses")
+        if not isinstance(uses, str) or not uses.startswith("actions/checkout@"):
+            continue
+        with_block = step.get("with")
+        ref = with_block.get("ref") if isinstance(with_block, dict) else None
+        refs.append(ref if ref is None or isinstance(ref, str) else str(ref))
+    return refs
 
 
 # ---------------------------------------------------------------------
@@ -470,6 +597,9 @@ def workflow_has_pr_trigger(text: str) -> bool:
 #       "environments": [
 #         {"name": str, "required_reviewers": int, "secrets": [name, ...],
 #          "branch_policy_branches": [name, ...] | None,  # custom policy
+#          "branch_policy_mode": "custom" | "protected" | None,  # None = no
+#          #   policy at all; key absent in text-only models (MI-1 clause 1
+#          #   is skipped when the key is absent, never when it is None)
 #          "prevent_self_review": bool | None,  # None = no reviewer rule
 #          "can_admins_bypass": bool,
 #          "reviewers": ["User:login" | "Team:slug", ...]}
@@ -873,6 +1003,145 @@ def check_reviewer_drift(state: dict) -> tuple[list[str], list[str]]:
     return violations, warnings
 
 
+def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
+    """MI-1: gated-secret reachability (module docstring, five clauses).
+
+    Runs in both modes. In --repo-local the model carries no environment
+    inventory, so the escape hatch resolves against the pinned baselines
+    (GATED_ENV_PROTECTION_BASELINE via MI1_DISPATCH_SAFE_ENVS) and the
+    policy-shape clause is skipped; --live additionally verifies the
+    live reviewer count and the policy shape.
+    """
+    violations: list[str] = []
+    # Clause-5 consistency, checkable in every mode: a dispatch-safe pin
+    # is only sound while the baseline pins >= 1 reviewer for that
+    # environment -- the reviewer it depends on must itself be
+    # drift-tracked. An entry whose reviewer pin is emptied (the first
+    # step of removing the reviewer) goes red here before the removal
+    # can land.
+    for (repo_name, env_name), _why in sorted(MI1_DISPATCH_SAFE_ENVS.items()):
+        pinned = GATED_ENV_PROTECTION_BASELINE.get((repo_name, env_name))
+        if not (pinned and pinned["reviewers"]):
+            violations.append(
+                f"MI1-ESCAPE: {repo_name}/{env_name} is pinned "
+                f"dispatch-safe but GATED_ENV_PROTECTION_BASELINE pins no "
+                f"required reviewer for it; the escape hatch IS the "
+                f"reviewer, so pin the reviewer or remove the dispatch "
+                f"reachability before removing this environment's gate"
+            )
+    for repo in state["repos"]:
+        if repo["name"] not in MI1_ENFORCED_REPOS:
+            continue
+        envs_by_name = {e["name"]: e for e in repo["environments"]}
+        # Clause 1: every gated environment's deployment branch policy is
+        # custom, never protected_branches (any protected ref -- a PR
+        # merge ref qualifies -- satisfies "protected") and never absent
+        # (no policy lets every ref deploy). Only evaluated when the
+        # model carries policy data (--live; fixtures opt in) -- a
+        # missing environment already fails ENV-DRIFT.
+        gated_env_names = set(EXPECTED_GATED_ENVIRONMENTS.get(repo["name"], {}))
+        gated_env_names.update(
+            e for r, e in MI1_DISPATCH_SAFE_ENVS if r == repo["name"]
+        )
+        for env_name in sorted(gated_env_names):
+            env = envs_by_name.get(env_name)
+            if env is None or "branch_policy_mode" not in env:
+                continue
+            if env["branch_policy_mode"] != "custom":
+                violations.append(
+                    f"MI1-POLICY: {repo['name']}/{env_name} deployment "
+                    f"branch policy is "
+                    f"{env['branch_policy_mode'] or 'absent'}; a gated "
+                    f"environment must carry a CUSTOM branch policy -- "
+                    f"'protected_branches' is satisfied by any protected "
+                    f"ref (a PR merge ref qualifies), and no policy at "
+                    f"all lets every ref deploy"
+                )
+        for path, by_branch in sorted(repo["workflows"].items()):
+            for branch, text in sorted(by_branch.items()):
+                where = f"{repo['name']}/{path}@{branch}"
+                parsed = _parse_workflow(text)
+                if parsed is None:
+                    # Same fail-closed stance as the bypass invariant: an
+                    # unparseable workflow that mentions an environment
+                    # must fail the audit, not slip past the parse.
+                    if re.search(r"^\s*environment\s*:", text, re.MULTILINE):
+                        violations.append(
+                            f"MI1-UNPARSEABLE: {where} does not parse as "
+                            f"YAML but declares an environment; fix the "
+                            f"YAML so reachability can be verified"
+                        )
+                    continue
+                triggers, jobs = parsed
+                dispatch = "workflow_dispatch" in triggers
+                forbidden = triggers & MI1_FORBIDDEN_TRIGGERS
+                if not dispatch and not forbidden:
+                    continue
+                for job_id, job in jobs.items():
+                    env_name = _job_environment(job)
+                    if env_name is None:
+                        continue
+                    job_where = f"{where} job '{job_id}' (environment {env_name})"
+                    if forbidden:
+                        violations.append(
+                            f"MI1-TRIGGER: {job_where} is reachable from "
+                            f"{', '.join(sorted(forbidden))}; those events "
+                            f"run with a base/default-branch github.ref "
+                            f"that PASSES a main-scoped deployment branch "
+                            f"policy, so the policy gives them zero "
+                            f"isolation -- gated jobs may only be "
+                            f"reachable from push"
+                        )
+                    if not dispatch:
+                        continue
+                    if (
+                        env_name == "?"
+                        or (repo["name"], env_name) not in MI1_DISPATCH_SAFE_ENVS
+                    ):
+                        violations.append(
+                            f"MI1-DISPATCH: {job_where} is reachable from "
+                            f"workflow_dispatch; a dispatch on ref=main "
+                            f"yields github.ref=refs/heads/main and PASSES "
+                            f"a main-scoped branch policy (the policy "
+                            f"binds the ref, not the actor) -- remove "
+                            f"workflow_dispatch, or, for a dispatch-only "
+                            f"canary, pin the environment in "
+                            f"MI1_DISPATCH_SAFE_ENVS with a permanent "
+                            f"required reviewer"
+                        )
+                        continue
+                    env = envs_by_name.get(env_name)
+                    if env is not None and env["required_reviewers"] < 1:
+                        violations.append(
+                            f"MI1-ESCAPE: {job_where} relies on the "
+                            f"dispatch-safe escape hatch but the live "
+                            f"environment has no required reviewer; the "
+                            f"reviewer is the load-bearing control for "
+                            f"dispatch reachability -- restore it or "
+                            f"remove workflow_dispatch"
+                        )
+                    # Clause 4: a dispatched run executes the dispatched
+                    # ref's workflow copy, so every checkout in the gated
+                    # job must pin a trusted ref -- the repo-controlled
+                    # logic running with the gated secret in scope has to
+                    # be lead-controlled.
+                    for ref in _checkout_refs(job):
+                        if ref is None or not MI1_TRUSTED_REF_RE.match(ref):
+                            shown = (
+                                "the dispatched ref (no ref: pin)"
+                                if ref is None
+                                else repr(ref)
+                            )
+                            violations.append(
+                                f"MI1-CHECKOUT: {job_where} checks out "
+                                f"{shown} in a dispatch-reachable gated "
+                                f"job; pin `ref: main` (or a full commit "
+                                f"SHA) so the code running with the gated "
+                                f"secret in scope is lead-controlled"
+                            )
+    return violations, []
+
+
 CHECKS = (
     check_sa_invariant,
     check_bypass_invariant,
@@ -880,6 +1149,7 @@ CHECKS = (
     check_web_merge_confinement,
     check_env_protection_drift,
     check_reviewer_drift,
+    check_mi1_reachability,
 )
 
 # Checks that operate purely on workflow TEXT, so they are meaningful in
@@ -888,7 +1158,10 @@ CHECKS = (
 # API model and run only in --live: on the empty local model they would either
 # no-op (nothing to see) or, once EXPECTED_GATED_ENVIRONMENTS is populated,
 # false-positive on the missing (unqueryable) environments.
-WORKFLOW_TEXT_CHECKS = (check_bypass_invariant,)
+# check_mi1_reachability qualifies: its trigger/checkout clauses need only
+# workflow text plus the static pins, and its environment-shaped clauses
+# skip themselves when the model carries no environment data.
+WORKFLOW_TEXT_CHECKS = (check_bypass_invariant, check_mi1_reachability)
 
 
 def run_checks(state: dict, checks: tuple = CHECKS) -> tuple[list[str], list[str]]:
@@ -1197,11 +1470,19 @@ def collect_live_state() -> dict:
             # Custom deployment-branch-policy names, or None when the
             # environment has no custom policy configured. Consumed by the
             # REVIEWERLESS_ENV_BASELINE verification (a reviewerless pin is
-            # only sound while its main-only policy is live).
+            # only sound while its main-only policy is live). The mode
+            # (custom / protected / None) feeds MI-1 clause 1: a gated
+            # environment must never rely on protected_branches (a PR
+            # merge ref satisfies "protected") or run policy-free.
+            deployment_branch_policy = env.get("deployment_branch_policy") or {}
+            if deployment_branch_policy.get("custom_branch_policies"):
+                branch_policy_mode = "custom"
+            elif deployment_branch_policy.get("protected_branches"):
+                branch_policy_mode = "protected"
+            else:
+                branch_policy_mode = None
             branch_policy_branches = None
-            if (env.get("deployment_branch_policy") or {}).get(
-                "custom_branch_policies"
-            ):
+            if branch_policy_mode == "custom":
                 policies = gh_api_items(
                     f"/repos/{ORG}/{name}/environments/{env_path}"
                     f"/deployment-branch-policies",
@@ -1215,6 +1496,7 @@ def collect_live_state() -> dict:
                     "required_reviewers": reviewer_count,
                     "secrets": [s["name"] for s in env_secrets],
                     "branch_policy_branches": branch_policy_branches,
+                    "branch_policy_mode": branch_policy_mode,
                     "prevent_self_review": prevent_self_review,
                     "can_admins_bypass": bool(env.get("can_admins_bypass")),
                     "reviewers": reviewers,
@@ -1994,6 +2276,7 @@ def self_test() -> int:
                         "name": "op-github-gated",
                         "required_reviewers": 1,
                         "secrets": gly_op_secrets,
+                        "branch_policy_mode": "custom",
                         "prevent_self_review": True,
                         **lead_gate,
                     },
@@ -2001,6 +2284,7 @@ def self_test() -> int:
                         "name": "release-gated",
                         "required_reviewers": 1,
                         "secrets": gly_release_secrets,
+                        "branch_policy_mode": "custom",
                         "prevent_self_review": psr_flip,
                         "can_admins_bypass": cab_flip,
                         "reviewers": (
@@ -2228,6 +2512,208 @@ def self_test() -> int:
         )
     finally:
         EXPECTED_GATED_ENVIRONMENTS = _production_map
+
+    # 35+. MI-1 gated-secret reachability. The workflow-text fixtures run
+    # against an empty expectation map like the early single-repo fixtures,
+    # so each stays isolated to the reachability clause it exercises (the
+    # populated map would demand the full multi-repo environment model).
+    EXPECTED_GATED_ENVIRONMENTS = {}
+
+    release_dispatch_wf = (
+        "on:\n  push:\n    branches: [main]\n  workflow_dispatch:\n"
+        "jobs:\n  release:\n    environment: release-gated\n    steps: []\n"
+    )
+
+    def canary_wf(checkout: str) -> str:
+        return (
+            "on:\n  workflow_dispatch:\n"
+            "jobs:\n  canary:\n    environment: op-github-gated\n"
+            f"    steps:\n{checkout}"
+        )
+
+    PINNED_CHECKOUT = (
+        "      - uses: actions/checkout@sha\n        with:\n          ref: main\n"
+    )
+    UNPINNED_CHECKOUT = "      - uses: actions/checkout@sha\n"
+    DEV_REF_CHECKOUT = (
+        "      - uses: actions/checkout@sha\n        with:\n          ref: develop\n"
+    )
+
+    def _mi1_state(wf: str, path: str = ".github/workflows/x.yml") -> dict:
+        return {
+            "org_secrets": [],
+            "repos": [_repo("GlycemicGPT", workflows={path: wf})],
+        }
+
+    # Clause 2: dispatch reachability of a job gated on an environment NOT
+    # pinned dispatch-safe fails. release-gated holds a reviewer today, but
+    # its design target is reviewerless (release-auto) -- dispatch must be
+    # closed before that reviewer can come off, so the reviewer's presence
+    # must not excuse the trigger.
+    expect(
+        "mi1-dispatch-gated",
+        _mi1_state(release_dispatch_wf, ".github/workflows/release.yml"),
+        {"MI1-DISPATCH"},
+    )
+    # The same gated job reachable only from push is the compliant shape.
+    expect(
+        "mi1-push-only-clean",
+        _mi1_state(
+            release_dispatch_wf.replace("  workflow_dispatch:\n", ""),
+            ".github/workflows/release.yml",
+        ),
+        set(),
+    )
+    # Clause 3: every zero-isolation event hard-fails -- no escape hatch.
+    for trig in sorted(MI1_FORBIDDEN_TRIGGERS):
+        expect(
+            f"mi1-trigger-{trig}",
+            _mi1_state(
+                f"on:\n  {trig}:\njobs:\n  j:\n"
+                "    environment: op-github-gated\n    steps: []\n"
+            ),
+            {"MI1-TRIGGER"},
+        )
+    # Clauses 4+5: the dispatch-only canary on a dispatch-safe pinned
+    # environment with a trusted-ref checkout is compliant; an unpinned or
+    # untrusted checkout runs dispatched-ref code with the gated secret in
+    # scope and fails.
+    expect(
+        "mi1-canary-dispatch-clean",
+        _mi1_state(canary_wf(PINNED_CHECKOUT)),
+        set(),
+    )
+    expect(
+        "mi1-canary-unpinned-checkout",
+        _mi1_state(canary_wf(UNPINNED_CHECKOUT)),
+        {"MI1-CHECKOUT"},
+    )
+    expect(
+        "mi1-canary-untrusted-checkout",
+        _mi1_state(canary_wf(DEV_REF_CHECKOUT)),
+        {"MI1-CHECKOUT"},
+    )
+    # A dynamic environment name cannot be statically proven safe -> the
+    # dispatch clause fails closed.
+    expect(
+        "mi1-dynamic-env-dispatch",
+        _mi1_state(
+            "on:\n  workflow_dispatch:\njobs:\n  j:\n"
+            "    environment: ${{ inputs.target }}\n    steps: []\n"
+        ),
+        {"MI1-DISPATCH"},
+    )
+    # Unparseable YAML that declares an environment fails closed rather
+    # than slipping past the trigger parse.
+    expect(
+        "mi1-unparseable",
+        _mi1_state(
+            "on: [workflow_dispatch\njobs:\n  j:\n    environment: release-gated\n"
+        ),
+        {"MI1-UNPARSEABLE"},
+    )
+    # The ratchet is per-repo: the same dispatch shape on a repo not yet
+    # ported stays clean (the porting checklist adds each repo to
+    # MI1_ENFORCED_REPOS once its workflows comply).
+    expect(
+        "mi1-nonenforced-repo-clean",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "android-unofficial",
+                    workflows={".github/workflows/release.yml": release_dispatch_wf},
+                )
+            ],
+        },
+        set(),
+    )
+
+    # Clause 1: gated policy shape. Posture fields mirror the live pin so
+    # only the policy mode under test deviates.
+    def _op_env(mode: str | None) -> dict:
+        return {
+            "name": "op-github-gated",
+            "required_reviewers": 1,
+            "secrets": [],
+            "branch_policy_mode": mode,
+            "prevent_self_review": True,
+            "can_admins_bypass": False,
+            "reviewers": ["User:jlengelbrecht"],
+        }
+
+    expect(
+        "mi1-policy-protected",
+        {
+            "org_secrets": [],
+            "repos": [_repo("GlycemicGPT", environments=[_op_env("protected")])],
+        },
+        {"MI1-POLICY"},
+    )
+    expect(
+        "mi1-policy-absent",
+        {
+            "org_secrets": [],
+            "repos": [_repo("GlycemicGPT", environments=[_op_env(None)])],
+        },
+        {"MI1-POLICY"},
+    )
+    expect(
+        "mi1-policy-custom-clean",
+        {
+            "org_secrets": [],
+            "repos": [_repo("GlycemicGPT", environments=[_op_env("custom")])],
+        },
+        set(),
+    )
+
+    # Clause 5, static leg: emptying the baseline reviewer pin for a
+    # dispatch-safe environment (the first step of removing its gate) goes
+    # red before any live drift is observable.
+    _op_key = ("GlycemicGPT", "op-github-gated")
+    _saved_posture = GATED_ENV_PROTECTION_BASELINE[_op_key]
+    GATED_ENV_PROTECTION_BASELINE[_op_key] = {**_saved_posture, "reviewers": set()}
+    try:
+        expect(
+            "mi1-escape-pin-reviewerless",
+            {"org_secrets": [], "repos": []},
+            {"MI1-ESCAPE"},
+        )
+    finally:
+        GATED_ENV_PROTECTION_BASELINE[_op_key] = _saved_posture
+    # Clause 5, live leg: the canary environment observed without its
+    # reviewer trips MI-1 alongside the independent reviewer-drift and
+    # posture-drift checks -- three controls notice the same removal.
+    expect(
+        "mi1-escape-live-reviewerless",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "GlycemicGPT",
+                    workflows={
+                        ".github/workflows/secrets-plumbing-check.yml": canary_wf(
+                            PINNED_CHECKOUT
+                        )
+                    },
+                    environments=[
+                        {
+                            "name": "op-github-gated",
+                            "required_reviewers": 0,
+                            "secrets": [],
+                            "branch_policy_mode": "custom",
+                            "prevent_self_review": None,
+                            "can_admins_bypass": False,
+                            "reviewers": [],
+                        }
+                    ],
+                )
+            ],
+        },
+        {"MI1-ESCAPE", "ENV-UNGATED", "ENV-PROTECTION"},
+    )
+
+    EXPECTED_GATED_ENVIRONMENTS = _production_map
 
     if failures:
         for f in failures:

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -60,9 +60,11 @@ via MI1_ENFORCED_REPOS as the pattern is proven and ported):
                     trigger names only trusted branches; (3) hard fail on
                     pull_request_target / workflow_run /
                     repository_dispatch / workflow_call / schedule
-                    reachability -- those events run with a base or
+                    reachability -- the first four run with a base or
                     default-branch github.ref, so the policy gives them
-                    zero isolation; (4) a dispatch-reachable gated job
+                    zero isolation, and workflow_call inherits the
+                    caller's ref, which cannot be resolved statically
+                    from the callee; (4) a dispatch-reachable gated job
                     that checks out repo code pins a trusted ref --
                     defense in depth only, because a dispatched run
                     executes the DISPATCHED ref's copy of the workflow
@@ -456,7 +458,7 @@ UNGATED_ENV_BASELINE: set[tuple[str, str]] = {
 # stays visible instead of assumed (same rule as every other pin in
 # this file: exemptions warn, they never go silent).
 # ---------------------------------------------------------------------
-MI1_ENFORCED_REPOS = frozenset({"GlycemicGPT"})
+MI1_ENFORCED_REPOS: frozenset[str] = frozenset({"GlycemicGPT"})
 
 # Clause-1 upper bound: the exact branch set each gated environment's
 # custom deployment branch policy may contain. Narrowing is always
@@ -486,13 +488,15 @@ MI1_DISPATCH_SAFE_ENVS: dict[tuple[str, str], str] = {
     ),
 }
 
-# Clause-3 events: they deliver secrets while github.ref is the PR's base
-# branch (pull_request_target), the default branch (workflow_run), or an
-# arbitrary trusted context (repository_dispatch, workflow_call,
-# schedule) -- every one of them passes a main-scoped deployment branch
-# policy, so a gated job reachable from any of these is a hard fail with
-# no escape hatch.
-MI1_FORBIDDEN_TRIGGERS = frozenset(
+# Clause-3 events, hard fail with no escape hatch. pull_request_target
+# runs with the PR's base-branch github.ref; workflow_run,
+# repository_dispatch and schedule run with the default branch's -- all
+# four pass a main-scoped deployment branch policy while an untrusted
+# actor controls when (and for p_r_t, around what) they fire.
+# workflow_call is forbidden for a different reason: the callee inherits
+# the CALLER's github.ref, so the effective (event, ref) pair cannot be
+# resolved statically from the callee -- fail closed.
+MI1_FORBIDDEN_TRIGGERS: frozenset[str] = frozenset(
     {
         "pull_request_target",
         "workflow_run",
@@ -591,7 +595,7 @@ def _job_environment(job: Any) -> str | None:
     return env
 
 
-def _checkout_refs(job: dict) -> list[str | None]:
+def _checkout_refs(job: dict[str, Any]) -> list[str | None]:
     """The `ref:` of every actions/checkout step in a job.
 
     None entries mean the step checks out the event's default ref (for
@@ -1067,24 +1071,23 @@ def _push_branch_filter(trigger_map: dict[Any, Any]) -> list[str] | None:
     return [b if isinstance(b, str) else str(b) for b in branches]
 
 
-def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
-    """MI-1: gated-secret reachability (module docstring, five clauses).
+def _mi1_gated_env_names(repo_name: str) -> set[str]:
+    """The environments MI-1 treats as gated on a repo: everything the
+    expectation map pins there, plus any dispatch-safe pinned env."""
+    names = set(EXPECTED_GATED_ENVIRONMENTS.get(repo_name, {}))
+    names.update(e for r, e in MI1_DISPATCH_SAFE_ENVS if r == repo_name)
+    return names
 
-    Runs in both modes. In --repo-local the model carries no environment
-    inventory, so the escape hatch resolves against the pinned baselines
-    (GATED_ENV_PROTECTION_BASELINE via MI1_DISPATCH_SAFE_ENVS) and the
-    policy-shape clause is skipped; --live additionally verifies the
-    live reviewer count, the policy shape, and the policy branch bound.
-    """
+
+def _mi1_escape_pin_consistency() -> list[str]:
+    """Clause-5 consistency, checkable in every mode: a dispatch-safe pin
+    is only sound while the baseline pins >= 1 reviewer for that
+    environment -- the reviewer it depends on must itself be
+    drift-tracked. An entry whose reviewer pin is emptied (the first
+    step of removing the reviewer) goes red here before the removal can
+    land."""
     violations: list[str] = []
-    warnings: list[str] = []
-    # Clause-5 consistency, checkable in every mode: a dispatch-safe pin
-    # is only sound while the baseline pins >= 1 reviewer for that
-    # environment -- the reviewer it depends on must itself be
-    # drift-tracked. An entry whose reviewer pin is emptied (the first
-    # step of removing the reviewer) goes red here before the removal
-    # can land.
-    for (repo_name, env_name), _why in sorted(MI1_DISPATCH_SAFE_ENVS.items()):
+    for repo_name, env_name in sorted(MI1_DISPATCH_SAFE_ENVS):
         pinned = GATED_ENV_PROTECTION_BASELINE.get((repo_name, env_name))
         if not (pinned and pinned["reviewers"]):
             violations.append(
@@ -1094,195 +1097,248 @@ def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
                 f"reviewer, so pin the reviewer or remove the dispatch "
                 f"reachability before removing this environment's gate"
             )
-    for repo in state["repos"]:
-        gated_env_names = set(EXPECTED_GATED_ENVIRONMENTS.get(repo["name"], {}))
-        gated_env_names.update(
-            e for r, e in MI1_DISPATCH_SAFE_ENVS if r == repo["name"]
-        )
-        if repo["name"] not in MI1_ENFORCED_REPOS:
-            # Visibility for the un-ported tail: a repo holding gated
-            # secrets whose workflows contain a dispatch/forbidden-
-            # reachable gated job carries exactly the exposure MI-1
-            # exists to close. Warn (once per repo) rather than stay
-            # silent; the porting checklist converts the warning into
-            # enforcement.
-            for path, by_branch in sorted(repo["workflows"].items()):
-                pending = False
-                for _branch, text in sorted(by_branch.items()):
-                    parsed = _parse_workflow(text)
-                    if parsed is None:
-                        continue
-                    trigger_map, jobs = parsed
-                    if not (
-                        "workflow_dispatch" in trigger_map
-                        or set(trigger_map) & MI1_FORBIDDEN_TRIGGERS
-                    ):
-                        continue
-                    if any(
-                        _job_environment(j) in gated_env_names for j in jobs.values()
-                    ):
-                        pending = True
-                        break
-                if pending:
-                    warnings.append(
-                        f"MI1-PENDING: {repo['name']} holds gated secrets "
-                        f"and {path} has a dispatch/forbidden-reachable "
-                        f"gated job, but the repo is not yet in "
-                        f"MI1_ENFORCED_REPOS; port it per the release-gate "
-                        f"checklist"
-                    )
-                    break
+    return violations
+
+
+def _mi1_pending_warnings(repo: dict, gated_env_names: set[str]) -> list[str]:
+    """Visibility for the un-ported tail: a repo holding gated secrets
+    whose workflows contain a dispatch/forbidden-reachable gated job
+    carries exactly the exposure MI-1 exists to close. Warn (once per
+    repo) rather than stay silent; the porting checklist converts the
+    warning into enforcement."""
+    for path, by_branch in sorted(repo["workflows"].items()):
+        for _branch, text in sorted(by_branch.items()):
+            parsed = _parse_workflow(text)
+            if parsed is None:
+                continue
+            trigger_map, jobs = parsed
+            if not (
+                "workflow_dispatch" in trigger_map
+                or set(trigger_map) & MI1_FORBIDDEN_TRIGGERS
+            ):
+                continue
+            if any(_job_environment(j) in gated_env_names for j in jobs.values()):
+                return [
+                    f"MI1-PENDING: {repo['name']} holds gated secrets "
+                    f"and {path} has a dispatch/forbidden-reachable "
+                    f"gated job, but the repo is not yet in "
+                    f"MI1_ENFORCED_REPOS; port it per the release-gate "
+                    f"checklist"
+                ]
+    return []
+
+
+def _mi1_policy_shape(repo: dict, gated_env_names: set[str]) -> list[str]:
+    """Clause 1: every gated environment's deployment branch policy is
+    custom, never protected_branches (any protected ref -- a PR merge
+    ref qualifies -- satisfies "protected") and never absent (no policy
+    lets every ref deploy); a custom policy's branch list must stay
+    within its pinned bound so widening cannot pass silently. Only
+    evaluated when the model carries policy data (--live; fixtures opt
+    in) -- a missing environment already fails ENV-DRIFT."""
+    violations: list[str] = []
+    envs_by_name = {e["name"]: e for e in repo["environments"]}
+    for env_name in sorted(gated_env_names):
+        env = envs_by_name.get(env_name)
+        if env is None or "branch_policy_mode" not in env:
             continue
-        envs_by_name = {e["name"]: e for e in repo["environments"]}
-        # Clause 1: every gated environment's deployment branch policy is
-        # custom, never protected_branches (any protected ref -- a PR
-        # merge ref qualifies -- satisfies "protected") and never absent
-        # (no policy lets every ref deploy); a custom policy's branch
-        # list must stay within its pinned bound so widening cannot pass
-        # silently. Only evaluated when the model carries policy data
-        # (--live; fixtures opt in) -- a missing environment already
-        # fails ENV-DRIFT.
-        for env_name in sorted(gated_env_names):
-            env = envs_by_name.get(env_name)
-            if env is None or "branch_policy_mode" not in env:
+        if env["branch_policy_mode"] != "custom":
+            violations.append(
+                f"MI1-POLICY: {repo['name']}/{env_name} deployment "
+                f"branch policy is "
+                f"{env['branch_policy_mode'] or 'absent'}; a gated "
+                f"environment must carry a CUSTOM branch policy -- "
+                f"'protected_branches' is satisfied by any protected "
+                f"ref (a PR merge ref qualifies), and no policy at "
+                f"all lets every ref deploy"
+            )
+            continue
+        branches = env.get("branch_policy_branches")
+        if branches is None:
+            continue
+        bound = MI1_POLICY_BRANCH_BOUND.get((repo["name"], env_name))
+        if bound is None:
+            violations.append(
+                f"MI1-POLICY: {repo['name']}/{env_name} has a custom "
+                f"branch policy ({sorted(branches)}) with no "
+                f"MI1_POLICY_BRANCH_BOUND pin; every gated policy "
+                f"must state its allowed branch set"
+            )
+        elif not set(branches) <= bound:
+            violations.append(
+                f"MI1-POLICY: {repo['name']}/{env_name} branch policy "
+                f"({sorted(branches)}) exceeds its pinned bound "
+                f"({sorted(bound)}); narrowing is fine, widening "
+                f"must be a reviewed edit of the pin"
+            )
+    return violations
+
+
+def _mi1_job_reachability(
+    repo: dict,
+    envs_by_name: dict[str, dict],
+    job_where: str,
+    env_name: str,
+    job: dict[str, Any],
+    *,
+    dispatch: bool,
+    forbidden: set[str],
+    has_push: bool,
+    push_branches: list[str] | None,
+) -> tuple[list[str], list[str]]:
+    """Clauses 2-5 for one gated job. See check_mi1_reachability."""
+    violations: list[str] = []
+    warnings: list[str] = []
+    if forbidden:
+        violations.append(
+            f"MI1-TRIGGER: {job_where} is reachable from "
+            f"{', '.join(sorted(forbidden))}; pull_request_target, "
+            f"workflow_run, repository_dispatch and schedule run with a "
+            f"base/default-branch github.ref that PASSES a main-scoped "
+            f"deployment branch policy, and workflow_call inherits the "
+            f"CALLER's ref, which cannot be resolved statically -- "
+            f"gated jobs may only be reachable from push"
+        )
+    # Clause 2, push half: the push trigger must name a provable
+    # whitelist of trusted branches. A gated job on push:develop would
+    # hand every merged PR a gated run built from the just-merged
+    # workflow copy.
+    if has_push and (
+        push_branches is None
+        or not all(MI1_TRUSTED_REF_RE.match(b) for b in push_branches)
+    ):
+        shown = (
+            "no provable branch whitelist"
+            if push_branches is None
+            else f"branches {push_branches}"
+        )
+        violations.append(
+            f"MI1-PUSH: {job_where} is reachable from push with {shown}; "
+            f"a gated job's push trigger must whitelist only "
+            f"lead-controlled branches (main)"
+        )
+    if not dispatch:
+        return violations, warnings
+    key = (repo["name"], env_name)
+    if env_name == "?" or key not in MI1_DISPATCH_SAFE_ENVS:
+        violations.append(
+            f"MI1-DISPATCH: {job_where} is reachable from "
+            f"workflow_dispatch; a dispatch on ref=main yields "
+            f"github.ref=refs/heads/main and PASSES a main-scoped branch "
+            f"policy (the policy binds the ref, not the actor) -- remove "
+            f"workflow_dispatch, or, for a dispatch-only canary, pin the "
+            f"environment in MI1_DISPATCH_SAFE_ENVS with a permanent "
+            f"required reviewer"
+        )
+        return violations, warnings
+    # The sanctioned hole is never invisible (the SA_ALLOWLIST rule):
+    # every run reports which jobs the escape hatch is carrying and why.
+    warnings.append(
+        f"MI1-DISPATCH-PINNED: {job_where} is dispatch-reachable under "
+        f"the clause-5 escape hatch ({MI1_DISPATCH_SAFE_ENVS[key]}); the "
+        f"environment's required reviewer is the load-bearing control"
+    )
+    env = envs_by_name.get(env_name)
+    if env is not None and env.get("required_reviewers", 0) < 1:
+        violations.append(
+            f"MI1-ESCAPE-LIVE: {job_where} relies on the dispatch-safe "
+            f"escape hatch but the live environment has no required "
+            f"reviewer; the reviewer is the load-bearing control for "
+            f"dispatch reachability -- restore it or remove "
+            f"workflow_dispatch"
+        )
+    # Clause 4, defense in depth only: a dispatched run executes the
+    # DISPATCHED ref's copy of this workflow YAML -- inline run steps
+    # included -- and no checkout pin changes that; the clause-5
+    # reviewer is the primary control. What the pin does buy: the
+    # checked-out tree (composite actions, scripts) comes from a
+    # lead-controlled ref instead of the dispatched one.
+    for ref in _checkout_refs(job):
+        if ref is None or not MI1_TRUSTED_REF_RE.match(ref):
+            shown = "the dispatched ref (no ref: pin)" if ref is None else repr(ref)
+            violations.append(
+                f"MI1-CHECKOUT: {job_where} checks out {shown} in a "
+                f"dispatch-reachable gated job; pin `ref: main` (or a "
+                f"full commit SHA) so the checked-out tree running with "
+                f"the gated secret in scope is lead-controlled"
+            )
+    return violations, warnings
+
+
+def _mi1_workflow_reachability(repo: dict) -> tuple[list[str], list[str]]:
+    """Clauses 2-5 over every workflow copy of an enforced repo."""
+    violations: list[str] = []
+    warnings: list[str] = []
+    envs_by_name = {e["name"]: e for e in repo["environments"]}
+    for path, by_branch in sorted(repo["workflows"].items()):
+        for branch, text in sorted(by_branch.items()):
+            where = f"{repo['name']}/{path}@{branch}"
+            parsed = _parse_workflow(text)
+            if parsed is None:
+                # Same fail-closed stance as the bypass invariant: an
+                # unparseable workflow that mentions an environment must
+                # fail the audit, not slip past the parse.
+                if re.search(r"^\s*environment\s*:", text, re.MULTILINE):
+                    violations.append(
+                        f"MI1-UNPARSEABLE: {where} does not parse as "
+                        f"YAML but declares an environment; fix the "
+                        f"YAML so reachability can be verified"
+                    )
                 continue
-            if env["branch_policy_mode"] != "custom":
-                violations.append(
-                    f"MI1-POLICY: {repo['name']}/{env_name} deployment "
-                    f"branch policy is "
-                    f"{env['branch_policy_mode'] or 'absent'}; a gated "
-                    f"environment must carry a CUSTOM branch policy -- "
-                    f"'protected_branches' is satisfied by any protected "
-                    f"ref (a PR merge ref qualifies), and no policy at "
-                    f"all lets every ref deploy"
-                )
+            trigger_map, jobs = parsed
+            triggers = set(trigger_map)
+            dispatch = "workflow_dispatch" in triggers
+            forbidden = triggers & MI1_FORBIDDEN_TRIGGERS
+            has_push = "push" in triggers
+            if not dispatch and not forbidden and not has_push:
                 continue
-            branches = env.get("branch_policy_branches")
-            if branches is None:
-                continue
-            bound = MI1_POLICY_BRANCH_BOUND.get((repo["name"], env_name))
-            if bound is None:
-                violations.append(
-                    f"MI1-POLICY: {repo['name']}/{env_name} has a custom "
-                    f"branch policy ({sorted(branches)}) with no "
-                    f"MI1_POLICY_BRANCH_BOUND pin; every gated policy "
-                    f"must state its allowed branch set"
-                )
-            elif not set(branches) <= bound:
-                violations.append(
-                    f"MI1-POLICY: {repo['name']}/{env_name} branch policy "
-                    f"({sorted(branches)}) exceeds its pinned bound "
-                    f"({sorted(bound)}); narrowing is fine, widening "
-                    f"must be a reviewed edit of the pin"
-                )
-        for path, by_branch in sorted(repo["workflows"].items()):
-            for branch, text in sorted(by_branch.items()):
-                where = f"{repo['name']}/{path}@{branch}"
-                parsed = _parse_workflow(text)
-                if parsed is None:
-                    # Same fail-closed stance as the bypass invariant: an
-                    # unparseable workflow that mentions an environment
-                    # must fail the audit, not slip past the parse.
-                    if re.search(r"^\s*environment\s*:", text, re.MULTILINE):
-                        violations.append(
-                            f"MI1-UNPARSEABLE: {where} does not parse as "
-                            f"YAML but declares an environment; fix the "
-                            f"YAML so reachability can be verified"
-                        )
+            push_branches = _push_branch_filter(trigger_map)
+            for job_id, job in jobs.items():
+                env_name = _job_environment(job)
+                if env_name is None:
                     continue
-                trigger_map, jobs = parsed
-                triggers = set(trigger_map)
-                dispatch = "workflow_dispatch" in triggers
-                forbidden = triggers & MI1_FORBIDDEN_TRIGGERS
-                has_push = "push" in triggers
-                if not dispatch and not forbidden and not has_push:
-                    continue
-                push_branches = _push_branch_filter(trigger_map)
-                for job_id, job in jobs.items():
-                    env_name = _job_environment(job)
-                    if env_name is None:
-                        continue
-                    job_where = f"{where} job '{job_id}' (environment {env_name})"
-                    if forbidden:
-                        violations.append(
-                            f"MI1-TRIGGER: {job_where} is reachable from "
-                            f"{', '.join(sorted(forbidden))}; those events "
-                            f"run with a base/default-branch github.ref "
-                            f"that PASSES a main-scoped deployment branch "
-                            f"policy, so the policy gives them zero "
-                            f"isolation -- gated jobs may only be "
-                            f"reachable from push"
-                        )
-                    # Clause 2, push half: the push trigger must name a
-                    # provable whitelist of trusted branches. A gated job
-                    # on push:develop would hand every merged PR a gated
-                    # run built from the just-merged workflow copy.
-                    if has_push and (
-                        push_branches is None
-                        or not all(MI1_TRUSTED_REF_RE.match(b) for b in push_branches)
-                    ):
-                        shown = (
-                            "no provable branch whitelist"
-                            if push_branches is None
-                            else f"branches {push_branches}"
-                        )
-                        violations.append(
-                            f"MI1-PUSH: {job_where} is reachable from push "
-                            f"with {shown}; a gated job's push trigger "
-                            f"must whitelist only lead-controlled "
-                            f"branches (main)"
-                        )
-                    if not dispatch:
-                        continue
-                    if (
-                        env_name == "?"
-                        or (repo["name"], env_name) not in MI1_DISPATCH_SAFE_ENVS
-                    ):
-                        violations.append(
-                            f"MI1-DISPATCH: {job_where} is reachable from "
-                            f"workflow_dispatch; a dispatch on ref=main "
-                            f"yields github.ref=refs/heads/main and PASSES "
-                            f"a main-scoped branch policy (the policy "
-                            f"binds the ref, not the actor) -- remove "
-                            f"workflow_dispatch, or, for a dispatch-only "
-                            f"canary, pin the environment in "
-                            f"MI1_DISPATCH_SAFE_ENVS with a permanent "
-                            f"required reviewer"
-                        )
-                        continue
-                    env = envs_by_name.get(env_name)
-                    if env is not None and env.get("required_reviewers", 0) < 1:
-                        violations.append(
-                            f"MI1-ESCAPE-LIVE: {job_where} relies on the "
-                            f"dispatch-safe escape hatch but the live "
-                            f"environment has no required reviewer; the "
-                            f"reviewer is the load-bearing control for "
-                            f"dispatch reachability -- restore it or "
-                            f"remove workflow_dispatch"
-                        )
-                    # Clause 4, defense in depth only: a dispatched run
-                    # executes the DISPATCHED ref's copy of this workflow
-                    # YAML -- inline run steps included -- and no checkout
-                    # pin changes that; the clause-5 reviewer is the
-                    # primary control. What the pin does buy: the
-                    # checked-out tree (composite actions, scripts) comes
-                    # from a lead-controlled ref instead of the
-                    # dispatched one.
-                    for ref in _checkout_refs(job):
-                        if ref is None or not MI1_TRUSTED_REF_RE.match(ref):
-                            shown = (
-                                "the dispatched ref (no ref: pin)"
-                                if ref is None
-                                else repr(ref)
-                            )
-                            violations.append(
-                                f"MI1-CHECKOUT: {job_where} checks out "
-                                f"{shown} in a dispatch-reachable gated "
-                                f"job; pin `ref: main` (or a full commit "
-                                f"SHA) so the checked-out tree running "
-                                f"with the gated secret in scope is "
-                                f"lead-controlled"
-                            )
+                env_shown = (
+                    "an unresolvable expression" if env_name == "?" else env_name
+                )
+                v, w = _mi1_job_reachability(
+                    repo,
+                    envs_by_name,
+                    f"{where} job '{job_id}' (environment {env_shown})",
+                    env_name,
+                    job,
+                    dispatch=dispatch,
+                    forbidden=forbidden,
+                    has_push=has_push,
+                    push_branches=push_branches,
+                )
+                violations.extend(v)
+                warnings.extend(w)
+    return violations, warnings
+
+
+def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
+    """MI-1: gated-secret reachability (module docstring, five clauses).
+
+    Composed from one helper per concern: static escape-hatch pin
+    consistency, the un-ported-repo warning, the policy-shape clause,
+    and per-workflow reachability. Runs in both modes: in --repo-local
+    the model carries no environment inventory, so the escape hatch
+    resolves against the pinned baselines (GATED_ENV_PROTECTION_BASELINE
+    via MI1_DISPATCH_SAFE_ENVS) and the policy-shape clause is skipped;
+    --live additionally verifies the live reviewer count, the policy
+    shape, and the policy branch bound.
+    """
+    violations = _mi1_escape_pin_consistency()
+    warnings: list[str] = []
+    for repo in state["repos"]:
+        gated_env_names = _mi1_gated_env_names(repo["name"])
+        if repo["name"] not in MI1_ENFORCED_REPOS:
+            warnings.extend(_mi1_pending_warnings(repo, gated_env_names))
+            continue
+        violations.extend(_mi1_policy_shape(repo, gated_env_names))
+        v, w = _mi1_workflow_reachability(repo)
+        violations.extend(v)
+        warnings.extend(w)
     return violations, warnings
 
 
@@ -2659,7 +2715,7 @@ def self_test() -> int:
     finally:
         EXPECTED_GATED_ENVIRONMENTS = _production_map
 
-    # 35+. MI-1 gated-secret reachability. The workflow-text fixtures run
+    # 35-62. MI-1 gated-secret reachability. The workflow-text fixtures run
     # against an empty expectation map like the early single-repo fixtures,
     # so each stays isolated to the reachability clause it exercises (the
     # populated map would demand the full multi-repo environment model).
@@ -2760,24 +2816,29 @@ def self_test() -> int:
         {"MI1-DISPATCH"},
     )
     # Clauses 4+5: the dispatch-only canary on a dispatch-safe pinned
-    # environment with a trusted-ref checkout is compliant; an unpinned or
-    # untrusted checkout runs dispatched-ref code with the gated secret in
-    # scope and fails.
+    # environment with a trusted-ref checkout is compliant -- but never
+    # silent: the escape hatch reports every job it carries as a
+    # MI1-DISPATCH-PINNED warning. An unpinned or untrusted checkout
+    # runs dispatched-ref code with the gated secret in scope and fails.
     CANARY_PATH = ".github/workflows/secrets-plumbing-check.yml"
+    CANARY_WARN = {"MI1-DISPATCH-PINNED"}
     expect(
         "mi1-canary-dispatch-clean",
         _mi1_state(canary_wf(PINNED_CHECKOUT), CANARY_PATH),
         set(),
+        warn_codes=CANARY_WARN,
     )
     expect(
         "mi1-canary-unpinned-checkout",
         _mi1_state(canary_wf(UNPINNED_CHECKOUT), CANARY_PATH),
         {"MI1-CHECKOUT"},
+        warn_codes=CANARY_WARN,
     )
     expect(
         "mi1-canary-untrusted-checkout",
         _mi1_state(canary_wf(DEV_REF_CHECKOUT), CANARY_PATH),
         {"MI1-CHECKOUT"},
+        warn_codes=CANARY_WARN,
     )
     # GitHub resolves action owner/repo case-insensitively, so
     # Actions/Checkout is the real checkout and must not evade clause 4.
@@ -2785,12 +2846,26 @@ def self_test() -> int:
         "mi1-canary-cased-checkout-evasion",
         _mi1_state(canary_wf("      - uses: Actions/Checkout@sha\n"), CANARY_PATH),
         {"MI1-CHECKOUT"},
+        warn_codes=CANARY_WARN,
     )
     # A pinned first checkout does not excuse an unpinned second one.
     expect(
         "mi1-canary-second-checkout-unpinned",
         _mi1_state(canary_wf(PINNED_CHECKOUT + UNPINNED_CHECKOUT), CANARY_PATH),
         {"MI1-CHECKOUT"},
+        warn_codes=CANARY_WARN,
+    )
+    # An ungated job in a dispatch-only workflow (the real canary's
+    # no_environment negative control) is not MI-1's concern -- pinning
+    # this shape keeps the check from ever firing spuriously on it.
+    expect(
+        "mi1-ungated-job-in-dispatch-clean",
+        _mi1_state(
+            "on:\n  workflow_dispatch:\njobs:\n  no_environment:\n"
+            "    steps:\n      - uses: actions/checkout@sha\n",
+            CANARY_PATH,
+        ),
+        set(),
     )
     # A dynamic environment name cannot be statically proven safe -> the
     # dispatch clause fails closed.
@@ -2938,6 +3013,7 @@ def self_test() -> int:
             ],
         },
         {"MI1-ESCAPE-LIVE", "ENV-UNGATED", "ENV-PROTECTION"},
+        warn_codes=CANARY_WARN,
     )
 
     # An un-enforced repo that holds gated secrets AND has a

--- a/scripts/security/check-secret-invariants.py
+++ b/scripts/security/check-secret-invariants.py
@@ -53,19 +53,26 @@ via MI1_ENFORCED_REPOS as the pattern is proven and ported):
                     policy, handing the gated secret's run to any write
                     actor. Five clauses: (1) gated policies are custom,
                     never protected_branches (a PR merge ref satisfies
-                    "protected"); (2) no workflow containing a gated job
-                    declares workflow_dispatch; (3) hard fail on
+                    "protected"), and their branch list stays within a
+                    pinned bound (MI1_POLICY_BRANCH_BOUND) so widening
+                    cannot pass silently; (2) no workflow containing a
+                    gated job declares workflow_dispatch, and its push
+                    trigger names only trusted branches; (3) hard fail on
                     pull_request_target / workflow_run /
                     repository_dispatch / workflow_call / schedule
                     reachability -- those events run with a base or
                     default-branch github.ref, so the policy gives them
                     zero isolation; (4) a dispatch-reachable gated job
-                    checks out a pinned trusted ref; (5) escape hatch --
-                    where reachability cannot be proven statically
-                    (dispatch-only canaries), the environment must keep
-                    required_reviewers >= 1 and is pinned in
-                    MI1_DISPATCH_SAFE_ENVS: the reviewer, not the branch
-                    policy, is then the load-bearing control.
+                    that checks out repo code pins a trusted ref --
+                    defense in depth only, because a dispatched run
+                    executes the DISPATCHED ref's copy of the workflow
+                    YAML itself, which no checkout pin can change; (5)
+                    escape hatch -- where reachability cannot be proven
+                    statically (dispatch-only canaries), the environment
+                    must keep required_reviewers >= 1 and is pinned in
+                    MI1_DISPATCH_SAFE_ENVS: that reviewer, not the branch
+                    policy and not the checkout pin, is the load-bearing
+                    control for dispatch reachability.
 
 Three drift checks (scaffolding for the gated-environment migration; the
 EXPECTED_GATED_ENVIRONMENTS map is populated as each secret moves behind
@@ -149,6 +156,12 @@ Known gaps, tracked rather than hidden:
     unreadable the check verifies selection+permissions+key placement
     and emits a warning for the unverified repo list instead of a
     hollow clean.
+  - MI-1 clause 4 sees only actions/checkout steps (case-insensitively);
+    a checkout performed by a fork of the action or by raw git commands
+    in a run step is not flagged, and jobs inside an externally-hosted
+    reusable workflow are invisible to the static scan. The clause-5
+    reviewer remains the primary control for every dispatch-reachable
+    shape.
 
 Exit codes: 0 clean, 1 violations, 2 operational error (missing token,
 missing permissions, truncated API listing -- the audit fails closed
@@ -436,9 +449,26 @@ UNGATED_ENV_BASELINE: set[tuple[str, str]] = {
 # ---------------------------------------------------------------------
 # MI-1 -- gated-secret reachability (see the module docstring). Enforced
 # per repo, monorepo first; add a repo here only after its workflows have
-# been brought into compliance (the release-gate porting checklist).
+# been brought into compliance (the release-gate porting checklist). A
+# repo that holds gated secrets but is not yet enforced surfaces as a
+# MI1-PENDING warning whenever its workflows contain a
+# dispatch/forbidden-reachable gated job, so the un-ported exposure
+# stays visible instead of assumed (same rule as every other pin in
+# this file: exemptions warn, they never go silent).
 # ---------------------------------------------------------------------
 MI1_ENFORCED_REPOS = frozenset({"GlycemicGPT"})
+
+# Clause-1 upper bound: the exact branch set each gated environment's
+# custom deployment branch policy may contain. Narrowing is always
+# allowed and expected -- the pending lead action drops develop from
+# both policies, leaving {main}; shrink these pins to {"main"} when that
+# lands. Widening (a new branch, a wildcard) fails the audit. A gated
+# environment with a custom policy and no pin here is itself a
+# violation: every policy must state its bound.
+MI1_POLICY_BRANCH_BOUND: dict[tuple[str, str], set[str]] = {
+    ("GlycemicGPT", "release-gated"): {"main", "develop"},
+    ("GlycemicGPT", "op-github-gated"): {"main", "develop"},
+}
 
 # Clause-5 pins: environments whose DESIGN posture keeps a required
 # reviewer permanently, which makes workflow_dispatch reachability of
@@ -472,23 +502,32 @@ MI1_FORBIDDEN_TRIGGERS = frozenset(
     }
 )
 
-# Clause-4 trusted checkout refs: the default branch (only the lead can
-# push it) or an immutable full commit SHA.
-MI1_TRUSTED_REF_RE = re.compile(r"^(main|[0-9a-f]{40})$")
+# Clause-4 trusted checkout refs (also the clause-2 trusted push-branch
+# names): the default branch (only the lead can push it) or an immutable
+# full commit SHA. \Z, not $: $ would accept a trailing newline (a YAML
+# block-scalar `ref: |` value), which resolves as an invalid ref at best
+# and must not read as trusted. Hardcodes `main` for now -- when a repo
+# whose trunk is not `main` (android-unofficial's gated workflows live
+# on develop) joins MI1_ENFORCED_REPOS, derive this from the repo's
+# default branch instead of widening the pattern.
+MI1_TRUSTED_REF_RE = re.compile(r"^(main|[0-9a-f]{40})\Z")
 
 
 class OperationalError(Exception):
     """The audit could not gather ground truth. Fail closed (exit 2)."""
 
 
-def _parse_workflow(text: str) -> tuple[set[Any], dict[str, Any]] | None:
-    """Parse workflow YAML into (trigger-name set, jobs mapping).
+def _parse_workflow(text: str) -> tuple[dict[Any, Any], dict[str, Any]] | None:
+    """Parse workflow YAML into (trigger map, jobs mapping).
 
-    Every documented `on:` shape is recognized: `on: pull_request`,
-    `on: [push, pull_request]`, `on: {pull_request: ...}`, block
-    mappings, and quoted keys (YAML 1.1 parses an unquoted `on` key as
-    boolean True). Returns None when the text does not parse as YAML;
-    each caller decides its own fail-closed behavior.
+    The trigger map is {trigger name: config-or-None} so callers can
+    inspect per-trigger configuration (MI-1 reads push branch filters);
+    set(trigger_map) is the trigger-name set. Every documented `on:`
+    shape is recognized: `on: pull_request`, `on: [push, pull_request]`,
+    `on: {pull_request: ...}`, block mappings, and quoted keys (YAML 1.1
+    parses an unquoted `on` key as boolean True). Returns None when the
+    text does not parse as YAML; each caller decides its own fail-closed
+    behavior.
     """
     try:
         import yaml
@@ -501,20 +540,20 @@ def _parse_workflow(text: str) -> tuple[set[Any], dict[str, Any]] | None:
     except yaml.YAMLError:
         return None
     if not isinstance(doc, dict):
-        return set(), {}
+        return {}, {}
     triggers = doc.get(True, doc.get("on"))
     if triggers is None:
-        names: set[Any] = set()
+        trigger_map: dict[Any, Any] = {}
     elif isinstance(triggers, str):
-        names = {triggers}
+        trigger_map = {triggers: None}
     elif isinstance(triggers, list):
-        names = set(triggers)
+        trigger_map = dict.fromkeys(triggers)
     elif isinstance(triggers, dict):
-        names = set(triggers.keys())
+        trigger_map = dict(triggers)
     else:
-        names = set()
+        trigger_map = {}
     jobs = doc.get("jobs")
-    return names, (jobs if isinstance(jobs, dict) else {})
+    return trigger_map, (jobs if isinstance(jobs, dict) else {})
 
 
 def workflow_has_pr_trigger(text: str) -> bool:
@@ -528,8 +567,8 @@ def workflow_has_pr_trigger(text: str) -> bool:
     parsed = _parse_workflow(text)
     if parsed is None:
         return True
-    names, _ = parsed
-    return bool(names & PR_TRIGGERS)
+    trigger_map, _ = parsed
+    return bool(set(trigger_map) & PR_TRIGGERS)
 
 
 def _job_environment(job: Any) -> str | None:
@@ -568,7 +607,12 @@ def _checkout_refs(job: dict) -> list[str | None]:
         if not isinstance(step, dict):
             continue
         uses = step.get("uses")
-        if not isinstance(uses, str) or not uses.startswith("actions/checkout@"):
+        # lower(): GitHub resolves action owner/repo case-insensitively,
+        # so `Actions/Checkout@sha` runs the real action and must not
+        # evade the ref check.
+        if not isinstance(uses, str) or not uses.lower().startswith(
+            "actions/checkout@"
+        ):
             continue
         with_block = step.get("with")
         ref = with_block.get("ref") if isinstance(with_block, dict) else None
@@ -1003,6 +1047,26 @@ def check_reviewer_drift(state: dict) -> tuple[list[str], list[str]]:
     return violations, warnings
 
 
+def _push_branch_filter(trigger_map: dict[Any, Any]) -> list[str] | None:
+    """The push trigger's provable branch whitelist, or None when it has
+    no provable one.
+
+    None covers every non-whitelist shape, each of which reaches refs a
+    branch policy cannot be trusted to reject: a bare `push` (all
+    branches), `branches-ignore` (a blacklist), and tag filters (tag
+    refs). Callers fail closed on None.
+    """
+    cfg = trigger_map.get("push")
+    if not isinstance(cfg, dict):
+        return None
+    if any(k in cfg for k in ("branches-ignore", "tags", "tags-ignore")):
+        return None
+    branches = cfg.get("branches")
+    if not isinstance(branches, list) or not branches:
+        return None
+    return [b if isinstance(b, str) else str(b) for b in branches]
+
+
 def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
     """MI-1: gated-secret reachability (module docstring, five clauses).
 
@@ -1010,9 +1074,10 @@ def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
     inventory, so the escape hatch resolves against the pinned baselines
     (GATED_ENV_PROTECTION_BASELINE via MI1_DISPATCH_SAFE_ENVS) and the
     policy-shape clause is skipped; --live additionally verifies the
-    live reviewer count and the policy shape.
+    live reviewer count, the policy shape, and the policy branch bound.
     """
     violations: list[str] = []
+    warnings: list[str] = []
     # Clause-5 consistency, checkable in every mode: a dispatch-safe pin
     # is only sound while the baseline pins >= 1 reviewer for that
     # environment -- the reviewer it depends on must itself be
@@ -1023,26 +1088,60 @@ def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
         pinned = GATED_ENV_PROTECTION_BASELINE.get((repo_name, env_name))
         if not (pinned and pinned["reviewers"]):
             violations.append(
-                f"MI1-ESCAPE: {repo_name}/{env_name} is pinned "
+                f"MI1-ESCAPE-PIN: {repo_name}/{env_name} is pinned "
                 f"dispatch-safe but GATED_ENV_PROTECTION_BASELINE pins no "
                 f"required reviewer for it; the escape hatch IS the "
                 f"reviewer, so pin the reviewer or remove the dispatch "
                 f"reachability before removing this environment's gate"
             )
     for repo in state["repos"]:
+        gated_env_names = set(EXPECTED_GATED_ENVIRONMENTS.get(repo["name"], {}))
+        gated_env_names.update(
+            e for r, e in MI1_DISPATCH_SAFE_ENVS if r == repo["name"]
+        )
         if repo["name"] not in MI1_ENFORCED_REPOS:
+            # Visibility for the un-ported tail: a repo holding gated
+            # secrets whose workflows contain a dispatch/forbidden-
+            # reachable gated job carries exactly the exposure MI-1
+            # exists to close. Warn (once per repo) rather than stay
+            # silent; the porting checklist converts the warning into
+            # enforcement.
+            for path, by_branch in sorted(repo["workflows"].items()):
+                pending = False
+                for _branch, text in sorted(by_branch.items()):
+                    parsed = _parse_workflow(text)
+                    if parsed is None:
+                        continue
+                    trigger_map, jobs = parsed
+                    if not (
+                        "workflow_dispatch" in trigger_map
+                        or set(trigger_map) & MI1_FORBIDDEN_TRIGGERS
+                    ):
+                        continue
+                    if any(
+                        _job_environment(j) in gated_env_names for j in jobs.values()
+                    ):
+                        pending = True
+                        break
+                if pending:
+                    warnings.append(
+                        f"MI1-PENDING: {repo['name']} holds gated secrets "
+                        f"and {path} has a dispatch/forbidden-reachable "
+                        f"gated job, but the repo is not yet in "
+                        f"MI1_ENFORCED_REPOS; port it per the release-gate "
+                        f"checklist"
+                    )
+                    break
             continue
         envs_by_name = {e["name"]: e for e in repo["environments"]}
         # Clause 1: every gated environment's deployment branch policy is
         # custom, never protected_branches (any protected ref -- a PR
         # merge ref qualifies -- satisfies "protected") and never absent
-        # (no policy lets every ref deploy). Only evaluated when the
-        # model carries policy data (--live; fixtures opt in) -- a
-        # missing environment already fails ENV-DRIFT.
-        gated_env_names = set(EXPECTED_GATED_ENVIRONMENTS.get(repo["name"], {}))
-        gated_env_names.update(
-            e for r, e in MI1_DISPATCH_SAFE_ENVS if r == repo["name"]
-        )
+        # (no policy lets every ref deploy); a custom policy's branch
+        # list must stay within its pinned bound so widening cannot pass
+        # silently. Only evaluated when the model carries policy data
+        # (--live; fixtures opt in) -- a missing environment already
+        # fails ENV-DRIFT.
         for env_name in sorted(gated_env_names):
             env = envs_by_name.get(env_name)
             if env is None or "branch_policy_mode" not in env:
@@ -1056,6 +1155,25 @@ def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
                     f"'protected_branches' is satisfied by any protected "
                     f"ref (a PR merge ref qualifies), and no policy at "
                     f"all lets every ref deploy"
+                )
+                continue
+            branches = env.get("branch_policy_branches")
+            if branches is None:
+                continue
+            bound = MI1_POLICY_BRANCH_BOUND.get((repo["name"], env_name))
+            if bound is None:
+                violations.append(
+                    f"MI1-POLICY: {repo['name']}/{env_name} has a custom "
+                    f"branch policy ({sorted(branches)}) with no "
+                    f"MI1_POLICY_BRANCH_BOUND pin; every gated policy "
+                    f"must state its allowed branch set"
+                )
+            elif not set(branches) <= bound:
+                violations.append(
+                    f"MI1-POLICY: {repo['name']}/{env_name} branch policy "
+                    f"({sorted(branches)}) exceeds its pinned bound "
+                    f"({sorted(bound)}); narrowing is fine, widening "
+                    f"must be a reviewed edit of the pin"
                 )
         for path, by_branch in sorted(repo["workflows"].items()):
             for branch, text in sorted(by_branch.items()):
@@ -1072,11 +1190,14 @@ def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
                             f"YAML so reachability can be verified"
                         )
                     continue
-                triggers, jobs = parsed
+                trigger_map, jobs = parsed
+                triggers = set(trigger_map)
                 dispatch = "workflow_dispatch" in triggers
                 forbidden = triggers & MI1_FORBIDDEN_TRIGGERS
-                if not dispatch and not forbidden:
+                has_push = "push" in triggers
+                if not dispatch and not forbidden and not has_push:
                     continue
+                push_branches = _push_branch_filter(trigger_map)
                 for job_id, job in jobs.items():
                     env_name = _job_environment(job)
                     if env_name is None:
@@ -1091,6 +1212,25 @@ def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
                             f"policy, so the policy gives them zero "
                             f"isolation -- gated jobs may only be "
                             f"reachable from push"
+                        )
+                    # Clause 2, push half: the push trigger must name a
+                    # provable whitelist of trusted branches. A gated job
+                    # on push:develop would hand every merged PR a gated
+                    # run built from the just-merged workflow copy.
+                    if has_push and (
+                        push_branches is None
+                        or not all(MI1_TRUSTED_REF_RE.match(b) for b in push_branches)
+                    ):
+                        shown = (
+                            "no provable branch whitelist"
+                            if push_branches is None
+                            else f"branches {push_branches}"
+                        )
+                        violations.append(
+                            f"MI1-PUSH: {job_where} is reachable from push "
+                            f"with {shown}; a gated job's push trigger "
+                            f"must whitelist only lead-controlled "
+                            f"branches (main)"
                         )
                     if not dispatch:
                         continue
@@ -1111,20 +1251,23 @@ def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
                         )
                         continue
                     env = envs_by_name.get(env_name)
-                    if env is not None and env["required_reviewers"] < 1:
+                    if env is not None and env.get("required_reviewers", 0) < 1:
                         violations.append(
-                            f"MI1-ESCAPE: {job_where} relies on the "
+                            f"MI1-ESCAPE-LIVE: {job_where} relies on the "
                             f"dispatch-safe escape hatch but the live "
                             f"environment has no required reviewer; the "
                             f"reviewer is the load-bearing control for "
                             f"dispatch reachability -- restore it or "
                             f"remove workflow_dispatch"
                         )
-                    # Clause 4: a dispatched run executes the dispatched
-                    # ref's workflow copy, so every checkout in the gated
-                    # job must pin a trusted ref -- the repo-controlled
-                    # logic running with the gated secret in scope has to
-                    # be lead-controlled.
+                    # Clause 4, defense in depth only: a dispatched run
+                    # executes the DISPATCHED ref's copy of this workflow
+                    # YAML -- inline run steps included -- and no checkout
+                    # pin changes that; the clause-5 reviewer is the
+                    # primary control. What the pin does buy: the
+                    # checked-out tree (composite actions, scripts) comes
+                    # from a lead-controlled ref instead of the
+                    # dispatched one.
                     for ref in _checkout_refs(job):
                         if ref is None or not MI1_TRUSTED_REF_RE.match(ref):
                             shown = (
@@ -1136,10 +1279,11 @@ def check_mi1_reachability(state: dict) -> tuple[list[str], list[str]]:
                                 f"MI1-CHECKOUT: {job_where} checks out "
                                 f"{shown} in a dispatch-reachable gated "
                                 f"job; pin `ref: main` (or a full commit "
-                                f"SHA) so the code running with the gated "
-                                f"secret in scope is lead-controlled"
+                                f"SHA) so the checked-out tree running "
+                                f"with the gated secret in scope is "
+                                f"lead-controlled"
                             )
-    return violations, []
+    return violations, warnings
 
 
 CHECKS = (
@@ -2277,6 +2421,7 @@ def self_test() -> int:
                         "required_reviewers": 1,
                         "secrets": gly_op_secrets,
                         "branch_policy_mode": "custom",
+                        "branch_policy_branches": ["develop", "main"],
                         "prevent_self_review": True,
                         **lead_gate,
                     },
@@ -2285,6 +2430,7 @@ def self_test() -> int:
                         "required_reviewers": 1,
                         "secrets": gly_release_secrets,
                         "branch_policy_mode": "custom",
+                        "branch_policy_branches": ["develop", "main"],
                         "prevent_self_review": psr_flip,
                         "can_admins_bypass": cab_flip,
                         "reviewers": (
@@ -2574,23 +2720,76 @@ def self_test() -> int:
             ),
             {"MI1-TRIGGER"},
         )
+    # Clause 2, push half: a gated job's push trigger must carry a
+    # provable whitelist of trusted branches -- a bare push (all
+    # branches) or a develop entry hands every merged PR a gated run.
+    expect(
+        "mi1-push-unfiltered",
+        _mi1_state(
+            "on: push\njobs:\n  j:\n    environment: release-gated\n    steps: []\n"
+        ),
+        {"MI1-PUSH"},
+    )
+    expect(
+        "mi1-push-develop",
+        _mi1_state(
+            "on:\n  push:\n    branches: [develop, main]\n"
+            "jobs:\n  j:\n    environment: release-gated\n    steps: []\n"
+        ),
+        {"MI1-PUSH"},
+    )
+    # A workflow carrying both a forbidden trigger and dispatch reports
+    # both clauses -- neither masks the other.
+    expect(
+        "mi1-dispatch-plus-forbidden",
+        _mi1_state(
+            "on:\n  workflow_dispatch:\n  workflow_run:\n"
+            "jobs:\n  j:\n    environment: release-gated\n    steps: []\n"
+        ),
+        {"MI1-TRIGGER", "MI1-DISPATCH"},
+    )
+    # The environment mapping form (name: + url:) resolves like the
+    # string form.
+    expect(
+        "mi1-dispatch-env-mapping-form",
+        _mi1_state(
+            "on:\n  workflow_dispatch:\njobs:\n  j:\n"
+            "    environment:\n      name: release-gated\n"
+            "      url: https://example.invalid\n    steps: []\n"
+        ),
+        {"MI1-DISPATCH"},
+    )
     # Clauses 4+5: the dispatch-only canary on a dispatch-safe pinned
     # environment with a trusted-ref checkout is compliant; an unpinned or
     # untrusted checkout runs dispatched-ref code with the gated secret in
     # scope and fails.
+    CANARY_PATH = ".github/workflows/secrets-plumbing-check.yml"
     expect(
         "mi1-canary-dispatch-clean",
-        _mi1_state(canary_wf(PINNED_CHECKOUT)),
+        _mi1_state(canary_wf(PINNED_CHECKOUT), CANARY_PATH),
         set(),
     )
     expect(
         "mi1-canary-unpinned-checkout",
-        _mi1_state(canary_wf(UNPINNED_CHECKOUT)),
+        _mi1_state(canary_wf(UNPINNED_CHECKOUT), CANARY_PATH),
         {"MI1-CHECKOUT"},
     )
     expect(
         "mi1-canary-untrusted-checkout",
-        _mi1_state(canary_wf(DEV_REF_CHECKOUT)),
+        _mi1_state(canary_wf(DEV_REF_CHECKOUT), CANARY_PATH),
+        {"MI1-CHECKOUT"},
+    )
+    # GitHub resolves action owner/repo case-insensitively, so
+    # Actions/Checkout is the real checkout and must not evade clause 4.
+    expect(
+        "mi1-canary-cased-checkout-evasion",
+        _mi1_state(canary_wf("      - uses: Actions/Checkout@sha\n"), CANARY_PATH),
+        {"MI1-CHECKOUT"},
+    )
+    # A pinned first checkout does not excuse an unpinned second one.
+    expect(
+        "mi1-canary-second-checkout-unpinned",
+        _mi1_state(canary_wf(PINNED_CHECKOUT + UNPINNED_CHECKOUT), CANARY_PATH),
         {"MI1-CHECKOUT"},
     )
     # A dynamic environment name cannot be statically proven safe -> the
@@ -2613,8 +2812,11 @@ def self_test() -> int:
         {"MI1-UNPARSEABLE"},
     )
     # The ratchet is per-repo: the same dispatch shape on a repo not yet
-    # ported stays clean (the porting checklist adds each repo to
-    # MI1_ENFORCED_REPOS once its workflows comply).
+    # ported does not fail (the porting checklist adds each repo to
+    # MI1_ENFORCED_REPOS once its workflows comply). With the empty
+    # expectation map the repo holds no gated environments, so not even
+    # the MI1-PENDING warning fires -- the warning fixture below covers
+    # the secrets-held case.
     expect(
         "mi1-nonenforced-repo-clean",
         {
@@ -2629,14 +2831,15 @@ def self_test() -> int:
         set(),
     )
 
-    # Clause 1: gated policy shape. Posture fields mirror the live pin so
-    # only the policy mode under test deviates.
-    def _op_env(mode: str | None) -> dict:
+    # Clause 1: gated policy shape and branch bound. Posture fields
+    # mirror the live pin so only the policy under test deviates.
+    def _op_env(mode: str | None, branches: list[str] | None = None) -> dict:
         return {
             "name": "op-github-gated",
             "required_reviewers": 1,
             "secrets": [],
             "branch_policy_mode": mode,
+            "branch_policy_branches": branches,
             "prevent_self_review": True,
             "can_admins_bypass": False,
             "reviewers": ["User:jlengelbrecht"],
@@ -2662,7 +2865,35 @@ def self_test() -> int:
         "mi1-policy-custom-clean",
         {
             "org_secrets": [],
-            "repos": [_repo("GlycemicGPT", environments=[_op_env("custom")])],
+            "repos": [
+                _repo(
+                    "GlycemicGPT",
+                    environments=[_op_env("custom", ["develop", "main"])],
+                )
+            ],
+        },
+        set(),
+    )
+    # Widening the policy past its pinned bound fails; narrowing (the
+    # pending lead action drops develop) stays green.
+    expect(
+        "mi1-policy-bound-widened",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "GlycemicGPT",
+                    environments=[_op_env("custom", ["develop", "main", "staging"])],
+                )
+            ],
+        },
+        {"MI1-POLICY"},
+    )
+    expect(
+        "mi1-policy-bound-narrowed-clean",
+        {
+            "org_secrets": [],
+            "repos": [_repo("GlycemicGPT", environments=[_op_env("custom", ["main"])])],
         },
         set(),
     )
@@ -2677,7 +2908,7 @@ def self_test() -> int:
         expect(
             "mi1-escape-pin-reviewerless",
             {"org_secrets": [], "repos": []},
-            {"MI1-ESCAPE"},
+            {"MI1-ESCAPE-PIN"},
         )
     finally:
         GATED_ENV_PROTECTION_BASELINE[_op_key] = _saved_posture
@@ -2691,11 +2922,7 @@ def self_test() -> int:
             "repos": [
                 _repo(
                     "GlycemicGPT",
-                    workflows={
-                        ".github/workflows/secrets-plumbing-check.yml": canary_wf(
-                            PINNED_CHECKOUT
-                        )
-                    },
+                    workflows={CANARY_PATH: canary_wf(PINNED_CHECKOUT)},
                     environments=[
                         {
                             "name": "op-github-gated",
@@ -2710,7 +2937,39 @@ def self_test() -> int:
                 )
             ],
         },
-        {"MI1-ESCAPE", "ENV-UNGATED", "ENV-PROTECTION"},
+        {"MI1-ESCAPE-LIVE", "ENV-UNGATED", "ENV-PROTECTION"},
+    )
+
+    # An un-enforced repo that holds gated secrets AND has a
+    # dispatch-reachable gated job warns (never silently exempt): the
+    # porting checklist turns the warning into enforcement. Scoped to an
+    # android-only expectation map so the fixture models one repo.
+    EXPECTED_GATED_ENVIRONMENTS = {
+        "android-unofficial": {"release-gated": {"MERGE_APP_ID"}}
+    }
+    expect(
+        "mi1-pending-nonenforced-warns",
+        {
+            "org_secrets": [],
+            "repos": [
+                _repo(
+                    "android-unofficial",
+                    workflows={".github/workflows/release.yml": release_dispatch_wf},
+                    environments=[
+                        {
+                            "name": "release-gated",
+                            "required_reviewers": 1,
+                            "secrets": ["MERGE_APP_ID"],
+                            "prevent_self_review": False,
+                            "can_admins_bypass": False,
+                            "reviewers": ["User:jlengelbrecht"],
+                        }
+                    ],
+                )
+            ],
+        },
+        set(),
+        warn_codes={"MI1-PENDING"},
     )
 
     EXPECTED_GATED_ENVIRONMENTS = _production_map


### PR DESCRIPTION
## What

Removes the `workflow_dispatch` reachability path into the `release-gated` environment and encodes the gated-secret reachability invariant (MI-1) so the path cannot silently return.

A deployment branch policy binds the ref, not the actor: a dispatch on any policy-listed branch passes the policy, so any write-access collaborator could start a gated release, changelog, or merge run. This lands the prerequisites for the planned reviewer-fatigue reduction; no environment reviewer is touched here.

## Changes

- `release.yml`, `changelog-pr.yml`: drop `workflow_dispatch`; remove the dispatch branch of the changelog job's `if:` and the now-dead time fallback (the job's `if:` matches on `head_commit.message`, so `head_commit.timestamp` always exists — a fail-closed guard replaces the fallback).
- `scripts/security/check-secret-invariants.py`: new MI-1 reachability check, all five clauses — custom-policy shape with a pinned branch-set bound, no dispatch on workflows containing gated jobs, hard fail on `pull_request_target` / `workflow_run` / `repository_dispatch` / `workflow_call` / `schedule`, trusted-ref checkout pinning for dispatch-reachable gated jobs, and the escape hatch for dispatch-only canaries (environment-keyed, requires a permanently pinned reviewer, surfaced as a warning on every run). Enforced per repo starting with this one; un-ported repos holding gated secrets warn as `MI1-PENDING`. Self-test grows from 60 to 89 red-team fixtures.
- `secrets-plumbing-check.yml`: pin the canary checkout to `ref: main` (defense in depth; the header states plainly that the required reviewer is the load-bearing control).
- `workflow-lint.yml`: correct guidance that recommended `pull_request_target`/`workflow_run` to authors needing secrets — both defeat deployment branch policies for gated jobs; the non-gated `workflow_run` + artifact pattern is documented with its enforcement scope stated.
- `regen-gradle-lockfiles-push.yml`: fix a stale comment claiming the Renovate app inherits a develop-ruleset bypass (live rulesets show none).
- `docs/dev/gated-environments.md`: align the consumer description and the `prevent_self_review` rationale with the invariant.

## Verification

- `check-secret-invariants.py --self-test`: 89/89 fixtures pass.
- `--repo-local .github/workflows`: clean (one expected pinned warning naming the canary escape hatch).
- Negative proof: temporarily re-adding `workflow_dispatch` to `release.yml` fails the audit with 4 MI1-DISPATCH violations (exit 1); reverted.
- Both ruff commands clean; edited workflows parse; CodeRabbit CLI review (committed, base develop): no findings; independent adversarial, code-quality, and security reviews completed with all findings addressed.

## Operational notes

- The dispatch path is only closed once this reaches `main` via a promotion — `main`'s workflow copies still carry the trigger until then.
- For the same reason, the scheduled Secrets Hygiene live audit will report MI-1 violations against `main`'s copies between this merge and the promotion. That is fail-closed on real, still-live exposure; the promotion is the closing action and should follow promptly.
- Sibling repos (`website`, `android-unofficial`) intentionally remain un-enforced and surface as `MI1-PENDING` warnings until each is ported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added stronger safeguards for workflows handling gated secrets, including trusted branch, trigger, checkout, and reviewer validation.
  * Expanded automated checks to detect policy drift and unsafe workflow configurations.

* **Documentation**
  * Clarified deployment branch policies, approval controls, workflow restrictions, and recovery procedures.
  * Updated guidance for gated environments and trusted workflow execution.

* **Chores**
  * Restricted release and changelog automation to pushes to the main branch, removing manual runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->