### PR TITLE
fix(web): mock SSE stream lifecycle, unknown-event scenario, and clinical report guard

### DIFF
--- a/apps/web/src/app/dashboard/reports/clinical/BolusTable.test.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/BolusTable.test.tsx
@@ -63,7 +63,7 @@ describe("clinical report BolusTable", () => {
     warnSpy.mockRestore();
   });
 
-  it("shows the no-data message when every row is filtered out", () => {
+  it("shows a distinct message (not the no-data message) when every row is filtered out", () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
     render(
@@ -85,10 +85,21 @@ describe("clinical report BolusTable", () => {
     );
 
     expect(
-      screen.getByText("No bolus events for this period."),
+      screen.getByText("1 bolus event could not be displayed."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No bolus events for this period."),
+    ).not.toBeInTheDocument();
 
     warnSpy.mockRestore();
+  });
+
+  it("shows the true no-data message when there are no bolus events at all", () => {
+    render(<BolusTable boluses={[]} totalCount={0} />);
+
+    expect(
+      screen.getByText("No bolus events for this period."),
+    ).toBeInTheDocument();
   });
 
   it("shows a truncation notice measured against the known-row count", () => {

--- a/apps/web/src/app/dashboard/reports/clinical/BolusTable.test.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/BolusTable.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import { BolusTable } from "./page";
+import { BolusTable } from "./BolusTable";
 import type { BolusReviewItem } from "@/lib/api";
 
 function makeBoluses(): BolusReviewItem[] {

--- a/apps/web/src/app/dashboard/reports/clinical/BolusTable.test.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/BolusTable.test.tsx
@@ -102,10 +102,69 @@ describe("clinical report BolusTable", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows a truncation notice measured against the known-row count", () => {
+  it("shows a truncation notice measured against the unfiltered fetch count", () => {
     render(<BolusTable boluses={makeBoluses()} totalCount={150} />);
     expect(
-      screen.getByText(/Showing most recent 2 of 150 bolus/),
+      screen.getByText(
+        /This response shows 2 recognized bolus events from 150 total bolus events/,
+      ),
     ).toBeInTheDocument();
+  });
+
+  it("separates withheld-row and pagination messages for a mixed known/unknown fetch (GLY-270)", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const boluses: BolusReviewItem[] = [
+      ...makeBoluses(),
+      {
+        event_timestamp: "2026-03-01T09:00:00Z",
+        event_type: "device_event",
+        units: 1.2,
+        is_automated: false,
+        control_iq_reason: null,
+        pump_activity_mode: null,
+        iob_at_event: null,
+        bg_at_event: null,
+      },
+    ];
+
+    // totalCount === boluses.length: nothing more exists server-side, so the
+    // pagination hint must stay hidden even though a row was withheld.
+    render(<BolusTable boluses={boluses} totalCount={boluses.length} />);
+
+    expect(
+      screen.getByText(
+        "1 bolus event could not be displayed because the event type is unrecognized.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/total bolus events/),
+    ).not.toBeInTheDocument();
+
+    warnSpy.mockRestore();
+  });
+
+  it("clamps implausible dose, BG, and IoB values instead of rendering them raw (GLY-270)", () => {
+    render(
+      <BolusTable
+        boluses={[
+          {
+            event_timestamp: "2026-03-01T14:30:00Z",
+            event_type: "bolus",
+            units: 9001,
+            is_automated: false,
+            control_iq_reason: null,
+            pump_activity_mode: null,
+            iob_at_event: 500,
+            bg_at_event: 9999,
+          },
+        ]}
+        totalCount={1}
+      />,
+    );
+
+    expect(screen.getByText(">60 U")).toBeInTheDocument();
+    expect(screen.getByText(">20 U")).toBeInTheDocument();
+    expect(screen.getByText("500")).toBeInTheDocument();
+    expect(screen.queryByText("9999")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/dashboard/reports/clinical/BolusTable.test.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/BolusTable.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for the clinical report's `BolusTable` (GLY-270).
+ *
+ * Mirrors the guard test in BolusReviewTable.test.tsx and
+ * dashboard/bolus-review-table.tsx: an unrecognized `event_type` must never
+ * render as a real insulin dose in the clinician-facing report.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { BolusTable } from "./page";
+import type { BolusReviewItem } from "@/lib/api";
+
+function makeBoluses(): BolusReviewItem[] {
+  return [
+    {
+      event_timestamp: "2026-03-01T14:30:00Z",
+      event_type: "bolus",
+      units: 3.5,
+      is_automated: false,
+      control_iq_reason: null,
+      pump_activity_mode: null,
+      iob_at_event: 2.1,
+      bg_at_event: 185,
+    },
+    {
+      event_timestamp: "2026-03-01T12:00:00Z",
+      event_type: "correction",
+      units: 0.8,
+      is_automated: true,
+      control_iq_reason: "Correction",
+      pump_activity_mode: null,
+      iob_at_event: 1.5,
+      bg_at_event: 210,
+    },
+  ];
+}
+
+describe("clinical report BolusTable", () => {
+  it("never renders a row with an unrecognized event_type as a dose (GLY-270)", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const boluses: BolusReviewItem[] = [
+      {
+        event_timestamp: "2026-03-01T07:00:00Z",
+        event_type: "closed_loop_micro_dose",
+        units: 0.5,
+        is_automated: true,
+        control_iq_reason: null,
+        pump_activity_mode: null,
+        iob_at_event: 1.3,
+        bg_at_event: 142,
+      },
+      ...makeBoluses(),
+    ];
+
+    render(<BolusTable boluses={boluses} totalCount={boluses.length} />);
+
+    expect(screen.queryByText("0.50 U")).not.toBeInTheDocument();
+    expect(screen.getByText("3.50 U")).toBeInTheDocument();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("closed_loop_micro_dose"),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("shows the no-data message when every row is filtered out", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <BolusTable
+        boluses={[
+          {
+            event_timestamp: "2026-03-01T07:00:00Z",
+            event_type: "device_event",
+            units: 42,
+            is_automated: false,
+            control_iq_reason: null,
+            pump_activity_mode: null,
+            iob_at_event: null,
+            bg_at_event: null,
+          },
+        ]}
+        totalCount={1}
+      />,
+    );
+
+    expect(
+      screen.getByText("No bolus events for this period."),
+    ).toBeInTheDocument();
+
+    warnSpy.mockRestore();
+  });
+
+  it("shows a truncation notice measured against the known-row count", () => {
+    render(<BolusTable boluses={makeBoluses()} totalCount={150} />);
+    expect(
+      screen.getByText(/Showing most recent 2 of 150 bolus/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/dashboard/reports/clinical/BolusTable.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/BolusTable.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { formatGlucose, type GlucoseUnit } from "@/lib/glucose-units";
+import type { BolusReviewItem } from "@/lib/api";
+import {
+  isKnownBolusReviewEventType,
+  warnUnknownBolusReviewEventType,
+} from "@/components/InsulinTimeline/insulin-timeline-data";
+
+function filterKnownBoluses(
+  boluses: readonly BolusReviewItem[],
+): BolusReviewItem[] {
+  return boluses.filter((bolus) => {
+    if (isKnownBolusReviewEventType(bolus.event_type)) {
+      return true;
+    }
+    warnUnknownBolusReviewEventType(bolus.event_type, "ClinicalReportBolusTable");
+    return false;
+  });
+}
+
+export function BolusTable({
+  boluses,
+  totalCount,
+  unit = "mgdl",
+}: {
+  boluses: BolusReviewItem[];
+  totalCount: number;
+  unit?: GlucoseUnit;
+}) {
+  const knownBoluses = filterKnownBoluses(boluses);
+
+  if (knownBoluses.length === 0) {
+    // A clinician must never read an all-filtered result as "took no
+    // insulin" -- that's a different clinical fact than "every event this
+    // period had an unrecognized type and was withheld from the report".
+    return (
+      <p className="text-sm text-slate-500">
+        {boluses.length > 0
+          ? `${boluses.length} bolus event${boluses.length === 1 ? "" : "s"} could not be displayed.`
+          : "No bolus events for this period."}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b-2 border-slate-300 dark:border-slate-600 print:border-slate-400">
+              <th className="py-1.5 px-2 text-left text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
+                Date/Time
+              </th>
+              <th className="py-1.5 px-2 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
+                Units
+              </th>
+              <th className="py-1.5 px-2 text-center text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
+                Type
+              </th>
+              <th className="py-1.5 px-2 text-left text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
+                Reason
+              </th>
+              <th className="py-1.5 px-2 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
+                BG
+              </th>
+              <th className="py-1.5 px-2 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
+                IoB
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {knownBoluses.map((b, i) => {
+              const modeLabel: Record<string, string> = {
+                SLEEP: "Sleep Mode",
+                EXERCISE: "Exercise Mode",
+              };
+              const reasonLabel = b.is_automated
+                ? (b.control_iq_reason || "Auto-correction")
+                : (b.pump_activity_mode && b.pump_activity_mode !== "NONE"
+                    ? modeLabel[b.pump_activity_mode] ?? b.pump_activity_mode
+                    : "Manual");
+              return (
+                <tr
+                  key={`${b.event_timestamp}-${i}`}
+                  className="border-b border-slate-200 dark:border-slate-700 print:border-slate-300"
+                >
+                  <td className="py-1.5 px-2 text-slate-600 dark:text-slate-300 print:text-slate-700 whitespace-nowrap">
+                    {new Date(b.event_timestamp).toLocaleString([], {
+                      month: "short",
+                      day: "numeric",
+                      hour: "numeric",
+                      minute: "2-digit",
+                    })}
+                  </td>
+                  <td className="py-1.5 px-2 text-right font-medium text-slate-900 dark:text-white print:text-black">
+                    {b.units.toFixed(2)} U
+                  </td>
+                  <td className="py-1.5 px-2 text-center">
+                    {b.is_automated ? (
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-xs font-medium bg-violet-100 text-violet-700 print:bg-violet-50 print:text-violet-800">
+                        Auto
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-xs font-medium bg-slate-100 text-slate-600 print:bg-slate-50 print:text-slate-700">
+                        Manual
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-1.5 px-2 text-left text-xs text-slate-500 dark:text-slate-400 print:text-slate-600">
+                    {reasonLabel}
+                  </td>
+                  <td className="py-1.5 px-2 text-right text-slate-600 dark:text-slate-300 print:text-slate-700">
+                    {b.bg_at_event != null
+                      ? formatGlucose(b.bg_at_event, unit)
+                      : "---"}
+                  </td>
+                  <td className="py-1.5 px-2 text-right text-slate-600 dark:text-slate-300 print:text-slate-700">
+                    {b.iob_at_event != null
+                      ? `${b.iob_at_event.toFixed(1)} U`
+                      : "---"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      {totalCount > knownBoluses.length && (
+        <p className="text-xs text-slate-400 print:text-slate-500">
+          Showing most recent {knownBoluses.length} of {totalCount} bolus
+          events.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/reports/clinical/BolusTable.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/BolusTable.tsx
@@ -2,6 +2,7 @@
 
 import { formatGlucose, type GlucoseUnit } from "@/lib/glucose-units";
 import type { BolusReviewItem } from "@/lib/api";
+import { INSULIN_DOSE_LIMITS, MAX_DISPLAY_IOB_UNITS } from "@/lib/insulin";
 import {
   isKnownBolusReviewEventType,
   warnUnknownBolusReviewEventType,
@@ -19,6 +20,29 @@ function filterKnownBoluses(
   });
 }
 
+const BG_MIN = 20;
+const BG_MAX = 500;
+
+// Matches the display-only sanity clamps in dashboard/bolus-review-table.tsx
+// and BolusReviewTable.tsx: cap implausible/unit-confused values rather than
+// render them as a real dose or reading in a clinician-facing report.
+function formatUnits(value: number, maxDisplay: number): string {
+  if (!Number.isFinite(value) || value < 0) return "---";
+  if (value > maxDisplay) return `>${maxDisplay} U`;
+  return `${value.toFixed(2)} U`;
+}
+
+function formatBg(value: number, unit: GlucoseUnit): string {
+  const clamped = Math.min(BG_MAX, Math.max(BG_MIN, value));
+  return formatGlucose(clamped, unit);
+}
+
+function formatIob(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return "---";
+  if (value > MAX_DISPLAY_IOB_UNITS) return `>${MAX_DISPLAY_IOB_UNITS} U`;
+  return `${value.toFixed(1)} U`;
+}
+
 export function BolusTable({
   boluses,
   totalCount,
@@ -29,6 +53,7 @@ export function BolusTable({
   unit?: GlucoseUnit;
 }) {
   const knownBoluses = filterKnownBoluses(boluses);
+  const skippedCount = boluses.length - knownBoluses.length;
 
   if (knownBoluses.length === 0) {
     // A clinician must never read an all-filtered result as "took no
@@ -94,7 +119,12 @@ export function BolusTable({
                     })}
                   </td>
                   <td className="py-1.5 px-2 text-right font-medium text-slate-900 dark:text-white print:text-black">
-                    {b.units.toFixed(2)} U
+                    {formatUnits(
+                      b.units,
+                      b.event_type === "basal_injection"
+                        ? INSULIN_DOSE_LIMITS.maxBasalInjectionUnits
+                        : INSULIN_DOSE_LIMITS.maxBolusUnits,
+                    )}
                   </td>
                   <td className="py-1.5 px-2 text-center">
                     {b.is_automated ? (
@@ -112,12 +142,12 @@ export function BolusTable({
                   </td>
                   <td className="py-1.5 px-2 text-right text-slate-600 dark:text-slate-300 print:text-slate-700">
                     {b.bg_at_event != null
-                      ? formatGlucose(b.bg_at_event, unit)
+                      ? formatBg(b.bg_at_event, unit)
                       : "---"}
                   </td>
                   <td className="py-1.5 px-2 text-right text-slate-600 dark:text-slate-300 print:text-slate-700">
                     {b.iob_at_event != null
-                      ? `${b.iob_at_event.toFixed(1)} U`
+                      ? formatIob(b.iob_at_event)
                       : "---"}
                   </td>
                 </tr>
@@ -126,10 +156,16 @@ export function BolusTable({
           </tbody>
         </table>
       </div>
-      {totalCount > knownBoluses.length && (
+      {skippedCount > 0 && (
+        <p className="text-xs text-amber-700 dark:text-amber-300 print:text-amber-800">
+          {skippedCount} bolus event{skippedCount === 1 ? "" : "s"} could not
+          be displayed because the event type is unrecognized.
+        </p>
+      )}
+      {totalCount > boluses.length && (
         <p className="text-xs text-slate-400 print:text-slate-500">
-          Showing most recent {knownBoluses.length} of {totalCount} bolus
-          events.
+          This response shows {knownBoluses.length} recognized bolus events
+          from {totalCount} total bolus events.
         </p>
       )}
     </div>

--- a/apps/web/src/app/dashboard/reports/clinical/page.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/page.tsx
@@ -1442,9 +1442,14 @@ export function BolusTable({
   const knownBoluses = filterKnownBoluses(boluses);
 
   if (knownBoluses.length === 0) {
+    // A clinician must never read an all-filtered result as "took no
+    // insulin" -- that's a different clinical fact than "every event this
+    // period had an unrecognized type and was withheld from the report".
     return (
       <p className="text-sm text-slate-500">
-        No bolus events for this period.
+        {boluses.length > 0
+          ? `${boluses.length} bolus event${boluses.length === 1 ? "" : "s"} could not be displayed.`
+          : "No bolus events for this period."}
       </p>
     );
   }

--- a/apps/web/src/app/dashboard/reports/clinical/page.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/page.tsx
@@ -78,10 +78,7 @@ import {
 } from "@/lib/api";
 import { formatGlucose, unitLabel, type GlucoseUnit } from "@/lib/glucose-units";
 import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
-import {
-  isKnownBolusReviewEventType,
-  warnUnknownBolusReviewEventType,
-} from "@/components/InsulinTimeline/insulin-timeline-data";
+import { BolusTable } from "./BolusTable";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1414,135 +1411,6 @@ function PumpSettingsSection({
           minute: "2-digit",
         })}
       </p>
-    </div>
-  );
-}
-
-function filterKnownBoluses(
-  boluses: readonly BolusReviewItem[],
-): BolusReviewItem[] {
-  return boluses.filter((bolus) => {
-    if (isKnownBolusReviewEventType(bolus.event_type)) {
-      return true;
-    }
-    warnUnknownBolusReviewEventType(bolus.event_type, "ClinicalReportBolusTable");
-    return false;
-  });
-}
-
-export function BolusTable({
-  boluses,
-  totalCount,
-  unit = "mgdl",
-}: {
-  boluses: BolusReviewItem[];
-  totalCount: number;
-  unit?: GlucoseUnit;
-}) {
-  const knownBoluses = filterKnownBoluses(boluses);
-
-  if (knownBoluses.length === 0) {
-    // A clinician must never read an all-filtered result as "took no
-    // insulin" -- that's a different clinical fact than "every event this
-    // period had an unrecognized type and was withheld from the report".
-    return (
-      <p className="text-sm text-slate-500">
-        {boluses.length > 0
-          ? `${boluses.length} bolus event${boluses.length === 1 ? "" : "s"} could not be displayed.`
-          : "No bolus events for this period."}
-      </p>
-    );
-  }
-
-  return (
-    <div className="space-y-2">
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b-2 border-slate-300 dark:border-slate-600 print:border-slate-400">
-              <th className="py-1.5 px-2 text-left text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
-                Date/Time
-              </th>
-              <th className="py-1.5 px-2 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
-                Units
-              </th>
-              <th className="py-1.5 px-2 text-center text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
-                Type
-              </th>
-              <th className="py-1.5 px-2 text-left text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
-                Reason
-              </th>
-              <th className="py-1.5 px-2 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
-                BG
-              </th>
-              <th className="py-1.5 px-2 text-right text-xs font-semibold text-slate-500 print:text-slate-600 uppercase tracking-wider">
-                IoB
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {knownBoluses.map((b, i) => {
-              const modeLabel: Record<string, string> = {
-                SLEEP: "Sleep Mode",
-                EXERCISE: "Exercise Mode",
-              };
-              const reasonLabel = b.is_automated
-                ? (b.control_iq_reason || "Auto-correction")
-                : (b.pump_activity_mode && b.pump_activity_mode !== "NONE"
-                    ? modeLabel[b.pump_activity_mode] ?? b.pump_activity_mode
-                    : "Manual");
-              return (
-                <tr
-                  key={`${b.event_timestamp}-${i}`}
-                  className="border-b border-slate-200 dark:border-slate-700 print:border-slate-300"
-                >
-                  <td className="py-1.5 px-2 text-slate-600 dark:text-slate-300 print:text-slate-700 whitespace-nowrap">
-                    {new Date(b.event_timestamp).toLocaleString([], {
-                      month: "short",
-                      day: "numeric",
-                      hour: "numeric",
-                      minute: "2-digit",
-                    })}
-                  </td>
-                  <td className="py-1.5 px-2 text-right font-medium text-slate-900 dark:text-white print:text-black">
-                    {b.units.toFixed(2)} U
-                  </td>
-                  <td className="py-1.5 px-2 text-center">
-                    {b.is_automated ? (
-                      <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-xs font-medium bg-violet-100 text-violet-700 print:bg-violet-50 print:text-violet-800">
-                        Auto
-                      </span>
-                    ) : (
-                      <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-xs font-medium bg-slate-100 text-slate-600 print:bg-slate-50 print:text-slate-700">
-                        Manual
-                      </span>
-                    )}
-                  </td>
-                  <td className="py-1.5 px-2 text-left text-xs text-slate-500 dark:text-slate-400 print:text-slate-600">
-                    {reasonLabel}
-                  </td>
-                  <td className="py-1.5 px-2 text-right text-slate-600 dark:text-slate-300 print:text-slate-700">
-                    {b.bg_at_event != null
-                      ? formatGlucose(b.bg_at_event, unit)
-                      : "---"}
-                  </td>
-                  <td className="py-1.5 px-2 text-right text-slate-600 dark:text-slate-300 print:text-slate-700">
-                    {b.iob_at_event != null
-                      ? `${b.iob_at_event.toFixed(1)} U`
-                      : "---"}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-      {totalCount > knownBoluses.length && (
-        <p className="text-xs text-slate-400 print:text-slate-500">
-          Showing most recent {knownBoluses.length} of {totalCount} bolus
-          events.
-        </p>
-      )}
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/reports/clinical/page.tsx
+++ b/apps/web/src/app/dashboard/reports/clinical/page.tsx
@@ -78,6 +78,10 @@ import {
 } from "@/lib/api";
 import { formatGlucose, unitLabel, type GlucoseUnit } from "@/lib/glucose-units";
 import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
+import {
+  isKnownBolusReviewEventType,
+  warnUnknownBolusReviewEventType,
+} from "@/components/InsulinTimeline/insulin-timeline-data";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1414,7 +1418,19 @@ function PumpSettingsSection({
   );
 }
 
-function BolusTable({
+function filterKnownBoluses(
+  boluses: readonly BolusReviewItem[],
+): BolusReviewItem[] {
+  return boluses.filter((bolus) => {
+    if (isKnownBolusReviewEventType(bolus.event_type)) {
+      return true;
+    }
+    warnUnknownBolusReviewEventType(bolus.event_type, "ClinicalReportBolusTable");
+    return false;
+  });
+}
+
+export function BolusTable({
   boluses,
   totalCount,
   unit = "mgdl",
@@ -1423,7 +1439,9 @@ function BolusTable({
   totalCount: number;
   unit?: GlucoseUnit;
 }) {
-  if (boluses.length === 0) {
+  const knownBoluses = filterKnownBoluses(boluses);
+
+  if (knownBoluses.length === 0) {
     return (
       <p className="text-sm text-slate-500">
         No bolus events for this period.
@@ -1458,7 +1476,7 @@ function BolusTable({
             </tr>
           </thead>
           <tbody>
-            {boluses.map((b, i) => {
+            {knownBoluses.map((b, i) => {
               const modeLabel: Record<string, string> = {
                 SLEEP: "Sleep Mode",
                 EXERCISE: "Exercise Mode",
@@ -1514,9 +1532,10 @@ function BolusTable({
           </tbody>
         </table>
       </div>
-      {totalCount > boluses.length && (
+      {totalCount > knownBoluses.length && (
         <p className="text-xs text-slate-400 print:text-slate-500">
-          Showing most recent {boluses.length} of {totalCount} bolus events.
+          Showing most recent {knownBoluses.length} of {totalCount} bolus
+          events.
         </p>
       )}
     </div>

--- a/apps/web/src/components/InsulinTimeline/insulin-timeline-data.ts
+++ b/apps/web/src/components/InsulinTimeline/insulin-timeline-data.ts
@@ -152,28 +152,39 @@ export function isKnownBolusReviewEventType(
   return KNOWN_BOLUS_REVIEW_EVENT_TYPES.has(eventType);
 }
 
-// Tracks event_type values already warned about, so a feed that keeps emitting
-// the same unrecognized value doesn't spam a console.warn (and a Sentry
-// breadcrumb) on every render.
+// Tracks `source:event_type` pairs already warned about, so a feed that
+// keeps emitting the same unrecognized value doesn't spam a console.warn
+// (and a Sentry breadcrumb) on every render. Keyed per source -- otherwise
+// the dashboard's table warning about a value would silently suppress the
+// clinical report's warning about the same value.
 const warnedUnknownBolusReviewEventTypes = new Set<string>();
+
+// Caps the interpolated event_type in the log line so a future free-form
+// value can't bloat logs/breadcrumbs.
+const MAX_LOGGED_EVENT_TYPE_LENGTH = 64;
 
 /** Warns (dev-visible; Sentry picks up console breadcrumbs where configured)
  * whenever a row is skipped for carrying an unrecognized `event_type`, so the
- * skip is observable instead of silent. Deduped per unique `event_type` across
- * the whole session -- otherwise a recurring unknown value would re-warn on
- * every render/poll. */
+ * skip is observable instead of silent. Deduped per `source` + `event_type`
+ * pair across the whole session -- otherwise a recurring unknown value would
+ * re-warn on every render/poll, or silence a different surface's warning. */
 export function warnUnknownBolusReviewEventType(
   eventType: BolusReviewItem["event_type"],
   source: string
 ): void {
-  const key = JSON.stringify(eventType);
-  if (warnedUnknownBolusReviewEventTypes.has(key)) {
+  const rawKey = JSON.stringify(eventType);
+  const dedupeKey = `${source}:${rawKey}`;
+  if (warnedUnknownBolusReviewEventTypes.has(dedupeKey)) {
     return;
   }
-  warnedUnknownBolusReviewEventTypes.add(key);
+  warnedUnknownBolusReviewEventTypes.add(dedupeKey);
 
+  const loggedKey =
+    rawKey.length > MAX_LOGGED_EVENT_TYPE_LENGTH
+      ? `${rawKey.slice(0, MAX_LOGGED_EVENT_TYPE_LENGTH)}...`
+      : rawKey;
   console.warn(
-    `[${source}] skipping BolusReviewItem with unrecognized event_type: ${key}`
+    `[${source}] skipping BolusReviewItem with unrecognized event_type: ${loggedKey}`
   );
 }
 

--- a/apps/web/src/mocks/DevMockPanel.test.tsx
+++ b/apps/web/src/mocks/DevMockPanel.test.tsx
@@ -199,6 +199,22 @@ describe("DevMockPanel", () => {
     ).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("can include the unrecognized bolus review event type scenario", async () => {
+    const user = userEvent.setup();
+    render(<DevMockPanel runtimeActive />);
+    await user.click(await screen.findByRole("tab", { name: "API" }));
+
+    const unknownEventToggle = await screen.findByRole("checkbox", {
+      name: /Include unrecognized bolus review event type/i,
+    });
+
+    expect(unknownEventToggle).not.toBeChecked();
+
+    await user.click(unknownEventToggle);
+
+    expect(getMockRuntimeState().bolusReviewIncludeUnknownEventType).toBe(true);
+  });
+
   it("dispatches every V2 notification variant", async () => {
     const user = userEvent.setup();
     const requests: MockNotificationRequest[] = [];

--- a/apps/web/src/mocks/DevMockPanel.tsx
+++ b/apps/web/src/mocks/DevMockPanel.tsx
@@ -696,17 +696,6 @@ export function DevMockPanel({ runtimeActive = false }: DevMockPanelProps) {
                     }
                   />
 
-                  <Checkbox
-                    checked={draft.bolusReviewIncludeUnknownEventType}
-                    label="Include unrecognized bolus review event type"
-                    labelClassName={labelClassName("text-foreground-primary")}
-                    onCheckedChange={(bolusReviewIncludeUnknownEventType) =>
-                      applyRuntimeState({
-                        bolusReviewIncludeUnknownEventType,
-                      })
-                    }
-                  />
-
                   <button
                     aria-pressed={draft.tandemAutomaticSyncShouldFail}
                     className={buttonClassName(
@@ -726,6 +715,33 @@ export function DevMockPanel({ runtimeActive = false }: DevMockPanelProps) {
                       ? "Clear automatic pump sync failure"
                       : "Trigger automatic pump sync failure"}
                   </button>
+
+                  <Checkbox
+                    checked={draft.bolusReviewIncludeUnknownEventType}
+                    label={
+                      <span className="grid">
+                        <span
+                          className={labelClassName("text-foreground-primary")}
+                        >
+                          Include unrecognized bolus review event type
+                        </span>
+                        <span
+                          className={captionClassName(
+                            "text-foreground-secondary",
+                          )}
+                        >
+                          Logs one console warning per session (deduped) and
+                          adds 1 to the &quot;Showing N of M bolus events&quot;
+                          footer count.
+                        </span>
+                      </span>
+                    }
+                    onCheckedChange={(bolusReviewIncludeUnknownEventType) =>
+                      applyRuntimeState({
+                        bolusReviewIncludeUnknownEventType,
+                      })
+                    }
+                  />
                 </div>
 
                 <div className="grid content-start gap-3 border-border-default lg:border-l lg:pl-4">

--- a/apps/web/src/mocks/DevMockPanel.tsx
+++ b/apps/web/src/mocks/DevMockPanel.tsx
@@ -730,9 +730,9 @@ export function DevMockPanel({ runtimeActive = false }: DevMockPanelProps) {
                             "text-foreground-secondary",
                           )}
                         >
-                          Logs one console warning per session (deduped) and
-                          adds 1 to the &quot;Showing N of M bolus events&quot;
-                          footer count.
+                          Logs one console warning per surface per session
+                          (deduped) and adds 1 to the &quot;Showing N of M
+                          bolus events&quot; footer count.
                         </span>
                       </span>
                     }

--- a/apps/web/src/mocks/DevMockPanel.tsx
+++ b/apps/web/src/mocks/DevMockPanel.tsx
@@ -696,6 +696,17 @@ export function DevMockPanel({ runtimeActive = false }: DevMockPanelProps) {
                     }
                   />
 
+                  <Checkbox
+                    checked={draft.bolusReviewIncludeUnknownEventType}
+                    label="Include unrecognized bolus review event type"
+                    labelClassName={labelClassName("text-foreground-primary")}
+                    onCheckedChange={(bolusReviewIncludeUnknownEventType) =>
+                      applyRuntimeState({
+                        bolusReviewIncludeUnknownEventType,
+                      })
+                    }
+                  />
+
                   <button
                     aria-pressed={draft.tandemAutomaticSyncShouldFail}
                     className={buttonClassName(

--- a/apps/web/src/mocks/MockProvider.test.tsx
+++ b/apps/web/src/mocks/MockProvider.test.tsx
@@ -204,6 +204,36 @@ describe("MockProvider", () => {
     await waitFor(() => expect(onMount).toHaveBeenCalledTimes(2));
   });
 
+  it("remounts application content when the unrecognized bolus review event type scenario changes", async () => {
+    const onMount = jest.fn();
+
+    function MountProbe() {
+      useEffect(() => {
+        onMount();
+      }, []);
+
+      return <div>App content</div>;
+    }
+
+    render(
+      <MockProvider initialShouldMock>
+        <MountProbe />
+      </MockProvider>,
+    );
+
+    expect(await screen.findByText("App content")).toBeInTheDocument();
+    expect(onMount).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setMockRuntimeState({
+        bolusReviewIncludeUnknownEventType: true,
+        enabled: true,
+      });
+    });
+
+    await waitFor(() => expect(onMount).toHaveBeenCalledTimes(2));
+  });
+
   it("does not remount application content for profile-only state changes", async () => {
     const onMount = jest.fn();
 

--- a/apps/web/src/mocks/MockProvider.tsx
+++ b/apps/web/src/mocks/MockProvider.tsx
@@ -26,6 +26,8 @@ function contentStateKey(state: MockRuntimeState): string {
     glucoseEvent: state.glucoseEvent,
     glucoseUnit: state.glucoseUnit,
     tandemAutomaticSyncShouldFail: state.tandemAutomaticSyncShouldFail,
+    bolusReviewIncludeUnknownEventType:
+      state.bolusReviewIncludeUnknownEventType,
   });
 }
 

--- a/apps/web/src/mocks/data.test.ts
+++ b/apps/web/src/mocks/data.test.ts
@@ -37,6 +37,7 @@ const baseState: MockRuntimeState = {
   tandemSyncIntervalMinutes: 15,
   tandemAutomaticSyncShouldFail: false,
   tandemSyncShouldFail: false,
+  bolusReviewIncludeUnknownEventType: false,
   cgmBackfillDays: 30,
   knowledgeDocumentCount: 1,
   liveMode: true,
@@ -488,6 +489,7 @@ describe("mock data generator", () => {
       new Date("2026-07-06T20:00:00.000Z"),
     );
     const response = buildBolusReview(
+      state,
       snapshot,
       new URLSearchParams("days=1&limit=500"),
     );
@@ -547,6 +549,7 @@ describe("mock data generator", () => {
       (event) => event.event_type === "basal_injection",
     );
     const review = buildBolusReview(
+      state,
       snapshot,
       new URLSearchParams("days=2&limit=20"),
     );
@@ -619,7 +622,7 @@ describe("mock data generator", () => {
 
     expect(snapshot.pumpEvents).toEqual([]);
     expect(
-      buildBolusReview(snapshot, new URLSearchParams("days=2&limit=20")),
+      buildBolusReview(state, snapshot, new URLSearchParams("days=2&limit=20")),
     ).toMatchObject({ boluses: [], total_count: 0 });
     expect(
       buildInsulinSummary(snapshot, new URLSearchParams("days=2")),

--- a/apps/web/src/mocks/data.ts
+++ b/apps/web/src/mocks/data.ts
@@ -1,6 +1,7 @@
 import type {
   ActiveAlertsResponse,
   AlertThresholdResponse,
+  BolusReviewItem,
   BolusReviewResponse,
   CgmSourcesResponse,
   CurrentUserResponse,
@@ -40,6 +41,7 @@ import type {
 import { formatGlucose, unitLabel } from "@/lib/glucose-units";
 import type { GlucoseUnit } from "@/lib/glucose-units";
 
+import { bolusReviewUnknownEventTypeFixture } from "./fixtures";
 import type {
   MockCgmSource,
   MockDailyBriefResponse,
@@ -1609,6 +1611,7 @@ export function recordMockInsightResponse(
 }
 
 export function buildBolusReview(
+  state: MockRuntimeState,
   snapshot: MockDataSnapshot,
   params: URLSearchParams,
 ): BolusReviewResponse {
@@ -1629,20 +1632,30 @@ export function buildBolusReview(
         event.event_type === "basal_injection",
     )
     .reverse();
-  const boluses = reviewEvents.slice(offset, offset + limit).map((event) => ({
-    event_timestamp: event.event_timestamp,
-    event_type: event.event_type,
-    units: event.units ?? 0,
-    is_automated: event.is_automated,
-    control_iq_reason: event.control_iq_reason,
-    pump_activity_mode: event.pump_activity_mode,
-    iob_at_event: event.iob_at_event,
-    bg_at_event: event.bg_at_event,
-  }));
+  const boluses: BolusReviewItem[] = reviewEvents
+    .slice(offset, offset + limit)
+    .map((event) => ({
+      event_timestamp: event.event_timestamp,
+      event_type: event.event_type,
+      units: event.units ?? 0,
+      is_automated: event.is_automated,
+      control_iq_reason: event.control_iq_reason,
+      pump_activity_mode: event.pump_activity_mode,
+      iob_at_event: event.iob_at_event,
+      bg_at_event: event.bg_at_event,
+    }));
+
+  // GLY-270: gives the DevMockPanel a live entry point for
+  // `bolusReviewUnknownEventTypeFixture`, which otherwise only unit tests
+  // exercised. Appended after pagination so the scenario is always visible
+  // without disturbing the windowed/paginated bolus/correction rows above.
+  if (state.bolusReviewIncludeUnknownEventType) {
+    boluses.push(bolusReviewUnknownEventTypeFixture);
+  }
 
   return {
     boluses,
-    total_count: reviewEvents.length,
+    total_count: reviewEvents.length + (state.bolusReviewIncludeUnknownEventType ? 1 : 0),
     period_days: periodDays,
   };
 }

--- a/apps/web/src/mocks/data.ts
+++ b/apps/web/src/mocks/data.ts
@@ -41,7 +41,6 @@ import type {
 import { formatGlucose, unitLabel } from "@/lib/glucose-units";
 import type { GlucoseUnit } from "@/lib/glucose-units";
 
-import { bolusReviewUnknownEventTypeFixture } from "./fixtures";
 import type {
   MockCgmSource,
   MockDailyBriefResponse,
@@ -1617,6 +1616,30 @@ export function recordMockInsightResponse(
   };
 }
 
+// GLY-270: mirrors `contracts/fixtures/bolus_review_unknown_event_type.json`
+// (`bolusReviewUnknownEventTypeFixture` in ./fixtures.ts) but is defined
+// inline rather than imported from there. `fixtures.ts` pulls in
+// `contracts/fixtures/*.json`, which does not exist inside the web Docker
+// build context (`docker-compose.yml` builds the image with
+// `context: ./apps/web`); `data.ts` is part of the real bundle (dev-mock
+// mode ships in production JS, gated by a runtime header, not build-time
+// tree-shaking), so importing fixtures.ts from here breaks
+// `docker compose build web`. Pinned equal to the fixture (modulo
+// `event_timestamp`, which the fixture's caller always overrides) by a test
+// in `fixtures.test.ts` -- not `data.test.ts`, since that file IS part of
+// the Next build graph and importing fixtures.ts from it would reintroduce
+// this same break. A drifted copy fails that test.
+export const bolusReviewUnknownEventTypeRow = {
+  event_timestamp: "2026-01-15T20:10:00Z",
+  event_type: "closed_loop_micro_dose",
+  units: 0.5,
+  is_automated: true,
+  control_iq_reason: null,
+  pump_activity_mode: null,
+  iob_at_event: 1.3,
+  bg_at_event: 142,
+} satisfies BolusReviewItem;
+
 export function buildBolusReview(
   state: MockRuntimeState,
   snapshot: MockDataSnapshot,
@@ -1656,16 +1679,16 @@ export function buildBolusReview(
   }));
 
   // GLY-270: gives the DevMockPanel a live entry point for
-  // `bolusReviewUnknownEventTypeFixture`, which otherwise only unit tests
+  // `bolusReviewUnknownEventTypeRow`, which otherwise only unit tests
   // exercised. Injected into the range-filtered collection BEFORE the
   // pagination slice, so both `boluses` and `total_count` are derived from
   // the same post-injection collection and the row can't duplicate onto a
   // later page. Spread-copied with the request window's own end timestamp
-  // -- the fixture's fixed date isn't the point, its unrecognized
-  // `event_type` is, and it must land inside whatever range was requested.
+  // -- the row's fixed date isn't the point, its unrecognized `event_type`
+  // is, and it must land inside whatever range was requested.
   if (state.bolusReviewIncludeUnknownEventType) {
     mappedBoluses.unshift({
-      ...bolusReviewUnknownEventTypeFixture,
+      ...bolusReviewUnknownEventTypeRow,
       event_timestamp: iso(new Date(endTime)),
     });
   }

--- a/apps/web/src/mocks/data.ts
+++ b/apps/web/src/mocks/data.ts
@@ -1647,15 +1647,23 @@ export function buildBolusReview(
 
   // GLY-270: gives the DevMockPanel a live entry point for
   // `bolusReviewUnknownEventTypeFixture`, which otherwise only unit tests
-  // exercised. Appended after pagination so the scenario is always visible
-  // without disturbing the windowed/paginated bolus/correction rows above.
-  if (state.bolusReviewIncludeUnknownEventType) {
-    boluses.push(bolusReviewUnknownEventTypeFixture);
+  // exercised. Only injected on the first page (offset 0) so the scenario
+  // row doesn't shift across paginated requests or inflate later pages, and
+  // spread-copied with a fresh `event_timestamp` -- the fixture's own fixed
+  // date isn't the point, its unrecognized `event_type` is.
+  const includeUnknownEvent =
+    state.bolusReviewIncludeUnknownEventType && offset === 0;
+  const unknownEventDelta = includeUnknownEvent ? 1 : 0;
+  if (includeUnknownEvent) {
+    boluses.push({
+      ...bolusReviewUnknownEventTypeFixture,
+      event_timestamp: iso(new Date()),
+    });
   }
 
   return {
     boluses,
-    total_count: reviewEvents.length + (state.bolusReviewIncludeUnknownEventType ? 1 : 0),
+    total_count: reviewEvents.length + unknownEventDelta,
     period_days: periodDays,
   };
 }
@@ -1992,10 +2000,7 @@ function mockIobValueForEvent(event: MockGlucoseEvent): number {
 }
 
 type MockAlertType =
-  | "low_urgent"
-  | "low_warning"
-  | "high_warning"
-  | "high_urgent";
+  "low_urgent" | "low_warning" | "high_warning" | "high_urgent";
 type MockAlertSeverity = "info" | "warning" | "urgent" | "emergency";
 
 // Deterministic but UUID-shaped, like the real `Alert.id` the dashboard keys

--- a/apps/web/src/mocks/data.ts
+++ b/apps/web/src/mocks/data.ts
@@ -1186,7 +1186,12 @@ function insulinEventWindow(
   params: URLSearchParams,
   defaultDays: number,
   maxDays: number,
-): { events: PumpEventReading[]; periodDays: number } {
+): {
+  events: PumpEventReading[];
+  periodDays: number;
+  startTime: number;
+  endTime: number;
+} {
   const requestedDays = Number(params.get("days") ?? String(defaultDays));
   const fallbackDays = Number.isFinite(requestedDays)
     ? clamp(Math.round(requestedDays), 1, maxDays)
@@ -1213,6 +1218,8 @@ function insulinEventWindow(
       return timestamp >= startTime && timestamp <= endTime;
     }),
     periodDays,
+    startTime,
+    endTime,
   };
 }
 
@@ -1623,7 +1630,12 @@ export function buildBolusReview(
   const offset = Number.isFinite(requestedOffset)
     ? Math.max(0, Math.round(requestedOffset))
     : 0;
-  const { events, periodDays } = insulinEventWindow(snapshot, params, 7, 30);
+  const { events, periodDays, endTime } = insulinEventWindow(
+    snapshot,
+    params,
+    7,
+    30,
+  );
   const reviewEvents = events
     .filter(
       (event) =>
@@ -1632,38 +1644,35 @@ export function buildBolusReview(
         event.event_type === "basal_injection",
     )
     .reverse();
-  const boluses: BolusReviewItem[] = reviewEvents
-    .slice(offset, offset + limit)
-    .map((event) => ({
-      event_timestamp: event.event_timestamp,
-      event_type: event.event_type,
-      units: event.units ?? 0,
-      is_automated: event.is_automated,
-      control_iq_reason: event.control_iq_reason,
-      pump_activity_mode: event.pump_activity_mode,
-      iob_at_event: event.iob_at_event,
-      bg_at_event: event.bg_at_event,
-    }));
+  const mappedBoluses: BolusReviewItem[] = reviewEvents.map((event) => ({
+    event_timestamp: event.event_timestamp,
+    event_type: event.event_type,
+    units: event.units ?? 0,
+    is_automated: event.is_automated,
+    control_iq_reason: event.control_iq_reason,
+    pump_activity_mode: event.pump_activity_mode,
+    iob_at_event: event.iob_at_event,
+    bg_at_event: event.bg_at_event,
+  }));
 
   // GLY-270: gives the DevMockPanel a live entry point for
   // `bolusReviewUnknownEventTypeFixture`, which otherwise only unit tests
-  // exercised. Only injected on the first page (offset 0) so the scenario
-  // row doesn't shift across paginated requests or inflate later pages, and
-  // spread-copied with a fresh `event_timestamp` -- the fixture's own fixed
-  // date isn't the point, its unrecognized `event_type` is.
-  const includeUnknownEvent =
-    state.bolusReviewIncludeUnknownEventType && offset === 0;
-  const unknownEventDelta = includeUnknownEvent ? 1 : 0;
-  if (includeUnknownEvent) {
-    boluses.push({
+  // exercised. Injected into the range-filtered collection BEFORE the
+  // pagination slice, so both `boluses` and `total_count` are derived from
+  // the same post-injection collection and the row can't duplicate onto a
+  // later page. Spread-copied with the request window's own end timestamp
+  // -- the fixture's fixed date isn't the point, its unrecognized
+  // `event_type` is, and it must land inside whatever range was requested.
+  if (state.bolusReviewIncludeUnknownEventType) {
+    mappedBoluses.unshift({
       ...bolusReviewUnknownEventTypeFixture,
-      event_timestamp: iso(new Date()),
+      event_timestamp: iso(new Date(endTime)),
     });
   }
 
   return {
-    boluses,
-    total_count: reviewEvents.length + unknownEventDelta,
+    boluses: mappedBoluses.slice(offset, offset + limit),
+    total_count: mappedBoluses.length,
     period_days: periodDays,
   };
 }

--- a/apps/web/src/mocks/fixtures.test.ts
+++ b/apps/web/src/mocks/fixtures.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@/lib/glucose-classification";
 import { INSULIN_DOSE_LIMITS } from "@/lib/insulin";
 
+import { bolusReviewUnknownEventTypeRow } from "./data";
 import {
   CONTRACT_FIXTURES,
   activeAlertFixture,
@@ -177,6 +178,22 @@ describe("shared contract fixtures", () => {
   it("reports a connected integration state", () => {
     expect(integrationConnectionStateFixture.status).toBe("connected");
     expect(integrationConnectionStateFixture.integration_type).toBe("tandem");
+  });
+
+  it("keeps the DevMockPanel's inline unknown-event row (GLY-270, src/mocks/data.ts) pinned to this fixture", () => {
+    // `data.ts` cannot import `bolusReviewUnknownEventTypeFixture` directly --
+    // it is part of the real Next.js bundle, and this file's
+    // `contracts/fixtures/*.json` imports do not resolve inside the web
+    // Docker build context. So `data.ts` keeps its own inline copy; this test
+    // is what keeps that copy from silently drifting. `event_timestamp` is
+    // excluded because the inline copy's caller always overrides it with the
+    // request window's own end time.
+    const { event_timestamp: _rowTimestamp, ...rowRest } =
+      bolusReviewUnknownEventTypeRow;
+    const { event_timestamp: _fixtureTimestamp, ...fixtureRest } =
+      bolusReviewUnknownEventTypeFixture;
+
+    expect(rowRest).toEqual(fixtureRest);
   });
 
   it("drops an unknown future event type instead of guessing it into a bolus", () => {

--- a/apps/web/src/mocks/fixtures.ts
+++ b/apps/web/src/mocks/fixtures.ts
@@ -175,8 +175,13 @@ export const integrationConnectionStateFixture = {
 // that list with a `Literal` is filed as GLY-241 (see the comment on
 // `BolusReviewItem` in `lib/api.ts` and on `KNOWN_BOLUS_REVIEW_EVENT_TYPES` in
 // `InsulinTimeline/insulin-timeline-data.ts`). Until it closes, every consumer
-// must gate on `isKnownBolusReviewEventType`; this fixture is what proves they
-// do.
+// must gate on `isKnownBolusReviewEventType`. What actually enforces that:
+// unit tests on `BolusReviewTable`, `dashboard/bolus-review-table`, and the
+// clinical report's `BolusTable` (GLY-270) each assert this fixture is
+// filtered out rather than rendered as a dose; the DevMockPanel's
+// "Include unrecognized bolus review event type" scenario (also GLY-270)
+// wires it into the live `/integrations/bolus/review` mock response so the
+// same guard is exercisable outside unit tests.
 export const bolusReviewUnknownEventTypeFixture =
   bolusReviewUnknownEventTypeJson satisfies BolusReviewItem;
 

--- a/apps/web/src/mocks/handlers.test.ts
+++ b/apps/web/src/mocks/handlers.test.ts
@@ -6,6 +6,11 @@ import { setupMockApiServer } from "./test-server";
 
 setupMockApiServer();
 
+// GLY-270: shared origin for the new test blocks below (file-wide migration
+// of the pre-existing hardcoded occurrences is a noted follow-up, not this
+// story's scope).
+const MOCK_ORIGIN = "http://localhost:3003";
+
 describe("mock API handlers", () => {
   it("paginates the configured knowledge base documents", async () => {
     const { setMockRuntimeState } = await import("./state");
@@ -499,8 +504,10 @@ describe("mock API handlers", () => {
 
   it("only injects the unknown-event fixture row into the bolus review response when the DevMockPanel scenario is on", async () => {
     const { setMockRuntimeState } = await import("./state");
-    const query =
-      "http://localhost:3003/api/integrations/bolus/review?days=1&limit=20";
+    // limit=500 (the max) so the fixture's `+1` delta is observable in
+    // `boluses.length` too, not just `total_count` -- a small limit would
+    // mask the delta once real events already fill the page.
+    const query = `${MOCK_ORIGIN}/api/integrations/bolus/review?days=1&limit=500`;
     type BolusReviewBody = {
       boluses: Array<{ event_type?: string; units: number }>;
       total_count: number;
@@ -534,6 +541,35 @@ describe("mock API handlers", () => {
     );
     expect(scenario.boluses.length).toBe(baseline.boluses.length + 1);
     expect(scenario.total_count).toBe(baseline.total_count + 1);
+  });
+
+  it("keeps the injected unknown-event row inside an explicit historical window and respects the page limit", async () => {
+    const { setMockRuntimeState } = await import("./state");
+    const end = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const start = new Date(end.getTime() - 6 * 24 * 60 * 60 * 1000);
+    const limit = 3;
+    const query = `${MOCK_ORIGIN}/api/integrations/bolus/review?start=${start.toISOString()}&end=${end.toISOString()}&limit=${limit}`;
+    type BolusReviewBody = {
+      boluses: Array<{ event_type?: string; event_timestamp: string }>;
+      total_count: number;
+    };
+
+    setMockRuntimeState({
+      pumpSources: ["tandem"],
+      bolusReviewIncludeUnknownEventType: true,
+    });
+    const response = await fetch(query);
+    const body = (await response.json()) as BolusReviewBody;
+
+    expect(response.status).toBe(200);
+    expect(body.boluses.length).toBeLessThanOrEqual(limit);
+    const row = body.boluses.find(
+      (bolus) => bolus.event_type === "closed_loop_micro_dose",
+    );
+    expect(row).toBeDefined();
+    const rowTime = new Date(row!.event_timestamp).getTime();
+    expect(rowTime).toBeGreaterThanOrEqual(start.getTime());
+    expect(rowTime).toBeLessThanOrEqual(end.getTime());
   });
 
   it("aggregates the same selected glucose range served to the trend chart", async () => {
@@ -630,26 +666,20 @@ describe("mock API handlers", () => {
       const connectionB = new AbortController();
 
       try {
-        const responseA = await fetch(
-          "http://localhost:3003/api/v1/glucose/stream",
-          {
-            headers: { Accept: "text/event-stream" },
-            signal: connectionA.signal,
-          },
-        );
+        const responseA = await fetch(`${MOCK_ORIGIN}/api/v1/glucose/stream`, {
+          headers: { Accept: "text/event-stream" },
+          signal: connectionA.signal,
+        });
         const readerA = responseA.body!.getReader();
         const firstReadFromA = await readerA.read();
         expect(firstReadFromA.done).toBe(false);
 
         // Simulate a scenario switch: a new stream connects without the
         // browser's `abort` event for the old one reaching this handler yet.
-        const responseB = await fetch(
-          "http://localhost:3003/api/v1/glucose/stream",
-          {
-            headers: { Accept: "text/event-stream" },
-            signal: connectionB.signal,
-          },
-        );
+        const responseB = await fetch(`${MOCK_ORIGIN}/api/v1/glucose/stream`, {
+          headers: { Accept: "text/event-stream" },
+          signal: connectionB.signal,
+        });
         const readerB = responseB.body!.getReader();
         const firstReadFromB = await readerB.read();
         expect(firstReadFromB.done).toBe(false);

--- a/apps/web/src/mocks/handlers.test.ts
+++ b/apps/web/src/mocks/handlers.test.ts
@@ -497,6 +497,46 @@ describe("mock API handlers", () => {
     );
   });
 
+  it("only injects the unknown-event fixture row into the bolus review response when the DevMockPanel scenario is on", async () => {
+    const { setMockRuntimeState } = await import("./state");
+    const query =
+      "http://localhost:3003/api/integrations/bolus/review?days=1&limit=20";
+    type BolusReviewBody = {
+      boluses: Array<{ event_type?: string; units: number }>;
+      total_count: number;
+    };
+
+    setMockRuntimeState({
+      pumpSources: ["tandem"],
+      cgmBackfillDays: 2,
+      bolusReviewIncludeUnknownEventType: false,
+    });
+    const baselineResponse = await fetch(query);
+    const baseline = (await baselineResponse.json()) as BolusReviewBody;
+
+    setMockRuntimeState({ bolusReviewIncludeUnknownEventType: true });
+    const scenarioResponse = await fetch(query);
+    const scenario = (await scenarioResponse.json()) as BolusReviewBody;
+
+    expect(baselineResponse.status).toBe(200);
+    expect(scenarioResponse.status).toBe(200);
+    expect(
+      baseline.boluses.some(
+        (bolus) => bolus.event_type === "closed_loop_micro_dose",
+      ),
+    ).toBe(false);
+    expect(scenario.boluses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event_type: "closed_loop_micro_dose",
+          units: 0.5,
+        }),
+      ]),
+    );
+    expect(scenario.boluses.length).toBe(baseline.boluses.length + 1);
+    expect(scenario.total_count).toBe(baseline.total_count + 1);
+  });
+
   it("aggregates the same selected glucose range served to the trend chart", async () => {
     const { setMockRuntimeState } = await import("./state");
     setMockRuntimeState({ cgmBackfillDays: 30, glucoseEvent: "baseline" });
@@ -553,5 +593,55 @@ describe("mock API handlers", () => {
     expect(detail).toBe(
       "Missing mock API handler for POST /api/mock-uncovered-route",
     );
+  });
+
+  describe("glucose SSE stream lifecycle (GLY-270)", () => {
+    it("closes the previous connection's interval and controller when a scenario switch opens a new stream", async () => {
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const connectionA = new AbortController();
+      const connectionB = new AbortController();
+
+      try {
+        const responseA = await fetch(
+          "http://localhost:3003/api/v1/glucose/stream",
+          { headers: { Accept: "text/event-stream" }, signal: connectionA.signal },
+        );
+        const readerA = responseA.body!.getReader();
+        const firstReadFromA = await readerA.read();
+        expect(firstReadFromA.done).toBe(false);
+
+        // Simulate a scenario switch: a new stream connects without the
+        // browser's `abort` event for the old one reaching this handler yet.
+        const responseB = await fetch(
+          "http://localhost:3003/api/v1/glucose/stream",
+          { headers: { Accept: "text/event-stream" }, signal: connectionB.signal },
+        );
+        const readerB = responseB.body!.getReader();
+        const firstReadFromB = await readerB.read();
+        expect(firstReadFromB.done).toBe(false);
+
+        // The stale connection must be cleanly closed by the new one, not
+        // left to enqueue onto a controller the browser has moved on from.
+        // Already-queued chunks from the pre-switch `sendGlucose()` call
+        // (glucose + heartbeat + optional alert) drain before the stream
+        // reports done, so read it out rather than asserting on one read.
+        let readFromAAfterSwitch: ReadableStreamReadResult<Uint8Array>;
+        let readsAfterSwitch = 0;
+        do {
+          readFromAAfterSwitch = await readerA.read();
+          readsAfterSwitch += 1;
+        } while (
+          !readFromAAfterSwitch.done &&
+          readsAfterSwitch < 10
+        );
+        expect(readFromAAfterSwitch.done).toBe(true);
+
+        expect(errorSpy).not.toHaveBeenCalled();
+      } finally {
+        connectionA.abort();
+        connectionB.abort();
+        errorSpy.mockRestore();
+      }
+    });
   });
 });

--- a/apps/web/src/mocks/handlers.test.ts
+++ b/apps/web/src/mocks/handlers.test.ts
@@ -509,7 +509,6 @@ describe("mock API handlers", () => {
     setMockRuntimeState({
       pumpSources: ["tandem"],
       cgmBackfillDays: 2,
-      bolusReviewIncludeUnknownEventType: false,
     });
     const baselineResponse = await fetch(query);
     const baseline = (await baselineResponse.json()) as BolusReviewBody;
@@ -595,16 +594,48 @@ describe("mock API handlers", () => {
     );
   });
 
-  describe("glucose SSE stream lifecycle (GLY-270)", () => {
+  describe("glucose SSE stream lifecycle", () => {
+    const DRAIN_TIMEOUT_MS = 250;
+    const MAX_DRAIN_READS = 10;
+    const DRAIN_TIMED_OUT = Symbol("drain-timeout");
+
+    function timeoutAfter(ms: number): Promise<typeof DRAIN_TIMED_OUT> {
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(DRAIN_TIMED_OUT), ms);
+      });
+    }
+
+    // Already-queued chunks from the pre-switch `sendGlucose()` call
+    // (glucose + heartbeat + optional alert) drain before the stream
+    // reports done, so read it out rather than asserting on one read.
+    async function drainUntilDone(
+      reader: ReadableStreamDefaultReader<Uint8Array>,
+    ): Promise<ReadableStreamReadResult<Uint8Array>> {
+      let result: ReadableStreamReadResult<Uint8Array>;
+      let reads = 0;
+      do {
+        result = await reader.read();
+        reads += 1;
+      } while (!result.done && reads < MAX_DRAIN_READS);
+      return result;
+    }
+
     it("closes the previous connection's interval and controller when a scenario switch opens a new stream", async () => {
-      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const { setMockRuntimeState } = await import("./state");
+      // Decouple from the 5s liveMode tick: pin the 30s branch so no
+      // interval fires mid-test regardless of the suite's default state.
+      setMockRuntimeState({ liveMode: false });
+
       const connectionA = new AbortController();
       const connectionB = new AbortController();
 
       try {
         const responseA = await fetch(
           "http://localhost:3003/api/v1/glucose/stream",
-          { headers: { Accept: "text/event-stream" }, signal: connectionA.signal },
+          {
+            headers: { Accept: "text/event-stream" },
+            signal: connectionA.signal,
+          },
         );
         const readerA = responseA.body!.getReader();
         const firstReadFromA = await readerA.read();
@@ -614,33 +645,34 @@ describe("mock API handlers", () => {
         // browser's `abort` event for the old one reaching this handler yet.
         const responseB = await fetch(
           "http://localhost:3003/api/v1/glucose/stream",
-          { headers: { Accept: "text/event-stream" }, signal: connectionB.signal },
+          {
+            headers: { Accept: "text/event-stream" },
+            signal: connectionB.signal,
+          },
         );
         const readerB = responseB.body!.getReader();
         const firstReadFromB = await readerB.read();
         expect(firstReadFromB.done).toBe(false);
 
         // The stale connection must be cleanly closed by the new one, not
-        // left to enqueue onto a controller the browser has moved on from.
-        // Already-queued chunks from the pre-switch `sendGlucose()` call
-        // (glucose + heartbeat + optional alert) drain before the stream
-        // reports done, so read it out rather than asserting on one read.
-        let readFromAAfterSwitch: ReadableStreamReadResult<Uint8Array>;
-        let readsAfterSwitch = 0;
-        do {
-          readFromAAfterSwitch = await readerA.read();
-          readsAfterSwitch += 1;
-        } while (
-          !readFromAAfterSwitch.done &&
-          readsAfterSwitch < 10
-        );
-        expect(readFromAAfterSwitch.done).toBe(true);
-
-        expect(errorSpy).not.toHaveBeenCalled();
+        // left open indefinitely -- bound the drain so a regression fails
+        // red instead of hanging the Jest process (this suite's CI job has
+        // no timeout-minutes).
+        const drained = await Promise.race([
+          drainUntilDone(readerA),
+          timeoutAfter(DRAIN_TIMEOUT_MS),
+        ]);
+        if (drained === DRAIN_TIMED_OUT) {
+          throw new Error(
+            "stream did not close after the switch: readerA was still open " +
+              `${DRAIN_TIMEOUT_MS}ms after connection B opened`,
+          );
+        }
+        expect(drained.done).toBe(true);
+        await expect(readerA.closed).resolves.toBeUndefined();
       } finally {
         connectionA.abort();
         connectionB.abort();
-        errorSpy.mockRestore();
       }
     });
   });

--- a/apps/web/src/mocks/handlers.ts
+++ b/apps/web/src/mocks/handlers.ts
@@ -2037,7 +2037,12 @@ export const handlers = [
       getMockRuntimeState().liveMode ? 5_000 : 30_000,
     );
 
+    let isClosed = false;
     const close = () => {
+      if (isClosed) {
+        return;
+      }
+      isClosed = true;
       clearInterval(interval);
       client.close();
       if (closeActiveGlucoseStreamConnection === close) {

--- a/apps/web/src/mocks/handlers.ts
+++ b/apps/web/src/mocks/handlers.ts
@@ -55,15 +55,23 @@ function requestParams(request: Request): URLSearchParams {
 
 const SNAPSHOT_CACHE_BUCKET_MS = 5 * 60_000;
 
-interface GlucoseStreamConnection {
-  close: () => void;
-}
-
 // Tracks the single live `/v1/glucose/stream` connection so a reconnect (a
-// mock scenario switch remounts the app content) can close the previous
-// connection's interval and controller before it becomes stale -- see
-// GLY-270.
-let activeGlucoseStreamConnection: GlucoseStreamConnection | null = null;
+// mock scenario switch remounts the app content, which races the browser's
+// `abort` delivery for the old connection against the new connection's
+// resolver) can force-close the stale connection's interval and controller
+// before it enqueues onto a controller the browser has moved on from -- see
+// GLY-270. Assumes one consumer per page: a second real EventSource against
+// this same mock worker (e.g. two dashboard tabs) would fight over this
+// singleton, and only the most recently opened connection survives --
+// acceptable for mock/dev-only tooling.
+//
+// Residual leak: if a connection is torn down without a successor AND
+// without `request.signal` ever firing `abort` (e.g. a frozen/suspended
+// tab), the `setInterval` below has nothing left to clear it -- msw exposes
+// no "the browser gave up on this stream" signal independent of that abort
+// event. Not attempting a speculative tick-based self-close for that case:
+// it would also terminate legitimately long-running dev sessions.
+let closeActiveGlucoseStreamConnection: (() => void) | null = null;
 
 let snapshotCache: {
   key: string;
@@ -1983,12 +1991,14 @@ export const handlers = [
     heartbeat: string;
     alert: string;
   }>(`${API}/v1/glucose/stream`, ({ client, request }) => {
-    // A scenario switch remounts the app content, so the browser can open a
-    // new EventSource before the old one's `abort` event reaches this
-    // handler. Proactively tear down the previous connection's interval and
-    // controller so it never enqueues onto a stream the browser moved on
-    // from -- see GLY-270.
-    activeGlucoseStreamConnection?.close();
+    // Force-close any still-live connection before opening this one -- see
+    // the singleton comment on `closeActiveGlucoseStreamConnection` above.
+    if (closeActiveGlucoseStreamConnection) {
+      console.warn(
+        "[mock] Force-closing a stale /v1/glucose/stream connection before opening a new one (GLY-270).",
+      );
+      closeActiveGlucoseStreamConnection();
+    }
 
     const sendGlucose = () => {
       const { state, data } = snapshot();
@@ -2019,25 +2029,24 @@ export const handlers = [
 
     sendGlucose();
 
+    // Bare (not `window.`) so this resolver also runs under
+    // `handlers.test.ts`'s `@jest-environment node`, where `window` is
+    // undefined.
     const interval = setInterval(
       sendGlucose,
       getMockRuntimeState().liveMode ? 5_000 : 30_000,
     );
 
-    const connection: GlucoseStreamConnection = {
-      close: () => {
-        clearInterval(interval);
-        client.close();
-      },
-    };
-    activeGlucoseStreamConnection = connection;
-
-    request.signal.addEventListener("abort", () => {
+    const close = () => {
       clearInterval(interval);
-      if (activeGlucoseStreamConnection === connection) {
-        activeGlucoseStreamConnection = null;
+      client.close();
+      if (closeActiveGlucoseStreamConnection === close) {
+        closeActiveGlucoseStreamConnection = null;
       }
-    });
+    };
+    closeActiveGlucoseStreamConnection = close;
+
+    request.signal.addEventListener("abort", close, { once: true });
   }),
 
   http.all(`${API}/*`, ({ request }) => {

--- a/apps/web/src/mocks/handlers.ts
+++ b/apps/web/src/mocks/handlers.ts
@@ -55,6 +55,16 @@ function requestParams(request: Request): URLSearchParams {
 
 const SNAPSHOT_CACHE_BUCKET_MS = 5 * 60_000;
 
+interface GlucoseStreamConnection {
+  close: () => void;
+}
+
+// Tracks the single live `/v1/glucose/stream` connection so a reconnect (a
+// mock scenario switch remounts the app content) can close the previous
+// connection's interval and controller before it becomes stale -- see
+// GLY-270.
+let activeGlucoseStreamConnection: GlucoseStreamConnection | null = null;
+
 let snapshotCache: {
   key: string;
   data: ReturnType<typeof buildMockDataSnapshot>;
@@ -912,8 +922,8 @@ export const handlers = [
   }),
 
   http.get(`${API}/integrations/bolus/review`, ({ request }) => {
-    const { data } = snapshot();
-    return ok(buildBolusReview(data, requestParams(request)));
+    const { state, data } = snapshot();
+    return ok(buildBolusReview(state, data, requestParams(request)));
   }),
 
   http.get(`${API}/integrations/tandem/sync/status`, () => {
@@ -1973,6 +1983,13 @@ export const handlers = [
     heartbeat: string;
     alert: string;
   }>(`${API}/v1/glucose/stream`, ({ client, request }) => {
+    // A scenario switch remounts the app content, so the browser can open a
+    // new EventSource before the old one's `abort` event reaches this
+    // handler. Proactively tear down the previous connection's interval and
+    // controller so it never enqueues onto a stream the browser moved on
+    // from -- see GLY-270.
+    activeGlucoseStreamConnection?.close();
+
     const sendGlucose = () => {
       const { state, data } = snapshot();
       const latest = data.glucoseHistory.at(-1);
@@ -2002,13 +2019,24 @@ export const handlers = [
 
     sendGlucose();
 
-    const interval = window.setInterval(
+    const interval = setInterval(
       sendGlucose,
       getMockRuntimeState().liveMode ? 5_000 : 30_000,
     );
 
+    const connection: GlucoseStreamConnection = {
+      close: () => {
+        clearInterval(interval);
+        client.close();
+      },
+    };
+    activeGlucoseStreamConnection = connection;
+
     request.signal.addEventListener("abort", () => {
-      window.clearInterval(interval);
+      clearInterval(interval);
+      if (activeGlucoseStreamConnection === connection) {
+        activeGlucoseStreamConnection = null;
+      }
     });
   }),
 

--- a/apps/web/src/mocks/state.test.ts
+++ b/apps/web/src/mocks/state.test.ts
@@ -46,6 +46,12 @@ describe("mock runtime state", () => {
     expect(getMockRuntimeState().tandemAutomaticSyncShouldFail).toBe(true);
   });
 
+  it("persists the unrecognized bolus review event type scenario", () => {
+    setMockRuntimeState({ bolusReviewIncludeUnknownEventType: true });
+
+    expect(getMockRuntimeState().bolusReviewIncludeUnknownEventType).toBe(true);
+  });
+
   it("persists Tandem automatic sync settings", () => {
     setMockRuntimeState({
       tandemSyncEnabled: false,

--- a/apps/web/src/mocks/state.ts
+++ b/apps/web/src/mocks/state.ts
@@ -189,6 +189,10 @@ function normalizeState(input: unknown): MockRuntimeState {
       typeof candidate.tandemSyncShouldFail === "boolean"
         ? candidate.tandemSyncShouldFail
         : DEFAULT_MOCK_RUNTIME_STATE.tandemSyncShouldFail,
+    bolusReviewIncludeUnknownEventType:
+      typeof candidate.bolusReviewIncludeUnknownEventType === "boolean"
+        ? candidate.bolusReviewIncludeUnknownEventType
+        : DEFAULT_MOCK_RUNTIME_STATE.bolusReviewIncludeUnknownEventType,
     cgmBackfillDays: backfillDays,
     knowledgeDocumentCount,
     liveMode:

--- a/apps/web/src/mocks/types.ts
+++ b/apps/web/src/mocks/types.ts
@@ -52,6 +52,7 @@ export interface MockRuntimeState {
   tandemSyncIntervalMinutes: number;
   tandemAutomaticSyncShouldFail: boolean;
   tandemSyncShouldFail: boolean;
+  bolusReviewIncludeUnknownEventType: boolean;
   cgmBackfillDays: number;
   knowledgeDocumentCount: number;
   liveMode: boolean;
@@ -278,6 +279,7 @@ export const DEFAULT_MOCK_RUNTIME_STATE: MockRuntimeState = {
   tandemSyncIntervalMinutes: 15,
   tandemAutomaticSyncShouldFail: false,
   tandemSyncShouldFail: false,
+  bolusReviewIncludeUnknownEventType: false,
   cgmBackfillDays: MOCK_CGM_BACKFILL_DEFAULT_DAYS,
   knowledgeDocumentCount: MOCK_KNOWLEDGE_DOCUMENT_DEFAULT_COUNT,
   liveMode: true,


### PR DESCRIPTION
## Summary

- Fixes the dev-only mock SSE stream lifecycle: switching a scenario in the developer mock panel remounts the app subtree, and the old stream's interval kept writing to a closed connection, logging repeated stream errors. The mock handler now tracks the active connection and closes the previous one before serving a new stream. Verified in-browser: rapid scenario switches produce zero console errors.
- Adds a developer mock scenario that serves the unknown-event-type contract fixture through the bolus review mock, so the safe-unknown rendering path is drivable against a running app. The injected row participates in pagination and windowing honestly, and the mock row is pinned to the canonical fixture by a deep-equality test rather than a runtime import (which would break the web container build, since the fixture JSONs live outside its build context).
- Production fix: the clinical report's bolus table did not filter unrecognized event types the way both dashboard bolus tables do, so an unknown event could render as a real dose row in a clinician-facing report. It now uses the same guard, the skipped-row case renders an explicit "N bolus events could not be displayed" message instead of "No bolus events" (filtered rows must never read as no insulin taken), and the skip warning is deduplicated per surface so the report's own skips stay observable. The table component moved to its own module so the page keeps only legal Next.js exports.
- Test hardening: the stream-lifecycle regression test fails red with a bounded timeout instead of hanging Jest; the new scenario flag has the same panel/state/remount test coverage as its siblings.

## Notes for review

- No dependency or CI workflow changes. Everything except the clinical report guard is development-only mock code, unreachable from production builds.
- The in-image container build was verified directly (`docker compose build web`), including the Next.js page-export contract and the build-context isolation that plain typecheck and Jest do not enforce.

## Testing

- Web typecheck, lint, and full Jest suite green (246 suites); container build green; contract regeneration unchanged.
- Sentry-enabled stack run: dashboard and a generated clinical report exercised with real pump data (91 boluses, 14-day window); no new issues in the run window.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lumose-health/glycemicgpt/pull/999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a clinical bolus table displaying glucose, insulin-on-board, warnings, and recent-event notices.
  - Added clear empty states when no recognized bolus events are available.
  - Added a mock-control option for simulating unrecognized bolus event types.

- **Bug Fixes**
  - Improved warning clarity by grouping repeated unknown-event messages.
  - Ensured new glucose data streams close previous connections cleanly.

- **Tests**
  - Added coverage for filtering, empty states, pagination, warnings, mock scenarios, and stream lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->