### PR TITLE
fix: patch HIGH-severity nanoid and js-yaml advisories

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1483,9 +1483,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9892,9 +9892,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -11678,9 +11678,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/sidecar/package-lock.json
+++ b/sidecar/package-lock.json
@@ -2695,9 +2695,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -28,6 +28,9 @@
     "esbuild": "^0.28.1",
     "@opentelemetry/core": "^2.8.0",
     "brace-expansion": "^5.0.9",
-    "vite": "^7.3.5"
+    "vite": "^7.3.5",
+    "postcss": {
+      "nanoid": "^3.3.18"
+    }
   }
 }


### PR DESCRIPTION
## Summary

The Dependency Vulnerability Scan (OSV-Scanner) gate is red on `develop`, blocking the pending promotion PR. Four HIGH-severity advisories in transitive npm dependencies, all with upstream patches available:

| Package | Current | Fixed | Lockfile |
|---|---|---|---|
| `nanoid` (GHSA-2v37-7h3g-55p8) | 3.3.16 | 3.3.18 | `apps/web/package-lock.json` |
| `nanoid` (dev, same advisory) | 3.3.16 | 3.3.18 | `sidecar/package-lock.json` |
| `js-yaml` (dev, GHSA-5p4m-2wfm-xmqj) | 3.15.0 | 3.15.1 | `apps/web/package-lock.json` |
| `js-yaml` (dev, same advisory) | 4.3.0 | 4.3.1 | `apps/web/package-lock.json` |

- **apps/web**: patched via a plain lockfile update — the existing parent ranges (`postcss`'s `nanoid` range, `@istanbuljs/load-nyc-config`'s and `@eslint/eslintrc`'s `js-yaml` ranges) already permit the fixed versions, so only `package-lock.json` moved.
- **sidecar**: `nanoid` is nested two levels down (`vitest` -> `vite` -> `postcss` -> `nanoid`) with no direct top-level consumer, so a plain update is a no-op (verified against a clean baseline). Added a scoped `overrides` entry (`"postcss": { "nanoid": "^3.3.18" }`) to move it without touching unrelated packages.

No source code changed — dependency lockfiles/manifest only.

## Verification

- OSV-Scanner (same command CI runs, `osv-scanner@v2.3.3`): before 4 unfiltered HIGH findings (exit 1) -> after 0 unfiltered findings (exit 0). The 10 previously-filtered advisories (ecdsa, setuptools, Next.js-nested postcss set) are unchanged — same GHSA IDs, same filter reasons.
- Jest (`apps/web`): 243/243 suites, 2251/2251 tests passing.
- Vitest (`sidecar`): 12/12 files, 125/125 tests passing.
- `docker compose build` succeeded for all services; API and web health checks returned healthy on an isolated verification stack.
- Dashboard rendered correctly (headless render check) with no console/build errors from the transitive bumps — Playwright MCP's interactive browser launch was not available in this session (environment-level tooling issue, unrelated to this change), so the check was done via a headless DOM render instead.
- Adversarial and senior code-quality reviews: no HIGH findings. One MEDIUM (redundant override) was raised and independently disproven with a clean-baseline test; one MEDIUM is a pre-existing, unrelated `osv-scanner.toml` suppression (`ecdsa`/GHSA-wj6h-64fc-37mp) that expires 2026-08-25 — flagged as a follow-up, not addressed here since it's outside this PR's scope.
- CodeRabbit CLI flagged nanoid 3.3.18 as possibly unpublished; verified directly against the live npm registry (`npm view nanoid@3.3.18`) and it exists and matches the lockfile integrity hash exactly — dismissed as a stale/incorrect finding.
- Security review of the diff: clean, no secrets, no supply-chain concerns, override is a floor-raise only.

## Test plan

- [x] OSV-Scanner: 0 unfiltered HIGH findings, 10 filtered advisories unchanged
- [x] `apps/web` Jest suite passes
- [x] `sidecar` Vitest suite passes
- [x] Docker stack builds and health checks pass
- [x] Adversarial + senior code-quality review
- [x] CodeRabbit CLI review
- [x] Security review of diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling configuration to use a compatible version of `nanoid`.
  * Improved reliability of the application’s asset-processing and build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->